### PR TITLE
Log test host standard error

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.resx
@@ -118,15 +118,15 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AbortedTestDiscovery" xml:space="preserve">
-    <value>The active Test Discovery was aborted. Due to {0}</value>
+    <value>The active test discovery was aborted. {0}</value>
   </data>
   <data name="AbortedTestRun" xml:space="preserve">
-    <value>The active Test Run was aborted. Due to {0}</value>
+    <value>The active test run was aborted. {0}</value>
   </data>
   <data name="ConnectionClosed" xml:space="preserve">
     <value>An existing connection was forcibly closed by the remote host.</value>
   </data>
   <data name="UnableToCommunicateToTestHost" xml:space="preserve">
-    <value>Unable to communicate with test execution process.</value>
+    <value>Unable to communicate with test host process.</value>
   </data>
 </root>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.resx
@@ -118,10 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AbortedTestDiscovery" xml:space="preserve">
-    <value>The active test discovery was aborted. {0}</value>
+    <value>The active test discovery was aborted. Reason: {0}</value>
   </data>
   <data name="AbortedTestRun" xml:space="preserve">
-    <value>The active test run was aborted. {0}</value>
+    <value>The active test run was aborted. Reason: {0}</value>
   </data>
   <data name="ConnectionClosed" xml:space="preserve">
     <value>An existing connection was forcibly closed by the remote host.</value>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.cs.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active test run was aborted. {0}</source>
+        <source>The active test run was aborted. Reason: {0}</source>
         <target state="new">Aktivní testovací běh se přerušil.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active test discovery was aborted. {0}</source>
+        <source>The active test discovery was aborted. Reason: {0}</source>
         <target state="new">Aktivní zjišťování testu se přerušilo.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.cs.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active Test Run was aborted. Due to {0}</source>
+        <source>The active test run was aborted. {0}</source>
         <target state="new">Aktivní testovací běh se přerušil.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active Test Discovery was aborted. Due to {0}</source>
+        <source>The active test discovery was aborted. {0}</source>
         <target state="new">Aktivní zjišťování testu se přerušilo.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -48,8 +48,8 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="6" adjWordcount="5.1" curWordcount="5.1"</note>
       </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
-        <source>Unable to communicate with test execution process.</source>
-        <target state="translated">Nepovedlo se navázat komunikaci s procesem provedení testu.</target>
+        <source>Unable to communicate with test host process.</source>
+        <target state="new">Nepovedlo se navázat komunikaci s procesem provedení testu.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Nelze komunikovat s proces spuštění testu.</target>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.de.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active test run was aborted. {0}</source>
+        <source>The active test run was aborted. Reason: {0}</source>
         <target state="new">Der aktive Testlauf wurde abgebrochen.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active test discovery was aborted. {0}</source>
+        <source>The active test discovery was aborted. Reason: {0}</source>
         <target state="new">Die aktive Testermittlung wurde abgebrochen.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.de.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active Test Run was aborted. Due to {0}</source>
+        <source>The active test run was aborted. {0}</source>
         <target state="new">Der aktive Testlauf wurde abgebrochen.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active Test Discovery was aborted. Due to {0}</source>
+        <source>The active test discovery was aborted. {0}</source>
         <target state="new">Die aktive Testermittlung wurde abgebrochen.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -48,8 +48,8 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="6" adjWordcount="5.1" curWordcount="5.1"</note>
       </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
-        <source>Unable to communicate with test execution process.</source>
-        <target state="translated">Die Kommunikation mit dem Testausführungsvorgang ist nicht möglich.</target>
+        <source>Unable to communicate with test host process.</source>
+        <target state="new">Die Kommunikation mit dem Testausführungsvorgang ist nicht möglich.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Kommunikation mit Test Ausführung nicht möglich.</target>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.es.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active test run was aborted. {0}</source>
+        <source>The active test run was aborted. Reason: {0}</source>
         <target state="new">Se ha anulado la serie de pruebas activa.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active test discovery was aborted. {0}</source>
+        <source>The active test discovery was aborted. Reason: {0}</source>
         <target state="new">Se ha anulado la detección de pruebas activa.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.es.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active Test Run was aborted. Due to {0}</source>
+        <source>The active test run was aborted. {0}</source>
         <target state="new">Se ha anulado la serie de pruebas activa.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active Test Discovery was aborted. Due to {0}</source>
