### PR TITLE
Change assembly signing to public

### DIFF
--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -10,8 +10,8 @@
     <VersionSuffix Condition="'$(VersionSuffix)' == ''">dev</VersionSuffix>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!--<PublicSign>true</PublicSign>-->
-    <DelaySign>true</DelaySign>
+    <PublicSign>true</PublicSign>
+    <!--<DelaySign>true</DelaySign>-->
     <!--<GenerateDocumentationFile>true</GenerateDocumentationFile>-->
     <AssemblyOriginatorKeyFile>$(TestPlatformRoot)scripts/key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
- To avoid strong name exception