### PR TITLE
Console Logger related fixes.

### DIFF
--- a/src/Microsoft.TestPlatform.Common/Logging/TestLoggerManager.cs
+++ b/src/Microsoft.TestPlatform.Common/Logging/TestLoggerManager.cs
@@ -65,11 +65,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Logging
         /// <summary>
         /// Default constructor.
         /// </summary>
-        protected TestLoggerManager()
+        protected TestLoggerManager(TestSessionMessageLogger sessionLogger, InternalTestLoggerEvents loggerEvents)
         {
-            this.messageLogger = TestSessionMessageLogger.Instance;
+            this.messageLogger = sessionLogger;
             this.testLoggerExtensionManager = TestLoggerExtensionManager.Create(messageLogger);
-            this.loggerEvents = new InternalTestLoggerEvents((TestSessionMessageLogger)messageLogger);
+            this.loggerEvents = loggerEvents;
         }
 
         /// <summary>
@@ -85,7 +85,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Logging
                     {
                         if (testLoggerManager == null)
                         {
-                            testLoggerManager = new TestLoggerManager();
+                            testLoggerManager = new TestLoggerManager(TestSessionMessageLogger.Instance,
+                                new InternalTestLoggerEvents(TestSessionMessageLogger.Instance));
                         }
                     }
                 }
