### PR TITLE
Make adapter thread as background thread

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -271,7 +271,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
 
         protected abstract void InvokeExecutor(LazyExtension<ITestExecutor, ITestExecutorCapabilities> executor, Tuple<Uri, string> executorUriExtensionTuple, RunContext runContext, IFrameworkHandle frameworkHandle);
 
-#endregion
+        #endregion
 
         #region Private methods
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -501,6 +501,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
 
             // .NetStandard 1.5 lib does not have ApartmentState - hence ifdef
             thread.SetApartmentState(GetApartmentStateAppSetting());
+            thread.IsBackground = true;
             thread.Start();
             thread.Join();
 


### PR DESCRIPTION
Foreground threads block the process from terminating themselves whereas background thread do not. TPV1 sets this too. 