### PR TITLE
Port misc fixes from RC branch to master

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -239,8 +239,8 @@ function Publish-Package
 
 function Publish-Package-Internal($packagename, $framework, $output, $runtime)
 {
-    Write-Verbose "$dotnetExe publish $packagename --no-build --configuration $TPB_Configuration --framework $framework --output $output"
-    & $dotnetExe publish $packagename --no-build --configuration $TPB_Configuration --framework $framework --output $output
+    Write-Verbose "$dotnetExe publish $packagename --no-build --configuration $TPB_Configuration --framework $framework --output $output --runtime $TPB_TargetRuntime"
+    & $dotnetExe publish $packagename --no-build --configuration $TPB_Configuration --framework $framework --output $output --runtime $TPB_TargetRuntime
 }
 
 function Create-VsixPackage
@@ -305,7 +305,7 @@ function Create-NugetPackages
         }
 
         Write-Verbose "$nugetExe pack $stagingDir\$file -OutputDirectory $stagingDir -Version=$Version-$VersionSuffix -Properties Version=$Version-$VersionSuffix $additionalArgs"
-        & $nugetExe pack $stagingDir\$file -OutputDirectory $stagingDir -Version $Version-$VersionSuffix -Properties Version=$Version-$VersionSuffix $additionalArgs
+        & $nugetExe pack $stagingDir\$file -OutputDirectory $stagingDir -Version $Version-$VersionSuffix -Properties Version=$Version-$VersionSuffix`;Runtime=$TPB_TargetRuntime $additionalArgs
     }
 
     Write-Log "Create-NugetPackages: Complete. {$(Get-ElapsedTime($timer))}"

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.cs.xlf
@@ -170,6 +170,11 @@
         <target state="new">Could not find testhost.dll. Make sure test project has a nuget reference of package "microsoft.testplatform.testhost".</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="NoDotnetExeFound">
+        <source>Could not find {0}. Make sure that the dotnet is installed on the machine.</source>
+        <target state="new">Could not find {0}. Make sure that the dotnet is installed on the machine.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.de.xlf
@@ -170,6 +170,11 @@
         <target state="new">Could not find testhost.dll. Make sure test project has a nuget reference of package "microsoft.testplatform.testhost".</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="NoDotnetExeFound">
+        <source>Could not find {0}. Make sure that the dotnet is installed on the machine.</source>
+        <target state="new">Could not find {0}. Make sure that the dotnet is installed on the machine.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.es.xlf
@@ -170,6 +170,11 @@
         <target state="new">Could not find testhost.dll. Make sure test project has a nuget reference of package "microsoft.testplatform.testhost".</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="NoDotnetExeFound">
+        <source>Could not find {0}. Make sure that the dotnet is installed on the machine.</source>
+        <target state="new">Could not find {0}. Make sure that the dotnet is installed on the machine.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.fr.xlf
@@ -170,6 +170,11 @@
         <target state="new">Could not find testhost.dll. Make sure test project has a nuget reference of package "microsoft.testplatform.testhost".</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="NoDotnetExeFound">
+        <source>Could not find {0}. Make sure that the dotnet is installed on the machine.</source>
+        <target state="new">Could not find {0}. Make sure that the dotnet is installed on the machine.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.it.xlf
@@ -170,6 +170,11 @@
         <target state="new">Could not find testhost.dll. Make sure test project has a nuget reference of package "microsoft.testplatform.testhost".</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="NoDotnetExeFound">
+        <source>Could not find {0}. Make sure that the dotnet is installed on the machine.</source>
+        <target state="new">Could not find {0}. Make sure that the dotnet is installed on the machine.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ja.xlf
@@ -170,6 +170,11 @@
         <target state="new">Could not find testhost.dll. Make sure test project has a nuget reference of package "microsoft.testplatform.testhost".</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="NoDotnetExeFound">
+        <source>Could not find {0}. Make sure that the dotnet is installed on the machine.</source>
+        <target state="new">Could not find {0}. Make sure that the dotnet is installed on the machine.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ko.xlf
@@ -170,6 +170,11 @@
         <target state="new">Could not find testhost.dll. Make sure test project has a nuget reference of package "microsoft.testplatform.testhost".</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="NoDotnetExeFound">
+        <source>Could not find {0}. Make sure that the dotnet is installed on the machine.</source>
+        <target state="new">Could not find {0}. Make sure that the dotnet is installed on the machine.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pl.xlf
@@ -170,6 +170,11 @@
         <target state="new">Could not find testhost.dll. Make sure test project has a nuget reference of package "microsoft.testplatform.testhost".</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="NoDotnetExeFound">
+        <source>Could not find {0}. Make sure that the dotnet is installed on the machine.</source>
+        <target state="new">Could not find {0}. Make sure that the dotnet is installed on the machine.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pt-BR.xlf
@@ -170,6 +170,11 @@
         <target state="new">Could not find testhost.dll. Make sure test project has a nuget reference of package "microsoft.testplatform.testhost".</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="NoDotnetExeFound">
+        <source>Could not find {0}. Make sure that the dotnet is installed on the machine.</source>
+        <target state="new">Could not find {0}. Make sure that the dotnet is installed on the machine.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ru.xlf
@@ -170,6 +170,11 @@
         <target state="new">Could not find testhost.dll. Make sure test project has a nuget reference of package "microsoft.testplatform.testhost".</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="NoDotnetExeFound">
+        <source>Could not find {0}. Make sure that the dotnet is installed on the machine.</source>
+        <target state="new">Could not find {0}. Make sure that the dotnet is installed on the machine.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.tr.xlf
@@ -170,6 +170,11 @@
         <target state="new">Could not find testhost.dll. Make sure test project has a nuget reference of package "microsoft.testplatform.testhost".</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="NoDotnetExeFound">
+        <source>Could not find {0}. Make sure that the dotnet is installed on the machine.</source>
+        <target state="new">Could not find {0}. Make sure that the dotnet is installed on the machine.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hans.xlf
@@ -170,6 +170,11 @@
         <target state="new">Could not find testhost.dll. Make sure test project has a nuget reference of package "microsoft.testplatform.testhost".</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="NoDotnetExeFound">
+        <source>Could not find {0}. Make sure that the dotnet is installed on the machine.</source>
+        <target state="new">Could not find {0}. Make sure that the dotnet is installed on the machine.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hant.xlf
@@ -170,6 +170,11 @@
         <target state="new">Could not find testhost.dll. Make sure test project has a nuget reference of package "microsoft.testplatform.testhost".</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="NoDotnetExeFound">
+        <source>Could not find {0}. Make sure that the dotnet is installed on the machine.</source>
+        <target state="new">Could not find {0}. Make sure that the dotnet is installed on the machine.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
@@ -39,6 +39,10 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
         {
             get
             {
+#if NET46
+                // This is a workaround for https://github.com/dotnet/corefx/issues/13566
+                return WindowsSystemInformation.GetArchitecture();
+#else
                 var arch = RuntimeInformation.OSArchitecture;
 
                 switch (arch)
@@ -50,6 +54,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
                     default:
                         return ObjectModel.Architecture.ARM;
                 }
+#endif
             }
         }
 
@@ -339,4 +344,60 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
             return null;
         }
     }
+
+#if NET46
+    internal static class WindowsSystemInformation
+    {
+        internal const ushort PROCESSOR_ARCHITECTURE_INTEL = 0;
+        internal const ushort PROCESSOR_ARCHITECTURE_ARM = 5;
+        internal const ushort PROCESSOR_ARCHITECTURE_IA64 = 6;
+        internal const ushort PROCESSOR_ARCHITECTURE_AMD64 = 9;
+        internal const ushort PROCESSOR_ARCHITECTURE_UNKNOWN = 0xFFFF;
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct SYSTEM_INFO
+        {
+            public ushort wProcessorArchitecture;
+            public ushort wReserved;
+            public uint dwPageSize;
+            public IntPtr lpMinimumApplicationAddress;
+            public IntPtr lpMaximumApplicationAddress;
+            public UIntPtr dwActiveProcessorMask;
+            public uint dwNumberOfProcessors;
+            public uint dwProcessorType;
+            public uint dwAllocationGranularity;
+            public ushort wProcessorLevel;
+            public ushort wProcessorRevision;
+        };
+
+        [DllImport("kernel32.dll")]
+        internal static extern void GetNativeSystemInfo(ref SYSTEM_INFO lpSystemInfo);
+
+        public static ObjectModel.Architecture GetArchitecture()
+        {
+            SYSTEM_INFO sysInfo = new SYSTEM_INFO();
+
+            // GetNativeSystemInfo is supported from Windows XP onwards. Since test platform
+            // requires Windows 7 OS at the minimum, we don't require a fallback.
+            GetNativeSystemInfo(ref sysInfo);
+
+            switch (sysInfo.wProcessorArchitecture)
+            {
+                case PROCESSOR_ARCHITECTURE_INTEL:
+                    return ObjectModel.Architecture.X86;
+                case PROCESSOR_ARCHITECTURE_ARM:
+                    return ObjectModel.Architecture.ARM;
+                case PROCESSOR_ARCHITECTURE_IA64:
+                    return ObjectModel.Architecture.X64;
+                case PROCESSOR_ARCHITECTURE_AMD64:
+                    return ObjectModel.Architecture.X64;
+                case PROCESSOR_ARCHITECTURE_UNKNOWN:
+                    EqtTrace.Error("WindowsSystemInformation.GetArchitecture: Unknown architecture found, will use default.");
+                    break;
+            }
+
+            return ObjectModel.Architecture.Default;
+        }
+    }
+#endif
 }

--- a/src/TestPlatform.ObjectModel.nuspec
+++ b/src/TestPlatform.ObjectModel.nuspec
@@ -51,8 +51,8 @@
     </frameworkAssemblies>
   </metadata>
   <files>	
-    <file src="net46\win7-x64\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" target="lib\net46\" />
-    <file src="net46\win7-x64\Microsoft.TestPlatform.CoreUtilities.dll" target="lib\net46\" />
+    <file src="net46\$Runtime$\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" target="lib\net46\" />
+    <file src="net46\$Runtime$\Microsoft.TestPlatform.CoreUtilities.dll" target="lib\net46\" />
 
     <file src="netcoreapp1.0\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" target="lib\netstandard1.5\" />
     <file src="netcoreapp1.0\Microsoft.TestPlatform.CoreUtilities.dll" target="lib\netstandard1.5\" />

--- a/src/TestPlatform.TranslationLayer.nuspec
+++ b/src/TestPlatform.TranslationLayer.nuspec
@@ -17,12 +17,12 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="net46\win7-x64\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.dll" target="lib\net46\" />
-    <file src="net46\win7-x64\Microsoft.TestPlatform.CommunicationUtilities.dll" target="lib\net46\" />
-    <file src="net46\win7-x64\Microsoft.TestPlatform.CoreUtilities.dll" target="lib\net46\" />
-    <file src="net46\win7-x64\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.dll" target="lib\net46\" />
-    <file src="net46\win7-x64\Microsoft.VisualStudio.TestPlatform.Common.dll" target="lib\net46\" />
-    <file src="net46\win7-x64\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" target="lib\net46\" />
+    <file src="net46\$Runtime$\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.dll" target="lib\net46\" />
+    <file src="net46\$Runtime$\Microsoft.TestPlatform.CommunicationUtilities.dll" target="lib\net46\" />
+    <file src="net46\$Runtime$\Microsoft.TestPlatform.CoreUtilities.dll" target="lib\net46\" />
+    <file src="net46\$Runtime$\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.dll" target="lib\net46\" />
+    <file src="net46\$Runtime$\Microsoft.VisualStudio.TestPlatform.Common.dll" target="lib\net46\" />
+    <file src="net46\$Runtime$\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" target="lib\net46\" />
 
     <file src="netcoreapp1.0\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.dll" target="lib\netstandard1.5\" />
     <file src="netcoreapp1.0\Microsoft.TestPlatform.CommunicationUtilities.dll" target="lib\netstandard1.5\" />

--- a/src/TestPlatform.nuspec
+++ b/src/TestPlatform.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright © Microsoft Corporation</copyright>
   </metadata>
   <files>
-    <file src="net46\win7-x64\**\*.*" target="tools\net46\" />
+    <file src="net46\$Runtime$\**\*.*" target="tools\net46\" />
     <file src="netcoreapp1.0\**\*.*" target="tools\netcoreapp1.0\" />
     <file src="netcoreapp1.0\**\*.*" target="lib\netcoreapp1.0\" />
   </files>

--- a/src/package/sign/sign.proj
+++ b/src/package/sign/sign.proj
@@ -110,13 +110,13 @@
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.TestPlatform.CoreUtilities.dll" />
 
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\win7-x64\Microsoft.TestPlatform.CommunicationUtilities.dll" />
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\win7-x64\Microsoft.TestPlatform.CoreUtilities.dll" />
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\win7-x64\Microsoft.TestPlatform.CrossPlatEngine.dll" />
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\win7-x64\Microsoft.VisualStudio.TestPlatform.Common.dll" />
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\win7-x64\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" />
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\win7-x64\testhost.exe" />
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\win7-x64\testhost.x86.exe" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\$(TargetRuntime)\Microsoft.TestPlatform.CommunicationUtilities.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\$(TargetRuntime)\Microsoft.TestPlatform.CoreUtilities.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\$(TargetRuntime)\Microsoft.TestPlatform.CrossPlatEngine.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\$(TargetRuntime)\Microsoft.VisualStudio.TestPlatform.Common.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\$(TargetRuntime)\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\$(TargetRuntime)\testhost.exe" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\$(TargetRuntime)\testhost.x86.exe" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/vstest.console/project.json
+++ b/src/vstest.console/project.json
@@ -7,6 +7,7 @@
     "publicSign": false,
     "keyFile": "../../scripts/key.snk",
     "warningsAsErrors": true,
+    "platform": "anycpu",
     "embed": [ "Resources/*.resx" ]
   },
 


### PR DESCRIPTION
* Make vstest.console anycpu
* Remove any hardcoded runtime identifiers. Able to build for win7-x86 and win7-x64
* Use GetNativeSystemInfo to determine OS architecture instead of environment variables