@@ -159,7 +160,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Logging
                 {
                     if (logger.Value is ITestLoggerWithParameters)
                     {
-                        ((ITestLoggerWithParameters)logger.Value).Initialize(this.loggerEvents, this.UpdateLoggerParamters(parameters));
+                        ((ITestLoggerWithParameters)logger.Value).Initialize(this.loggerEvents, this.UpdateLoggerParameters(parameters));
                     }
                     else
                     {
@@ -376,7 +377,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Logging
         /// <summary>
         /// Populates user supplied and default logger parameters.
         /// </summary>
-        private Dictionary<string, string> UpdateLoggerParamters(Dictionary<string, string> parameters)
+        private Dictionary<string, string> UpdateLoggerParameters(Dictionary<string, string> parameters)
         {
             var loggerParams = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             if (parameters != null)
@@ -425,7 +426,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Logging
         {
             this.loggerEvents.CompleteTestRun(e.TestRunStatistics, e.IsCanceled, e.IsAborted, e.Error, e.AttachmentSets, e.ElapsedTimeInRunningTests);
         }
-
 
         /// <summary>
         /// Called when data collection message is received.

--- a/src/Microsoft.TestPlatform.Common/Logging/TestLoggerManager.cs
+++ b/src/Microsoft.TestPlatform.Common/Logging/TestLoggerManager.cs
@@ -130,6 +130,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Logging
 
         #region Public Methods
 
+        /// <summary>
+        /// Add and initialize the logger with the given parameters
+        /// </summary>
+        /// <param name="logger">The logger that needs to be initialized</param>
+        /// <param name="extensionUri">URI of the logger</param>
+        /// <param name="parameters">Logger parameters</param>
         public void AddLogger(ITestLogger logger, string extensionUri, Dictionary<string, string> parameters)
         {
             this.CheckDisposed();

--- a/src/Microsoft.TestPlatform.Common/Logging/TestLoggerManager.cs
+++ b/src/Microsoft.TestPlatform.Common/Logging/TestLoggerManager.cs
@@ -130,6 +130,19 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Logging
 
         #region Public Methods
 
+        public void AddLogger(ITestLogger logger, string extensionUri, Dictionary<string, string> parameters)
+        {
+            this.CheckDisposed();
+
+            // If the logger has already been initialized just return.
+            if (this.initializedLoggers.Contains(extensionUri, StringComparer.OrdinalIgnoreCase))
+            {
+                return;
+            }
+            this.initializedLoggers.Add(extensionUri);
+            InitializeLogger(logger, extensionUri, parameters);
+        }
+
         /// <summary>
         /// Adds the logger with the specified URI and parameters.
         /// For ex. TfsPublisher takes parameters such as  Platform, Flavor etc.
@@ -154,37 +167,40 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Logging
             var extensionManager = this.testLoggerExtensionManager;
             var logger = extensionManager.TryGetTestExtension(uri.AbsoluteUri);
 
-            if (logger != null)
-            {
-                try
-                {
-                    if (logger.Value is ITestLoggerWithParameters)
-                    {
-                        ((ITestLoggerWithParameters)logger.Value).Initialize(this.loggerEvents, this.UpdateLoggerParameters(parameters));
-                    }
-                    else
-                    {
-                        ((ITestLogger)logger.Value).Initialize(this.loggerEvents, this.GetResultsDirectory(RunSettingsManager.Instance.ActiveRunSettings));
-                    }
-                }
-                catch (Exception e)
-                {
-                    this.messageLogger.SendMessage(
-                        TestMessageLevel.Error,
-                        string.Format(
-                            CultureInfo.CurrentUICulture,
-                            CommonResources.LoggerInitializationError,
-                            logger.Metadata.ExtensionUri,
-                            e));
-                }
-            }
-            else
+            if (logger == null)
             {
                 throw new InvalidOperationException(
                     String.Format(
                         CultureInfo.CurrentUICulture,
                         CommonResources.LoggerNotFound,
                         uri.OriginalString));
+            }
+
+            InitializeLogger(logger.Value, logger.Metadata.ExtensionUri, parameters);
+        }
+
+        private void InitializeLogger(ITestLogger logger, string extensionUri, Dictionary<string, string> parameters)
+        {
+            try
+            {
+                if (logger is ITestLoggerWithParameters)
+                {
+                    ((ITestLoggerWithParameters)logger).Initialize(this.loggerEvents, this.UpdateLoggerParameters(parameters));
+                }
+                else
+                {
+                    ((ITestLogger)logger).Initialize(this.loggerEvents, this.GetResultsDirectory(RunSettingsManager.Instance.ActiveRunSettings));
+                }
+            }
+            catch (Exception e)
+            {
+                this.messageLogger.SendMessage(
+                    TestMessageLevel.Error,
+                    string.Format(
+                        CultureInfo.CurrentUICulture,
+                        CommonResources.LoggerInitializationError,
+                        extensionUri,
+                        e));
             }
         }
 

--- a/src/vstest.console/CommandLine/CommandLineOptions.cs
+++ b/src/vstest.console/CommandLine/CommandLineOptions.cs
@@ -129,6 +129,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine
         public string TestAdapterPath { get; set; }
 
         /// <summary>
+        /// True if console runner is running in design mode. 
+        /// </summary>
+        public bool IsDesignMode { get; set; }
+
+        /// <summary>
         /// Process Id of the process which launched vstest runner
         /// </summary>
         public int ParentProcessId { get; set; }

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -142,9 +142,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
             }
 
             var verbosityExists = parameters.TryGetValue(ConsoleLogger.VerbosityParam, out string verbosity);
-            if (verbosityExists && Enum.Parse(typeof(Verbosity), verbosity, ignoreCase:true).Equals(Verbosity.Minimal))
+            if (verbosityExists && Enum.TryParse(verbosity, true, out Verbosity verbosityLevel))
             {
-                this.verbosityLevel = Verbosity.Minimal;
+                this.verbosityLevel = verbosityLevel;
             }
 
             this.Initialize(events, String.Empty);

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -45,17 +45,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
 
         #endregion
 
-        public class Verbosity
+        internal enum Verbosity
         {
-            public static Verbosity Minimal = new Verbosity("minimal");
-            public static Verbosity Normal = new Verbosity("normal");
-
-            public string level;
-
-            Verbosity(string level)
-            {
-                this.level = level;
-            }
+            Minimal,
+            Normal
         }
 
         #region Fields
@@ -103,9 +96,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
             get;
             private set;
         }
+
+        /// <summary>
+        /// Get the verbosity level for the console logger
+        /// </summary>
+        public Verbosity VerbosityLevel => verbosityLevel;
+        
         #endregion
 
-        #region ITestLogger
+        #region ITestLoggerWithParameters
 
         /// <summary>
         /// Initializes the Test Logger.
@@ -142,8 +141,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
                 throw new ArgumentException("No default parameters added", nameof(parameters));
             }
 
