### PR TITLE
Issue: dotnet vstest.console.dll need full path to run tests

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -148,10 +148,8 @@ function Publish-Package
     $fullCLRPackageDir = Get-FullCLRPackageDirectory
     $coreCLRPackageDir = Get-CoreCLRPackageDirectory
 	$testHostProjectDirectory = Join-Path $env:TP_ROOT_DIR "src\testhost"
-	$testHostX86ProjectDirectory = Join-Path $env:TP_ROOT_DIR "src\testhost.x86"
 	$vstestConsoleProjectDirectory = Join-Path $env:TP_ROOT_DIR "src\vstest.console"
 	$dataCollectorProjectDirectory = Join-Path $env:TP_ROOT_DIR "src\datacollector"
-	$dataCollectorX86ProjectDirectory = Join-Path $env:TP_ROOT_DIR "src\datacollector.x86"
 
     Write-Log ".. Package: Publish package\project.json"
     
@@ -161,7 +159,7 @@ function Publish-Package
     Write-Verbose "$dotnetExe publish $env:TP_PACKAGE_PROJ_DIR\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
     & $dotnetExe publish $env:TP_PACKAGE_PROJ_DIR\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
 	
-	# Publish testhost, testhost.x86, vstest.console and datacollector, datacollector.x86 exclusively because *.deps.json file is not getting publish when we are publishing aforementioned project through dependency.
+	# Publish testhost, vstest.console and datacollector exclusively because *.deps.json file is not getting publish when we are publishing aforementioned project through dependency.
 	Write-Log ".. Package: Publish src\vstest.console\project.json"
 	Write-Verbose "$dotnetExe publish $vstestConsoleProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
 	& $dotnetExe publish $vstestConsoleProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
@@ -170,18 +168,10 @@ function Publish-Package
 	Write-Verbose "$dotnetExe publish $testHostProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
 	& $dotnetExe publish $testHostProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
 	
-	Write-Log ".. Package: Publish src\testhost.x86\project.json"
-	Write-Verbose "$dotnetExe publish $testHostX86ProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
-	& $dotnetExe publish $testHostX86ProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
-	
 	Write-Log ".. Package: Publish src\datacollector\project.json"
 	Write-Verbose "$dotnetExe publish $dataCollectorProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
 	& $dotnetExe publish $dataCollectorProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
 	
-	Write-Log ".. Package: Publish src\datacollector.x86\project.json"
-	Write-Verbose "$dotnetExe publish $dataCollectorX86ProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
-	& $dotnetExe publish $dataCollectorX86ProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
-
     if ($lastExitCode -ne 0) {
         Set-ScriptFailed
     }

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -148,8 +148,10 @@ function Publish-Package
     $fullCLRPackageDir = Get-FullCLRPackageDirectory
     $coreCLRPackageDir = Get-CoreCLRPackageDirectory
 	$testHostProjectDirectory = Join-Path $env:TP_ROOT_DIR "src\testhost"
+	$testHostX86ProjectDirectory = Join-Path $env:TP_ROOT_DIR "src\testhost.x86"
 	$vstestConsoleProjectDirectory = Join-Path $env:TP_ROOT_DIR "src\vstest.console"
 	$dataCollectorProjectDirectory = Join-Path $env:TP_ROOT_DIR "src\datacollector"
+	$dataCollectorX86ProjectDirectory = Join-Path $env:TP_ROOT_DIR "src\datacollector.x86"
 
     Write-Log ".. Package: Publish package\project.json"
     
@@ -159,7 +161,7 @@ function Publish-Package
     Write-Verbose "$dotnetExe publish $env:TP_PACKAGE_PROJ_DIR\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
     & $dotnetExe publish $env:TP_PACKAGE_PROJ_DIR\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
 	
-	# Publish testhost, vstest.console and datacollector exclusively because *.deps.json file is not getting publish when we are publishing aforementioned project through dependency.
+	# Publish testhost, testhost.x86, vstest.console and datacollector, datacollector.x86 exclusively because *.deps.json file is not getting publish when we are publishing aforementioned project through dependency.
 	Write-Log ".. Package: Publish src\vstest.console\project.json"
 	Write-Verbose "$dotnetExe publish $vstestConsoleProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
 	& $dotnetExe publish $vstestConsoleProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
