### PR TITLE
Add auto-generated header to generated Program files

### DIFF
--- a/src/Microsoft.NET.Test.Sdk.targets
+++ b/src/Microsoft.NET.Test.Sdk.targets
@@ -40,11 +40,13 @@
           Outputs="$(GeneratedProgramFile)">
 
     <ItemGroup Condition="'$(Language)'=='C#'">
+      <Line Include="// &lt;auto-generated&gt; This file has been auto generated. &lt;/auto-generated&gt; "/>
       <Line Include="using System%3b "/>
       <Line Include="class Program {static void Main(string[] args){}}"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(Language)'=='VB'">
+      <Line Include="' &lt;auto-generated&gt; This file has been auto generated. &lt;/auto-generated&gt; "/>
       <Line Include="Imports System"/>
       <Line Include="Module Program"/>
       <Line Include="Sub Main(args As String())"/>


### PR DESCRIPTION
Add auto-generated header comment to generated ```Program.cs``` and ```Program.vb``` files to resolve #420.

I've used escaped entities to err on the side of caution, and I've added one for VB as well, which I've assumed would use the same format for the text in the comment.