+        <source>The active test discovery was aborted. {0}</source>
         <target state="new">Se ha anulado la detección de pruebas activa.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -48,8 +48,8 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="6" adjWordcount="5.1" curWordcount="5.1"</note>
       </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
-        <source>Unable to communicate with test execution process.</source>
-        <target state="translated">No se puede establecer comunicación con el proceso de ejecución de pruebas.</target>
+        <source>Unable to communicate with test host process.</source>
+        <target state="new">No se puede establecer comunicación con el proceso de ejecución de pruebas.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">No se ha podido comunicar con el proceso de ejecución de prueba.</target>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.fr.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active test run was aborted. {0}</source>
+        <source>The active test run was aborted. Reason: {0}</source>
         <target state="new">La série de tests active a été abandonnée.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active test discovery was aborted. {0}</source>
+        <source>The active test discovery was aborted. Reason: {0}</source>
         <target state="new">La découverte de tests active a été abandonnée.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.fr.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active Test Run was aborted. Due to {0}</source>
+        <source>The active test run was aborted. {0}</source>
         <target state="new">La série de tests active a été abandonnée.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active Test Discovery was aborted. Due to {0}</source>
+        <source>The active test discovery was aborted. {0}</source>
         <target state="new">La découverte de tests active a été abandonnée.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -48,8 +48,8 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="6" adjWordcount="5.1" curWordcount="5.1"</note>
       </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
-        <source>Unable to communicate with test execution process.</source>
-        <target state="translated">Impossible de communiquer avec le processus d'exécution de tests.</target>
+        <source>Unable to communicate with test host process.</source>
+        <target state="new">Impossible de communiquer avec le processus d'exécution de tests.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Impossible de communiquer avec le processus d’exécution de test.</target>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.it.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active Test Run was aborted. Due to {0}</source>
+        <source>The active test run was aborted. {0}</source>
         <target state="new">L'esecuzione dei test attiva è stata interrotta.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active Test Discovery was aborted. Due to {0}</source>
+        <source>The active test discovery was aborted. {0}</source>
         <target state="new">L'individuazione dei test attiva è stata interrotta.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -48,8 +48,8 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="6" adjWordcount="5.1" curWordcount="5.1"</note>
       </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
-        <source>Unable to communicate with test execution process.</source>
-        <target state="translated">Non è possibile comunicare con il processo di esecuzione dei test.</target>
+        <source>Unable to communicate with test host process.</source>
+        <target state="new">Non è possibile comunicare con il processo di esecuzione dei test.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Impossibile comunicare con il processo di esecuzione di test.</target>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.it.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active test run was aborted. {0}</source>
+        <source>The active test run was aborted. Reason: {0}</source>
         <target state="new">L'esecuzione dei test attiva è stata interrotta.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active test discovery was aborted. {0}</source>
+        <source>The active test discovery was aborted. Reason: {0}</source>
         <target state="new">L'individuazione dei test attiva è stata interrotta.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ja.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active test run was aborted. {0}</source>
+        <source>The active test run was aborted. Reason: {0}</source>
         <target state="new">アクティブなテストの実行が中止されました。</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active test discovery was aborted. {0}</source>
+        <source>The active test discovery was aborted. Reason: {0}</source>
         <target state="new">アクティブなテスト探索が中止されました。</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ja.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active Test Run was aborted. Due to {0}</source>
+        <source>The active test run was aborted. {0}</source>
         <target state="new">アクティブなテストの実行が中止されました。</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active Test Discovery was aborted. Due to {0}</source>
+        <source>The active test discovery was aborted. {0}</source>
         <target state="new">アクティブなテスト探索が中止されました。</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -48,8 +48,8 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="6" adjWordcount="5.1" curWordcount="5.1"</note>
       </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
-        <source>Unable to communicate with test execution process.</source>
-        <target state="translated">テスト実行プロセスと通信できません。</target>
+        <source>Unable to communicate with test host process.</source>
+        <target state="new">テスト実行プロセスと通信できません。</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">テストの実行プロセスと通信できません。</target>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ko.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active test run was aborted. {0}</source>
+        <source>The active test run was aborted. Reason: {0}</source>
         <target state="new">활성 테스트 실행이 중단되었습니다.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active test discovery was aborted. {0}</source>
+        <source>The active test discovery was aborted. Reason: {0}</source>
         <target state="new">활성 테스트 검색이 중단되었습니다.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ko.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active Test Run was aborted. Due to {0}</source>
