### PR TITLE
Add test script to run unit tests using local vstest.console runner.

### DIFF
--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -90,6 +90,7 @@ function Invoke-Test
                 Write-Log ".. Test: Source: $_"
 
                 # Tests are only built for x86 at the moment, though we don't have architecture requirement
+                $testAdapterPath = "$env:TP_PACKAGES_DIR\MSTest.TestAdapter\1.0.3-preview\build\_common"
                 $testContainerName = $_.Directory.Name
                 $testOutputPath = Join-Path $_.Directory.FullName "bin/$($Script:TPT_Configuration)/$($Script:TPT_TargetFramework)/win7-x86"
                 $testContainerPath = Join-Path $testOutputPath "$($testContainerName).dll"
@@ -99,8 +100,8 @@ function Invoke-Test
                 } elseif (!($testContainerName -match $Script:TPT_Pattern)) {
                     Write-Log ".. . $testContainerName doesn't match test container pattern '$($Script:TPT_Pattern)'. Skipped from run."
                 } else {
-                    Write-Verbose "vstest.console.exe $testContainerPath /testAdapterPath:$testOutputPath"
-                    $output = & $vstestConsolePath $testContainerPath /testAdapterPath:"$testOutputPath"
+                    Write-Verbose "vstest.console.exe $testContainerPath /testAdapterPath:$testAdapterPath"
+                    $output = & $vstestConsolePath $testContainerPath /testAdapterPath:"$testAdapterPath"
 
                     #Write-Verbose "$dotnetExe test $_ --configuration $Configuration"
                     #& $dotnetExe test $_ --configuration $Configuration

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -1,0 +1,172 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Build script for Test Platform.
+
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$false)]
+    [ValidateSet("Debug", "Release")]
+    [Alias("c")]
+    [System.String] $Configuration = "Debug",
+
+    # Only test sources matching the pattern are run.
+    # Use End2End to run E2E tests. Or to run any one assembly tests, use the 
+    # assembly name. E.g. test -p Microsoft.TestPlatform.CoreUtilities.UnitTests 
+    [Parameter(Mandatory=$false)]
+    [Alias("p")]
+    [System.String] $Pattern = "Unit",
+
+    # Stop test run on first failure
+    [Parameter(Mandatory=$false)]
+    [Alias("ff")]
+    [Switch] $FailFast = $false
+)
+
+$ErrorActionPreference = "Stop"
+
+#
+# Variables
+#
+Write-Verbose "Setup environment variables."
+$env:TP_ROOT_DIR = (Get-Item (Split-Path $MyInvocation.MyCommand.Path)).Parent.FullName
+$env:TP_TOOLS_DIR = Join-Path $env:TP_ROOT_DIR "tools"
+$env:TP_PACKAGES_DIR = Join-Path $env:TP_ROOT_DIR "packages"
+$env:TP_OUT_DIR = Join-Path $env:TP_ROOT_DIR "artifacts"
+
+#
+# Dotnet configuration
+#
+# Disable first run since we want to control all package sources 
+Write-Verbose "Setup dotnet configuration."
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1 
+# Dotnet build doesn't support --packages yet. See https://github.com/dotnet/cli/issues/2712
+$env:NUGET_PACKAGES = $env:TP_PACKAGES_DIR
+
+#
+# Test configuration
+#
+# Folders to build. TODO move to props
+Write-Verbose "Setup build configuration."
+$Script:TPT_Configuration = $Configuration
+$Script:TPT_SourceFolders =  @("test")
+$Script:TPT_TargetFramework = "net46"
+$Script:TPT_TargetRuntime = "win7-x64"
+$Script:TPT_SkipProjects = @("Microsoft.TestPlatform.CoreUtilities.UnitTests")
+$Script:TPT_Pattern = $Pattern
+$Script:TPT_FailFast = $FailFast
+
+function Write-Log ([string] $message)
+{
+    $currentColor = $Host.UI.RawUI.ForegroundColor
+    $Host.UI.RawUI.ForegroundColor = "Green"
+    if ($message)
+    {
+        Write-Output "... $message"
+    }
+    $Host.UI.RawUI.ForegroundColor = $currentColor
+}
+
+function Write-VerboseLog([string] $message)
+{
+    Write-Verbose $message
+}
+
+function Invoke-Test
+{
+    $timer = Start-Timer
+    Write-Log "Invoke-Test: Start test."
+    $dotnetExe = Get-DotNetPath
+
+    foreach ($src in $Script:TPT_SourceFolders) {
+        # Invoke test for each project.json since we want a custom output
+        # path.
+        $vstestConsolePath = Join-Path (Get-PackageDirectory) "vstest.console.exe"
+        if (!(Test-Path $vstestConsolePath)) {
+            Write-Log "Unable to find vstest.console.exe at $vstestConsolePath. Did you run build.cmd?"
+            Write-Error "Test aborted."
+        }
+
+        foreach ($fx in $Script:TPT_TargetFramework) {
+            Get-ChildItem -Recurse -Path $src -Include "project.json" | ForEach-Object {
+                Write-Log ".. Test: Source: $_"
+
+                # Tests are only built for x86 at the moment, though we don't have architecture requirement
+                $testContainerName = $_.Directory.Name
+                $testOutputPath = Join-Path $_.Directory.FullName "bin/$($Script:TPT_Configuration)/$($Script:TPT_TargetFramework)/win7-x86"
+                $testContainerPath = Join-Path $testOutputPath "$($testContainerName).dll"
+
+                if ($Script:TPT_SkipProjects.Contains($testContainerName)) {
+                    Write-Log ".. . $testContainerName is in skipped test list."
+                } elseif (!($testContainerName -match $Script:TPT_Pattern)) {
+                    Write-Log ".. . $testContainerName doesn't match test container pattern '$($Script:TPT_Pattern)'. Skipped from run."
+                } else {
+                    Write-Verbose "vstest.console.exe $testContainerPath /testAdapterPath:$testOutputPath"
+                    $output = & $vstestConsolePath $testContainerPath /testAdapterPath:"$testOutputPath"
+
+                    #Write-Verbose "$dotnetExe test $_ --configuration $Configuration"
+                    #& $dotnetExe test $_ --configuration $Configuration
+
+                    if ($output[-2].Contains("Test Run Successful.")) {
+                        Write-Log ".. . $($output[-3])"
+                    } else {
+                        Write-Log ".. . $($output[-2])"
+                        Write-Log ".. . Failed tests:"
+                        Write-Log ".. .  $($output -match '^Failed')"
+
+                        if ($Script:TPT_FailFast) {
+                            Write-Log ".. Stop execution since fail fast is enabled."
+                            continue
+                        }
+                    }
+                }
+
+                Write-Log ".. Test: Complete."
+            }
+        }
+        #Write-Verbose "$dotnetExe test $src\**\project.json --configuration $Configuration"
+        #& $dotnetExe test $_ $src\**\project.json --configuration $Configuration
+    }
+
+    Write-Log "Invoke-Test: Complete. {$(Get-ElapsedTime($timer))}"
+}
+
+#
+# Helper functions
+#
+function Get-DotNetPath
+{
+    $dotnetPath = Join-Path $env:TP_TOOLS_DIR "dotnet\dotnet.exe"
+    if (-not (Test-Path $dotnetPath)) {
+        Write-Error "Dotnet.exe not found at $dotnetPath. Did the dotnet cli installation succeed?"
+    }
+
+    return $dotnetPath
+}
+
+function Get-PackageDirectory
+{
+    return $(Join-Path $env:TP_OUT_DIR "$($Script:TPT_Configuration)\$($Script:TPT_TargetFramework)\$($Script:TPT_TargetRuntime)")
+}
+
+function Start-Timer
+{
+    return [System.Diagnostics.Stopwatch]::StartNew()
+}
+
+function Get-ElapsedTime([System.Diagnostics.Stopwatch] $timer)
+{
+    $timer.Stop()
+    return $timer.Elapsed
+}
+
+# Execute build
+$timer = Start-Timer
+Write-Log "Build started: args = '$args'"
+Write-Log "Test platform environment variables: "
+Get-ChildItem env: | Where-Object -FilterScript { $_.Name.StartsWith("TP_") } | Format-Table
+
+Write-Log "Test run configuration: "
+Get-Variable | Where-Object -FilterScript { $_.Name.StartsWith("TPT_") } | Format-Table
+
+Invoke-Test
+
+Write-Log "Build complete. {$(Get-ElapsedTime($timer))}"