@@ -168,9 +170,17 @@ function Publish-Package
 	Write-Verbose "$dotnetExe publish $testHostProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
 	& $dotnetExe publish $testHostProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
 	
+	Write-Log ".. Package: Publish src\testhost.x86\project.json"
+	Write-Verbose "$dotnetExe publish $testHostX86ProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
+	& $dotnetExe publish $testHostX86ProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
+	
 	Write-Log ".. Package: Publish src\datacollector\project.json"
 	Write-Verbose "$dotnetExe publish $dataCollectorProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
 	& $dotnetExe publish $dataCollectorProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
+	
+	Write-Log ".. Package: Publish src\datacollector.x86\project.json"
+	Write-Verbose "$dotnetExe publish $dataCollectorX86ProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
+	& $dotnetExe publish $dataCollectorX86ProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
 
     if ($lastExitCode -ne 0) {
         Set-ScriptFailed

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -171,7 +171,7 @@ function Publish-Package
 	Write-Log ".. Package: Publish src\datacollector\project.json"
 	Write-Verbose "$dotnetExe publish $dataCollectorProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir"
 	& $dotnetExe publish $dataCollectorProjectDirectory\project.json --framework $TPB_TargetFrameworkCore --no-build --configuration $TPB_Configuration --output $coreCLRPackageDir
-	
+
     if ($lastExitCode -ne 0) {
         Set-ScriptFailed
     }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Hosting/DefaultTestHostManager.cs
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
         /// <returns>ProcessStartInfo of the test host</returns>
         public virtual TestProcessStartInfo GetTestHostProcessStartInfo(IDictionary<string, string> environmentVariables, IList<string> commandLineArguments)
         {
-            string testHostProcessName = (this.architecture == Architecture.X86) ? X86TestHostProcessName : X64TestHostProcessName;
+            string testHostProcessName = X64TestHostProcessName;
             string testHostDirectory = Path.GetDirectoryName(typeof(DefaultTestHostManager).GetTypeInfo().Assembly.Location);
             string testhostProcessPath;
 
@@ -141,6 +141,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
                 }
                 else
                 {
+                    testHostProcessName = (this.architecture == Architecture.X86) ? X86TestHostProcessName : X64TestHostProcessName;
                     testhostProcessPath = Path.Combine(testHostDirectory, testHostProcessName);
                 }
             }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Hosting/DefaultTestHostManager.cs
@@ -111,9 +111,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
         /// <returns>ProcessStartInfo of the test host</returns>
         public virtual TestProcessStartInfo GetTestHostProcessStartInfo(IDictionary<string, string> environmentVariables, IList<string> commandLineArguments)
         {
-            var testHostProcessName = (this.architecture == Architecture.X86) ? X86TestHostProcessName : X64TestHostProcessName;
-            var currentWorkingDirectory = Path.GetDirectoryName(typeof(DefaultTestHostManager).GetTypeInfo().Assembly.Location);
-            string testhostProcessPath, processWorkingDirectory;
+            string testHostProcessName = (this.architecture == Architecture.X86) ? X86TestHostProcessName : X64TestHostProcessName;
+            string testHostDirectory = Path.GetDirectoryName(typeof(DefaultTestHostManager).GetTypeInfo().Assembly.Location);
+            string testhostProcessPath;
 
             // If we are running in the dotnet.exe context we do not want to launch testhost.exe but dotnet.exe with the testhost assembly. 
             // Since dotnet.exe is already built for multiple platforms this would avoid building testhost.exe also in multiple platforms.
@@ -122,10 +122,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
             {
                 testhostProcessPath = currentProcessFileName;
                 var testhostAssemblyPath = Path.Combine(
-                    currentWorkingDirectory,
+                    testHostDirectory,
                     testHostProcessName.Replace("exe", "dll"));
                 commandLineArguments.Insert(0, "\"" + testhostAssemblyPath + "\"");
-                processWorkingDirectory = Path.GetDirectoryName(currentProcessFileName);
             }
             else
             {
@@ -142,16 +141,16 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
                 }
                 else
                 {
-                    testhostProcessPath = Path.Combine(currentWorkingDirectory, testHostProcessName);
+                    testhostProcessPath = Path.Combine(testHostDirectory, testHostProcessName);
                 }
- 
-                // For IDEs and other scenario - Current directory should be the working directory - not the vstest.console.exe location
-                // For VS - this becomes the solution directory for example
-                // "TestResults" directory will be created at "current directory" of test host
-                processWorkingDirectory = Directory.GetCurrentDirectory();
             }
 