-            var verbosityExists = parameters.TryGetValue(ConsoleLogger.VerbosityParam, out string verbosityLevel);
-            if (verbosityExists && verbosityLevel.Equals(Verbosity.Minimal.level))
+            var verbosityExists = parameters.TryGetValue(ConsoleLogger.VerbosityParam, out string verbosity);
+            if (verbosityExists && Enum.Parse(typeof(Verbosity), verbosity, ignoreCase:true).Equals(Verbosity.Minimal))
             {
                 this.verbosityLevel = Verbosity.Minimal;
             }

--- a/src/vstest.console/Processors/EnableLoggerArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnableLoggerArgumentProcessor.cs
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
     using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities;
 
     using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;
+    using Microsoft.VisualStudio.TestPlatform.CommandLine.Internal;
 
     /// <summary>
     /// An argument processor that allows the user to enable a specific logger
@@ -154,25 +155,32 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
 
                 if (parseSucceeded)
                 {
-                    // First assume the logger is specified by URI. If that fails try with friendly name.
-                    try
+                    if (loggerIdentifier == "console")
                     {
-                        this.AddLoggerByUri(loggerIdentifier, parameters);
+                        this.loggerManager.AddLogger(new ConsoleLogger(), ConsoleLogger.ExtensionUri, parameters);
                     }
-                    catch (CommandLineException)
+                    else
                     {
-                        string loggerUri;
-                        if (this.loggerManager.TryGetUriFromFriendlyName(loggerIdentifier, out loggerUri))
+                        // First assume the logger is specified by URI. If that fails try with friendly name.
+                        try
                         {
-                            this.AddLoggerByUri(loggerUri, parameters);
+                            this.AddLoggerByUri(loggerIdentifier, parameters);
                         }
-                        else
+                        catch (CommandLineException)
                         {
-                            throw new CommandLineException(
-                            String.Format(
-                            CultureInfo.CurrentUICulture,
-                            CommandLineResources.LoggerNotFound,
-                            argument));
+                            string loggerUri;
+                            if (this.loggerManager.TryGetUriFromFriendlyName(loggerIdentifier, out loggerUri))
+                            {
+                                this.AddLoggerByUri(loggerUri, parameters);
+                            }
+                            else
+                            {
+                                throw new CommandLineException(
+                                String.Format(
+                                CultureInfo.CurrentUICulture,
+                                CommandLineResources.LoggerNotFound,
+                                argument));
+                            }
                         }
                     }
                 }