--- a/src/Microsoft.TestPlatform.Common/Logging/TestLoggerManager.cs
+++ b/src/Microsoft.TestPlatform.Common/Logging/TestLoggerManager.cs
@@ -86,6 +86,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Logging
                 }
                 return testLoggerManager;
             }
+
             protected set
             {
                 testLoggerManager = value;

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/project.json
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/project.json
@@ -8,7 +8,6 @@
   },
 
   "dependencies": {
-    
     "Microsoft.TestPlatform.ObjectModel": "15.0.0-*",
     "Microsoft.TestPlatform.CoreUtilities": "15.0.0-*"
   },

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -37,8 +37,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
 
         #region Fields
 
-        private static IOutput output;
-
         private TestOutcome testOutcome = TestOutcome.None;
         private int testsTotal = 0;
         private int testsPassed = 0;
@@ -62,7 +60,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
         /// <param name="output"></param>
         internal ConsoleLogger(IOutput output)
         {
-            ConsoleLogger.output = output;
+            ConsoleLogger.Output = output;
         }
 
         #endregion
@@ -74,10 +72,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
         /// <remarks>Protected so this can be detoured for testing purposes.</remarks>
         protected static IOutput Output
         {
-            get
-            {
-                return output;
-            }
+            get;
+            private set;
         }
         #endregion
         
@@ -95,9 +91,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
                 throw new ArgumentNullException("events");
             }
 
-            if (output == null)
+            if (ConsoleLogger.Output == null)
             {
-                output = ConsoleOutput.Instance;
+                ConsoleLogger.Output = ConsoleOutput.Instance;
             }
 
             // Register for the events.

--- a/test.cmd
+++ b/test.cmd
@@ -1,0 +1,6 @@
+@echo off
+
+REM Copyright (c) Microsoft. All rights reserved.
+
+powershell -NoProfile -NoLogo -Command "%~dp0scripts\test.ps1 %*; exit $LastExitCode;" 
+if %errorlevel% neq 0 exit /b %errorlevel% 

--- a/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeTestHostLauncherFactoryTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeTestHostLauncherFactoryTests.cs
@@ -2,9 +2,12 @@
 
 namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.DesignMode
 {
-    using System;    using System.Collections.Generic;    using System.Linq;    using System.Threading.Tasks;
-        using Microsoft.VisualStudio.TestPlatform.Client.DesignMode;    using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;    using Microsoft.VisualStudio.TestPlatform.ObjectModel;    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;    using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Moq;
+    using Microsoft.VisualStudio.TestPlatform.Client.DesignMode;
+    using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using Moq;
 
     [TestClass]
     public class DesignModeTestHostLauncherFactoryTests
@@ -13,32 +16,20 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.DesignMode
         public void DesignModeTestHostFactoryShouldReturnNonDebugLauncherIfDebuggingDisabled()
         {
             var mockDesignModeClient = new Mock<IDesignModeClient>();
-            var testRunRequestPayload = new TestRunRequestPayload() { DebuggingEnabled = false };
+            var testRunRequestPayload = new TestRunRequestPayload { DebuggingEnabled = false };
             var launcher = DesignModeTestHostLauncherFactory.GetCustomHostLauncherForTestRun(mockDesignModeClient.Object, testRunRequestPayload);
             
             Assert.IsFalse(launcher.IsDebug, "Factory must not return debug launcher if debugging is disabled.");
-
-            var testProcessStartInfo = new TestProcessStartInfo();
-
-            launcher.LaunchTestHost(testProcessStartInfo);
-
-            mockDesignModeClient.Verify(md => md.LaunchCustomHost(testProcessStartInfo), Times.Once, "Launcher should use provided design mode client");
         }
 
         [TestMethod]
         public void DesignModeTestHostFactoryShouldReturnDebugLauncherIfDebuggingEnabled()
         {
             var mockDesignModeClient = new Mock<IDesignModeClient>();
-            var testRunRequestPayload = new TestRunRequestPayload() { DebuggingEnabled = true };
+            var testRunRequestPayload = new TestRunRequestPayload { DebuggingEnabled = true };
             var launcher = DesignModeTestHostLauncherFactory.GetCustomHostLauncherForTestRun(mockDesignModeClient.Object, testRunRequestPayload);
 
             Assert.IsTrue(launcher.IsDebug, "Factory must not return debug launcher if debugging is disabled.");
-
-            var testProcessStartInfo = new TestProcessStartInfo();
-
-            launcher.LaunchTestHost(testProcessStartInfo);
-
-            mockDesignModeClient.Verify(md => md.LaunchCustomHost(testProcessStartInfo), Times.Once, "Launcher should use provided design mode client");
         }
     }
 }

