### PR TITLE
Reverting the version of Microsoft.Extensions.DependencyModel 

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Microsoft.TestPlatform.CrossPlatEngine.csproj
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Microsoft.TestPlatform.CrossPlatEngine.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyModel">
-      <Version>1.1.0</Version>
+      <Version>1.0.1-beta-000933</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">


### PR DESCRIPTION
Reverting the version of Microsoft.Extensions.DependencyModel as it is not working in dotnet cli
