### PR TITLE
Use polling for socket receive message instead of timeouts.

### DIFF
--- a/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
+++ b/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
@@ -7,13 +7,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.DesignMode
     using System.Threading;
     using System.Threading.Tasks;
 
+    using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
-    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
-    using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-    using System.Diagnostics;
 
     /// <summary>
     /// The design mode client.
@@ -74,11 +72,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.DesignMode
         {
             EqtTrace.Info("Trying to connect to server on port : {0}", port);
             this.communicationManager.SetupClientAsync(port);
-            this.communicationManager.SendMessage(MessageType.SessionConnected);
 
             // Wait for the connection to the server and listen for requests.
             if (this.communicationManager.WaitForServerConnection(ClientListenTimeOut))
             {
+                this.communicationManager.SendMessage(MessageType.SessionConnected);
                 this.ProcessRequests(testRequestManager);
             }
             else
@@ -99,7 +97,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.DesignMode
         /// <summary>
         /// Process Requests from the IDE
         /// </summary>
-        /// <param name="handler"></param>
+        /// <param name="testRequestManager">
+        /// The test Request Manager.
+        /// </param>
         private void ProcessRequests(ITestRequestManager testRequestManager)
         {
             var isSessionEnd = false;

--- a/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
+++ b/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
@@ -45,6 +45,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.DesignMode
         /// <param name="communicationManager">
         /// The communication manager.
         /// </param>
+        /// <param name="dataSerializer">
+        /// The data Serializer.
+        /// </param>
         internal DesignModeClient(ICommunicationManager communicationManager, IDataSerializer dataSerializer)
         {
             this.communicationManager = communicationManager;
@@ -67,7 +70,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.DesignMode
         /// <summary>
         /// Creates a client and waits for server to accept connection asynchronously
         /// </summary>
-        /// <param name="port">port number to connect</param>
+        /// <param name="port">
+        /// Port number to connect
+        /// </param>
+        /// <param name="testRequestManager">
+        /// The test Request Manager.
+        /// </param>
         public void ConnectToClientAndProcessRequests(int port, ITestRequestManager testRequestManager)
         {
             EqtTrace.Info("Trying to connect to server on port : {0}", port);
@@ -202,7 +210,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.DesignMode
         /// <summary>
         /// Send a custom host launch message to IDE
         /// </summary>
-        /// <param name="customTestHostLaunchPayload">Payload required to launch a custom host</param>
+        /// <param name="testProcessStartInfo">
+        /// The test Process Start Info.
+        /// </param>
         public int LaunchCustomHost(TestProcessStartInfo testProcessStartInfo)
         {
             lock (ackLockObject)

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Messages/MessageType.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Messages/MessageType.cs
@@ -160,6 +160,5 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel
         public const string AfterTestRunEndResult = "DataCollection.AfterTestRunEndResult";
 
         #endregion
-
     }
 }

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleRequestSender.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleRequestSender.cs
@@ -198,7 +198,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         /// </summary>
         public void CancelTestRun()
         {
-                this.communicationManager.SendMessage(MessageType.CancelTestRun);
+            this.communicationManager.SendMessage(MessageType.CancelTestRun);
         }
 
         /// <summary>
@@ -365,7 +365,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
                 eventHandler.HandleLogMessage(TestMessageLevel.Error, Resources.AbortedTestsRun);
                 var completeArgs = new TestRunCompleteEventArgs(null, false, true, exception, null, TimeSpan.Zero);
                 eventHandler.HandleTestRunComplete(completeArgs, null, null, null);
-                CleanupCommunicationIfProcessExit();
+                this.CleanupCommunicationIfProcessExit();
             }
         }
 
@@ -377,6 +377,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
                 this.communicationManager.StopServer();
             }
         }
+
         private Message TryReceiveMessage()
         {
             Message message = null;


### PR DESCRIPTION
In design mode client, wait for communication channel to be connected before sending version check. Fix #110.