+        <source>The active test run was aborted. {0}</source>
         <target state="new">활성 테스트 실행이 중단되었습니다.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active Test Discovery was aborted. Due to {0}</source>
+        <source>The active test discovery was aborted. {0}</source>
         <target state="new">활성 테스트 검색이 중단되었습니다.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -48,8 +48,8 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="6" adjWordcount="5.1" curWordcount="5.1"</note>
       </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
-        <source>Unable to communicate with test execution process.</source>
-        <target state="translated">테스트 실행 프로세스와 통신할 수 없습니다.</target>
+        <source>Unable to communicate with test host process.</source>
+        <target state="new">테스트 실행 프로세스와 통신할 수 없습니다.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">테스트 실행 프로세스와 통신할 수 없습니다.</target>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pl.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active test run was aborted. {0}</source>
+        <source>The active test run was aborted. Reason: {0}</source>
         <target state="new">Aktywne uruchomienie testu zostało przerwane.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active test discovery was aborted. {0}</source>
+        <source>The active test discovery was aborted. Reason: {0}</source>
         <target state="new">Aktywny proces wykrywania testu został przerwany.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pl.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active Test Run was aborted. Due to {0}</source>
+        <source>The active test run was aborted. {0}</source>
         <target state="new">Aktywne uruchomienie testu zostało przerwane.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active Test Discovery was aborted. Due to {0}</source>
+        <source>The active test discovery was aborted. {0}</source>
         <target state="new">Aktywny proces wykrywania testu został przerwany.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -48,8 +48,8 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="6" adjWordcount="5.1" curWordcount="5.1"</note>
       </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
-        <source>Unable to communicate with test execution process.</source>
-        <target state="translated">Nie można nawiązać komunikacji z procesem wykonywania testu.</target>
+        <source>Unable to communicate with test host process.</source>
+        <target state="new">Nie można nawiązać komunikacji z procesem wykonywania testu.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Nie można się komunikować z procesem wykonanie testu.</target>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pt-BR.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active Test Run was aborted. Due to {0}</source>
+        <source>The active test run was aborted. {0}</source>
         <target state="new">A Execução de Teste ativa foi anulada.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active Test Discovery was aborted. Due to {0}</source>
+        <source>The active test discovery was aborted. {0}</source>
         <target state="new">A Descoberta de Teste ativa foi anulada.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -48,8 +48,8 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="6" adjWordcount="5.1" curWordcount="5.1"</note>
       </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
-        <source>Unable to communicate with test execution process.</source>
-        <target state="translated">Não é possível se comunicar com o processo de execução de teste.</target>
+        <source>Unable to communicate with test host process.</source>
+        <target state="new">Não é possível se comunicar com o processo de execução de teste.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Não é possível se comunicar com o processo de execução de teste.</target>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pt-BR.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active test run was aborted. {0}</source>
+        <source>The active test run was aborted. Reason: {0}</source>
         <target state="new">A Execução de Teste ativa foi anulada.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active test discovery was aborted. {0}</source>
+        <source>The active test discovery was aborted. Reason: {0}</source>
         <target state="new">A Descoberta de Teste ativa foi anulada.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ru.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active Test Run was aborted. Due to {0}</source>
+        <source>The active test run was aborted. {0}</source>
         <target state="new">Активный тестовый запуск прерван.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active Test Discovery was aborted. Due to {0}</source>
+        <source>The active test discovery was aborted. {0}</source>
         <target state="new">Активное обнаружение тестов прервано.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -48,8 +48,8 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="6" adjWordcount="5.1" curWordcount="5.1"</note>
       </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
-        <source>Unable to communicate with test execution process.</source>
-        <target state="translated">Не удается связаться с процессом выполнения теста.</target>
+        <source>Unable to communicate with test host process.</source>
+        <target state="new">Не удается связаться с процессом выполнения теста.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Не удается установить соединение с процессом выполнения теста.</target>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ru.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active test run was aborted. {0}</source>
+        <source>The active test run was aborted. Reason: {0}</source>
         <target state="new">Активный тестовый запуск прерван.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active test discovery was aborted. {0}</source>
+        <source>The active test discovery was aborted. Reason: {0}</source>
         <target state="new">Активное обнаружение тестов прервано.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.tr.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active test run was aborted. {0}</source>
+        <source>The active test run was aborted. Reason: {0}</source>
         <target state="new" state-qualifier="mt-suggestion">Etkin Test Çalıştırması iptal edildi.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active test discovery was aborted. {0}</source>
