### PR TITLE
For desktop OM, use environment variable to detect processor architecture

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Hosting/DotnetTestHostManager.cs
@@ -224,6 +224,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
             char separator = ';';
             var dotnetExeName = "dotnet.exe";
 
+#if !NET46
             // Use semicolon(;) as path separator for windows
             // colon(:) for Linux and OSX
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -231,6 +232,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
                 separator = ':';
                 dotnetExeName = "dotnet";
             }
+#endif
 
             var pathString = Environment.GetEnvironmentVariable("PATH");
             foreach (string path in pathString.Split(separator))

--- a/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
@@ -39,6 +39,22 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
         {
             get
             {
+#if NET46
+                var procArch = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
+                var procArch6432 = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITEW6432");
+                if (string.Equals(procArch, "amd64", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(procArch, "ia64", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(procArch6432, "amd64", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(procArch6432, "ia64", StringComparison.OrdinalIgnoreCase))
+                {
+                    return ObjectModel.Architecture.X64;
+                }
+                if (string.Equals(procArch, "x86", StringComparison.OrdinalIgnoreCase))
+                {
+                    return ObjectModel.Architecture.X86;
+                }
+                return ObjectModel.Architecture.ARM;
+#else
                 var arch = RuntimeInformation.OSArchitecture;
 
                 switch (arch)
@@ -50,6 +66,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
                     default:
                         return ObjectModel.Architecture.ARM;
                 }
+#endif
             }
         }
 

--- a/src/Microsoft.TestPlatform.ObjectModel/project.json
+++ b/src/Microsoft.TestPlatform.ObjectModel/project.json
@@ -16,8 +16,7 @@
     } 
   },
   "dependencies": {
-    "Microsoft.TestPlatform.CoreUtilities": "15.0.0-*",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+    "Microsoft.TestPlatform.CoreUtilities": "15.0.0-*"
   },
   "frameworks": {
     "net46": {
@@ -42,6 +41,7 @@
         "System.Xml.XPath.XmlDocument": "4.0.1",
         "System.ComponentModel.EventBasedAsync": "4.0.11",
         "System.Runtime.InteropServices": "4.1.0",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "System.IO.FileSystem": "4.0.1",
         "System.ComponentModel.TypeConverter": "4.1.0",
         "System.Security.Cryptography.Algorithms": "4.2.0",

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -207,11 +207,13 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Hosting
 
             char separator = ';';
             var dotnetExeName = "dotnet.exe";
+#if !NET46
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 separator = ':';
                 dotnetExeName = "dotnet";
             }
+#endif
 
             // Setup the first directory on PATH to return true for existence check for dotnet
             var paths = Environment.GetEnvironmentVariable("PATH").Split(separator);
@@ -233,15 +235,17 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Hosting
 
             char separator = ';';
             var dotnetExeName = "dotnet.exe";
+#if !NET46
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 separator = ':';
                 dotnetExeName = "dotnet";
             }
+#endif
 
             var paths = Environment.GetEnvironmentVariable("PATH").Split(separator);
 
-            foreach(string path in paths)
+            foreach (string path in paths)
             {
                 string dotnetExeFullPath = Path.Combine(path.Trim(), dotnetExeName);
                 this.mockFileHelper.Setup(fh => fh.Exists(dotnetExeFullPath)).Returns(false);


### PR DESCRIPTION
RuntimeInformation.OSArchitecture API has dependencies which may not be available on Windows 7.

Validations:
- [ ] OS Matrix: Win7, Win8, Win8.1, Win10
- [ ] Scenario Matrix:
    - [x] Tests targeting x86, x64 from console
    - [x] Tests targeting .net core from IDE
    - [x] LUT tests targeting x86, x64