### PR TITLE
Display message in IDE output window on testhost crash

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -99,6 +99,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             // Currently each of the operations are not separate tasks since they should not each take much time. This is just a notification.
             while (!isDiscoveryComplete)
             {
+                //TODO Handle communication failures
                 var rawMessage = this.communicationManager.ReceiveRawMessage();
 
                 // Send raw message first to unblock handlers waiting to send message to IDEs
@@ -167,7 +168,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         private void ListenAndReportTestResults(ITestRunEventsHandler testRunEventsHandler)
         {
             var isTestRunComplete = false;
-
             // Cycle through the messages that the testhost sends. 
             // Currently each of the operations are not separate tasks since they should not each take much time. This is just a notification.
             while (!isTestRunComplete)
@@ -232,11 +232,22 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         private void OnTestRunAbort(ITestRunEventsHandler testRunEventsHandler, Exception exception, string reason)
         {
-            // log console message to user
-            testRunEventsHandler.HandleLogMessage(TestMessageLevel.Error, string.Format(Resources.AbortedTestRun, reason));
+            // log console message to vstest console
+            var errorMessage = string.Format(Resources.AbortedTestRun, reason);
+            testRunEventsHandler.HandleLogMessage(TestMessageLevel.Error, errorMessage);
+
+            //log console message to vstest console wrapper
+            var testMessagePayload = new TestMessagePayload { MessageLevel = TestMessageLevel.Error, Message = string.Format(Resources.AbortedTestRun, reason) };
+            var rawMessage = this.dataSerializer.SerializePayload(MessageType.TestMessage, testMessagePayload);
+            testRunEventsHandler.HandleRawMessage(rawMessage);
+
+            // notify test run abort to vstest console wrapper
+            var completeArgs = new TestRunCompleteEventArgs(null, false, true, exception, null, TimeSpan.Zero);
+            var payload = new TestRunCompletePayload { TestRunCompleteArgs = completeArgs };
+            rawMessage = this.dataSerializer.SerializePayload(MessageType.ExecutionComplete, payload);
+            testRunEventsHandler.HandleRawMessage(rawMessage);
 
             // notify of a test run complete and bail out.
-            var completeArgs = new TestRunCompleteEventArgs(null, false, true, exception, null, TimeSpan.Zero);
             testRunEventsHandler.HandleTestRunComplete(completeArgs, null, null, null);
         }
         

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
@@ -393,7 +393,8 @@ namespace TestPlatform.CommunicationUtilities.UnitTests
         {
             var mockHandler = new Mock<ITestRunEventsHandler>();
             var runCriteria = new TestRunCriteriaWithSources(null, null, null);
-            this.mockCommunicationManager.Setup(mc => mc.ReceiveRawMessage()).Throws(new IOException());
+            var exception = new IOException();
+            this.mockCommunicationManager.Setup(mc => mc.ReceiveRawMessage()).Throws(exception);
             var waitHandle = new AutoResetEvent(false);
             mockHandler.Setup(mh => mh.HandleTestRunComplete(It.IsAny<TestRunCompleteEventArgs>(),
                 null, null, null)).Callback
@@ -405,6 +406,7 @@ namespace TestPlatform.CommunicationUtilities.UnitTests
 
             mockHandler.Verify(mh => mh.HandleLogMessage(TestMessageLevel.Error, string.Format(Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources.AbortedTestRun, Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources.ConnectionClosed)), Times.Once);
             mockHandler.Verify(mh => mh.HandleTestRunComplete(It.IsAny<TestRunCompleteEventArgs>(), null, null, null), Times.Once);
+            mockHandler.Verify(mh => mh.HandleRawMessage(It.IsAny<string>()), Times.AtLeastOnce);
             mockCommunicationManager.Verify(mc => mc.SendMessage(MessageType.SessionEnd), Times.Never);
 
         }


### PR DESCRIPTION
- Send abort and log raw message to vsTestConsoleWrapper from vstest cosole.
