### PR TITLE
TestCase ID Generation algorithm to  SHA1 on par with TPV1

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/Utilities/EqtHash.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Utilities/EqtHash.cs
@@ -7,9 +7,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
 
-#if NET46
-using System.Security.Cryptography;
-#endif
+    using System.Security.Cryptography;
 
     /// <summary>
     /// Wrapper class for cryptographic hashing.
@@ -25,11 +23,13 @@ using System.Security.Cryptography;
         public static Guid GuidFromString(string data)
         {
             Debug.Assert(data != null);
-#if NET46
+            // Do NOT change the algorithm ever as this will have compat implications
+            // TC-TA team has a feature in VS where workitems are associated based on TestCase Ids
+            // If Algorithm changes, then all the bugs/workitems filed in TFS Server against a given TestCase become unassociated if IDs change
+            // Any algorithm or logic change must require a sign off from feature owners of above
+            // Also, TPV2 and TPV1 must use same Algorithm until the time TPV1 is completely deleted to be on-par
+            // If LUT or .Net core scenario uses TPV2 to discover, but if it uses TPV1 in Devenv, then there will be testcase matching issues
             using (HashAlgorithm provider = SHA1.Create())
-#else
-            using (var provider = System.Security.Cryptography.SHA256.Create())
-#endif
             {
                 byte[] hash = provider.ComputeHash(System.Text.Encoding.Unicode.GetBytes(data));
 

--- a/src/Microsoft.TestPlatform.ObjectModel/Utilities/EqtHash.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Utilities/EqtHash.cs
@@ -26,7 +26,7 @@ using System.Security.Cryptography;
         {
             Debug.Assert(data != null);
 #if NET46
-            using (HashAlgorithm provider = new SHA256CryptoServiceProvider())
+            using (HashAlgorithm provider = SHA1.Create())
 #else
             using (var provider = System.Security.Cryptography.SHA256.Create())
 #endif


### PR DESCRIPTION
Change algorithm to SHA1 to be in compat with Associate-WorkItem scenarios

Also TPV1 and TPV2 should use same algorithm since Devenv uses TPV1 even if LUT
Or .NetCore use TPV2