### PR TITLE
Update Publish-Package to copy *.deps.json in package.

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -25,6 +25,9 @@ $env:TP_TOOLS_DIR = Join-Path $env:TP_ROOT_DIR "tools"
 $env:TP_PACKAGES_DIR = Join-Path $env:TP_ROOT_DIR "packages"
 $env:TP_OUT_DIR = Join-Path $env:TP_ROOT_DIR "artifacts"
 $env:TP_PACKAGE_PROJ_DIR = Join-Path $env:TP_ROOT_DIR "src\package"
+$env:TP_TESTHOST_PROJ_DIR = Join-Path $env:TP_ROOT_DIR "src\testhost"
+$env:TP_VSTESTCONSOLE_PROJ_DIR = Join-Path $env:TP_ROOT_DIR "src\vstest.console"
+$env:TP_DATACOLLECTOR_PROJ_DIR = Join-Path $env:TP_ROOT_DIR "src\datacollector"
 
 #
 # Dotnet configuration
@@ -155,6 +158,19 @@ function Publish-Package
     
     Write-Verbose "$dotnetExe publish $env:TP_PACKAGE_PROJ_DIR\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
     & $dotnetExe publish $env:TP_PACKAGE_PROJ_DIR\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
+	
+	# Publish testhost, vstest.console and datacollector exclusively because *.deps.json file is not getting publish when we are publishing aforementioned project through dependency.
+	Write-Log ".. Package: Publish src\vstest.console\project.json"
+	Write-Verbose "$dotnetExe publish $env:TP_VSTESTCONSOLE_PROJ_DIR\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
+	& $dotnetExe publish $env:TP_VSTESTCONSOLE_PROJ_DIR\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
+	
+	Write-Log ".. Package: Publish src\testhost\project.json"
+	Write-Verbose "$dotnetExe publish $env:TP_TESTHOST_PROJ_DIR\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
+	& $dotnetExe publish $env:TP_TESTHOST_PROJ_DIR\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
+	
+	Write-Log ".. Package: Publish src\datacollector\project.json"
+	Write-Verbose "$dotnetExe publish $env:TP_DATACOLLECTOR_PROJ_DIR\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
+	& $dotnetExe publish $env:TP_DATACOLLECTOR_PROJ_DIR\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
 
     if ($lastExitCode -ne 0) {
         Set-ScriptFailed

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -25,9 +25,6 @@ $env:TP_TOOLS_DIR = Join-Path $env:TP_ROOT_DIR "tools"
 $env:TP_PACKAGES_DIR = Join-Path $env:TP_ROOT_DIR "packages"
 $env:TP_OUT_DIR = Join-Path $env:TP_ROOT_DIR "artifacts"
 $env:TP_PACKAGE_PROJ_DIR = Join-Path $env:TP_ROOT_DIR "src\package"
-$env:TP_TESTHOST_PROJ_DIR = Join-Path $env:TP_ROOT_DIR "src\testhost"
-$env:TP_VSTESTCONSOLE_PROJ_DIR = Join-Path $env:TP_ROOT_DIR "src\vstest.console"
-$env:TP_DATACOLLECTOR_PROJ_DIR = Join-Path $env:TP_ROOT_DIR "src\datacollector"
 
 #
 # Dotnet configuration
@@ -150,6 +147,9 @@ function Publish-Package
     $dotnetExe = Get-DotNetPath
     $fullCLRPackageDir = Get-FullCLRPackageDirectory
     $coreCLRPackageDir = Get-CoreCLRPackageDirectory
+	$testHostProjectDirectory = Join-Path $env:TP_ROOT_DIR "src\testhost"
+	$vstestConsoleProjectDirectory = Join-Path $env:TP_ROOT_DIR "src\vstest.console"
+	$dataCollectorProjectDirectory = Join-Path $env:TP_ROOT_DIR "src\datacollector"
 
     Write-Log ".. Package: Publish package\project.json"
     
@@ -161,16 +161,16 @@ function Publish-Package
 	
 	# Publish testhost, vstest.console and datacollector exclusively because *.deps.json file is not getting publish when we are publishing aforementioned project through dependency.
 	Write-Log ".. Package: Publish src\vstest.console\project.json"
-	Write-Verbose "$dotnetExe publish $env:TP_VSTESTCONSOLE_PROJ_DIR\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
-	& $dotnetExe publish $env:TP_VSTESTCONSOLE_PROJ_DIR\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
+	Write-Verbose "$dotnetExe publish $vstestConsoleProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
+	& $dotnetExe publish $vstestConsoleProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
 	
 	Write-Log ".. Package: Publish src\testhost\project.json"
-	Write-Verbose "$dotnetExe publish $env:TP_TESTHOST_PROJ_DIR\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
-	& $dotnetExe publish $env:TP_TESTHOST_PROJ_DIR\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
+	Write-Verbose "$dotnetExe publish $testHostProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
+	& $dotnetExe publish $testHostProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
 	
 	Write-Log ".. Package: Publish src\datacollector\project.json"
-	Write-Verbose "$dotnetExe publish $env:TP_DATACOLLECTOR_PROJ_DIR\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
-	& $dotnetExe publish $env:TP_DATACOLLECTOR_PROJ_DIR\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
+	Write-Verbose "$dotnetExe publish $dataCollectorProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
+	& $dotnetExe publish $dataCollectorProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
 
     if ($lastExitCode -ne 0) {
         Set-ScriptFailed


### PR DESCRIPTION
Currently we are publishing package\project.json which has a dependency of vstest.console. This way we nugget is not coping vstest.console.deps.json file. Hence explicitly publishing vstest.console\project.json.