--- a/src/vstest.console/Processors/EnableLoggerArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnableLoggerArgumentProcessor.cs
@@ -155,7 +155,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
 
                 if (parseSucceeded)
                 {
-                    if (loggerIdentifier == "console")
+                    if (loggerIdentifier.Equals(ConsoleLogger.FriendlyName, StringComparison.OrdinalIgnoreCase))
                     {
                         this.loggerManager.AddLogger(new ConsoleLogger(), ConsoleLogger.ExtensionUri, parameters);
                     }

--- a/src/vstest.console/Processors/ParentProcessIdArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ParentProcessIdArgumentProcessor.cs
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
 
         public override bool IsAction => false;
 
-        public override ArgumentProcessorPriority Priority => ArgumentProcessorPriority.ParentProcessId;
+        public override ArgumentProcessorPriority Priority => ArgumentProcessorPriority.DesignMode;
 
         public override string HelpContentResourceName => CommandLineResources.ParentProcessIdArgumentHelp;
 

--- a/src/vstest.console/Processors/PortArgumentProcessor.cs
+++ b/src/vstest.console/Processors/PortArgumentProcessor.cs
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
 
         public override bool IsAction => false;
 
-        public override ArgumentProcessorPriority Priority => ArgumentProcessorPriority.Normal;
+        public override ArgumentProcessorPriority Priority => ArgumentProcessorPriority.DesignMode;
 
         public override string HelpContentResourceName => CommandLineResources.PortArgumentHelp;
 
@@ -152,20 +152,20 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
         /// <param name="argument">Argument that was provided with the command.</param>
         public void Initialize(string argument)
         {
-            int portNumber;
-            if (string.IsNullOrWhiteSpace(argument) || !int.TryParse(argument, out portNumber))
+            if (string.IsNullOrWhiteSpace(argument) || !int.TryParse(argument, out int portNumber))
             {
                 throw new CommandLineException(CommandLineResources.InvalidPortArgument);
             }
 
             this.commandLineOptions.Port = portNumber;
+            this.commandLineOptions.IsDesignMode = true;
             this.designModeClient = this.designModeInitializer?.Invoke(this.commandLineOptions.ParentProcessId);
         }
 
         /// <summary>
-        /// The port is already set, return success.
+        /// Initialize the design mode client.
         /// </summary>
-        /// <returns> The <see cref="ArgumentProcessorResult"/> Success </returns>
+        /// <returns> The <see cref="ArgumentProcessorResult.Success"/> if initialization is successful. </returns>
         public ArgumentProcessorResult Execute()
         {
             try

--- a/src/vstest.console/Processors/RunTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunTestsArgumentProcessor.cs
@@ -148,6 +148,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             Contract.Assert(this.commandLineOptions != null);
             Contract.Assert(!string.IsNullOrWhiteSpace(this.runSettingsManager?.ActiveRunSettings?.SettingsXml));
 
+            if(this.commandLineOptions.IsDesignMode)
+            {
+                // Do not attempt execution in case of design mode. Expect execution to happen
+                // via the design mode client.
+                return ArgumentProcessorResult.Success;
+            }
+
             // Ensure a test source file was provided
             var anySource = this.commandLineOptions.Sources.FirstOrDefault();
             if (anySource == null)

--- a/src/vstest.console/Processors/RunTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunTestsArgumentProcessor.cs
@@ -148,7 +148,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             Contract.Assert(this.commandLineOptions != null);
             Contract.Assert(!string.IsNullOrWhiteSpace(this.runSettingsManager?.ActiveRunSettings?.SettingsXml));
 
-            if(this.commandLineOptions.IsDesignMode)
+            if (this.commandLineOptions.IsDesignMode)
             {
                 // Do not attempt execution in case of design mode. Expect execution to happen
                 // via the design mode client.
@@ -191,7 +191,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             // for command line keep alive is always false.
             // for Windows Store apps it should be false, as Windows Store apps executor should terminate after finishing the test execution.
             var keepAlive = false;
-            
+
             var runRequestPayload = new TestRunRequestPayload() { Sources = this.commandLineOptions.Sources.ToList(), RunSettings = runSettings, KeepAlive = keepAlive };
             var result = this.testRequestManager.RunTests(runRequestPayload, null, this.testRunEventsRegistrar);
 

--- a/src/vstest.console/Processors/Utilities/ArgumentProcessorPriority.cs
+++ b/src/vstest.console/Processors/Utilities/ArgumentProcessorPriority.cs
@@ -19,53 +19,54 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
         Help = Maximum,
 
         /// <summary>
+        /// Priority of the Diag processor.
+        /// </summary>
+        Diag = 1,
+
+        /// <summary>
+        /// Priority of processors related to design mode. This needs to be higher priority
+        /// since some of the functionalities (like logger) depend on this.
+        /// </summary>
+        DesignMode = 2,
+
+        /// <summary>
         /// Priority of UseVsixArgumentProcessor.
-        /// The priority of useVsix processor is more than the logger because logger’s initialization 
+        /// The priority of useVsix processor is more than the logger because logger initialization 
         /// loads the extensions which are incomplete if vsix processor is enabled
         /// </summary>
-        VsixExtensions = 1,
+        VsixExtensions = 5,
 
         /// <summary>
         /// Priority of TestAdapterPathArgumentProcessor.
-        /// The priority of TestAdapterPath processor is more than the logger because logger’s initialization 
+        /// The priority of TestAdapterPath processor is more than the logger because logger initialization 
         /// loads the extensions which are incomplete if custom test adapter is enabled
         /// </summary>
-        TestAdapterPath = 1,
+        TestAdapterPath = 6,
 
         /// <summary>
         /// Priority of processors related to Run Settings.
         /// </summary>
-        RunSettings = 3,
+        RunSettings = 10,
 
         /// <summary>
         /// Priority of processors that needs to update runsettings.
         /// </summary>
-        AutoUpdateRunSettings = 5,
+        AutoUpdateRunSettings = 11,
 
         /// <summary>
         /// Priority of processors related to CLI Run Settings.
         /// </summary>
-        CLIRunSettings = 6,
+        CLIRunSettings = 12,
 
         /// <summary>
         /// Priority of processors related to logging.
         /// </summary>
-        Logging = 10,
+        Logging = 20,
 
         /// <summary>
         /// Priority of the StartLogging processor.
         /// </summary>
-        StartLogging = 11,
-
-        /// <summary>
-        /// Priority of the Diag processor.
-        /// </summary>
-        Diag = 12,
-
-        /// <summary>
-        /// Priority of a ParentProcessId processor.
-        /// </summary>
-        ParentProcessId = 45,
+        StartLogging = 21,
 
         /// <summary>
         /// Priority of a typical processor.

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -69,10 +69,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
             // Always enable logging for discovery or run requests
             this.testLoggerManager.EnableLogging();
 
-            // TODO: Is this required for design mode
-            // Add console logger as a listener to logger events.
-            var consoleLogger = new ConsoleLogger();
-            consoleLogger.Initialize(this.testLoggerManager.LoggerEvents, null);
+            if (!this.commandLineOptions.IsDesignMode)
+            {
+                var consoleLogger = new ConsoleLogger();
+                consoleLogger.Initialize(this.testLoggerManager.LoggerEvents, null);
+            }
         }
 
         #endregion

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -72,8 +72,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
             if (!this.commandLineOptions.IsDesignMode)
             {
                 var consoleLogger = new ConsoleLogger();
-                consoleLogger.Initialize(this.testLoggerManager.LoggerEvents, null);
-            }
+                this.testLoggerManager.AddLogger(consoleLogger, ConsoleLogger.ExtensionUri, null);
+             }
         }
 
         #endregion

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Logging/TestLoggerManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Logging/TestLoggerManagerTests.cs
@@ -431,7 +431,7 @@ namespace TestPlatform.Common.UnitTests.Logging
 
         internal class DummyTestLoggerManager : TestLoggerManager
         {
-            public DummyTestLoggerManager()
+            public DummyTestLoggerManager() : base(TestSessionMessageLogger.Instance, new InternalTestLoggerEvents(TestSessionMessageLogger.Instance)) 
             {
 
             }

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -101,6 +101,16 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
         }
 
         [TestMethod]
