### PR TITLE
For desktop OM, use environment variable to detect processor architecture

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Hosting/DotnetTestHostManager.cs
@@ -221,6 +221,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
             char separator = ';';
             var dotnetExeName = "dotnet.exe";
 
+#if !NET46
             // Use semicolon(;) as path separator for windows
             // colon(:) for Linux and OSX
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -228,6 +229,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
                 separator = ':';
                 dotnetExeName = "dotnet";
             }
+#endif
 
             var pathString = Environment.GetEnvironmentVariable("PATH");
             foreach (string path in pathString.Split(separator))

--- a/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
@@ -38,6 +38,22 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
         {
             get
             {
+#if NET46
+                var procArch = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
+                var procArch6432 = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITEW6432");
+                if (string.Equals(procArch, "amd64", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(procArch, "ia64", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(procArch6432, "amd64", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(procArch6432, "ia64", StringComparison.OrdinalIgnoreCase))
+                {
+                    return ObjectModel.Architecture.X64;
+                }
+                if (string.Equals(procArch, "x86", StringComparison.OrdinalIgnoreCase))
+                {
+                    return ObjectModel.Architecture.X86;
+                }
+                return ObjectModel.Architecture.ARM;
+#else
                 var arch = RuntimeInformation.OSArchitecture;
 
                 switch (arch)
@@ -49,6 +65,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
                     default:
                         return ObjectModel.Architecture.ARM;
                 }
+#endif
             }
         }
 

--- a/src/Microsoft.TestPlatform.ObjectModel/project.json
+++ b/src/Microsoft.TestPlatform.ObjectModel/project.json
@@ -15,8 +15,7 @@
     } 
   },
   "dependencies": {
-    "Microsoft.TestPlatform.CoreUtilities": "15.0.0-*",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+    "Microsoft.TestPlatform.CoreUtilities": "15.0.0-*"
   },
   "frameworks": {
     "net46": {
@@ -41,6 +40,7 @@
         "System.Xml.XPath.XmlDocument": "4.0.1",
         "System.ComponentModel.EventBasedAsync": "4.0.11",
         "System.Runtime.InteropServices": "4.1.0",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "System.IO.FileSystem": "4.0.1",
         "System.ComponentModel.TypeConverter": "4.1.0",
         "System.Security.Cryptography.Algorithms": "4.2.0",

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -217,11 +217,13 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Hosting
 
             char separator = ';';
             var dotnetExeName = "dotnet.exe";
+#if !NET46
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 separator = ':';
                 dotnetExeName = "dotnet";
             }
+#endif
 
             var paths = Environment.GetEnvironmentVariable("PATH").Split(separator);
             var acceptablePath = Path.Combine(paths[0], dotnetExeName);
@@ -238,8 +240,26 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Hosting
         {
             // To validate the else part, set current process to exe other than dotnet
             this.mockProcessHelper.Setup(ph => ph.GetCurrentProcessFileName()).Returns("vstest.console.exe");
+
+            char separator = ';';
+            var dotnetExeName = "dotnet.exe";
+#if !NET46
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                separator = ':';
+                dotnetExeName = "dotnet";
+            }
+#endif
+
+            var paths = Environment.GetEnvironmentVariable("PATH").Split(separator);
+
+            foreach (string path in paths)
+            {
+                string dotnetExeFullPath = Path.Combine(path.Trim(), dotnetExeName);
+                this.mockFileHelper.Setup(fh => fh.Exists(dotnetExeFullPath)).Returns(false);
+            }
+
             this.mockFileHelper.Setup(ph => ph.Exists("testhost.dll")).Returns(true);
-            var dotnetExeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
 
             var startInfo = this.GetDefaultStartInfo();
 


### PR DESCRIPTION
RuntimeInformation.OSArchitecture API has dependencies which may not be available on Windows 7.