### PR TITLE
Added new parameter in IFileHelper.GetStream API.

### DIFF
--- a/src/Microsoft.TestPlatform.CoreUtilities/Helpers/FileHelper.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Helpers/FileHelper.cs
@@ -35,9 +35,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities.Helpers
         }
 
         /// <inheritdoc/>
-        public Stream GetStream(string filePath, FileMode mode)
+        public Stream GetStream(string filePath, FileMode mode, FileAccess access = FileAccess.ReadWrite)
         {
-            return new FileStream(filePath, mode);
+            return new FileStream(filePath, mode, access);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.TestPlatform.CoreUtilities/Helpers/Interfaces/IFileHelper.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Helpers/Interfaces/IFileHelper.cs
@@ -37,8 +37,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces
         /// </summary>
         /// <param name="filePath">Path to the file.</param>
         /// <param name="mode"><see cref="FileMode"/> for file operations.</param>
+        /// <param name="access"><see cref="FileAccess"/> for file operations.</param>
         /// <returns>A <see cref="Stream"/> that supports read/write on the file.</returns>
-        Stream GetStream(string filePath, FileMode mode);
+        Stream GetStream(string filePath, FileMode mode, FileAccess access = FileAccess.ReadWrite);
 
         /// <summary>
         /// Enumerates files which match a pattern (case insensitive) in a directory.

--- a/src/Microsoft.TestPlatform.ObjectModel/Navigation/PortableSymbolReader.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Navigation/PortableSymbolReader.cs
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Navigation
             try
             {
                 var pdbFilePath = Path.ChangeExtension(binaryPath, ".pdb");
-                using (var pdbReader = new PortablePdbReader(new FileHelper().GetStream(pdbFilePath, FileMode.Open)))
+                using (var pdbReader = new PortablePdbReader(new FileHelper().GetStream(pdbFilePath, FileMode.Open, FileAccess.Read)))
                 {
                     // Load assembly
                     var asm = AssemblyLoadContext.Default.LoadFromAssemblyPath(binaryPath);

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -229,7 +229,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Hosting
             this.mockFileHelper.Setup(fh => fh.Exists(acceptablePath)).Returns(true);
             this.mockFileHelper.Setup(ph => ph.Exists("testhost.dll")).Returns(true);
             var startInfo = this.GetDefaultStartInfo();
-            
+
             Assert.AreEqual(acceptablePath, startInfo.FileName);
         }
 
@@ -338,7 +338,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Hosting
             // Absolute path to the source directory
             var sourcePath = Path.Combine($"{Path.DirectorySeparatorChar}tmp", "test.dll");
 
-            string runtimeConfigFileContent = 
+            string runtimeConfigFileContent =
 @"{
     ""runtimeOptions"": {
         ""additionalProbingPaths"": [
@@ -382,11 +382,11 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Hosting
 }";
 
             MemoryStream runtimeConfigStream = new MemoryStream(Encoding.UTF8.GetBytes(runtimeConfigFileContent));
-            this.mockFileHelper.Setup(ph => ph.GetStream("\\tmp\\test.runtimeconfig.dev.json", FileMode.Open)).Returns(runtimeConfigStream);
+            this.mockFileHelper.Setup(ph => ph.GetStream("\\tmp\\test.runtimeconfig.dev.json", FileMode.Open, FileAccess.ReadWrite)).Returns(runtimeConfigStream);
             this.mockFileHelper.Setup(ph => ph.Exists("\\tmp\\test.runtimeconfig.dev.json")).Returns(true);
-            
+
             MemoryStream depsFileStream = new MemoryStream(Encoding.UTF8.GetBytes(depsFileContent));
-            this.mockFileHelper.Setup(ph => ph.GetStream("\\tmp\\test.deps.json", FileMode.Open)).Returns(depsFileStream);
+            this.mockFileHelper.Setup(ph => ph.GetStream("\\tmp\\test.deps.json", FileMode.Open, FileAccess.ReadWrite)).Returns(depsFileStream);
             this.mockFileHelper.Setup(ph => ph.Exists("\\tmp\\test.deps.json")).Returns(true);
 
             string testHostFullPath = @"C:\packages\microsoft.testplatform.testhost/15.0.0-Dev\lib/netstandard1.5/testhost.dll";
@@ -414,7 +414,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Hosting
             : base(testHostLauncher, processHelper, fileHelper)
         { }
     }
-    
+
     [TestClass]
     public class DefaultTestHostLauncherTests
     {


### PR DESCRIPTION
By default, FileStream is opened in FileAccess.ReadWrite. This is resulting in this exception while debugging the framework:

> IOException: The process cannot access the file 'C:\Users\harjain\Documents\Visual Studio 2017\Projects\UnitTestProject4\UnitTestProject4\bin\Debug\netcoreapp1.0\UnitTestProject4.pdb' because it is being used by another process. 

Fix:
Added new parameter in IFileHelper.GetStream API.

`Stream GetStream(string filePath, FileMode mode, FileAccess access = FileAccess.ReadWrite);`