--- a/test/Microsoft.TestPlatform.Client.UnitTests/project.json
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/project.json
@@ -8,15 +8,11 @@
   },
 
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0"
-    },
-    "dotnet-test-mstest": {
-      "version": "1.0.1-preview",
+    "MSTest.TestFramework": "1.0.0-preview",
+    "MSTest.TestAdapter": {
+      "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "MSTest.TestFramework": "1.0.0-preview",
     "moq.netcore": "4.4.0-beta8",
     "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
     "Microsoft.TestPlatform.Client": "15.0.0-*"
@@ -27,8 +23,25 @@
       "imports": [
         "dnxcore50",
         "portable-net45+win8"
-      ]
-    }
+      ],
+
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        },
+        "dotnet-test-mstest": {
+          "version": "1.0.1-preview",
+          "exclude": "compile"
+        }
+      }
+    },
+
+    "net46": {
+      "frameworkAssemblies": {
+        "System.Runtime": ""
+      }
+    } 
   },
 
   "testRunner": "mstest"

--- a/test/Microsoft.TestPlatform.Client.UnitTests/project.json
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/project.json
@@ -13,8 +13,7 @@
       "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "moq.netcore": "4.4.0-beta8",
-    "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
+    "Moq": "4.6.36-*",
     "Microsoft.TestPlatform.Client": "15.0.0-*"
   },
 

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginCacheTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginCacheTests.cs
@@ -134,12 +134,18 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
         [TestMethod]
         public void GetDefaultResolutionPathsShouldReturnCurrentDirectoryByDefault()
         {
+            var currentDirectory = Path.GetDirectoryName(typeof(TestPluginCache).GetTypeInfo().Assembly.Location);
+            var defaultExtensionsDirectory = Path.Combine(currentDirectory, "Extensions");
+            var expectedDirectories = new List<string> { currentDirectory };
+            if (Directory.Exists(defaultExtensionsDirectory))
+            {
+                expectedDirectories.Add(defaultExtensionsDirectory);
+            }
+
             var resolutionPaths = TestPluginCache.Instance.GetDefaultResolutionPaths();
 
-            var currentDirectory = Path.GetDirectoryName(typeof(TestPluginCache).GetTypeInfo().Assembly.Location);
-
             Assert.IsNotNull(resolutionPaths);
-            CollectionAssert.AreEqual(new List<string> { currentDirectory }, resolutionPaths.ToList());
+            CollectionAssert.AreEqual(expectedDirectories, resolutionPaths.ToList());
         }
         
         [TestMethod]

--- a/test/Microsoft.TestPlatform.Common.UnitTests/project.json
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/project.json
@@ -8,15 +8,11 @@
   },
 
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0"
-    },
-    "dotnet-test-mstest": {
-      "version": "1.0.1-preview",
+    "MSTest.TestFramework": "1.0.0-preview",
+    "MSTest.TestAdapter": {
+      "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "MSTest.TestFramework": "1.0.0-preview",
     "moq.netcore": "4.4.0-beta8",
     "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
     "Microsoft.TestPlatform.Common": "15.0.0-*"
@@ -27,8 +23,25 @@
       "imports": [
         "dnxcore50",
         "portable-net45+win8"
-      ]
-    }
+      ],
+
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        },
+        "dotnet-test-mstest": {
+          "version": "1.0.1-preview",
+          "exclude": "compile"
+        }
+      }
+    },
+
+    "net46": {
+      "frameworkAssemblies": {
+        "System.Runtime": ""
+      }
+    } 
   },
 
   "testRunner": "mstest"

--- a/test/Microsoft.TestPlatform.Common.UnitTests/project.json
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/project.json
@@ -13,8 +13,7 @@
       "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "moq.netcore": "4.4.0-beta8",
-    "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
+    "Moq": "4.6.36-*",
     "Microsoft.TestPlatform.Common": "15.0.0-*"
   },
 

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/project.json
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/project.json
@@ -8,15 +8,11 @@
   },
 
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0"
-    },
-    "dotnet-test-mstest": {
-      "version": "1.0.1-preview",
+    "MSTest.TestFramework": "1.0.0-preview",
+    "MSTest.TestAdapter": {
+      "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "MSTest.TestFramework": "1.0.0-preview",
     "moq.netcore": "4.4.0-beta8",
     "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
     "Microsoft.TestPlatform.CommunicationUtilities": "15.0.0-*"
@@ -27,8 +23,25 @@
       "imports": [
         "dnxcore50",
         "portable-net45+win8"
-      ]
-    }
+      ],
+
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        },
+        "dotnet-test-mstest": {
+          "version": "1.0.1-preview",
+          "exclude": "compile"
+        }
+      }
+    },
+
+    "net46": {
+      "frameworkAssemblies": {
+        "System.Runtime": ""
+      }
+    } 
   },
 
   "testRunner": "mstest"

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/project.json
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/project.json
@@ -13,8 +13,7 @@
       "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "moq.netcore": "4.4.0-beta8",
