### PR TITLE
Fix assembly loading in symbol loader.

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/Navigation/PortableSymbolReader.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Navigation/PortableSymbolReader.cs
@@ -93,8 +93,10 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Navigation
                 var pdbFilePath = Path.ChangeExtension(binaryPath, ".pdb");
                 using (var pdbReader = new PortablePdbReader(new FileHelper().GetStream(pdbFilePath, FileMode.Open, FileAccess.Read)))
                 {
-                    // Load assembly
-                    var asm = AssemblyLoadContext.Default.LoadFromAssemblyPath(binaryPath);
+                    // At this point, the assembly should be already loaded into the load context. We query for a reference to
+                    // find the types and cache the symbol information. Let the loader follow default lookup order instead of
+                    // forcing load from a specific path.
+                    var asm = Assembly.Load(AssemblyLoadContext.GetAssemblyName(binaryPath));
 
                     foreach (var type in asm.GetTypes())
                     {


### PR DESCRIPTION
Instead of attempting to load the test assembly, try to query for it. It should
have been already loaded by the test adapter.

In netcoreapp1.1, attempting to load the same executable within itself throws.