### PR TITLE
Reduced timeout if connection fails with test host

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Constants.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Constants.cs
@@ -19,6 +19,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine
         /// <summary>
         /// The connection timeout for clients in milliseconds.
         /// </summary>
-        internal const int ClientConnectionTimeout = 5000 * 1000;
+        internal const int ClientConnectionTimeout = 60 * 1000;
     }
 }


### PR DESCRIPTION
Issue: The vstest.console was waiting for 80 minut if there is some connection problem in test host and vstest which is very large time.

Fix: Reduced it to one min