### PR TITLE
Always exit test script with 0

### DIFF
--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -176,3 +176,6 @@ Get-Variable | Where-Object -FilterScript { $_.Name.StartsWith("TPT_") } | Forma
 Invoke-Test
 
 Write-Log "Build complete. {$(Get-ElapsedTime($timer))}"
+
+# Always exit with 0. We capture vstest.console errors with stderr instead of exit code.
+Exit 0


### PR DESCRIPTION
Standard error is used to detect failure.