-    "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
+    "Moq": "4.6.36-*",
     "Microsoft.TestPlatform.CommunicationUtilities": "15.0.0-*"
   },
 

--- a/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/project.json
+++ b/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/project.json
@@ -13,8 +13,7 @@
       "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "moq.netcore": "4.4.0-beta8",
-    "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
+    "Moq": "4.6.36-*",
     "Microsoft.TestPlatform.CoreUtilities": "15.0.0-*"
   },
 

--- a/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/project.json
+++ b/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/project.json
@@ -8,15 +8,11 @@
   },
 
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0"
-    },
-    "dotnet-test-mstest": {
-      "version": "1.0.1-preview",
+    "MSTest.TestFramework": "1.0.0-preview",
+    "MSTest.TestAdapter": {
+      "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "MSTest.TestFramework": "1.0.0-preview",
     "moq.netcore": "4.4.0-beta8",
     "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
     "Microsoft.TestPlatform.CoreUtilities": "15.0.0-*"
@@ -27,8 +23,25 @@
       "imports": [
         "dnxcore50",
         "portable-net45+win8"
-      ]
-    }
+      ],
+
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        },
+        "dotnet-test-mstest": {
+          "version": "1.0.1-preview",
+          "exclude": "compile"
+        }
+      }
+    },
+
+    "net46": {
+      "frameworkAssemblies": {
+        "System.Runtime": ""
+      }
+    } 
   },
 
   "testRunner": "mstest"

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/InProcDataCollectionExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/InProcDataCollectionExtensionManagerTests.cs
@@ -4,7 +4,6 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
     using System;
     using System.Collections.ObjectModel;
     using System.Reflection;
-    using System.Runtime.Loader;
 
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.EventHandlers;
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution;

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -49,13 +49,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Hosting
                 };
                 
             this.testHostManager.LaunchTestHost(new Dictionary<string, string>(), new List<string>());
-            
-            var expectedProcessPath =
-                Path.Combine(
-                    Path.GetDirectoryName(typeof(DefaultTestHostManagerTests).GetTypeInfo().Assembly.Location),
-                    "testhost.x86.exe");
 
-            Assert.AreEqual(expectedProcessPath, processPath);
+            StringAssert.EndsWith(processPath, "testhost.x86.exe");
             Assert.AreEqual(1, times);
         }
 
@@ -77,12 +72,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Hosting
             
             this.testHostManager.LaunchTestHost(new Dictionary<string, string>(), new List<string>());
 
-            var expectedProcessPath =
-                Path.Combine(
-                    Path.GetDirectoryName(typeof(DefaultTestHostManagerTests).GetTypeInfo().Assembly.Location),
-                    "testhost.exe");
-
-            Assert.AreEqual(expectedProcessPath, processPath);
+            StringAssert.EndsWith(processPath, "testhost.exe");
             Assert.AreEqual(1, times);
         }
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/project.json
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/project.json
@@ -8,15 +8,11 @@
   },
 
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0"
-    },
-    "dotnet-test-mstest": {
-      "version": "1.0.1-preview",
+    "MSTest.TestFramework": "1.0.0-preview",
+    "MSTest.TestAdapter": {
+      "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "MSTest.TestFramework": "1.0.0-preview",
     "moq.netcore": "4.4.0-beta8",
     "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
     "Microsoft.TestPlatform.CrossPlatEngine": "15.0.0-*",
@@ -30,8 +26,25 @@
       "imports": [
         "dnxcore50",
         "portable-net45+win8"
-      ]
-    }
+      ],
+
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        },
+        "dotnet-test-mstest": {
+          "version": "1.0.1-preview",
+          "exclude": "compile"
+        }
+      }
+    },
+
+    "net46": {
+      "frameworkAssemblies": {
+        "System.Runtime": ""
+      }
+    } 
   },
 
   "testRunner": "mstest"

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/project.json
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/project.json
@@ -13,8 +13,7 @@
       "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "moq.netcore": "4.4.0-beta8",
-    "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
+    "Moq": "4.6.36-*",
     "Microsoft.TestPlatform.CrossPlatEngine": "15.0.0-*",
     "Microsoft.TestPlatform.ObjectModel": "15.0.0-*",
     "Microsoft.TestPlatform.Common": "15.0.0-*",

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/project.json
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/project.json
@@ -13,11 +13,10 @@
       "version": "1.0.0-preview",
       "exclude": "compile"
     },
-    "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
     "Microsoft.TestPlatform.Client": "15.0.0-*",
     "Microsoft.TestPlatform.Extensions.TrxLogger": "15.0.0-*",
     "Microsoft.TestPlatform.ObjectModel": "15.0.0-*",
