### PR TITLE
Move TestRunStatistics to ObjectModel

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/Client/TestRunStatistics.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/TestRunStatistics.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Client
 {


### PR DESCRIPTION
No DataClass should be in CrossPlatEngine
If TranslationLayer tries to deserialize data containing this class, it should not fail
