### PR TITLE
Discover test from a solution which may have non unit test project (#…

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             catch (Exception exception)
             {
                 eventHandler.HandleLogMessage(TestMessageLevel.Error, exception.Message);
-                eventHandler.HandleDiscoveryComplete(-1, new List<ObjectModel.TestCase>(), true);
+                eventHandler.HandleDiscoveryComplete(0, new List<ObjectModel.TestCase>(), false);
             }
         }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -127,7 +127,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             }
             catch (Exception exception)
             {
-                var completeArgs = new TestRunCompleteEventArgs(null, false, true, exception, new Collection<AttachmentSet>(), TimeSpan.Zero);
+                var completeArgs = new TestRunCompleteEventArgs(null, false, false, exception, new Collection<AttachmentSet>(), TimeSpan.Zero);
                 eventHandler.HandleLogMessage(TestMessageLevel.Error, exception.Message);
                 eventHandler.HandleTestRunComplete(completeArgs, null, null, null);
             }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
@@ -145,7 +145,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
             this.testDiscoveryManager.DiscoverTests(this.discoveryCriteria, mockTestDiscoveryEventsHandler.Object);
 
             // Verify
-            mockTestDiscoveryEventsHandler.Verify(s => s.HandleDiscoveryComplete(-1, It.IsAny<IEnumerable<TestCase>>(), true));
+            mockTestDiscoveryEventsHandler.Verify(s => s.HandleDiscoveryComplete(0, It.IsAny<IEnumerable<TestCase>>(), false));
             mockTestDiscoveryEventsHandler.Verify(s => s.HandleLogMessage(TestMessageLevel.Error, It.IsAny<string>()));
         }
 


### PR DESCRIPTION
### Scenario
If a sln includes classlibrary or console app .net core projects, test discovery fails intermittently.

### Fix
In case the project doesn't have a dependency on testhost (i.e. a non-test project), return the tests discovered as zero instead of aborting the test run.

The fix will impact error scenarios in .net core and LUT flows. There is no impact to Desktop or UWP test scenarios in VS.

### Validation checklist
- [x] Smoke tests for .net core, LUT
- [x] Targeted testing for error scenarios (expect no hang, graceful behavior)

  * [x] Debug a test, detach, debug
  * [x] Crash in testhost
  * [x] Incompatible testhost (dotnet-cli not installed)
  * [x] Mixed mode solution (net46, netcore projects)