-    "moq.netcore": "4.4.0-beta8"
+    "Moq": "4.6.36-*"
   },
 
   "frameworks": {

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/project.json
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/project.json
@@ -8,20 +8,16 @@
   },
 
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0"
-    },
-    "dotnet-test-mstest": {
-      "version": "1.0.1-preview",
+    "MSTest.TestFramework": "1.0.0-preview",
+    "MSTest.TestAdapter.Dotnet": {
+      "version": "1.0.0-preview",
       "exclude": "compile"
     },
-    "MSTest.TestFramework": "1.0.0-preview",
-    "moq.netcore": "4.4.0-beta8",
     "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
     "Microsoft.TestPlatform.Client": "15.0.0-*",
     "Microsoft.TestPlatform.Extensions.TrxLogger": "15.0.0-*",
-    "Microsoft.TestPlatform.ObjectModel": "15.0.0-*"
+    "Microsoft.TestPlatform.ObjectModel": "15.0.0-*",
+    "moq.netcore": "4.4.0-beta8"
   },
 
   "frameworks": {
@@ -29,8 +25,25 @@
       "imports": [
         "dnxcore50",
         "portable-net45+win8"
-      ]
-    }
+      ],
+
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        },
+        "dotnet-test-mstest": {
+          "version": "1.0.1-preview",
+          "exclude": "compile"
+        }
+      }
+    },
+
+    "net46": {
+      "frameworkAssemblies": {
+        "System.Runtime": ""
+      }
+    } 
   },
 
   "testRunner": "mstest"

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/project.json
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/project.json
@@ -8,16 +8,11 @@
   },
 
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0"
-    },
-    "dotnet-test-mstest": {
-      "version": "1.0.1-preview",
+    "MSTest.TestFramework": "1.0.0-preview",
+    "MSTest.TestAdapter": {
+      "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "MSTest.TestFramework": "1.0.0-preview",
-    "moq.netcore": "4.4.0-beta8",
     "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
     "Microsoft.TestPlatform.ObjectModel": "15.0.0-*"
   },
@@ -27,8 +22,26 @@
       "imports": [
         "dnxcore50",
         "portable-net45+win8"
-      ]
-    }
+      ],
+
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        },
+        "dotnet-test-mstest": {
+          "version": "1.0.1-preview",
+          "exclude": "compile"
+        },
+        "moq.netcore": "4.4.0-beta8"
+      }
+    },
+
+    "net46": {
+      "frameworkAssemblies": {
+        "System.Runtime": ""
+      }
+    } 
   },
 
   "testRunner": "mstest"

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/project.json
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/project.json
@@ -13,7 +13,6 @@
       "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
     "Microsoft.TestPlatform.ObjectModel": "15.0.0-*"
   },
 
@@ -32,8 +31,7 @@
         "dotnet-test-mstest": {
           "version": "1.0.1-preview",
           "exclude": "compile"
-        },
-        "moq.netcore": "4.4.0-beta8"
+        }
       }
     },
 

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/CodeCoverageDataAdapterUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/CodeCoverageDataAdapterUtilitiesTests.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+using System.Xml.XPath;
+
 namespace Microsoft.TestPlatform.Utilities.Tests
 {
     using System.Xml;
@@ -25,8 +27,7 @@ namespace Microsoft.TestPlatform.Utilities.Tests
             var xmlDocument = new XmlDocument();
             xmlDocument.LoadXml(runSettingsXml);
 
-            CodeCoverageDataAdapterUtilities.UpdateWithCodeCoverageSettingsIfNotConfigured(
-                xmlDocument.ToXPathNavigable());
+            CodeCoverageDataAdapterUtilities.UpdateWithCodeCoverageSettingsIfNotConfigured(GetXPathNavigable(xmlDocument));
 
             var expectedRunSettings =
                 "<RunSettings><DataCollectionRunSettings><DataCollectors><DataCollector uri=\"datacollector://microsoft/CodeCoverage/1.0\"></DataCollector></DataCollectors></DataCollectionRunSettings></RunSettings>";
@@ -48,12 +49,20 @@ namespace Microsoft.TestPlatform.Utilities.Tests
             var xmlDocument = new XmlDocument();
             xmlDocument.LoadXml(runSettingsXml);
 
-            CodeCoverageDataAdapterUtilities.UpdateWithCodeCoverageSettingsIfNotConfigured(
-                xmlDocument.ToXPathNavigable());
+            CodeCoverageDataAdapterUtilities.UpdateWithCodeCoverageSettingsIfNotConfigured(GetXPathNavigable(xmlDocument));
 
             var expectedRunSettings =
                 "<RunSettings><DataCollectionRunSettings><DataCollectors><DataCollector uri=\"datacollector://microsoft/CodeCoverage/2.0\"></DataCollector></DataCollectors></DataCollectionRunSettings></RunSettings>";
             Assert.AreEqual(expectedRunSettings, xmlDocument.OuterXml);
+        }
+
+        private static IXPathNavigable GetXPathNavigable(XmlDocument doc)
+        {
+#if NET46
+            return doc;
+#else
+            return doc.ToXPathNavigable();
+#endif
         }
     }
 }

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/MSTestSettingsUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/MSTestSettingsUtilitiesTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.TestPlatform.Utilities.Tests
                 () =>
                 MSTestSettingsUtilities.Import(
                     "C:\\temp\\r.runsettings",
-                    xmlDocument.ToXPathNavigable(),
+                    GetXPathNavigable(xmlDocument),
                     Architecture.X86,
                     FrameworkVersion.Framework45);
             ExceptionUtilities.ThrowsException<XmlException>(action, "Unexpected settings file specified.");
@@ -66,7 +66,7 @@ namespace Microsoft.TestPlatform.Utilities.Tests
                 () =>
                 MSTestSettingsUtilities.Import(
                     "C:\\temp\\r.testsettings",
-                    xmlDocument.ToXPathNavigable(),
+                    GetXPathNavigable(xmlDocument),
                     Architecture.X86,
                     FrameworkVersion.Framework45);
             ExceptionUtilities.ThrowsException<XmlException>(action, "Could not find 'RunSettings' node.");
@@ -80,7 +80,7 @@ namespace Microsoft.TestPlatform.Utilities.Tests
             xmlDocument.LoadXml(defaultRunSettingsXml);
             var finalxPath = MSTestSettingsUtilities.Import(
                 "C:\\temp\\r.testsettings",
-                xmlDocument.ToXPathNavigable(),
+                GetXPathNavigable(xmlDocument),
                 Architecture.X86,
                 FrameworkVersion.Framework45);
 
@@ -100,7 +100,7 @@ namespace Microsoft.TestPlatform.Utilities.Tests
             xmlDocument.LoadXml(defaultRunSettingsXml);
             var finalxPath = MSTestSettingsUtilities.Import(
                 "C:\\temp\\r.testsettings",
-                xmlDocument.ToXPathNavigable(),
+                GetXPathNavigable(xmlDocument),
                 Architecture.X86,
                 FrameworkVersion.Framework45);
 
@@ -113,5 +113,14 @@ namespace Microsoft.TestPlatform.Utilities.Tests
         }
 
         #endregion