+        <source>The active test discovery was aborted. Reason: {0}</source>
         <target state="new" state-qualifier="mt-suggestion">Etkin Test Bulma iptal edildi.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.tr.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active Test Run was aborted. Due to {0}</source>
+        <source>The active test run was aborted. {0}</source>
         <target state="new" state-qualifier="mt-suggestion">Etkin Test Çalıştırması iptal edildi.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active Test Discovery was aborted. Due to {0}</source>
+        <source>The active test discovery was aborted. {0}</source>
         <target state="new" state-qualifier="mt-suggestion">Etkin Test Bulma iptal edildi.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -48,8 +48,8 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="6" adjWordcount="5.1" curWordcount="5.1"</note>
       </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
-        <source>Unable to communicate with test execution process.</source>
-        <target state="translated" state-qualifier="mt-suggestion">Test yürütmesi işlemi ile iletişim kurulamıyor.</target>
+        <source>Unable to communicate with test host process.</source>
+        <target state="new" state-qualifier="mt-suggestion">Test yürütmesi işlemi ile iletişim kurulamıyor.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Test yürütme işlemi ile iletişim kurulamıyor.</target>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hans.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active test run was aborted. {0}</source>
+        <source>The active test run was aborted. Reason: {0}</source>
         <target state="new">活动的测试运行已中止。</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active test discovery was aborted. {0}</source>
+        <source>The active test discovery was aborted. Reason: {0}</source>
         <target state="new">活动的测试发现已中止。</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hans.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active Test Run was aborted. Due to {0}</source>
+        <source>The active test run was aborted. {0}</source>
         <target state="new">活动的测试运行已中止。</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active Test Discovery was aborted. Due to {0}</source>
+        <source>The active test discovery was aborted. {0}</source>
         <target state="new">活动的测试发现已中止。</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -48,8 +48,8 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="6" adjWordcount="5.1" curWordcount="5.1"</note>
       </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
-        <source>Unable to communicate with test execution process.</source>
-        <target state="translated">无法与测试执行过程通信。</target>
+        <source>Unable to communicate with test host process.</source>
+        <target state="new">无法与测试执行过程通信。</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">无法与测试执行过程中进行通信。</target>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hant.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active Test Run was aborted. Due to {0}</source>
+        <source>The active test run was aborted. {0}</source>
         <target state="new">已中止使用中的測試回合。</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active Test Discovery was aborted. Due to {0}</source>
+        <source>The active test discovery was aborted. {0}</source>
         <target state="new">已中止使用中的測試探索。</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -48,8 +48,8 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="6" adjWordcount="5.1" curWordcount="5.1"</note>
       </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
-        <source>Unable to communicate with test execution process.</source>
-        <target state="translated">無法與測試執行處理序通訊。</target>
+        <source>Unable to communicate with test host process.</source>
+        <target state="new">無法與測試執行處理序通訊。</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">无法与测试执行过程中进行通信。</target>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hant.xlf
@@ -21,7 +21,7 @@
     </header>
     <body>
       <trans-unit id="AbortedTestRun">
-        <source>The active test run was aborted. {0}</source>
+        <source>The active test run was aborted. Reason: {0}</source>
         <target state="new">已中止使用中的測試回合。</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="10" adjWordcount="8.5" curWordcount="8.5"</note>
       </trans-unit>
       <trans-unit id="AbortedTestDiscovery">
-        <source>The active test discovery was aborted. {0}</source>
+        <source>The active test discovery was aborted. Reason: {0}</source>
         <target state="new">已中止使用中的測試探索。</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
@@ -10,6 +10,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
     using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -28,7 +29,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         /// </summary>
         /// <param name="testHostManager">Test host manager instance.</param>
         public ProxyDiscoveryManager(ITestHostManager testHostManager)
-            : this(new TestRequestSender(), testHostManager, Constants.ClientConnectionTimeout)
+            : this(new TestRequestSender(), testHostManager, CrossPlatEngine.Constants.ClientConnectionTimeout)
         {
             this.testHostManager = testHostManager;
         }
