### PR TITLE
Revert "Include sign target as part of csproj. (#269)"

### DIFF
--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -10,7 +10,8 @@
     <VersionSuffix Condition="'$(VersionSuffix)' == ''">dev</VersionSuffix>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <PublicSign Condition="'$(CIBuild)' == '' Or '$(CIBuild)' == 'false'">true</PublicSign>
+    <PublicSign Condition="'$(CIBuild)' == '' or '$(CIBuild)' == 'false'">true</PublicSign>
+    <DelaySign Condition="'$(CIBuild)' == 'true'">true</DelaySign>
     <!--<GenerateDocumentationFile>true</GenerateDocumentationFile>-->
     <AssemblyOriginatorKeyFile>$(TestPlatformRoot)scripts/key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -39,7 +40,12 @@
     <!--</PackageReference>-->
   </ItemGroup>
 
-  <!-- Test project -->
+  <ItemGroup>
+    <AdditionalFiles Include="$(TestPlatformRoot)scripts\stylecop.json">
+      <Link>stylecop.json</Link>
+    </AdditionalFiles>
+  </ItemGroup>
+
   <Choose>
     <When Condition="$(TestProject) == 'true'"> 
       <PropertyGroup>
@@ -84,38 +90,9 @@
   </Choose>
 
   <!-- Code analysis settings -->
-  <ItemGroup>
-    <AdditionalFiles Include="$(TestPlatformRoot)scripts\stylecop.json">
-      <Link>stylecop.json</Link>
-    </AdditionalFiles>
-  </ItemGroup>
   <PropertyGroup>
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <CodeAnalysisRuleSet>$(TestPlatformRoot)scripts/stylecop.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRuleSet Condition="$(TestProject) == 'true'">$(TestPlatformRoot)scripts/stylecop.test.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-
-  <!-- Signing settings -->
-  <Choose>
-    <When Condition="'$(CIBuild)' == 'true'"> 
-      <PropertyGroup>
-        <PublicSign>false</PublicSign>
-        <DelaySign>true</DelaySign>
-      </PropertyGroup>
-
-      <ItemGroup>
-        <PackageReference Include="MicroBuild.Core">
-          <Version>0.2.0</Version>
-          <PrivateAssets>All</PrivateAssets>
-        </PackageReference>
-      </ItemGroup>
-
-      <ItemGroup>
-        <FilesToSign Include="$(OutDir)\$(TargetName)$(TargetExt)">
-          <Authenticode>Microsoft</Authenticode>
-          <StrongName>StrongName</StrongName>
-        </FilesToSign>
-      </ItemGroup>
-    </When>
-  </Choose>
 </Project>

--- a/src/package/package.csproj
+++ b/src/package/package.csproj
@@ -55,6 +55,10 @@
       <Version>0.1.2</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="MicroBuild.Core">
+      <Version>0.2.0</Version>
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/package/sign/sign.proj
+++ b/src/package/sign/sign.proj
@@ -53,16 +53,115 @@
       <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll" />
     </ItemGroup>
 