+
+        private static IXPathNavigable GetXPathNavigable(XmlDocument doc)
+        {
+#if NET46
+            return doc;
+#else
+            return doc.ToXPathNavigable();
+#endif
+        }
     }
 }

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/project.json
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/project.json
@@ -8,15 +8,11 @@
   },
 
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0"
-    },
-    "dotnet-test-mstest": {
-      "version": "1.0.1-preview",
+    "MSTest.TestFramework": "1.0.0-preview",
+    "MSTest.TestAdapter": {
+      "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "MSTest.TestFramework": "1.0.0-preview",
     "Microsoft.TestPlatform.Utilities": "15.0.0-*"
   },
 
@@ -25,8 +21,25 @@
       "imports": [
         "dnxcore50",
         "portable-net45+win8"
-      ]
-    }
+      ],
+
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        },
+        "dotnet-test-mstest": {
+          "version": "1.0.1-preview",
+          "exclude": "compile"
+        }
+      }
+    },
+
+    "net46": {
+      "frameworkAssemblies": {
+        "System.Runtime": ""
+      }
+    } 
   },
 
   "testRunner": "mstest"

--- a/test/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests/project.json
+++ b/test/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests/project.json
@@ -8,15 +8,11 @@
   },
 
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0"
-    },
-    "dotnet-test-mstest": {
-      "version": "1.0.1-preview",
+    "MSTest.TestFramework": "1.0.0-preview",
+    "MSTest.TestAdapter": {
+      "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "MSTest.TestFramework": "1.0.0-preview",
     "moq.netcore": "4.4.0-beta8",
     "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
     "Microsoft.TestPlatform.VsTestConsole.TranslationLayer": "15.0.0-*",
@@ -29,8 +25,25 @@
       "imports": [
         "dnxcore50",
         "portable-net45+win8"
-      ]
-    }
+      ],
+
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        },
+        "dotnet-test-mstest": {
+          "version": "1.0.1-preview",
+          "exclude": "compile"
+        }
+      }
+    },
+
+    "net46": {
+      "frameworkAssemblies": {
+        "System.Runtime": ""
+      }
+    } 
   },
 
   "testRunner": "mstest"

--- a/test/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests/project.json
+++ b/test/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests/project.json
@@ -13,8 +13,7 @@
       "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "moq.netcore": "4.4.0-beta8",
-    "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
+    "Moq": "4.6.36-*",
     "Microsoft.TestPlatform.VsTestConsole.TranslationLayer": "15.0.0-*",
     "Microsoft.TestPlatform.CommunicationUtilities": "15.0.0-*",
     "Microsoft.TestPlatform.ObjectModel": "15.0.0-*"

--- a/test/datacollector.x86.UnitTests/DataCollectionCoordinatorTests.cs
+++ b/test/datacollector.x86.UnitTests/DataCollectionCoordinatorTests.cs
@@ -8,6 +8,7 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector.UnitTests
     using System.Diagnostics;
     using System.Linq;
     using System.Threading;
+    using System.Threading.Tasks;
 
     using Microsoft.VisualStudio.TestPlatform.Common;
     using Microsoft.VisualStudio.TestPlatform.DataCollector.Interfaces;
@@ -27,7 +28,7 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector.UnitTests
         {
             this.dummyDataCollectionManagerV1 = new DummyDataCollectionManager();
             this.dummyDataCollectionManagerV2 = new DummyDataCollectionManager();
-            this.dataCollectionCoordinator = new DataCollectionCoordinator(new[] { dummyDataCollectionManagerV1, dummyDataCollectionManagerV2 });
+            this.dataCollectionCoordinator = new DataCollectionCoordinator(new IDataCollectionManager[] { dummyDataCollectionManagerV1, dummyDataCollectionManagerV2 });
         }
 
         [TestMethod]
