### PR TITLE
Find vstest.console.dll from the same directory where Microsoft.TestPlatform.targets reside

### DIFF
--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
@@ -13,7 +13,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Load Microsoft.TestPlatform.Build.Tasks.dll, this can be overridden to use a different version with $(VSTestTaskAssemblyFile) -->
   <PropertyGroup>
     <VSTestTaskAssemblyFile Condition="$(VSTestTaskAssemblyFile) == ''">Microsoft.TestPlatform.Build.dll</VSTestTaskAssemblyFile>
-    <VSTestConsoleFile Condition="$(VSTestConsoleFile) == ''">vstest.console.dll</VSTestConsoleFile>
+    <VSTestConsoleFile Condition="$(VSTestConsoleFile) == ''">$([System.IO.Path]::Combine($(MSBuildThisFileDirectory),"vstest.console.dll"))</VSTestConsoleFile>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <UsingTask TaskName="Microsoft.TestPlatform.Build.Tasks.VSTestTask" AssemblyFile="$(VSTestTaskAssemblyFile)" />
@@ -78,6 +78,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Message Text="VSTestDiag = $(VSTestDiag)" Importance="low" />
     <Message Text="VSTestCLIRunSettings = $(VSTestCLIRunSettings)" Importance="low" />
     <Message Text="VSTestResultsDirectory = $(VSTestResultsDirectory)" Importance="low" />
+    <Message Text="VSTestConsolePath = $(VSTestConsolePath)" Importance="low" />
   </Target>
 
 </Project>

--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
@@ -13,7 +13,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Load Microsoft.TestPlatform.Build.Tasks.dll, this can be overridden to use a different version with $(VSTestTaskAssemblyFile) -->
   <PropertyGroup>
     <VSTestTaskAssemblyFile Condition="$(VSTestTaskAssemblyFile) == ''">Microsoft.TestPlatform.Build.dll</VSTestTaskAssemblyFile>
-    <VSTestConsoleFile Condition="$(VSTestConsoleFile) == ''">$([System.IO.Path]::Combine($(MSBuildThisFileDirectory),"vstest.console.dll"))</VSTestConsoleFile>
+    <VSTestConsolePath Condition="$(VSTestConsoleFile) == ''">$([System.IO.Path]::Combine($(MSBuildThisFileDirectory),"vstest.console.dll"))</VSTestConsolePath>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <UsingTask TaskName="Microsoft.TestPlatform.Build.Tasks.VSTestTask" AssemblyFile="$(VSTestTaskAssemblyFile)" />
@@ -41,7 +41,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       VSTestListTests="$(VSTestListTests)"
       VSTestDiag="$(VSTestDiag)"
       VSTestCLIRunSettings="$(VSTestCLIRunSettings)"
-      VSTestConsolePath="$(VSTestConsoleFile)"
+      VSTestConsolePath="$(VSTestConsolePath)"
       VSTestResultsDirectory="$(VSTestResultsDirectory)"
     />
   </Target>


### PR DESCRIPTION
Issue: dotnet test is failing because the it is not able to find vstest.console.dll. The reason why it is not able to find vstest.console.dll  is that we are passing VSTestConsolePath ( whose current value is "vatest.console.dll") to VSTestTask which uses it as it is to create a processThis process Current working is the directory from where we are running test, hence it is not able to resolve vstets.console.dll.

Fix: Find full path of vstest.console.dll and pass it to VSTestTask.


Test Plan:
1) Manually validated the scenario by replacing Microsoft.TestPlatform.targets and Micrsosoft.Testplatform.build.dll
2) Manually enable trace log and verified that right path is getting pass to VstestTask.