### PR TITLE
Change test methods name of ArgumentProcessorTests

### DIFF
--- a/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         }
 
         [TestMethod]
-        public void ExecutorExecuteForFailedConnectionReturnsArgumentProcessorResultFail()
+        public void ExecutorExecuteForFailedConnectionShouldThrowCommandLineException()
         {
             var testRequestManager = new Mock<ITestRequestManager>();
             var testDesignModeClient = new Mock<IDesignModeClient>();

--- a/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         #region RunSpecificTestsArgumentExecutorTests
 
         [TestMethod]
-        public void ExecutorExecuteForNoSourcesShouldReturnFail()
+        public void ExecutorExecuteForNoSourcesShouldThrowCommandLineException()
         {
             CommandLineOptions.Instance.Reset();
 
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         }
 
         [TestMethod]
-        public void ExecutorExecuteForValidSourceWithTestCaseFilterShouldReturnFail()
+        public void ExecutorExecuteForValidSourceWithTestCaseFilterShouldThrowCommandLineException()
         {
             this.ResetAndAddSourceToCommandLineOptions();
 

--- a/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         #region RunTestsArgumentExecutorTests
 
         [TestMethod]
-        public void ExecutorExecuteForNoSourcesShouldReturnFail()
+        public void ExecutorExecuteForNoSourcesShouldThrowCommandLineException()
         {
             CommandLineOptions.Instance.Reset();
 


### PR DESCRIPTION
- Change test methods name from ShouldReturnFail to ShouldThrowCommandLineException