@@ -35,15 +36,15 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector.UnitTests
         {
             var envVars = new Dictionary<string, string>();
             envVars.Add("key", "value");
-            this.dummyDataCollectionManagerV1.envVariables = envVars;
-            this.dummyDataCollectionManagerV2.envVariables = new Dictionary<string, string>();
+            this.dummyDataCollectionManagerV1.EnvVariables = envVars;
+            this.dummyDataCollectionManagerV2.EnvVariables = new Dictionary<string, string>();
 
             var result = this.dataCollectionCoordinator.BeforeTestRunStart(settingsXml: string.Empty, resetDataCollectors: true, isRunStartingNow: true);
 
-            Assert.IsTrue(this.dummyDataCollectionManagerV1.isLoadCollectorsInvoked);
-            Assert.IsTrue(this.dummyDataCollectionManagerV2.isLoadCollectorsInvoked);
-            Assert.IsTrue(this.dummyDataCollectionManagerV1.isSessionStartedInvoked);
-            Assert.IsTrue(this.dummyDataCollectionManagerV2.isSessionStartedInvoked);
+            Assert.IsTrue(this.dummyDataCollectionManagerV1.IsLoadCollectorsInvoked);
+            Assert.IsTrue(this.dummyDataCollectionManagerV2.IsLoadCollectorsInvoked);
+            Assert.IsTrue(this.dummyDataCollectionManagerV1.IsSessionStartedInvoked);
+            Assert.IsTrue(this.dummyDataCollectionManagerV2.IsSessionStartedInvoked);
             Assert.AreEqual(1, result.EnvironmentVariables.Count);
             Assert.AreEqual(envVars.Keys.First(), result.EnvironmentVariables.Keys.First());
             Assert.AreEqual(envVars.Values.First(), result.EnvironmentVariables.Values.First());
@@ -54,15 +55,15 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector.UnitTests
         {
             var envVars = new Dictionary<string, string>();
             envVars.Add("key", "value");
-            this.dummyDataCollectionManagerV1.envVariables = envVars;
-            this.dummyDataCollectionManagerV2.envVariables = new Dictionary<string, string>();
+            this.dummyDataCollectionManagerV1.EnvVariables = envVars;
+            this.dummyDataCollectionManagerV2.EnvVariables = new Dictionary<string, string>();
 
             var result = this.dataCollectionCoordinator.BeforeTestRunStart(settingsXml: string.Empty, resetDataCollectors: true, isRunStartingNow: true);
 
             // Verify the two collectors are invoked in parallel
-            Assert.IsTrue(this.dummyDataCollectionManagerV1.ThreadId > 0);
-            Assert.IsTrue(this.dummyDataCollectionManagerV2.ThreadId > 0);
-            Assert.AreNotEqual(this.dummyDataCollectionManagerV1.ThreadId, this.dummyDataCollectionManagerV2.ThreadId);
+            Assert.IsTrue(this.dummyDataCollectionManagerV1.TaskId > 0);
+            Assert.IsTrue(this.dummyDataCollectionManagerV2.TaskId > 0);
+            Assert.AreNotEqual(this.dummyDataCollectionManagerV1.TaskId, this.dummyDataCollectionManagerV2.TaskId);
         }
 
         [TestMethod]
@@ -78,7 +79,7 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector.UnitTests
         [TestMethod]
         public void BeforeTestRunStartShouldThrowExceptionIfExceptionIsThrownByDataCollectionManager()
         {
-            this.dummyDataCollectionManagerV1.loadDataCollectorsThrowException = true;
+            this.dummyDataCollectionManagerV1.LoadDataCollectorsThrowException = true;
 
             Assert.ThrowsException<AggregateException>(
                 () =>
@@ -95,14 +96,14 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector.UnitTests
             attachmentset1.Attachments.Add(new UriDataAttachment(new Uri("DataCollection://Attachment/v11"), "AttachmentV1-Attachment1"));
             attachments1.Add(attachmentset1);
 
-            this.dummyDataCollectionManagerV1.attachments = attachments1;
-            this.dummyDataCollectionManagerV2.attachments = attachments1;
+            this.dummyDataCollectionManagerV1.Attachments = attachments1;
+            this.dummyDataCollectionManagerV2.Attachments = attachments1;
 
             var result = this.dataCollectionCoordinator.AfterTestRunEnd(isCancelled: false);
 
             Assert.IsNotNull(result);
-            Assert.IsTrue(this.dummyDataCollectionManagerV1.isSessionEndedInvoked);
-            Assert.IsTrue(this.dummyDataCollectionManagerV2.isSessionEndedInvoked);
+            Assert.IsTrue(this.dummyDataCollectionManagerV1.IsSessionEndedInvoked);
+            Assert.IsTrue(this.dummyDataCollectionManagerV2.IsSessionEndedInvoked);
             Assert.AreEqual(2, result.Count());
         }
 
@@ -114,15 +115,15 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector.UnitTests
             attachmentset1.Attachments.Add(new UriDataAttachment(new Uri("DataCollection://Attachment/v11"), "AttachmentV1-Attachment1"));
             attachments1.Add(attachmentset1);
 
-            this.dummyDataCollectionManagerV1.attachments = attachments1;
-            this.dummyDataCollectionManagerV2.attachments = attachments1;
+            this.dummyDataCollectionManagerV1.Attachments = attachments1;
+            this.dummyDataCollectionManagerV2.Attachments = attachments1;
 
             var result = this.dataCollectionCoordinator.AfterTestRunEnd(isCancelled: false);
 
             // Verify the two collectors are invoked in parallel
-            Assert.IsTrue(this.dummyDataCollectionManagerV1.ThreadId > 0);
-            Assert.IsTrue(this.dummyDataCollectionManagerV2.ThreadId > 0);
-            Assert.AreNotEqual(this.dummyDataCollectionManagerV1.ThreadId, this.dummyDataCollectionManagerV2.ThreadId);
+            Assert.IsTrue(this.dummyDataCollectionManagerV1.TaskId > 0);
+            Assert.IsTrue(this.dummyDataCollectionManagerV2.TaskId > 0);
+            Assert.AreNotEqual(this.dummyDataCollectionManagerV1.TaskId, this.dummyDataCollectionManagerV2.TaskId);
         }
 
         [TestMethod]
@@ -138,7 +139,7 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector.UnitTests
         [TestMethod]
         public void AfterTestRunEndShouldThrowExceptionIfExceptionIsThrownByDataCollectionManager()
         {
-            this.dummyDataCollectionManagerV1.sessionEndedThrowsException = true;
+            this.dummyDataCollectionManagerV1.SessionEndedThrowsException = true;
 
             Assert.ThrowsException<AggregateException>(
                 () =>
@@ -152,8 +153,8 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector.UnitTests
         {
             this.dataCollectionCoordinator.Dispose();
 
-            Assert.IsTrue(this.dummyDataCollectionManagerV1.isDisposedInvoked);
-            Assert.IsTrue(this.dummyDataCollectionManagerV2.isDisposedInvoked);
+            Assert.IsTrue(this.dummyDataCollectionManagerV1.IsDisposedInvoked);
+            Assert.IsTrue(this.dummyDataCollectionManagerV2.IsDisposedInvoked);
         }
 
         [TestMethod]
@@ -167,32 +168,32 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector.UnitTests
 
     internal class DummyDataCollectionManager : IDataCollectionManager
     {
-        public bool isLoadCollectorsInvoked;
-        public bool isSessionStartedInvoked;
-        public bool isSessionEndedInvoked;
-        public Dictionary<string, string> envVariables;
-        public bool loadDataCollectorsThrowException;
-        public Collection<AttachmentSet> attachments;
-        public bool sessionEndedThrowsException;
-        public bool isDisposedInvoked;
-        public int ThreadId;
+        public bool IsLoadCollectorsInvoked;
+        public bool IsSessionStartedInvoked;
+        public bool IsSessionEndedInvoked;
+        public Dictionary<string, string> EnvVariables;
+        public bool LoadDataCollectorsThrowException;
+        public Collection<AttachmentSet> Attachments;
+        public bool SessionEndedThrowsException;
+        public bool IsDisposedInvoked;
+        public int TaskId;
 
         public void Dispose()
         {
-            this.isDisposedInvoked = true;
+            this.IsDisposedInvoked = true;
         }
 
         public Dictionary<string, string> LoadDataCollectors(RunSettings settingsXml)
         {
-            this.ThreadId = Thread.CurrentThread.ManagedThreadId;
+            this.TaskId = Task.CurrentId.Value;
 
-            if (this.loadDataCollectorsThrowException)
+            if (this.LoadDataCollectorsThrowException)
             {
                 throw new Exception("DataCollectionManagerException");
             }
 
-            this.isLoadCollectorsInvoked = true;
-            return this.envVariables;
+            this.IsLoadCollectorsInvoked = true;
+            return this.EnvVariables;
 
         }
 
@@ -203,21 +204,21 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector.UnitTests
 
         public Collection<AttachmentSet> SessionEnded(bool isCancelled)
         {
-            this.ThreadId = Thread.CurrentThread.ManagedThreadId;
+            this.TaskId = Task.CurrentId.Value;
 
-            if (this.sessionEndedThrowsException)
+            if (this.SessionEndedThrowsException)
             {
                 throw new Exception("DataCollectionManagerException");
             }
 
-            this.isSessionEndedInvoked = true;
-            return this.attachments;
+            this.IsSessionEndedInvoked = true;
+            return this.Attachments;
         }
 
         public bool SessionStarted()
         {
-            this.ThreadId = Thread.CurrentThread.ManagedThreadId;
-            this.isSessionStartedInvoked = true;
+            this.TaskId = Task.CurrentId.Value;
+            this.IsSessionStartedInvoked = true;
             return true;
         }
 

--- a/test/datacollector.x86.UnitTests/project.json
+++ b/test/datacollector.x86.UnitTests/project.json
@@ -13,8 +13,7 @@
       "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "moq.netcore": "4.4.0-beta8",
-    "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
+    "Moq": "4.6.36-*",
     "datacollector": "15.0.0-*"
   },
 

--- a/test/datacollector.x86.UnitTests/project.json
+++ b/test/datacollector.x86.UnitTests/project.json
@@ -8,15 +8,11 @@
   },
 
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0"
-    },
-    "dotnet-test-mstest": {
-      "version": "1.0.1-preview",
+    "MSTest.TestFramework": "1.0.0-preview",
+    "MSTest.TestAdapter": {
+      "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "MSTest.TestFramework": "1.0.0-preview",
     "moq.netcore": "4.4.0-beta8",
     "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
     "datacollector": "15.0.0-*"
@@ -27,8 +23,25 @@
       "imports": [
         "dnxcore50",
         "portable-net45+win8"
-      ]
-    }
+      ],
+
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        },
+        "dotnet-test-mstest": {
+          "version": "1.0.1-preview",
+          "exclude": "compile"
+        }
+      }
+    },
+
+    "net46": {
+      "frameworkAssemblies": {
+        "System.Runtime": ""
+      }
+    } 
   },
 
   "testRunner": "mstest"