+    <!-- Sign test platform v2 assemblies for .NET 4.6-->
+    <ItemGroup>
+      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.TestPlatform.CommunicationUtilities.dll" />
+      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.TestPlatform.CoreUtilities.dll" />
+      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.TestPlatform.CrossPlatEngine.dll" />
+      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.TestPlatform.Utilities.dll" />
+      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.TestPlatform.VsTestConsole.TranslationLayer.dll" />
+      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestPlatform.Client.dll" />
+      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestPlatform.Common.dll" />
+      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" />
+      <AssembliesToSign Include="$(ArtifactsDirectory)testhost.exe" />
+      <AssembliesToSign Include="$(ArtifactsDirectory)testhost.x86.exe" />
+      <AssembliesToSign Include="$(ArtifactsDirectory)datacollector.exe" />
+      <AssembliesToSign Include="$(ArtifactsDirectory)datacollector.x86.exe" />
+      <AssembliesToSign Include="$(ArtifactsDirectory)vstest.console.exe" />
+      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger.dll" />
+    </ItemGroup>
+
+    <!-- Sign test platform v2 assemblies for .NET Core -->
+    <ItemGroup>
+      <CoreAssembliesToSign Include="$(ArtifactsCoreDirectory)DataCollector.dll" />
+      <CoreAssembliesToSign Include="$(ArtifactsCoreDirectory)Microsoft.TestPlatform.CommunicationUtilities.dll" />
+      <CoreAssembliesToSign Include="$(ArtifactsCoreDirectory)Microsoft.TestPlatform.CoreUtilities.dll" />
+      <CoreAssembliesToSign Include="$(ArtifactsCoreDirectory)Microsoft.TestPlatform.CrossPlatEngine.dll" />
+      <CoreAssembliesToSign Include="$(ArtifactsCoreDirectory)Microsoft.TestPlatform.Utilities.dll" />
+      <CoreAssembliesToSign Include="$(ArtifactsCoreDirectory)Microsoft.TestPlatform.VsTestConsole.TranslationLayer.dll" />
+      <CoreAssembliesToSign Include="$(ArtifactsCoreDirectory)Microsoft.VisualStudio.TestPlatform.Client.dll" />
+      <CoreAssembliesToSign Include="$(ArtifactsCoreDirectory)Microsoft.VisualStudio.TestPlatform.Common.dll" />
+      <CoreAssembliesToSign Include="$(ArtifactsCoreDirectory)Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" />
+      <CoreAssembliesToSign Include="$(ArtifactsCoreDirectory)vstest.console.dll" />
+
+      <CoreAssembliesToSign Include="$(ArtifactsCoreDirectory)TestHost\Microsoft.TestPlatform.CommunicationUtilities.dll" />
+      <CoreAssembliesToSign Include="$(ArtifactsCoreDirectory)TestHost\Microsoft.TestPlatform.CoreUtilities.dll" />
+      <CoreAssembliesToSign Include="$(ArtifactsCoreDirectory)TestHost\Microsoft.TestPlatform.CrossPlatEngine.dll" />
+      <CoreAssembliesToSign Include="$(ArtifactsCoreDirectory)TestHost\Microsoft.VisualStudio.TestPlatform.Common.dll" />
+      <CoreAssembliesToSign Include="$(ArtifactsCoreDirectory)TestHost\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" />
+      <CoreAssembliesToSign Include="$(ArtifactsCoreDirectory)TestHost\testhost.exe" />
+      <CoreAssembliesToSign Include="$(ArtifactsCoreDirectory)TestHost\testhost.x86.exe" />
+
+      <!-- NetCoreExtensions -->
+      <CoreAssembliesToSign Include="$(ArtifactsCoreDirectory)Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger.dll" />
+    </ItemGroup>
+
+    <!-- Sign Microsoft.TestPlatform.Build -->
+    <ItemGroup>
+      <BuildAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.Build\netstandard1.3\Microsoft.TestPlatform.Build.dll" />
+    </ItemGroup>
+
+    <!-- Sign Microsoft.TestPlatform.TestHost -->
+    <ItemGroup>
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\testhost.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.TestPlatform.CommunicationUtilities.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.TestPlatform.CrossPlatEngine.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.VisualStudio.TestPlatform.Common.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.TestPlatform.CoreUtilities.dll" />
+
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\$(TargetRuntime)\Microsoft.TestPlatform.CommunicationUtilities.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\$(TargetRuntime)\Microsoft.TestPlatform.CoreUtilities.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\$(TargetRuntime)\Microsoft.TestPlatform.CrossPlatEngine.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\$(TargetRuntime)\Microsoft.VisualStudio.TestPlatform.Common.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\$(TargetRuntime)\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\$(TargetRuntime)\testhost.exe" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net46\$(TargetRuntime)\testhost.x86.exe" />
+    </ItemGroup>
+
     <ItemGroup>
       <AssembliesToSign>
         <Authenticode>Microsoft</Authenticode>
         <StrongName>StrongName</StrongName>
       </AssembliesToSign>
+
+      <CoreAssembliesToSign>
+        <Authenticode>Microsoft</Authenticode>
+        <StrongName>StrongName</StrongName>
+      </CoreAssembliesToSign>
+
+      <BuildAssembliesToSign>
+        <Authenticode>Microsoft</Authenticode>
+        <StrongName>StrongName</StrongName>
+      </BuildAssembliesToSign>
+
+      <TestHostCoreAssembliesToSign>
+        <Authenticode>Microsoft</Authenticode>
+        <StrongName>StrongName</StrongName>
+      </TestHostCoreAssembliesToSign>
     </ItemGroup>
 
     <Message Text="Signing using authenticode certificate '%(AssembliesToSign.Authenticode)' for @(AssembliesToSign)"/>
     <SignFiles Files="@(AssembliesToSign)"
                BinariesDirectory="$(ArtifactsDirectory)"
+               IntermediatesDirectory="$(IntermediatesDirectory)"
+               Type="$(SignType)" />
+
+    <Message Text="Signing using authenticode certificate '%(AssembliesToSign.Authenticode)' for @(CoreAssembliesToSign)"/>
+    <SignFiles Files="@(CoreAssembliesToSign)"
+               BinariesDirectory="$(ArtifactsCoreDirectory)"
+               IntermediatesDirectory="$(IntermediatesDirectory)"
+               Type="$(SignType)" />
+
+    <Message Text="Signing using authenticode certificate '%(AssembliesToSign.Authenticode)' for @(BuildAssembliesToSign)"/>
+    <SignFiles Files="@(BuildAssembliesToSign)"
+               BinariesDirectory="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.Build"
+               IntermediatesDirectory="$(IntermediatesDirectory)"
+               Type="$(SignType)" />
+
+    <Message Text="Signing using authenticode certificate '%(AssembliesToSign.Authenticode)' for @(TestHostCoreAssembliesToSign)"/>
+    <SignFiles Files="@(TestHostCoreAssembliesToSign)"
+               BinariesDirectory="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost"
                IntermediatesDirectory="$(IntermediatesDirectory)"
                Type="$(SignType)" />
   </Target>


### PR DESCRIPTION
This reverts commit cda399a4b16bd37bba8b3d8018a9384348f0a65b.

dotnet-build is unable to load microbuild tasks.