### PR TITLE
Send error message in sdtout

### DIFF
--- a/src/Microsoft.TestPlatform.CoreUtilities/Output/ConsoleOutput.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Output/ConsoleOutput.cs
@@ -72,12 +72,17 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
             {
                 case OutputLevel.Information:
                 case OutputLevel.Warning:
-                case OutputLevel.Error:
                     this.standardOutput.Write(message);
                     break;
+
+                case OutputLevel.Error:
+                    this.standardError.Write(message);
+                    break;
+
                 default:
                     this.standardOutput.Write("ConsoleOutput.WriteLine: The output level is unrecognized: {0}", level);
                     break;
+
             }
         }
     }

--- a/src/Microsoft.TestPlatform.CoreUtilities/Output/ConsoleOutput.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Output/ConsoleOutput.cs
@@ -72,13 +72,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
             {
                 case OutputLevel.Information:
                 case OutputLevel.Warning:
+                case OutputLevel.Error:
                     this.standardOutput.Write(message);
                     break;
-
-                case OutputLevel.Error:
-                    this.standardError.Write(message);
-                    break;
-
                 default:
                     this.standardOutput.Write("ConsoleOutput.WriteLine: The output level is unrecognized: {0}", level);
                     break;

--- a/src/Microsoft.TestPlatform.CoreUtilities/Output/ConsoleOutput.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Output/ConsoleOutput.cs
@@ -82,7 +82,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
                 default:
                     this.standardOutput.Write("ConsoleOutput.WriteLine: The output level is unrecognized: {0}", level);
                     break;
-
             }
         }
     }

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -175,7 +175,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
                 hasData = true;
                 Output.WriteLine(CommandLineResources.ErrorMessageBanner, OutputLevel.Error);
                 string errorMessage = String.Format(CultureInfo.CurrentCulture, "{0}{1}", TestMessageFormattingPrefix, result.ErrorMessage);
-                Output.WriteLine(errorMessage, OutputLevel.Error);
+                Output.WriteLine(errorMessage, OutputLevel.Information);
             }
 
             if (!String.IsNullOrEmpty(result.ErrorStackTrace))
@@ -183,7 +183,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
                 hasData = true;
                 Output.WriteLine(CommandLineResources.StacktraceBanner, OutputLevel.Error);
                 string stackTrace = String.Format(CultureInfo.CurrentCulture, "{0}", result.ErrorStackTrace);
-                Output.Write(stackTrace, OutputLevel.Error);
+                Output.Write(stackTrace, OutputLevel.Information);
             }
 
             Collection<TestResultMessage> stdOutMessagesCollection = GetTestMessages(result.Messages, TestResultMessage.StandardOutCategory);

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -195,7 +195,7 @@ namespace Microsoft.TestPlatform.TestUtilities
                 Assert.IsTrue(flag, "Test {0} does not appear in failed tests list.", test);
 
                 // Verify stack information as well.
-                Assert.IsTrue(this.standardTestError.Contains(GetTestMethodName(test)), "No stack trace for failed test: {0}", test);
+                Assert.IsTrue(this.standardTestOutput.Contains(GetTestMethodName(test)), "No stack trace for failed test: {0}", test);
             }
         }
 


### PR DESCRIPTION
Issue: https://github.com/Microsoft/vstest/issues/285

Fix: Send error message of TestMethod in stdout

Validation: Manually validated the scenario with vstest.console.exe and "dotnet test"