### PR TITLE
Capability to send datacollection data as part of testcase end event …

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/InProcDataCollecionSink.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/InProcDataCollecionSink.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
+
+    // <inheritdoc />
+    internal class InProcDataCollectionSink : IDataCollectionSink
+    {
+        private IDictionary<Guid, TestCaseDataCollectionData> testCaseDataCollectionDataMap;
+
+        /// <summary>
+        /// In process data collection sink
+        /// </summary>
+        public InProcDataCollectionSink()
+        {
+            this.testCaseDataCollectionDataMap = new Dictionary<Guid, TestCaseDataCollectionData>();
+        }
+
+        // <inheritdoc />
+        public void SendData(DataCollectionContext dataCollectionContext, string key, string value)
+        {
+            ValidateArg.NotNullOrEmpty(key, "key");
+            ValidateArg.NotNullOrEmpty(value, "value");
+            ValidateArg.NotNullOrEmpty(dataCollectionContext.TestCase.Id.ToString(), "dataCollectionContext.TestCase.Id");
+
+            var testCaseId = dataCollectionContext.TestCase.Id;
+            this.AddKeyValuePairToDictionary(testCaseId, key, value);
+        }
+
+
+        /// <summary>
+        /// Gets the data collection data stored in the in process data collection sink
+        /// </summary>
+        /// <param name="testCaseId">valid test case id</param>
+        /// <returns>test data collection dictionary </returns>
+        public IDictionary<string, string> GetDataCollectionDataSetForTestCase(Guid testCaseId)
+        {
+            TestCaseDataCollectionData testCaseDataCollection = null;
+
+            if (!this.testCaseDataCollectionDataMap.TryGetValue(testCaseId, out testCaseDataCollection))
+            {
+                if (EqtTrace.IsWarningEnabled)
+                {
+                    EqtTrace.Warning("No DataCollection Data set for the test case {0}", testCaseId);
+                }
+                return new Dictionary<string, string>();
+            }
+            else
+            {                
+                this.testCaseDataCollectionDataMap.Remove(testCaseId);
+                return testCaseDataCollection.CollectionData;
+            }
+        }
+
+        private void AddKeyValuePairToDictionary(Guid testCaseId, string key, string value)
+        {
+            if (!this.testCaseDataCollectionDataMap.ContainsKey(testCaseId))
+            {
+                var testCaseCollectionData = new TestCaseDataCollectionData();
+                testCaseCollectionData.AddOrUpdateData(key, value);
+                this.testCaseDataCollectionDataMap[testCaseId] = testCaseCollectionData;
+
+            }
+            else
+            {
+                this.testCaseDataCollectionDataMap[testCaseId].AddOrUpdateData(key, value);
+            }
+        }
+
+        private class TestCaseDataCollectionData
+        {
+            public TestCaseDataCollectionData()
+            {
+                this.CollectionData = new Dictionary<string, string>();
+            }
+
+            internal IDictionary<string, string> CollectionData { get; private set; }
+
+            internal void AddOrUpdateData(string key, string value)
+            {
+                if (!this.CollectionData.ContainsKey(key))
+                {
+                    this.CollectionData[key] = value;
+                }
+                else
+                {
+                    if (EqtTrace.IsWarningEnabled)
+                    {
+                        EqtTrace.Warning("The data for inprocdata collector with key {0} has already been set. Will be reset with new value", key);
+                    }
+                    this.CollectionData[key] = value;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestCaseEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestCaseEventsHandler.cs
@@ -1,15 +1,16 @@
 
 namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.EventHandlers
 {
-    
+
     using System;
+
+    using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection;
 #if !NET46
     using System.Runtime.Loader;
 #endif
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution;
-
-    using TestPlatform.ObjectModel;
-    using TestPlatform.ObjectModel.Engine;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine;
 
     /// <summary>
     /// The test case events handler.
@@ -18,7 +19,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.EventHandlers
     {
 
         private InProcDataCollectionExtensionManager inProcDataCollectionExtensionManager;
-
         private ITestCaseEventsHandler testCaseEvents;
 
         /// <summary>
@@ -68,6 +68,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.EventHandlers
         /// </param>
         public void SendTestResult(TestResult result)
         {
+            this.inProcDataCollectionExtensionManager.TriggerUpdateTestResult(result);
             this.testCaseEvents?.SendTestResult(result);
         }
     }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/ExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/ExecutionManager.cs
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
     using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.Common.SettingsProvider;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
+    using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection;
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Discovery;
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.EventHandlers;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;

--- a/src/Microsoft.TestPlatform.ObjectModel/DataCollector/DataCollectionContext.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/DataCollector/DataCollectionContext.cs
@@ -2,6 +2,8 @@
 
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection
 {
+    using System;
+
     /// <summary>
     /// Class representing the context in which data collection occurs.
     /// </summary>
@@ -30,6 +32,15 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection
         //       class and pass to us for creating data collection events.
 
         /// <summary>
+        /// Constructs DataCollection Context for in process data collectors
+        /// </summary>
+        /// <param name="testCase">test case to identify the context</param>
+        public DataCollectionContext(TestCase testCase)
+        {
+            this.TestCase = testCase;
+        }
+
+        /// <summary>
         /// Constructs a DataCollectionContext indicating that there is a session,
         /// but no executing test, in context.
         /// </summary>
@@ -55,10 +66,14 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection
             this.testExecId = testExecId;
             this.hashCode = ComputeHashCode();
         }
-
         #endregion
 
         #region Properties
+
+        /// <summary>
+        /// Gets test case.
+        /// </summary>
+        public TestCase TestCase { get; private set; }
 
         /// <summary>
         /// Identifies the session under which the data collection occurs.  Will not be null.

--- a/src/Microsoft.TestPlatform.ObjectModel/DataCollector/IDataCollectionSink.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/DataCollector/IDataCollectionSink.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection
+{
+    /// <summary>
+    /// Class used by data collectors to send data to up-stream components
+    /// (agent, controller, client, etc).
+    /// </summary>
+    public interface IDataCollectionSink
+    {
+        /// <summary>
+        /// The send data will send the data collection data to upstream applications.
+        /// Key will be set as TestProperty in TestResult and value as corresponding value.
+        /// </summary>
+        /// <param name="dataCollectionContext">
+        /// The data collection context.
+        /// </param>
+        /// <param name="key">
+        /// The key should be unique for a data collector.
+        /// </param>
+        /// <param name="value">
+        /// The value should be a string or an object serialized into a JSON string.
+        /// </param>
+        void SendData(DataCollectionContext dataCollectionContext, string key, string value);
+
+    }
+}

--- a/src/Microsoft.TestPlatform.ObjectModel/DataCollector/InProcDataCollector/InProcDataCollector.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/DataCollector/InProcDataCollector/InProcDataCollector.cs
@@ -12,6 +12,12 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.InProcDataCollector
     public interface InProcDataCollection
     {
         /// <summary>
+        /// Initializes the In Process DataCollection with the DataCollectionSink
+        /// </summary>
+        /// <param name="dataCollectionSink">data collection sink object</param>
+        void Initialize(IDataCollectionSink dataCollectionSink);
+
+        /// <summary>
         /// Called when test session starts
         /// </summary>
         /// <param name="testSessionStartArgs">

--- a/src/Microsoft.TestPlatform.ObjectModel/DataCollector/InProcDataCollector/TestCaseEndArgs.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/DataCollector/InProcDataCollector/TestCaseEndArgs.cs
@@ -2,6 +2,8 @@
 
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollector.InProcDataCollector
 {
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
+
     /// <summary>
     /// The test case end args.
     /// </summary>
@@ -10,26 +12,26 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollector.InProcDa
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCaseEndArgs"/> class.
         /// </summary>
-        /// <param name="testCase">
-        /// The test case.
+        /// <param name="dataCollectionContext">
+        /// The data Collection Context.
         /// </param>
         /// <param name="outcome">
         /// The outcome.
         /// </param>
-        public TestCaseEndArgs(TestCase testCase, TestOutcome outcome)
+        public TestCaseEndArgs(DataCollectionContext dataCollectionContext, TestOutcome outcome)
         {
-            this.TestCase = testCase;
             this.TestOutcome = outcome;
+            this.DataCollectionContext = dataCollectionContext;
         }
-
-        /// <summary>
-        /// Gets the test case.
-        /// </summary>
-        public TestCase TestCase { get; private set; }
 
         /// <summary>
         /// Gets the outcome.
         /// </summary>
         public TestOutcome TestOutcome { get; private set; }
+
+        /// <summary>
+        /// Gets the data collection context.
+        /// </summary>
+        public DataCollectionContext DataCollectionContext { get; private set; }
     }
 }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/InProcDataCollectionExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/InProcDataCollectionExtensionManagerTests.cs
@@ -14,6 +14,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
 
     using Moq;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+    using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection;
 
     [TestClass]
     public class InProcDataCollectionExtensionManagerTests
@@ -33,21 +34,29 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
         }
 
         [TestMethod]
-        public void InProcDataCollectionTestCaseEventHandlerCallingTriggerTestCaseStart()
+        public void TriggerTestCaseStartShouldBeCalledWhenSendTestCaseStartIsCalled()
         {            
             this.testCasesEventsHandler.SendTestCaseStart(null);
             this.mockInProcDataCollectionHelper.Verify(x => x.TriggerTestCaseStart(null), Times.Once);
         }
 
         [TestMethod]
-        public void InProcDataCollectionTestCaseEventHandlerCallingTriggerTestCaseEnd()
+        public void TriggerTestCaseEndShouldBeCalledWhenSendTestCaseEndIsCalled()
         {
             this.testCasesEventsHandler.SendTestCaseEnd(null, TestOutcome.Passed);
             this.mockInProcDataCollectionHelper.Verify(x => x.TriggerTestCaseEnd(null, TestOutcome.Passed), Times.Once);
         }
 
         [TestMethod]
-        public void InProcDataCollectionTestCaseEventHandlerCallingTestCaseEventsFromClients()
+        [TestCategory("InPRocDC")]
+        public void TriggerUpdateTestResultShouldBeCalledWhenSendTestResultIsCalled()
+        {
+            this.testCasesEventsHandler.SendTestResult(null);
+            this.mockInProcDataCollectionHelper.Verify(x => x.TriggerUpdateTestResult(null), Times.Once);
+        }
+
+        [TestMethod]
+        public void TestCaseEventsFromClientsShouldBeCalledWhenTestCaseEventsAreCalled()
         {
             this.testCasesEventsHandler.SendTestCaseStart(null);
             this.testCasesEventsHandler.SendTestCaseEnd(null, TestOutcome.Passed);

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/InProcDataCollectionSinkTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/InProcDataCollectionSinkTests.cs
@@ -1,0 +1,85 @@
+﻿
+namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
+{
+    using System;
+
+    using Castle.DynamicProxy.Generators.Emitters;
+
+    using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using TestPlatform.CrossPlatEngine.UnitTests.Discovery;
+
+    [TestClass]
+    public class InProcDataCollectionSinkTests
+    {
+        private IDataCollectionSink dataCollectionSink;
+
+        private DataCollectionContext dataCollectionContext;
+
+        private TestCase testCase;
+
+        [TestInitialize]
+        public void InitializeTest()
+        {
+            this.dataCollectionSink = new InProcDataCollectionSink();
+            this.testCase = new TestCase("DummyNS.DummyC.DummyM", new Uri("executor://mstest/v1"), "Dummy.dll");
+            this.dataCollectionContext = new DataCollectionContext(this.testCase);
+        }
+
+        [TestMethod]
+        public void SendDataShouldAddKeyValueToDictionaryInSink()
+        {
+            this.testCase.SetPropertyValue(TestCaseProperties.Id, Guid.NewGuid());
+            this.dataCollectionSink.SendData(this.dataCollectionContext, "DummyKey", "DummyValue");            
+
+            var dict = ((InProcDataCollectionSink)this.dataCollectionSink).GetDataCollectionDataSetForTestCase(this.testCase.Id);
+
+            Assert.AreEqual<string>(dict["DummyKey"].ToString(), "DummyValue");
+        }
+
+        [TestMethod]
+        
+        public void SendDataShouldThrowArgumentExceptionIfKeyIsNull()
+        {
+            this.testCase.SetPropertyValue(TestCaseProperties.Id, Guid.NewGuid());
+
+            Assert.ThrowsException<ArgumentNullException>(
+                () => this.dataCollectionSink.SendData(this.dataCollectionContext, null, "DummyValue"));
+        }
+
+        [TestMethod]
+        public void SendDataShouldThrowArgumentExceptionIfValueIsNull()
+        {
+            this.testCase.SetPropertyValue(TestCaseProperties.Id, Guid.NewGuid());
+
+            Assert.ThrowsException<ArgumentNullException>(
+                () => this.dataCollectionSink.SendData(this.dataCollectionContext, "DummyKey", null));
+        }
+
+        [TestMethod]
+        [Ignore]
+
+        // TODO : Currently this code hits when test case id is null for core projects. For that we don't have algorithm to generate the guid. It's not implemented exception now (Source Code : EqtHash.cs).        
+        public void SendDataShouldThrowArgumentExceptionIfTestCaseIdIsNull()
+        {
+            Assert.ThrowsException<ArgumentNullException>(
+                () => this.dataCollectionSink.SendData(this.dataCollectionContext, "DummyKey", "DummyValue"));
+        }
+
+        [TestMethod]
+        public void GetDataCollectionDataSetForTestCaseShouldRemoveTestCaseAfterRetunredTheData()
+        {
+            this.testCase.SetPropertyValue(TestCaseProperties.Id, Guid.NewGuid());
+            this.dataCollectionSink.SendData(this.dataCollectionContext, "DummyKey", "DummyValue");
+
+            var dict = ((InProcDataCollectionSink)this.dataCollectionSink).GetDataCollectionDataSetForTestCase(this.testCase.Id);
+            Assert.AreEqual<string>(dict["DummyKey"].ToString(), "DummyValue");
+
+            var emptyDict = ((InProcDataCollectionSink)this.dataCollectionSink).GetDataCollectionDataSetForTestCase(this.testCase.Id);
+            Assert.AreEqual<int>(emptyDict.Keys.Count, 0);
+        }
+    }
+}


### PR DESCRIPTION
…using datacollection sink.
- DataCollection data set will be sent as part of test result to the clients.
- Data will be collected as Key, Value
- TestResult.GetPropertyValue API will be used with Key as TestProperty to read the value at client side.
- Unit tests for the changes.