-            var argumentsString = string.Join(" ", commandLineArguments);
+            // For IDEs and other scenario - Current directory should be the working directory - not the vstest.console.exe location
+            // For VS - this becomes the solution directory for example
+            // "TestResults" directory will be created at "current directory" of test host
+            string processWorkingDirectory = Directory.GetCurrentDirectory();
+
+            string argumentsString = string.Join(" ", commandLineArguments);
             return new TestProcessStartInfo { FileName = testhostProcessPath, Arguments = argumentsString, EnvironmentVariables = environmentVariables, WorkingDirectory = processWorkingDirectory };
         }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Hosting/DefaultTestHostManager.cs
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
         /// <returns>ProcessStartInfo of the test host</returns>
         public virtual TestProcessStartInfo GetTestHostProcessStartInfo(IDictionary<string, string> environmentVariables, IList<string> commandLineArguments)
         {
-            string testHostProcessName = X64TestHostProcessName;
+            var testHostProcessName = X64TestHostProcessName;
             string testHostDirectory = Path.GetDirectoryName(typeof(DefaultTestHostManager).GetTypeInfo().Assembly.Location);
             string testhostProcessPath;
 

--- a/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
@@ -6,10 +6,11 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
     using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
+    using System.Runtime.InteropServices;
     using System.Security;
     using System.Xml;
     using System.Xml.XPath;
-    
+
     /// <summary>
     /// Utilities for the run settings XML.
     /// </summary>
@@ -29,31 +30,26 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
         /// Gets the assembly qualified name of the data collector type
         /// </summary>
         private const string DataCollectorAssemblyQualifiedName = "Microsoft.VisualStudio.TraceCollector.UnitTestIsolationDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
-        
+
         /// <summary>
-        /// Gets the os architecture.
+        /// Gets the os architecture of the machine where this application is running
         /// </summary>
-        public static Architecture OSArchitecture
+        public static ObjectModel.Architecture OSArchitecture
         {
             [SecuritySafeCritical]
             get
             {
-                string processorArch = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
-                string processorArch6432 = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITEW6432");
-                if (string.Equals(processorArch, "amd64", StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(processorArch, "ia64", StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(processorArch6432, "amd64", StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(processorArch6432, "ia64", StringComparison.OrdinalIgnoreCase))
-                {
-                    return Architecture.X64;
-                }
+                var  arch = RuntimeInformation.OSArchitecture;
 
-                if (string.Equals(processorArch, "x86", StringComparison.OrdinalIgnoreCase))
+                switch (arch)
                 {
-                    return Architecture.X86;
+                    case Architecture.X64:
+                        return ObjectModel.Architecture.X64;
+                    case Architecture.X86:
+                        return ObjectModel.Architecture.X86;
+                    default:
+                        return ObjectModel.Architecture.ARM;
                 }
-
-                return Architecture.ARM;
             }
         }
 

--- a/src/Microsoft.TestPlatform.ObjectModel/project.json
+++ b/src/Microsoft.TestPlatform.ObjectModel/project.json
@@ -7,13 +7,15 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "Microsoft.TestPlatform.CoreUtilities": "15.0.0-*"
+    "Microsoft.TestPlatform.CoreUtilities": "15.0.0-*",
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
   },
   "frameworks": {
     "net46": {
       "frameworkAssemblies": {
         "System.Xml": "",
-        "System.Runtime.Serialization": ""
+        "System.Runtime.Serialization": "",
+        "System.Runtime": ""
       },
       "dependencies": {
         "Microsoft.Internal.Dia.Interop": "14.0.0"

--- a/src/package/project.json
+++ b/src/package/project.json
@@ -55,6 +55,9 @@
     "Microsoft.TestPlatform.ObjectModel": "15.0.0-*",
     "vstest.console": "15.0.0-*",
     "testhost": "15.0.0-*",
+    "testhost.x86": "15.0.0-*",
+    "datacollector": "15.0.0-*",
+    "datacollector.x86": "15.0.0-*",
     "Microsoft.TestPlatform.VsTestConsole.TranslationLayer": "15.0.0-*",
     "Microsoft.TestPlatform.Extensions.TrxLogger": "15.0.0-*"
   }

--- a/src/package/project.json
+++ b/src/package/project.json
@@ -13,25 +13,27 @@
       ]
     }
   },
-    
+
   "frameworks": {
     "net46": {
       "frameworkAssemblies": {
       },
       "dependencies": {
+        "testhost": "15.0.0-*",
+        "datacollector": "15.0.0-*",
         "testhost.x86": "15.0.0-*",
+        "datacollector.x86": "15.0.0-*",
         "Microsoft.Internal.TestPlatform.Extensions": {
           "type": "build",
-          "version":  "15.0.0"
+          "version": "15.0.0"
         },
-        "NuGet.CommandLine": 
-        {
-          "type": "build", 
-          "version": "3.4.3" 
+        "NuGet.CommandLine": {
+          "type": "build",
+          "version": "3.4.3"
         }
       }
     },
-    "netcoreapp1.0":{ 
+    "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
         "netstandardapp1.0",
@@ -54,10 +56,6 @@
     "Microsoft.TestPlatform.CrossPlatEngine": "15.0.0-*",
     "Microsoft.TestPlatform.ObjectModel": "15.0.0-*",
     "vstest.console": "15.0.0-*",
-    "testhost": "15.0.0-*",
-    "testhost.x86": "15.0.0-*",
-    "datacollector": "15.0.0-*",
-    "datacollector.x86": "15.0.0-*",
     "Microsoft.TestPlatform.VsTestConsole.TranslationLayer": "15.0.0-*",
     "Microsoft.TestPlatform.Extensions.TrxLogger": "15.0.0-*"
   }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -20,7 +20,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Hosting
     public class DefaultTestHostManagerTests
     {
         private DefaultTestHostManager testHostManager;
-        
+
         /// <summary>
         /// The mock process helper.
         /// </summary>
@@ -37,7 +37,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Hosting
         public void ConstructorShouldSetX86ProcessForX86Architecture()
         {
             this.testHostManager = new DefaultTestHostManager(Architecture.X86, Framework.DefaultFramework, this.mockProcessHelper);
-            
+
             // Setup mocks.
             var processPath = string.Empty;
             var times = 0;
@@ -48,7 +48,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Hosting
                     processPath = path;
                     return Process.GetCurrentProcess();
                 };
-                
+
             this.testHostManager.LaunchTestHost(new Dictionary<string, string>(), new List<string>());
 
             StringAssert.EndsWith(processPath, "testhost.x86.exe");
@@ -70,7 +70,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Hosting
                 processPath = path;
                 return Process.GetCurrentProcess();
             };
-            
+
             this.testHostManager.LaunchTestHost(new Dictionary<string, string>(), new List<string>());
 
             StringAssert.EndsWith(processPath, "testhost.exe");
@@ -146,7 +146,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Hosting
             this.testHostManager.LaunchTestHost(new Dictionary<string, string>(), new List<string>());
 
             var workingDirectory = Directory.GetCurrentDirectory();
-            
+
             Assert.AreEqual(workingDirectory, pwd);
             Assert.AreEqual(1, times);
         }
@@ -189,6 +189,160 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Hosting
         }
 
         [TestMethod]
+        public void LaunchTestHostShouldPassTestHostAssemblyInArgumentsIfRunningUnderDotnetCLIContextInX86()
+        {
+            this.testHostManager = new DefaultTestHostManager(Architecture.X86, Framework.DefaultFramework, this.mockProcessHelper);
+
+            string arguments = null;
+
+            // Setup mocks.
+            this.mockProcessHelper.LaunchProcessInvoker = (path, args, wd) =>
+                {
+                    arguments = args;
+                    return Process.GetCurrentProcess();
+                };
+            this.mockProcessHelper.CurrentProcessName = "c:\\temp\\dotnet.exe";
+
+            this.testHostManager.LaunchTestHost(new Dictionary<string, string>(), new List<string>());
+
+            var testhostAssemblyPath =Path.Combine(Path.GetDirectoryName(typeof(DefaultTestHostManager).GetTypeInfo().Assembly.Location),"testhost.dll");
+
+            StringAssert.Contains(arguments, testhostAssemblyPath);
+        }
+
+        [TestMethod]
+        public void LaunchTestHostShouldPassTestHostAssemblyInArgumentsIfRunningUnderDotnetCLIContextInX64()
+        {
+            this.testHostManager = new DefaultTestHostManager(Architecture.X64, Framework.DefaultFramework, this.mockProcessHelper);
+
+            string arguments = null;
+
+            // Setup mocks.
+            this.mockProcessHelper.LaunchProcessInvoker = (path, args, wd) =>
+            {
+                arguments = args;
+                return Process.GetCurrentProcess();
+            };
+            this.mockProcessHelper.CurrentProcessName = "c:\\temp\\dotnet.exe";
+
+            this.testHostManager.LaunchTestHost(new Dictionary<string, string>(), new List<string>());
+
+            var testhostAssemblyPath = Path.Combine(Path.GetDirectoryName(typeof(DefaultTestHostManager).GetTypeInfo().Assembly.Location), "testhost.dll");
+
+            StringAssert.Contains(arguments, testhostAssemblyPath);
+        }
+
+        [TestMethod]
+        public void LaunchTestHostShouldPassTestHostAssemblyInArgumentsIfFrameworkIsNETCoreApp()
+        {
+            this.testHostManager = new DefaultTestHostManager(Architecture.X64, Framework.FromString(".NETCoreApp,Version=1.0"), this.mockProcessHelper);
+
+            string arguments = null;
+
+            // Setup mocks.
+            this.mockProcessHelper.LaunchProcessInvoker = (path, args, wd) =>
+            {
+                arguments = args;
+                return Process.GetCurrentProcess();
+            };
+            this.mockProcessHelper.CurrentProcessName = "c:\\temp\\vstest.console.exe";
+
+            this.testHostManager.LaunchTestHost(new Dictionary<string, string>(), new List<string>());
+
+            var testhostAssemblyPath = Path.Combine(Path.GetDirectoryName("c:\\temp\\vstest.console.exe"), "NetCore", "testhost.dll");
+
+            StringAssert.Contains(arguments, testhostAssemblyPath);
+        }
+
+        [TestMethod]
+        public void LaunchTestHostShouldPassTestHostAssemblyInArgumentsIfFrameworkIsNETStandard()
+        {
+            this.testHostManager = new DefaultTestHostManager(Architecture.X64, Framework.FromString(".NETStandard,Version=1.0"), this.mockProcessHelper);
+
+            string arguments = null;
+
+            // Setup mocks.
+            this.mockProcessHelper.LaunchProcessInvoker = (path, args, wd) =>
+            {
+                arguments = args;
+                return Process.GetCurrentProcess();
+            };
+            this.mockProcessHelper.CurrentProcessName = "c:\\temp\\vstest.console.exe";
+
+            this.testHostManager.LaunchTestHost(new Dictionary<string, string>(), new List<string>());
+
+            var testhostAssemblyPath = Path.Combine(Path.GetDirectoryName("c:\\temp\\vstest.console.exe"), "NetCore", "testhost.dll");
+
+            StringAssert.Contains(arguments, testhostAssemblyPath);
+        }
+
+        [TestMethod]
+        public void LaunchTestHostShouldPassTestHostX86ExeInFileNameIfRunningUnderFullDotnetCLIContextInX86()
+        {
+            this.testHostManager = new DefaultTestHostManager(Architecture.X86, Framework.DefaultFramework, this.mockProcessHelper);
+
+            string filename = null;
+
+            // Setup mocks.
+            this.mockProcessHelper.LaunchProcessInvoker = (path, args, wd) =>
+            {
+                filename = path;
+                return Process.GetCurrentProcess();
+            };
+            this.mockProcessHelper.CurrentProcessName = "c:\\temp\\vstest.console.exe";
+
+            this.testHostManager.LaunchTestHost(new Dictionary<string, string>(), new List<string>());
+
+            var testhostAssemblyPath = Path.Combine(Path.GetDirectoryName(typeof(DefaultTestHostManager).GetTypeInfo().Assembly.Location), "testhost.x86.exe");
+
+            StringAssert.Contains(filename, testhostAssemblyPath);
+        }
+
+        [TestMethod]
+        public void LaunchTestHostShouldPassTestHostExeInFileNameIfRunningUnderFullDotnetCLIContextInX64()
+        {
+            this.testHostManager = new DefaultTestHostManager(Architecture.X64, Framework.DefaultFramework, this.mockProcessHelper);
+
+            string filename = null;
+
+            // Setup mocks.
+            this.mockProcessHelper.LaunchProcessInvoker = (path, args, wd) =>
+            {
+                filename = path;
+                return Process.GetCurrentProcess();
+            };
+            this.mockProcessHelper.CurrentProcessName = "c:\\temp\\vstest.console.exe";
+
+            this.testHostManager.LaunchTestHost(new Dictionary<string, string>(), new List<string>());
+
+            var testhostAssemblyPath = Path.Combine(Path.GetDirectoryName(typeof(DefaultTestHostManager).GetTypeInfo().Assembly.Location), "testhost.exe");
+
+            StringAssert.Contains(filename, testhostAssemblyPath);
+        }
+
+        [TestMethod]
+        public void GetTestHostProcessStartInfoShouldSetWorkingDirectoryAsParentProcess()
+        {
+            this.testHostManager = new DefaultTestHostManager(Architecture.X64, Framework.DefaultFramework, this.mockProcessHelper);
+
+            TestProcessStartInfo testProcessStartInfo = this.testHostManager.GetTestHostProcessStartInfo(null, new List<string>());
+
+            Assert.AreEqual(Directory.GetCurrentDirectory(), testProcessStartInfo.WorkingDirectory);
+        }
+
+        [TestMethod]
+        public void GetTestHostProcessStartInfoShouldSetWorkingDirectoryAsParentProcessIfRunningUnderDotnetCLIContext()
+        {
+            this.testHostManager = new DefaultTestHostManager(Architecture.X64, Framework.DefaultFramework, this.mockProcessHelper);
+
+            this.mockProcessHelper.CurrentProcessName = "dotnet.exe";
+
+            TestProcessStartInfo testProcessStartInfo = this.testHostManager.GetTestHostProcessStartInfo(null, new List<string>());
+
+            Assert.AreEqual(Directory.GetCurrentDirectory(), testProcessStartInfo.WorkingDirectory);
+        }
+
+        [TestMethod]
         public void PropertiesShouldReturnEmptyDictionary()
         {
             this.testHostManager = new DefaultTestHostManager(Architecture.X64, Framework.DefaultFramework, this.mockProcessHelper);
@@ -220,28 +374,6 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Hosting
             mockCustomLauncher.Verify(mc => mc.LaunchTestHost(It.IsAny<TestProcessStartInfo>()), Times.Once, "Custom launcher must be called if set.");
         }
 
-        [TestMethod]
-        public void GetTestHostProcessStartInfoShouldSetWorkingDirectoryAsParentProcess()
-        {
-            this.testHostManager = new DefaultTestHostManager(Architecture.X64, Framework.DefaultFramework, this.mockProcessHelper);
-
-            TestProcessStartInfo testProcessStartInfo = this.testHostManager.GetTestHostProcessStartInfo(null, new List<string>());
-
-            Assert.AreEqual(Directory.GetCurrentDirectory(), testProcessStartInfo.WorkingDirectory);
-        }
-
-        [TestMethod]
-        public void GetTestHostProcessStartInfoShouldSetWorkingDirectoryAsParentProcessIfRunningUnderDotnetCLIContext()
-        {
-            this.testHostManager = new DefaultTestHostManager(Architecture.X64, Framework.DefaultFramework, this.mockProcessHelper);
-
-            this.mockProcessHelper.CurrentProcessName = "dotnet.exe";
-
-            TestProcessStartInfo testProcessStartInfo = this.testHostManager.GetTestHostProcessStartInfo(null, new List<string>());
-
-            Assert.AreEqual(Directory.GetCurrentDirectory(), testProcessStartInfo.WorkingDirectory);
-        }
-
         #region implementations
 
         private class MockProcessHelper : IProcessHelper
@@ -251,7 +383,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Hosting
                 this.CurrentProcessName = "testhost.exe";
             }
 
-            public Func<string,string,string,Process> LaunchProcessInvoker { get; set; }
+            public Func<string, string, string, Process> LaunchProcessInvoker { get; set; }
 
             public string CurrentProcessName { get; set; }
 


### PR DESCRIPTION
Issue: https://github.com/Microsoft/vstest/issues/57

Fix: Make working directory same as parent process (dotnet.exe)
