### PR TITLE
Relative Path Fix

### DIFF
--- a/src/Microsoft.TestPlatform.CoreUtilities/Helpers/FileHelper.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Helpers/FileHelper.cs
@@ -23,6 +23,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities.Helpers
         }
 
         /// <inheritdoc/>
+        public string GetCurrentDirectory()
+        {
+            return Directory.GetCurrentDirectory();
+        }
+
+        /// <inheritdoc/>
         public bool Exists(string path)
         {
             return File.Exists(path);
@@ -52,5 +58,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities.Helpers
         {
             return new FileInfo(path).Attributes;
         }
+
+
     }
 }

--- a/src/Microsoft.TestPlatform.CoreUtilities/Helpers/Interfaces/IFileHelper.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Helpers/Interfaces/IFileHelper.cs
@@ -19,6 +19,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces
         DirectoryInfo CreateDirectory(string path);
 
         /// <summary>
+        /// Gets the current directory
+        /// </summary>
+        /// <returns>Current directory</returns>
+        string GetCurrentDirectory();
+
+        /// <summary>
         /// Exists utility to check if file exists (case sensitive).
         /// </summary>
         /// <param name="path"> The path of file. </param>

--- a/src/vstest.console/CommandLine/CommandLineOptions.cs
+++ b/src/vstest.console/CommandLine/CommandLineOptions.cs
@@ -14,6 +14,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine
     using Utilities.Helpers.Interfaces;
 
     using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;
+    using System.IO;
 
     /// <summary>
     /// Provides access to the command-line options.
@@ -253,6 +254,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine
             }
 
             source = source.Trim();
+
+            // Convert the relative path to absolute path
+            if(!Path.IsPathRooted(source))
+            {
+                source = Path.Combine(FileHelper.GetCurrentDirectory(), source);
+            }
+
             if (!FileHelper.Exists(source))
             {
                 throw new CommandLineException(

--- a/test/vstest.console.UnitTests/CommandLine/CommandLineOptionsTests.cs
+++ b/test/vstest.console.UnitTests/CommandLine/CommandLineOptionsTests.cs
@@ -10,17 +10,20 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.CommandLine
     using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
+    using System.IO;
 
     [TestClass]
     public class CommandLineOptionsTests
     {
         private readonly Mock<IFileHelper> fileHelper;
+        private readonly string currentDirectory = @"C:\\Temp";
 
         public CommandLineOptionsTests()
         {
             this.fileHelper = new Mock<IFileHelper>();
             CommandLineOptions.Instance.Reset();
             CommandLineOptions.Instance.FileHelper = this.fileHelper.Object;
+            this.fileHelper.Setup(fh => fh.GetCurrentDirectory()).Returns(currentDirectory);
         }
 
         [TestMethod]
@@ -57,6 +60,18 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.CommandLine
         {
             Assert.ThrowsException<CommandLineException>(() => CommandLineOptions.Instance.AddSource(null));
         }
+
+        [TestMethod]
+        public void CommandLineOptionsAddSourceShouldConvertRelativePathToAbsolutePath()
+        {
+            string relativeTestFilePath = "DummyTestFile.txt";
+            var absolutePath = Path.Combine(currentDirectory, relativeTestFilePath);
+            this.fileHelper.Setup(fh => fh.Exists(absolutePath)).Returns(true);
+
+            // Pass relative path
+            CommandLineOptions.Instance.AddSource(relativeTestFilePath);
+            Assert.IsTrue(CommandLineOptions.Instance.Sources.Contains(absolutePath));
+        }
         
         [TestMethod]
         public void CommandLineOptionsAddSourceShouldThrowCommandLineExceptionForInvalidSource()
@@ -67,7 +82,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.CommandLine
         [TestMethod]
         public void CommandLineOptionsAddSourceShouldAddSourceThrowExceptionIfDuplicateSource()
         {
-            var testFilePath = "DummyTestFile.txt";
+            var testFilePath = "C:\\DummyTestFile.txt";
             this.fileHelper.Setup(fh => fh.Exists(testFilePath)).Returns(true);
 
             CommandLineOptions.Instance.AddSource(testFilePath);
@@ -78,7 +93,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.CommandLine
         [TestMethod]
         public void CommandLineOptionsAddSourceShouldAddSourceForValidSource()
         {
-            string testFilePath = "DummyTestFile.txt";
+            string testFilePath = "C:\\DummyTestFile.txt";
             this.fileHelper.Setup(fh => fh.Exists(testFilePath)).Returns(true);
             
             CommandLineOptions.Instance.AddSource(testFilePath);


### PR DESCRIPTION
Fix for converting the relative path to absolute path for the test source.

Validations:
- Ran all the tests.
- CLI scenarios:
dotnet test <path>
dotnet vstest <path>
vstest.console <path>
- IDE and LUT.