@@ -93,6 +94,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             }
             catch (Exception exception)
             {
+                EqtTrace.Error("ProxyDiscoveryManager.DiscoverTests: Failed to discover tests: {0}", exception);
                 eventHandler.HandleLogMessage(TestMessageLevel.Error, exception.Message);
                 eventHandler.HandleDiscoveryComplete(0, new List<ObjectModel.TestCase>(), false);
             }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -128,6 +128,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             }
             catch (Exception exception)
             {
+                EqtTrace.Error("ProxyExecutionManager.StartTestRun: Failed to start test run: {0}", exception);
                 var completeArgs = new TestRunCompleteEventArgs(null, false, false, exception, new Collection<AttachmentSet>(), TimeSpan.Zero);
                 eventHandler.HandleLogMessage(TestMessageLevel.Error, exception.Message);
                 eventHandler.HandleTestRunComplete(completeArgs, null, null, null);

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -88,6 +88,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                         if (process.ExitCode != 0)
                         {
                             testHostProcessStdError = process.StandardError.ReadToEnd();
+                            EqtTrace.Error("Test host exited with error: {0}", testHostProcessStdError);
                         }
 
                         this.RequestSender.OnClientProcessExit(testHostProcessStdError);

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -101,7 +101,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
         /// <param name="pathToAdditionalExtensions">Paths to Additional extensions</param>
         public void InitializeExtensions(IEnumerable<string> pathToAdditionalExtensions)
         {
+            EqtTrace.Info("TestRequestManager.InitializeExtensions: Initialize extensions started.");
             this.testPlatform.Initialize(pathToAdditionalExtensions, false, true);
+            EqtTrace.Info("TestRequestManager.InitializeExtensions: Initialize extensions completed.");
         }
 
         /// <summary>
@@ -120,6 +122,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
         /// <returns>True, if successful</returns>
         public bool DiscoverTests(DiscoveryRequestPayload discoveryPayload, ITestDiscoveryEventsRegistrar discoveryEventsRegistrar)
         {
+            EqtTrace.Info("TestRequestManager.DiscoverTests: Discovery tests started.");
+
             bool success = false;
 
             // create discovery request
@@ -163,6 +167,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
                 }
             }
 
+            EqtTrace.Info("TestRequestManager.DiscoverTests: Discovery tests completed, sucessful: {0}.", success);
             return success;
         }
 
@@ -175,6 +180,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
         /// <returns>True, if successful</returns>
         public bool RunTests(TestRunRequestPayload testRunRequestPayload, ITestHostLauncher testHostLauncher, ITestRunEventsRegistrar testRunEventsRegistrar)
         {
+            EqtTrace.Info("TestRequestManager.RunTests: run tests started.");
+
             TestRunCriteria runCriteria = null;
             if (testRunRequestPayload.Sources != null && testRunRequestPayload.Sources.Any())
             {
@@ -198,7 +205,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
                                   testHostLauncher);
             }
 
-            return this.RunTests(runCriteria, testRunEventsRegistrar);
+            var success = this.RunTests(runCriteria, testRunEventsRegistrar);
+            EqtTrace.Info("TestRequestManager.RunTests: run tests completed, sucessful: {0}.", success);
+            return success;
         }
 
         /// <summary>
@@ -206,6 +215,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
         /// </summary>
         public void CancelTestRun()
         {
+            EqtTrace.Info("TestRequestManager.CancelTestRun: Sending cancel request.");
+
             this.runRequestCreatedEventHandle.WaitOne(runRequestTimeout);
             this.currentTestRunRequest?.CancelAsync();
         }
@@ -215,6 +226,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
         /// </summary>
         public void AbortTestRun()
         {
+            EqtTrace.Info("TestRequestManager.AbortTestRun: Sending abort request.");
+
             this.runRequestCreatedEventHandle.WaitOne(runRequestTimeout);
             this.currentTestRunRequest?.Abort();
         }
@@ -251,6 +264,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
                     }
                     catch (Exception ex)
                     {
+                        EqtTrace.Error("TestRequestManager.RunTests: failed to run tests: {0}", ex);
                         if (ex is TestPlatformException ||
                             ex is SettingsException ||
                             ex is InvalidOperationException)

--- a/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue);
             arguments = string.Concat(arguments, " /tests:ExitWithStdErrorMessageTest");
             this.InvokeVsTest(arguments);
-            this.StdErrorContains("The active Test Run was aborted.");
+            this.StdErrorContains("The active test run was aborted.");
         }
     }
 }


### PR DESCRIPTION
- Log test host standard error.
- Change error messages sentence for better grammar.
- Update respective xlf files.
- Related issue: #281 