+        public void InitializeWithParametersShouldDefaultToNormalVerbosityLevelForInvalidVerbosity()
+        {
+            var parameters = new Dictionary<string, string>();
+            parameters.Add("verbosity", "random");
+            this.consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, parameters);
+
+            Assert.AreEqual(ConsoleLogger.Verbosity.Normal, this.consoleLogger.VerbosityLevel);
+        }
+
+        [TestMethod]
         public void TestMessageHandlerShouldThrowExceptionIfEventArgsIsNull()
         {
             // Raise an event on mock object
@@ -160,7 +170,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
             parameters.Add("verbosity", "minimal");
             this.consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, parameters);
 
-            var eventArgs = new T estRunChangedEventArgs(null, this.GetTestResultsObject(), null);
+            var eventArgs = new TestRunChangedEventArgs(null, this.GetTestResultsObject(), null);
 
             // Raise an event on mock object
             this.testRunRequest.Raise(m => m.OnRunStatsChange += null, eventArgs);

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -51,14 +51,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
         {
             Assert.ThrowsException<ArgumentNullException>(() =>
             {
-                this.consoleLogger.Initialize(null, null);
+                this.consoleLogger.Initialize(null, string.Empty);
             });
         }
 
         [TestMethod]
         public void InitializeShouldNotThrowExceptionIfEventsIsNotNull()
         {
-            this.consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, null);
+            this.consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, string.Empty);
         }
 
         [TestMethod]
@@ -252,7 +252,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
             this.mockOutput = new Mock<IOutput>();
 
             this.consoleLogger = new ConsoleLogger(this.mockOutput.Object);
-            this.consoleLogger.Initialize(this.events.Object, null);
+            this.consoleLogger.Initialize(this.events.Object, string.Empty);
 
             DummyTestLoggerManager.Cleanup();
 

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
     using Microsoft.VisualStudio.TestPlatform.Utilities;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-
+    using vstest.console.UnitTests.TestDoubles;
     using Moq;
 
     using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;

--- a/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
@@ -6,10 +6,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
     using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
     using Microsoft.VisualStudio.TestPlatform.Common.Logging;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using System;
