### PR TITLE
Hadle exception in vstest.console

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketCommunicationManager.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketCommunicationManager.cs
@@ -349,8 +349,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             // Need to sync one by one to avoid buffer corruption
             lock (this.sendSyncObject)
             {
-                this.binaryWriter.Write(rawMessage);
-                this.binaryWriter.Flush();
+                this.binaryWriter?.Write(rawMessage);
+                this.binaryWriter?.Flush();
             }
         }
     }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Hosting/DotnetTestHostManager.cs
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
 
             var runtimeConfigDevPath = Path.Combine(sourceDirectory, string.Concat(sourceFile, ".runtimeconfig.dev.json"));
             var testHostPath = GetTestHostPath(runtimeConfigDevPath, depsFilePath, sourceDirectory);
-            
+
             if (this.fileHelper.Exists(testHostPath))
             {
                 EqtTrace.Verbose("DotnetTestHostmanager: Full path of testhost.dll is {0}", testHostPath);
@@ -157,8 +157,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
             }
             else
             {
-                EqtTrace.Verbose("DotnetTestHostmanager: {0}", Resources.NoTestHostFileExist);
-                throw new FileNotFoundException(Resources.NoTestHostFileExist);
+                string message = string.Format(Resources.NoTestHostFileExist, sourcePath);
+                EqtTrace.Verbose("DotnetTestHostmanager: " + message);
+                throw new FileNotFoundException(message);
             }
 
             // Create a additional probing path args with Nuget.Client

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
@@ -168,7 +168,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Could not find testhost.dll. Make sure test project has a nuget reference of package &quot;microsoft.testplatform.testhost&quot;..
+        ///    Looks up a localized string similar to Could not find testhost.dll. Make sure test project has a nuget reference of package &quot;microsoft.testplatform.testhost&quot; ({0})..
         /// </summary>
         public static string NoTestHostFileExist {
             get {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
@@ -168,7 +168,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Could not find testhost.dll. Make sure test project has a nuget reference of package &quot;microsoft.testplatform.testhost&quot; ({0})..
+        ///    Looks up a localized string similar to Could not find testhost.dll for source &apos;{0}&apos;. Make sure test project has a nuget reference of package &quot;microsoft.testplatform.testhost&quot;..
         /// </summary>
         public static string NoTestHostFileExist {
             get {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
@@ -157,7 +157,7 @@
     <comment>{0} - Executor uri String {1}-  Version - .net Version Eg:-2.0.50727.00</comment>
   </data>
   <data name="NoTestHostFileExist" xml:space="preserve">
-    <value>Could not find testhost.dll. Make sure test project has a nuget reference of package "microsoft.testplatform.testhost" ({0}).</value>
+    <value>Could not find testhost.dll for source '{0}'. Make sure test project has a nuget reference of package "microsoft.testplatform.testhost".</value>
   </data>
   <data name="NoValidSourceFoundForDiscovery" xml:space="preserve">
     <value>None of the specified source(s) '{0}' is valid. Fix the above errors/warnings and then try again. </value>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
@@ -157,7 +157,7 @@
     <comment>{0} - Executor uri String {1}-  Version - .net Version Eg:-2.0.50727.00</comment>
   </data>
   <data name="NoTestHostFileExist" xml:space="preserve">
-    <value>Could not find testhost.dll. Make sure test project has a nuget reference of package "microsoft.testplatform.testhost".</value>
+    <value>Could not find testhost.dll. Make sure test project has a nuget reference of package "microsoft.testplatform.testhost" ({0}).</value>
   </data>
   <data name="NoValidSourceFoundForDiscovery" xml:space="preserve">
     <value>None of the specified source(s) '{0}' is valid. Fix the above errors/warnings and then try again. </value>

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
@@ -10,6 +10,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     using Moq;
@@ -134,14 +135,18 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         }
 
         [TestMethod]
-        public void DiscoverTestsShouldThrowExceptionIfClientConnectionTimeout()
+        public void DiscoverTestsShouldcatchExceptionAndCallHandleDiscoveryComplete()
         {
             // Setup mocks.
             this.mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
+            Mock<ITestDiscoveryEventsHandler> mockTestDiscoveryEventsHandler = new Mock<ITestDiscoveryEventsHandler>();
 
             // Act.
-            Assert.ThrowsException<TestPlatformException>(
-                () => this.testDiscoveryManager.DiscoverTests(this.discoveryCriteria, null));
+            this.testDiscoveryManager.DiscoverTests(this.discoveryCriteria, mockTestDiscoveryEventsHandler.Object);
+
+            // Verify
+            mockTestDiscoveryEventsHandler.Verify(s => s.HandleDiscoveryComplete(-1, It.IsAny<IEnumerable<TestCase>>(), true));
+            mockTestDiscoveryEventsHandler.Verify(s => s.HandleLogMessage(TestMessageLevel.Error, It.IsAny<string>()));
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
@@ -154,11 +154,22 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         }
 
         [TestMethod]
-        public void StartTestRunShouldThrowExceptionIfClientConnectionTimeout()
+        public void SetupChannelShouldThrowExceptionIfClientConnectionTimeout()
         {
             this.mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
 
-            Assert.ThrowsException<TestPlatformException>(() => this.testExecutionManager.StartTestRun(this.mockTestRunCriteria.Object, null));
+            Assert.ThrowsException<TestPlatformException>(() => this.testExecutionManager.SetupChannel(new List<string> { "source.dll" }));
+        }
+
+        [TestMethod]
+        public void StartTestRunShouldCatchExceptionAndCallHandleTestRunComplete()
+        {
+            this.mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
+
+            Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+
+            this.testExecutionManager.StartTestRun(this.mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
+            mockTestRunEventsHandler.Verify(s => s.HandleTestRunComplete(It.IsAny<TestRunCompleteEventArgs>(), null, null, null));
         }
 
         [TestMethod]


### PR DESCRIPTION
Issue: Discovery and execution got stuck if project under test is not having nuget reference of TestHost and targeting netcoreapp1.0

Fix:- catch the exception and raise HandleDiscoveryComplete/HandleExecutionComplte event.

Test: 
1) Manually 
2) Unit test
