### PR TITLE
Unblocking running tests via dotnet core test dll

### DIFF
--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs
@@ -14,6 +14,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+#if !NET46
+    using System.Runtime.Loader;
+#endif
 
     /// <summary>
     /// Discovers test extensions in a directory.
@@ -21,7 +24,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
     internal class TestPluginDiscoverer
     {
         #region Fields
-        
+
 #if WINDOWS_UAP
         private static HashSet<string> platformAssemblies = new HashSet<string>(new string[] {
             "MICROSOFT.VISUALSTUDIO.TESTPLATFORM.UNITTESTFRAMEWORK.DLL",
@@ -53,22 +56,14 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
             bool loadOnlyWellKnownExtensions)
         {
             Debug.Assert(pathToExtensions != null);
-            
+
             var testExtensions = new TestExtensions
-                                     {
-                                         TestDiscoverers =
-                                             new Dictionary<string, TestDiscovererPluginInformation>(
-                                             StringComparer.OrdinalIgnoreCase),
-                                         TestExecutors =
-                                             new Dictionary<string, TestExecutorPluginInformation>(
-                                             StringComparer.OrdinalIgnoreCase),
-                                         TestSettingsProviders =
-                                             new Dictionary <string, TestSettingsProviderPluginInformation>(
-                                             StringComparer.OrdinalIgnoreCase),
-                                         TestLoggers =
-                                             new Dictionary<string, TestLoggerPluginInformation>(
-                                             StringComparer.OrdinalIgnoreCase)
-                                     };
+            {
+                TestDiscoverers = new Dictionary<string, TestDiscovererPluginInformation>(StringComparer.OrdinalIgnoreCase),
+                TestExecutors = new Dictionary<string, TestExecutorPluginInformation>(StringComparer.OrdinalIgnoreCase),
+                TestSettingsProviders = new Dictionary<string, TestSettingsProviderPluginInformation>(StringComparer.OrdinalIgnoreCase),
+                TestLoggers = new Dictionary<string, TestLoggerPluginInformation>(StringComparer.OrdinalIgnoreCase)
+            };
 
 
 #if !WINDOWS_UAP
@@ -165,8 +160,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
                 try
                 {
                     var assemblyName = Path.GetFileNameWithoutExtension(file);
+#if NET46
                     assembly = Assembly.Load(new AssemblyName(assemblyName));
-
+#else
+                    assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(file);
+#endif
+                    
                     // Check whether this assembly is known or not. 
                     //if (loadOnlyWellKnownExtensions && assembly != null)
                     //{

--- a/src/testhost.x86/project.json
+++ b/src/testhost.x86/project.json
@@ -24,7 +24,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "netstandardapp1.5",
+        "netstandardapp1.0",
         "portable-net45+win8",
         "portable-net45+wp80+win8+wpa81+dnxcore50"
       ],

--- a/src/testhost/project.json
+++ b/src/testhost/project.json
@@ -26,7 +26,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "netstandardapp1.5",
+        "netstandardapp1.0",
         "portable-net45+win8",
         "portable-net45+wp80+win8+wpa81+dnxcore50"
       ],


### PR DESCRIPTION
- Fixing the Assembly.Load to AssemblyLoadContext::LoadFromAssemblyPath
- Fixed the json import for testhost dll to import netstandardapp1.0 instead of 1.5