--- a/test/testhost.UnitTests/project.json
+++ b/test/testhost.UnitTests/project.json
@@ -13,8 +13,7 @@
       "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "moq.netcore": "4.4.0-beta8",
-    "System.Diagnostics.TraceSource": "4.0.0-rc2-24015"
+    "Moq": "4.6.36-*"
   },
 
   "frameworks": {

--- a/test/testhost.UnitTests/project.json
+++ b/test/testhost.UnitTests/project.json
@@ -8,15 +8,11 @@
   },
 
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0"
-    },
-    "dotnet-test-mstest": {
-      "version": "1.0.1-preview",
+    "MSTest.TestFramework": "1.0.0-preview",
+    "MSTest.TestAdapter": {
+      "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "MSTest.TestFramework": "1.0.0-preview",
     "moq.netcore": "4.4.0-beta8",
     "System.Diagnostics.TraceSource": "4.0.0-rc2-24015"
   },
@@ -26,8 +22,25 @@
       "imports": [
         "dnxcore50",
         "portable-net45+win8"
-      ]
-    }
+      ],
+
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        },
+        "dotnet-test-mstest": {
+          "version": "1.0.1-preview",
+          "exclude": "compile"
+        }
+      }
+    },
+
+    "net46": {
+      "frameworkAssemblies": {
+        "System.Runtime": ""
+      }
+    } 
   },
 
   "testRunner": "mstest"

--- a/test/vstest.console.UnitTests/project.json
+++ b/test/vstest.console.UnitTests/project.json
@@ -8,15 +8,11 @@
   },
 
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0"
-    },
-    "dotnet-test-mstest": {
-      "version": "1.0.1-preview",
+    "MSTest.TestFramework": "1.0.0-preview",
+    "MSTest.TestAdapter": {
+      "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "MSTest.TestFramework": "1.0.0-preview",
     "moq.netcore": "4.4.0-beta8",
     "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
     "vstest.console": "15.0.0-*",
@@ -28,8 +24,25 @@
       "imports": [
         "dnxcore50",
         "portable-net45+win8"
-      ]
-    }
+      ],
+
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        },
+        "dotnet-test-mstest": {
+          "version": "1.0.1-preview",
+          "exclude": "compile"
+        }
+      }
+    },
+
+    "net46": {
+      "frameworkAssemblies": {
+        "System.Runtime": ""
+      }
+    } 
   },
 
   "testRunner": "mstest"

--- a/test/vstest.console.UnitTests/project.json
+++ b/test/vstest.console.UnitTests/project.json
@@ -13,8 +13,7 @@
       "version": "1.0.3-preview",
       "exclude": "compile"
     },
-    "moq.netcore": "4.4.0-beta8",
-    "System.Diagnostics.TraceSource": "4.0.0-rc2-24015",
+    "Moq": "4.6.36-*",
     "vstest.console": "15.0.0-*",
     "Microsoft.TestPlatform.Client": "15.0.0-*"
   },


### PR DESCRIPTION
Fix data collector unit tests to depend on Task.Id instead of thread id. A task may
or may not execute in new thread.

Fix test run event tests to wait for logger events to get flushed before verification.

All test projects now build for net46 and netcoreapp1.0.
