### PR TITLE
Adding net46 folder in lib of Microsoft.TestPlatform Nuget Package

### DIFF
--- a/src/TestPlatform.nuspec
+++ b/src/TestPlatform.nuspec
@@ -16,5 +16,6 @@
     <file src="net46\$Runtime$\**\*.*" target="tools\net46\" />
     <file src="netcoreapp1.0\**\*.*" target="tools\netcoreapp1.0\" />
     <file src="netcoreapp1.0\**\*.*" target="lib\netcoreapp1.0\" />
+    <file src="_._" target="lib\net46\" />
   </files>
 </package>


### PR DESCRIPTION
Microsoft.TestPlatform Nuget Package currently is not installing for net46 because there is no folder in lib for net46. Adding that folder to resolve this issue.