-    using System.Collections.Generic;
-
-    using Castle.DynamicProxy.Contributors;
+    using vstest.console.UnitTests.TestDoubles;
 
     [TestClass]
     public class EnableLoggersArgumentProcessorTests
@@ -49,7 +46,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual(false, capabilities.AlwaysExecute);
             Assert.AreEqual(false, capabilities.IsSpecialCommand);
         }
-
 
         [TestMethod]
         public void ExecutorInitializeWithNullOrEmptyArgumentsShouldThrowException()
@@ -92,27 +88,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             var executor = new EnableLoggerArgumentExecutor(null);
             var result = executor.Execute();
             Assert.AreEqual(ArgumentProcessorResult.Success, result);
-        }
-    }
-
-    internal class DummyTestLoggerManager : TestLoggerManager
-    {
-        public DummyTestLoggerManager()
-        {
-
-        }
-
-        public HashSet<String> GetInitializedLoggers
-        {
-            get
-            {
-                return InitializedLoggers;
-            }
-        }
-
-        public static void Cleanup()
-        {
-            Instance = null;
         }
     }
 }

--- a/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
@@ -73,6 +73,17 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         }
 
         [TestMethod]
+        public void ExecutorInitializeWithValidArgumentsShouldAddConsoleloggerToTestLoggerManager()
+        {
+            RunTestsArgumentProcessorTests.SetupMockExtensions();
+            var testloggerManager = new DummyTestLoggerManager();
+            var executor = new EnableLoggerArgumentExecutor(testloggerManager);
+
+            executor.Initialize("console;verbosity=minimal");
+            Assert.IsTrue(testloggerManager.GetInitializedLoggers.Contains("logger://Microsoft/TestPlatform/ConsoleLogger/v2"));
+        }
+
+        [TestMethod]
         public void ExectorInitializeShouldThrowExceptionIfInvalidArgumentIsPassed()
         {
             var executor = new EnableLoggerArgumentExecutor(TestLoggerManager.Instance);

--- a/test/vstest.console.UnitTests/Processors/ParentProcessIdArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ParentProcessIdArgumentProcessorTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         }
 
         [TestMethod]
-        public void CapabilitiesShouldAppropriateProperties()
+        public void CapabilitiesShouldReturnAppropriateProperties()
         {
             var capabilities = new ParentProcessIdArgumentProcessorCapabilities();
             Assert.AreEqual("/ParentProcessId", capabilities.CommandName);
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
 
             Assert.AreEqual(HelpContentPriority.ParentProcessIdArgumentProcessorHelpPriority, capabilities.HelpPriority);
             Assert.AreEqual(false, capabilities.IsAction);
-            Assert.AreEqual(ArgumentProcessorPriority.ParentProcessId, capabilities.Priority);
+            Assert.AreEqual(ArgumentProcessorPriority.DesignMode, capabilities.Priority);
 
             Assert.AreEqual(false, capabilities.AllowMultiple);
             Assert.AreEqual(false, capabilities.AlwaysExecute);

--- a/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
@@ -8,7 +8,6 @@ using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
-using System.Threading;
 
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
 {
@@ -36,11 +35,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         {
             var capabilities = new PortArgumentProcessorCapabilities();
             Assert.AreEqual("/Port", capabilities.CommandName);
-            Assert.AreEqual("--Port|/Port:<Port>\n      The Port for socket connection and receiving the event messages.", capabilities.HelpContentResourceName);
+            Assert.AreEqual("--Port|/Port:<Port>\r\n      The Port for socket connection and receiving the event messages.", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.PortArgumentProcessorHelpPriority, capabilities.HelpPriority);
             Assert.AreEqual(false, capabilities.IsAction);
-            Assert.AreEqual(ArgumentProcessorPriority.Normal, capabilities.Priority);
+            Assert.AreEqual(ArgumentProcessorPriority.DesignMode, capabilities.Priority);
 
             Assert.AreEqual(false, capabilities.AllowMultiple);
             Assert.AreEqual(false, capabilities.AlwaysExecute);
@@ -80,13 +79,28 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         }
 
         [TestMethod]
-        public void ExecutorInitializeWithValidPortShouldAddPortToCommandLineOptionsAndInitializeDesignModeManger()
+        public void ExecutorInitializeWithValidPortShouldAddPortToCommandLineOptionsAndInitializeDesignModeManager()
         {
             var executor = new PortArgumentExecutor(CommandLineOptions.Instance, TestRequestManager.Instance);
             int port = 2345;
+            CommandLineOptions.Instance.ParentProcessId = 0;
+
             executor.Initialize(port.ToString());
+
             Assert.AreEqual(port, CommandLineOptions.Instance.Port);
             Assert.IsNotNull(DesignModeClient.Instance);
+        }
+
+        [TestMethod]
+        public void ExecutorInitializeShouldSetDesignMode()
+        {
+            var executor = new PortArgumentExecutor(CommandLineOptions.Instance, TestRequestManager.Instance);
+            int port = 2345;
+            CommandLineOptions.Instance.ParentProcessId = 0;
+
+            executor.Initialize(port.ToString());
+
+            Assert.IsTrue(CommandLineOptions.Instance.IsDesignMode);
         }
 
         [TestMethod]
@@ -102,7 +116,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             executor.Initialize(port.ToString());
             var result = executor.Execute();
 
-            testDesignModeClient.Verify(td => 
+            testDesignModeClient.Verify(td =>
                 td.ConnectToClientAndProcessRequests(port, testRequestManager.Object), Times.Once);
 
             Assert.AreEqual(ArgumentProcessorResult.Success, result);
@@ -117,7 +131,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             var executor = new PortArgumentExecutor(CommandLineOptions.Instance, testRequestManager.Object,
                 (parentProcessId) => testDesignModeClient.Object);
 
-            testDesignModeClient.Setup(td => td.ConnectToClientAndProcessRequests(It.IsAny<int>(), 
+            testDesignModeClient.Setup(td => td.ConnectToClientAndProcessRequests(It.IsAny<int>(),
                 It.IsAny<ITestRequestManager>())).Callback(() => { throw new TimeoutException(); });
 
             int port = 2345;

--- a/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
@@ -83,6 +83,17 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         #region RunTestsArgumentExecutorTests
 
         [TestMethod]
+        public void ExecutorExecuteShouldReturnSuccessWithoutExecutionInDesignMode()
+        {
+            CommandLineOptions.Instance.Reset();
+            CommandLineOptions.Instance.IsDesignMode = true;
+            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, new TestPlatform(), TestLoggerManager.Instance, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object);
+            var executor = new RunTestsArgumentExecutor(CommandLineOptions.Instance, null, testRequestManager);
+
+            Assert.AreEqual(ArgumentProcessorResult.Success, executor.Execute());
+        }
+
+        [TestMethod]
         public void ExecutorExecuteForNoSourcesShouldThrowCommandLineException()
         {
             CommandLineOptions.Instance.Reset();

--- a/test/vstest.console.UnitTests/TestDoubles/DummyLoggerEvents.cs
+++ b/test/vstest.console.UnitTests/TestDoubles/DummyLoggerEvents.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Microsoft.VisualStudio.TestPlatform.Common.Logging;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+
+namespace vstest.console.UnitTests.TestDoubles
+{
+    internal class DummyLoggerEvents : InternalTestLoggerEvents
+    {
+        public DummyLoggerEvents(TestSessionMessageLogger testSessionMessageLogger) : base(testSessionMessageLogger)
+        {
+        }
+
+        public override event EventHandler<TestResultEventArgs> TestResult;
+        public override event EventHandler<TestRunCompleteEventArgs> TestRunComplete;
+        public override event EventHandler<TestRunMessageEventArgs> TestRunMessage;
+
+        public bool EventsSubscribed()
+        {
+            return TestResult != null && TestRunComplete != null && TestRunMessage != null;
+        }
+    }
+}

--- a/test/vstest.console.UnitTests/TestDoubles/DummyLoggerEvents.cs
+++ b/test/vstest.console.UnitTests/TestDoubles/DummyLoggerEvents.cs
@@ -1,10 +1,13 @@
-﻿using System;
-using Microsoft.VisualStudio.TestPlatform.Common.Logging;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace vstest.console.UnitTests.TestDoubles
 {
+    using System;
+    using Microsoft.VisualStudio.TestPlatform.Common.Logging;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+
     internal class DummyLoggerEvents : InternalTestLoggerEvents
     {
         public DummyLoggerEvents(TestSessionMessageLogger testSessionMessageLogger) : base(testSessionMessageLogger)

--- a/test/vstest.console.UnitTests/TestDoubles/DummyTestLoggerManager.cs
+++ b/test/vstest.console.UnitTests/TestDoubles/DummyTestLoggerManager.cs
@@ -1,9 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.VisualStudio.TestPlatform.Common.Logging;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace vstest.console.UnitTests.TestDoubles
 {
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.VisualStudio.TestPlatform.Common.Logging;
+
     internal class DummyTestLoggerManager : TestLoggerManager
     {
         public DummyTestLoggerManager() : this(new DummyLoggerEvents(TestSessionMessageLogger.Instance))

--- a/test/vstest.console.UnitTests/TestDoubles/DummyTestLoggerManager.cs
+++ b/test/vstest.console.UnitTests/TestDoubles/DummyTestLoggerManager.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestPlatform.Common.Logging;
+
+namespace vstest.console.UnitTests.TestDoubles
+{
+    internal class DummyTestLoggerManager : TestLoggerManager
+    {
+        public DummyTestLoggerManager() : this(new DummyLoggerEvents(TestSessionMessageLogger.Instance))
+        {
+        }
+
+        public DummyTestLoggerManager(InternalTestLoggerEvents loggerEvents)
+            : base(TestSessionMessageLogger.Instance, loggerEvents)
+        {
+        }
+
+        public HashSet<String> GetInitializedLoggers
+        {
+            get
+            {
+                return InitializedLoggers;
+            }
+        }
+
+        public static void Cleanup()
+        {
+            Instance = null;
+        }
+    }
+}

--- a/test/vstest.console.UnitTests/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestRequestManagerTests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using vstest.console.UnitTests.TestDoubles;
+
+namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests
+{
+    using Microsoft.VisualStudio.TestPlatform.CommandLine;
+    using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
+    using Microsoft.VisualStudio.TestPlatform.Common.Logging;
+    using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Tracing.Interfaces;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class TestRequestManagerTests
+    {
+        private DummyLoggerEvents mockLoggerEvents;
+        private TestLoggerManager mockLoggerManager;
+
+        public TestRequestManagerTests()
+        {
+            this.mockLoggerEvents = new DummyLoggerEvents(TestSessionMessageLogger.Instance);
+            this.mockLoggerManager = new DummyTestLoggerManager(this.mockLoggerEvents);
+        }
+
+        [TestMethod]
+        public void TestRequestManagerShouldInitializeConsoleLogger()
+        {
+            CommandLineOptions.Instance.IsDesignMode = false;
+            var requestManager = new TestRequestManager(CommandLineOptions.Instance,
+                new Mock<ITestPlatform>().Object,
+                this.mockLoggerManager,
+                TestRunResultAggregator.Instance,
+                new Mock<ITestPlatformEventSource>().Object);
+
+            Assert.IsTrue(mockLoggerEvents.EventsSubscribed());
+        }
+
+        [TestMethod]
+        public void TestRequestManagerShouldNotInitializeConsoleLoggerIfDesignModeIsSet()
+        {
+            CommandLineOptions.Instance.IsDesignMode = true;
+            var requestManager = new TestRequestManager(CommandLineOptions.Instance,
+                new Mock<ITestPlatform>().Object,
+                this.mockLoggerManager,
+                TestRunResultAggregator.Instance,
+                new Mock<ITestPlatformEventSource>().Object);
+
+            Assert.IsFalse(mockLoggerEvents.EventsSubscribed());
+        }
+    }
+}

--- a/test/vstest.console.UnitTests/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestRequestManagerTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using vstest.console.UnitTests.TestDoubles;
-
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests
 {
     using Microsoft.VisualStudio.TestPlatform.CommandLine;
@@ -12,6 +10,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
+    using vstest.console.UnitTests.TestDoubles;
 
     [TestClass]
     public class TestRequestManagerTests


### PR DESCRIPTION
- Adding the IsDesignMode boolean in CommandlineOptions
- Make sure Console Logger does not get initialized in design mode.

Upcoming commit
- Add verbosity parameter for ConsoleLogger.