### PR TITLE
Display log messages to IDE output

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestDiscoveryEventHandlerExtensions.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestDiscoveryEventHandlerExtensions.cs
@@ -41,6 +41,5 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.EventHandle
             // Complete discovery.
             discoveryEventsHandler.HandleDiscoveryComplete(-1, null, true);
         }
-
     }
 }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestDiscoveryEventHandlerExtensions.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestDiscoveryEventHandlerExtensions.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.EventHandlers
+{
+    using System;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+
+    public static class TestDiscoveryEventHandlerExtensions
+    {
+        public static void OnAbort(this ITestDiscoveryEventsHandler discoveryEventsHandler, IDataSerializer dataSerializer, Exception exception)
+        {
+            ValidateArg.NotNull(dataSerializer, nameof(dataSerializer));
+
+            EqtTrace.Error("Server: TestExecution: Aborting test discovery because {0}: {1}", exception?.Message, exception?.StackTrace);
+
+            var reason = string.Format(Resources.Resources.AbortedTestDiscovery, exception?.Message);
+
+            // Log to vstest console.
+            discoveryEventsHandler.HandleLogMessage(TestMessageLevel.Error, reason);
+
+            // Log to vs ide test output.
+            var testMessagePayload = new TestMessagePayload { MessageLevel = TestMessageLevel.Error, Message = reason };
+            var rawMessage = dataSerializer.SerializePayload(MessageType.TestMessage, testMessagePayload);
+            discoveryEventsHandler.HandleRawMessage(rawMessage);
+
+            // Notify discovery abort to IDE test output.
+            var payload = new DiscoveryCompletePayload()
+            {
+                IsAborted = true,
+                LastDiscoveredTests = null,
+                TotalTests = -1
+            };
+            rawMessage = dataSerializer.SerializePayload(MessageType.DiscoveryComplete, payload);
+            discoveryEventsHandler.HandleRawMessage(rawMessage);
+
+            // Complete discovery.
+            discoveryEventsHandler.HandleDiscoveryComplete(-1, null, true);
+        }
+
+    }
+}

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestRunEventsHandlerExtensions.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestRunEventsHandlerExtensions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.EventHandlers
+{
+    using System;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+    public static class TestRunEventsHandlerExtensions
+    {
+        public static void OnAbort(this ITestRunEventsHandler testRunEventsHandler, IDataSerializer dataSerializer, Exception exception)
+        {
+            ValidateArg.NotNull(dataSerializer ,nameof(dataSerializer));
+
+            EqtTrace.Error("Server: TestExecution: Aborting test run because {0}:{1}", exception?.Message, exception?.StackTrace);
+
+            var reason = string.Format(Resources.Resources.AbortedTestRun, exception?.Message);
+            // Log console message to vstest console.
+            testRunEventsHandler.HandleLogMessage(TestMessageLevel.Error, reason);
+
+            // Log console message to IDE.
+            var testMessagePayload = new TestMessagePayload { MessageLevel = TestMessageLevel.Error, Message = reason };
+            var rawMessage = dataSerializer.SerializePayload(MessageType.TestMessage, testMessagePayload);
+            testRunEventsHandler.HandleRawMessage(rawMessage);
+
+            // Notify test run abort to IDE.
+            var completeArgs = new TestRunCompleteEventArgs(null, false, true, exception, null, TimeSpan.Zero);
+            var payload = new TestRunCompletePayload { TestRunCompleteArgs = completeArgs };
+            rawMessage = dataSerializer.SerializePayload(MessageType.ExecutionComplete, payload);
+            testRunEventsHandler.HandleRawMessage(rawMessage);
+
+            // Notify of a test run complete and bail out.
+            testRunEventsHandler.HandleTestRunComplete(completeArgs, null, null, null);
+        }
+    }
+}

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -9,9 +9,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
     using System.Threading;
     using System.Threading.Tasks;
 
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.EventHandlers;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
-    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.EventHandlers;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyDiscoveryManager.cs
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel
 
             // In Case of Cancel or Abort, no need to trigger discovery for rest of the data
             // If there are no more sources/testcases, a parallel executor is truly done with discovery
-            if (isAborted || !this.DiscoverTestsOnConcurrentManager(proxyDiscoveryManager))
+            if (!this.DiscoverTestsOnConcurrentManager(proxyDiscoveryManager))
             {
                 lock (this.discoveryStatusLockObject)
                 {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyDiscoveryManager.cs
@@ -104,9 +104,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel
                 this.concurrentManagerHandlerMap.Add(proxyDiscoveryManager, parallelEventsHandler);
             }
 
-            // In Case of Cancel or Abort, no need to trigger discovery for rest of the data
             // If there are no more sources/testcases, a parallel executor is truly done with discovery
-            if (!this.DiscoverTestsOnConcurrentManager(proxyDiscoveryManager))
+            if ( !this.DiscoverTestsOnConcurrentManager(proxyDiscoveryManager))
             {
                 lock (this.discoveryStatusLockObject)
                 {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyExecutionManager.cs
@@ -153,7 +153,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel
                 this.concurrentManagerHandlerMap.Add(proxyExecutionManager, parallelEventsHandler);
             }
 
-            // In Case of Cancel or Abort, no need to trigger run for rest of the data
+            // In Case of Cancel no need to trigger run for rest of the data
             // If there are no more sources/testcases, a parallel executor is truly done with execution
             if (testRunCompleteArgs.IsCanceled || !this.StartTestRunOnConcurrentManager(proxyExecutionManager))
             {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyExecutionManager.cs
@@ -155,7 +155,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel
 
             // In Case of Cancel or Abort, no need to trigger run for rest of the data
             // If there are no more sources/testcases, a parallel executor is truly done with execution
-            if (testRunCompleteArgs.IsAborted || testRunCompleteArgs.IsCanceled || !this.StartTestRunOnConcurrentManager(proxyExecutionManager))
+            if (testRunCompleteArgs.IsCanceled || !this.StartTestRunOnConcurrentManager(proxyExecutionManager))
             {
                 lock (this.executionStatusLockObject)
                 {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
@@ -10,6 +10,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
     using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.EventHandlers;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -20,6 +21,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
     public class ProxyDiscoveryManager : ProxyOperationManager, IProxyDiscoveryManager
     {
         private readonly ITestHostManager testHostManager;
+        private readonly IDataSerializer dataSerializer;
 
         #region Constructors
 
@@ -28,7 +30,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         /// </summary>
         /// <param name="testHostManager">Test host manager instance.</param>
         public ProxyDiscoveryManager(ITestHostManager testHostManager)
-            : this(new TestRequestSender(), testHostManager, Constants.ClientConnectionTimeout)
+            : this(new TestRequestSender(), testHostManager, Constants.ClientConnectionTimeout, JsonDataSerializer.Instance)
         {
             this.testHostManager = testHostManager;
         }
@@ -46,13 +48,16 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         /// <param name="clientConnectionTimeout">
         /// The client Connection Timeout
         /// </param>
+        /// <param name="dataSerializer">The data serializer</param>
         internal ProxyDiscoveryManager(
             ITestRequestSender requestSender,
             ITestHostManager testHostManager,
-            int clientConnectionTimeout)
+            int clientConnectionTimeout,
+            IDataSerializer dataSerializer)
             : base(requestSender, testHostManager, clientConnectionTimeout)
         {
             this.testHostManager = testHostManager;
+            this.dataSerializer = dataSerializer;
         }
 
         #endregion
@@ -93,8 +98,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             }
             catch (Exception exception)
             {
-                eventHandler.HandleLogMessage(TestMessageLevel.Error, exception.Message);
-                eventHandler.HandleDiscoveryComplete(0, new List<ObjectModel.TestCase>(), false);
+                eventHandler.OnAbort(this.dataSerializer, exception);
             }
         }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
@@ -9,8 +9,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
 
     using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
-    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.EventHandlers;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -88,6 +88,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                         if (process.ExitCode != 0)
                         {
                             testHostProcessStdError = process.StandardError.ReadToEnd();
+                            EqtTrace.Error("Testhost failed with error: {0}", testHostProcessStdError);
                         }
 
                         this.RequestSender.OnClientProcessExit(testHostProcessStdError);

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -88,7 +88,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                         if (process.ExitCode != 0)
                         {
                             testHostProcessStdError = process.StandardError.ReadToEnd();
-                            EqtTrace.Error("Testhost failed with error: {0}", testHostProcessStdError);
                         }
 
                         this.RequestSender.OnClientProcessExit(testHostProcessStdError);

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Events/DiscoveryCompleteEventArgs.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Events/DiscoveryCompleteEventArgs.cs
@@ -18,9 +18,8 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Client
         /// <param name="isAborted">Specifies if discovery has been aborted.</param>
         public DiscoveryCompleteEventArgs(long totalTests, bool isAborted)
         {
-            Debug.Assert((isAborted ? -1 == totalTests : true), "If discovery request is aborted totalTest should be -1.");
             this.TotalCount = totalTests;
-            this.IsAborted = isAborted;            
+            this.IsAborted = isAborted;
         }
 
         /// <summary>

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/EventHandlers/TestDiscoveryEventHandlerExtensionsTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/EventHandlers/TestDiscoveryEventHandlerExtensionsTests.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.EventHandlers
+{
+    using System;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.EventHandlers;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class TestDiscoveryEventHandlerExtensionsTests
+    {
+        private Exception exception;
+        private Mock<IDataSerializer> dataSerializerMock;
+        private ITestDiscoveryEventsHandler tesDiscoveryEventsHandler;
+        private Mock<ITestRequestHandler> testRequestHandler;
+
+        [TestInitialize]
+        public void Init()
+        {
+            this.exception = new Exception("Error Message");
+            this.dataSerializerMock = new Mock<IDataSerializer>();
+            this.testRequestHandler = new Mock<ITestRequestHandler>();
+            this.tesDiscoveryEventsHandler = new TestDiscoveryEventHandler(testRequestHandler.Object);
+        }
+
+        [TestMethod]
+        public void OnAbortShouldRaiseExceptionWhenDataSerializerIsNull()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => this.tesDiscoveryEventsHandler.OnAbort(null, exception));
+        }
+
+        [TestMethod]
+        public void OnAbortShouldCallSendLogAndSendExecutionCompleteIfExceptionIsNull()
+        {
+            this.tesDiscoveryEventsHandler.OnAbort(dataSerializerMock.Object, null);
+
+            this.testRequestHandler.Verify((rh) => rh.SendLog(TestMessageLevel.Error, It.IsAny<string>()));
+            this.testRequestHandler.Verify((rh) => rh.DiscoveryComplete(-1, null, true));
+        }
+
+        [TestMethod]
+        public void OnAbortShouldCallSendLog()
+        {
+            var message = string.Empty;
+            this.testRequestHandler.Setup((rh) => rh.SendLog(TestMessageLevel.Error, It.IsAny<string>()))
+                .Callback<TestMessageLevel, string>((l, m) => message = m);
+
+            this.tesDiscoveryEventsHandler.OnAbort(dataSerializerMock.Object, exception);
+
+            this.testRequestHandler.Verify((rh) => rh.SendLog(TestMessageLevel.Error, message));
+            StringAssert.Contains(message, exception.Message);
+        }
+
+        [TestMethod]
+        public void OnAbortShouldCallSendExecutionComplete()
+        {
+            this.tesDiscoveryEventsHandler.OnAbort(dataSerializerMock.Object, exception);
+
+            this.testRequestHandler.Verify((rh) => rh.DiscoveryComplete(-1, null, true));
+        }
+    }
+}

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/EventHandlers/TestRunEventHandlerExtensionsTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/EventHandlers/TestRunEventHandlerExtensionsTests.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.EventHandlers
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.EventHandlers;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class TestRunEventHandlerExtensionsTests
+    {
+        private Exception exception;
+        private Mock<IDataSerializer> dataSerializerMock;
+        private ITestRunEventsHandler testRunEventsHandler;
+        private Mock<ITestRequestHandler> testRequestHandler;
+
+        [TestInitialize]
+        public void Init()
+        {
+            this.exception = new Exception("Error Message");
+            this.dataSerializerMock = new Mock<IDataSerializer>();
+            this.testRequestHandler = new Mock<ITestRequestHandler>();
+            this.testRunEventsHandler = new TestRunEventsHandler(testRequestHandler.Object);
+        }
+
+        [TestMethod]
+        public void OnAbortShouldRaiseExceptionWhenDataSerializerIsNull()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => this.testRunEventsHandler.OnAbort(null, exception));
+        }
+
+        [TestMethod]
+        public void OnAbortShouldCallSendLogAndSendExecutionCompleteIfExceptionIsNull()
+        {
+            this.testRunEventsHandler.OnAbort(dataSerializerMock.Object, null);
+            this.testRequestHandler.Verify((rh) => rh.SendLog(TestMessageLevel.Error, It.IsAny<string>()));
+            this.testRequestHandler.Verify((rh) => rh.SendExecutionComplete(It.IsAny<TestRunCompleteEventArgs>(), null, null, null));
+        }
+
+        [TestMethod]
+        public void OnAbortShouldCallSendLog()
+        {
+            var message = string.Empty;
+            this.testRequestHandler.Setup((rh) => rh.SendLog(TestMessageLevel.Error, It.IsAny<string>()))
+                .Callback<TestMessageLevel, string>((l, m) => message = m);
+
+            this.testRunEventsHandler.OnAbort(dataSerializerMock.Object, exception);
+
+            this.testRequestHandler.Verify((rh) => rh.SendLog(TestMessageLevel.Error, message));
+            StringAssert.Contains(message, exception.Message);
+        }
+
+        [TestMethod]
+        public void OnAbortShouldCallSendExecutionComplete()
+        {
+            TestRunCompleteEventArgs testRunCompleteArgs = null;
+            this.testRequestHandler.Setup(rh => rh.SendExecutionComplete(
+                    It.IsAny<TestRunCompleteEventArgs>(),
+                    It.IsAny<TestRunChangedEventArgs>(),
+                    It.IsAny<ICollection<AttachmentSet>>(),
+                    It.IsAny<ICollection<string>>()))
+                .Callback
+                <TestRunCompleteEventArgs, TestRunChangedEventArgs, ICollection<AttachmentSet>, ICollection<string>>
+                ((completeArgs, changeArgs, attachments, utis) => { testRunCompleteArgs = completeArgs; });
+            this.testRunEventsHandler.OnAbort(dataSerializerMock.Object, exception);
+
+            this.testRequestHandler.Verify( rh => rh.SendExecutionComplete(It.IsAny<TestRunCompleteEventArgs>(), null, null, null));
+            Assert.IsNotNull(testRunCompleteArgs);
+            Assert.IsTrue(testRunCompleteArgs.IsAborted);
+        }
+    }
+}

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelProxyExecutionManagerTests.cs
@@ -21,20 +21,33 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
     [TestClass]
     public class ParallelProxyExecutionManagerTests
     {
+        private static readonly int eventTimeout = 1000 * 1500; // In milli seconds
+
         private IParallelProxyExecutionManager proxyParallelExecutionManager;
+        private List<Mock<IProxyExecutionManager>> createdMockManagers;
+        private Func<IProxyExecutionManager> proxyManagerFunc;
+        private Mock<ITestRunEventsHandler> mockHandler;
+        private List<string> sources;
+        private TestRunCriteria testRunCriteria;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            this.createdMockManagers = new List<Mock<IProxyExecutionManager>>();
+            this.proxyManagerFunc = () =>
+            {
+                var manager = new Mock<IProxyExecutionManager>();
+                createdMockManagers.Add(manager);
+                return manager.Object;
+            };
+            this.mockHandler = new Mock<ITestRunEventsHandler>();
+            this.sources = new List<string>() { "1.dll", "2.dll" };
+            this.testRunCriteria = new TestRunCriteria(sources, 100);
+        }
 
         [TestMethod]
         public void InitializeShouldCallAllConcurrentManagersOnce()
         {
-            var createdMockManagers = new List<Mock<IProxyExecutionManager>>();
-            Func<IProxyExecutionManager> proxyManagerFunc =
-                () =>
-                {
-                    var manager = new Mock<IProxyExecutionManager>();
-                    createdMockManagers.Add(manager);
-                    return manager.Object;
-                };
-
             this.proxyParallelExecutionManager = new ParallelProxyExecutionManager(proxyManagerFunc, 3);
             this.proxyParallelExecutionManager.Initialize();
 
@@ -49,16 +62,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         [TestMethod]
         public void AbortShouldCallAllConcurrentManagersOnce()
         {
-            var createdMockManagers = new List<Mock<IProxyExecutionManager>>();
-            Func<IProxyExecutionManager> proxyManagerFunc =
-                () =>
-                {
-                    var manager = new Mock<IProxyExecutionManager>();
-                    createdMockManagers.Add(manager);
-                    return manager.Object;
-                };
-
-            this.proxyParallelExecutionManager = new ParallelProxyExecutionManager(proxyManagerFunc, 4);
+            this.proxyParallelExecutionManager = new ParallelProxyExecutionManager(this.proxyManagerFunc, 4);
             this.proxyParallelExecutionManager.Abort();
 
             Assert.AreEqual(4, createdMockManagers.Count, "Number of Concurrent Managers created should be 4");
@@ -72,16 +76,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         [TestMethod]
         public void CancelShouldCallAllConcurrentManagersOnce()
         {
-            var createdMockManagers = new List<Mock<IProxyExecutionManager>>();
-            Func<IProxyExecutionManager> proxyManagerFunc =
-                () =>
-                {
-                    var manager = new Mock<IProxyExecutionManager>();
-                    createdMockManagers.Add(manager);
-                    return manager.Object;
-                };
-
-            this.proxyParallelExecutionManager = new ParallelProxyExecutionManager(proxyManagerFunc, 4);
+            this.proxyParallelExecutionManager = new ParallelProxyExecutionManager(this.proxyManagerFunc, 4);
             this.proxyParallelExecutionManager.Cancel();
 
             Assert.AreEqual(4, createdMockManagers.Count, "Number of Concurrent Managers created should be 4");
@@ -95,73 +90,35 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         [TestMethod]
         public void StartTestRunShouldProcessAllSources()
         {
-            var createdMockManagers = new List<Mock<IProxyExecutionManager>>();
-            Func<IProxyExecutionManager> proxyManagerFunc =
-                () =>
-                {
-                    var manager = new Mock<IProxyExecutionManager>();
-                    createdMockManagers.Add(manager);
-                    return manager.Object;
-                };
+            this.proxyParallelExecutionManager = new ParallelProxyExecutionManager(this.proxyManagerFunc, 2);
 
-            this.proxyParallelExecutionManager = new ParallelProxyExecutionManager(proxyManagerFunc, 2);
-
-            var mockHandler = new Mock<ITestRunEventsHandler>();
-
-            var sources = new List<string>() { "1.dll", "2.dll" };
-
-            var testRunCriteria = new TestRunCriteria(sources, 100) { TestCaseFilter = "Name~Test" };
-
+            // Testcase filter should be passed to all parallel test run criteria.
+            this.testRunCriteria.TestCaseFilter = "Name~Test";
             var processedSources = new List<string>();
-            var syncObject = new object();
-            foreach (var manager in createdMockManagers)
-            {
-                manager.Setup(m => m.StartTestRun(It.IsAny<TestRunCriteria>(), It.IsAny<ITestRunEventsHandler>())).
-                    Callback<TestRunCriteria, ITestRunEventsHandler>(
-                        (criteria, handler) =>
-                        {
-                            lock (syncObject)
-                            {
-                                processedSources.AddRange(criteria.Sources);
-                            }
-
-                            Task.Delay(100).Wait();
-
-                            // Duplicated testRunCriteria should match the actual one.
-                            Assert.AreEqual(testRunCriteria, criteria, "Mismastch in testRunCriteria");
-
-                            handler.HandleTestRunComplete(
-                                new TestRunCompleteEventArgs(
-                                    new TestRunStatistics(new Dictionary<TestOutcome, long>()),
-                                    false,
-                                    false,
-                                    null,
-                                    null,
-                                    TimeSpan.Zero),
-                                null,
-                                null,
-                                null);
-                        });
-            }
-
+            this.SetupMockManagers(processedSources);
             AutoResetEvent completeEvent = new AutoResetEvent(false);
+            this.SetupHandleTestRunComplete(completeEvent);
 
-            mockHandler.Setup(mh => mh.HandleTestRunComplete(It.IsAny<TestRunCompleteEventArgs>(),
-                It.IsAny<TestRunChangedEventArgs>(),
-                It.IsAny<ICollection<AttachmentSet>>(),
-                It.IsAny<ICollection<string>>()))
+            this.proxyParallelExecutionManager.StartTestRun(testRunCriteria, this.mockHandler.Object);
+            completeEvent.WaitOne(eventTimeout);
+
+            Assert.AreEqual(this.sources.Count, processedSources.Count, "All Sources must be processed.");
+            AssertMissingAndDuplicateSources(processedSources);
+        }
+
+        private void SetupHandleTestRunComplete(AutoResetEvent completeEvent)
+        {
+            this.mockHandler.Setup(mh => mh.HandleTestRunComplete(It.IsAny<TestRunCompleteEventArgs>(),
+                    It.IsAny<TestRunChangedEventArgs>(),
+                    It.IsAny<ICollection<AttachmentSet>>(),
+                    It.IsAny<ICollection<string>>()))
                 .Callback<TestRunCompleteEventArgs, TestRunChangedEventArgs, ICollection<AttachmentSet>, ICollection<string>>(
-                (testRunCompleteArgs, testRunChangedEventArgs, attachmentSets, executorUris) =>
-                {
-                    completeEvent.Set();
-                });
+                    (testRunCompleteArgs, testRunChangedEventArgs, attachmentSets, executorUris) => { completeEvent.Set(); });
+        }
 
-            this.proxyParallelExecutionManager.StartTestRun(testRunCriteria, mockHandler.Object);
-            completeEvent.WaitOne();
-
-            Assert.AreEqual(sources.Count, processedSources.Count, "All Sources must be processed.");
-
-            foreach (var source in sources)
+        private void AssertMissingAndDuplicateSources(List<string> processedSources)
+        {
+            foreach (var source in this.sources)
             {
                 bool matchFound = false;
 
@@ -169,7 +126,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
                 {
                     if (processedSrc.Equals(source))
                     {
-                        if (matchFound) Assert.Fail("Concurrreny issue detected: Source['{0}'] got processed twice", processedSrc);
+                        if (matchFound)
+                            Assert.Fail("Concurrreny issue detected: Source['{0}'] got processed twice", processedSrc);
                         matchFound = true;
                     }
                 }
@@ -178,33 +136,64 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
             }
         }
 
+        private static TestRunCompleteEventArgs CreateTestRunCompleteArgs(bool isCanceled=false, bool isAborted=false)
+        {
+            return new TestRunCompleteEventArgs(
+                new TestRunStatistics(new Dictionary<TestOutcome, long>()),
+                isCanceled,
+                isAborted,
+                null,
+                null,
+                TimeSpan.FromMilliseconds(1));
+        }
+
         [TestMethod]
         public void StartTestRunShouldProcessAllTestCases()
         {
-            var createdMockManagers = new List<Mock<IProxyExecutionManager>>();
-            Func<IProxyExecutionManager> proxyManagerFunc =
-                () =>
-                {
-                    var manager = new Mock<IProxyExecutionManager>();
-                    createdMockManagers.Add(manager);
-                    return manager.Object;
-                };
+            this.proxyParallelExecutionManager = new ParallelProxyExecutionManager(this.proxyManagerFunc, 3);
 
-            this.proxyParallelExecutionManager = new ParallelProxyExecutionManager(proxyManagerFunc, 3);
-
-            var mockHandler = new Mock<ITestRunEventsHandler>();
-
-            TestCase tc1 = new TestCase("dll1.class1.test1", new Uri("hello://x/"), "1.dll");
-            TestCase tc21 = new TestCase("dll2.class21.test21", new Uri("hello://x/"), "2.dll");
-            TestCase tc22 = new TestCase("dll2.class21.test22", new Uri("hello://x/"), "2.dll");
-            TestCase tc31 = new TestCase("dll3.class31.test31", new Uri("hello://x/"), "3.dll");
-            TestCase tc32 = new TestCase("dll3.class31.test32", new Uri("hello://x/"), "3.dll");
-
-            var tests = new List<TestCase>() { tc1, tc21, tc22, tc31, tc32 };
+            var tests = CreateTestCases();
 
             var testRunCriteria = new TestRunCriteria(tests, 100);
 
             var processedTestCases = new List<TestCase>();
+            SetupMockManagersForTestCase(processedTestCases, testRunCriteria);
+
+            AutoResetEvent completeEvent = new AutoResetEvent(false);
+            this.SetupHandleTestRunComplete(completeEvent);
+
+            this.proxyParallelExecutionManager.StartTestRun(testRunCriteria, this.mockHandler.Object);
+            completeEvent.WaitOne(eventTimeout);
+
+            Assert.AreEqual(tests.Count, processedTestCases.Count, "All Tests must be processed.");
+
+            AssertMissingAndDuplicateTestCases(tests, processedTestCases);
+
+        }
+
+        private static void AssertMissingAndDuplicateTestCases(List<TestCase> tests, List<TestCase> processedTestCases)
+        {
+            foreach (var test in tests)
+            {
+                bool matchFound = false;
+
+                foreach (var processedTest in processedTestCases)
+                {
+                    if (processedTest.FullyQualifiedName.Equals(test.FullyQualifiedName))
+                    {
+                        if (matchFound)
+                            Assert.Fail("Concurrreny issue detected: Test['{0}'] got processed twice", test.FullyQualifiedName);
+                        matchFound = true;
+                    }
+                }
+
+                Assert.IsTrue(matchFound, "Concurrency issue detected: Test['{0}'] did NOT get processed at all",
+                    test.FullyQualifiedName);
+            }
+        }
+
+        private void SetupMockManagersForTestCase(List<TestCase> processedTestCases, TestRunCriteria testRunCriteria)
+        {
             var syncObject = new object();
             foreach (var manager in createdMockManagers)
             {
@@ -222,70 +211,50 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
                             // Duplicated testRunCriteria should match the actual one.
                             Assert.AreEqual(testRunCriteria, criteria, "Mismastch in testRunCriteria");
 
-                            handler.HandleTestRunComplete(
-                                new TestRunCompleteEventArgs(new TestRunStatistics(new Dictionary<TestOutcome, long>())
-                                , false, false, null, null, TimeSpan.Zero)
-                                , null, null, null);
+                            handler.HandleTestRunComplete(CreateTestRunCompleteArgs(), null, null, null);
                         });
             }
+        }
 
-            AutoResetEvent completeEvent = new AutoResetEvent(false);
+        private static List<TestCase> CreateTestCases()
+        {
+            TestCase tc1 = new TestCase("dll1.class1.test1", new Uri("hello://x/"), "1.dll");
+            TestCase tc21 = new TestCase("dll2.class21.test21", new Uri("hello://x/"), "2.dll");
+            TestCase tc22 = new TestCase("dll2.class21.test22", new Uri("hello://x/"), "2.dll");
+            TestCase tc31 = new TestCase("dll3.class31.test31", new Uri("hello://x/"), "3.dll");
+            TestCase tc32 = new TestCase("dll3.class31.test32", new Uri("hello://x/"), "3.dll");
 
-            mockHandler.Setup(mh => mh.HandleTestRunComplete(It.IsAny<TestRunCompleteEventArgs>(),
-                It.IsAny<TestRunChangedEventArgs>(),
-                It.IsAny<ICollection<AttachmentSet>>(),
-                It.IsAny<ICollection<string>>()))
-                .Callback<TestRunCompleteEventArgs, TestRunChangedEventArgs, ICollection<AttachmentSet>, ICollection<string>>(
-                (testRunCompleteArgs, testRunChangedEventArgs, attachmentSets, executorUris) =>
-                {
-                    completeEvent.Set();
-                });
-
-            this.proxyParallelExecutionManager.StartTestRun(testRunCriteria, mockHandler.Object);
-            completeEvent.WaitOne();
-
-            Assert.AreEqual(tests.Count, processedTestCases.Count, "All Tests must be processed.");
-
-            foreach (var test in tests)
-            {
-                bool matchFound = false;
-
-                foreach (var processedTest in processedTestCases)
-                {
-                    if (processedTest.FullyQualifiedName.Equals(test.FullyQualifiedName))
-                    {
-                        if (matchFound) Assert.Fail("Concurrreny issue detected: Test['{0}'] got processed twice", test.FullyQualifiedName);
-                        matchFound = true;
-                    }
-                }
-
-                Assert.IsTrue(matchFound, "Concurrency issue detected: Test['{0}'] did NOT get processed at all", test.FullyQualifiedName);
-            }
-
+            var tests = new List<TestCase>() {tc1, tc21, tc22, tc31, tc32};
+            return tests;
         }
 
 
         [TestMethod]
         public void StartTestRunWithSourcesShouldNotSendCompleteUntilAllSourcesAreProcessed()
         {
-            var createdMockManagers = new List<Mock<IProxyExecutionManager>>();
-            Func<IProxyExecutionManager> proxyManagerFunc =
-                () =>
-                {
-                    var manager = new Mock<IProxyExecutionManager>();
-                    createdMockManagers.Add(manager);
-                    return manager.Object;
-                };
-
-            this.proxyParallelExecutionManager = new ParallelProxyExecutionManager(proxyManagerFunc, 2);
-
-            var mockHandler = new Mock<ITestRunEventsHandler>();
-
-            var sources = new List<string>() { "1.dll", "2.dll" };
-
-            var testRunCriteria = new TestRunCriteria(sources, 100);
+            this.proxyParallelExecutionManager = new ParallelProxyExecutionManager(this.proxyManagerFunc, 2);
 
             var processedSources = new List<string>();
+            this.SetupMockManagers(processedSources);
+
+            AutoResetEvent eventHandle = new AutoResetEvent(false);
+
+            SetupHandleTestRunComplete(eventHandle);
+
+            Task.Run(() =>
+            {
+                this.proxyParallelExecutionManager.StartTestRun(testRunCriteria, this.mockHandler.Object);
+            });
+
+            eventHandle.WaitOne(eventTimeout);
+
+            Assert.AreEqual(sources.Count, processedSources.Count, "All Sources must be processed.");
+
+            AssertMissingAndDuplicateSources(processedSources);
+        }
+
+        private void SetupMockManagers(List<string> processedSources, bool isCanceled = false, bool isAborted = false)
+        {
             var syncObject = new object();
             foreach (var manager in createdMockManagers)
             {
@@ -297,165 +266,80 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
                             {
                                 processedSources.AddRange(criteria.Sources);
                             }
-
                             Task.Delay(100).Wait();
 
-                            var completeArgs = new TestRunCompleteEventArgs(new
-                                 TestRunStatistics(new Dictionary<TestOutcome, long>()),
-                                 false, false, null, null, TimeSpan.FromMilliseconds(1));
-                            handler.HandleTestRunComplete(completeArgs, null, null, null);
+                            // Duplicated testRunCriteria should match the actual one.
+                            Assert.AreEqual(testRunCriteria, criteria, "Mismastch in testRunCriteria");
+                            handler.HandleTestRunComplete(CreateTestRunCompleteArgs(isCanceled, isAborted), null, null, null);
                         });
             }
-
-            AutoResetEvent eventHandle = new AutoResetEvent(false);
-
-            mockHandler.Setup(m => m.HandleTestRunComplete(
-                It.IsAny<TestRunCompleteEventArgs>(),
-                It.IsAny<TestRunChangedEventArgs>(),
-                It.IsAny<ICollection<AttachmentSet>>(),
-                It.IsAny<ICollection<string>>())).Callback
-                <TestRunCompleteEventArgs, TestRunChangedEventArgs, ICollection<AttachmentSet>, ICollection<string>>(
-                (completeArgs, runChangedArgs, runAttachments, executorUris) =>
-                {
-                    eventHandle.Set();
-                });
-
-            Task.Run(() =>
-            {
-                this.proxyParallelExecutionManager.StartTestRun(testRunCriteria, mockHandler.Object);
-            });
-
-            eventHandle.WaitOne();
-
-            Assert.AreEqual(sources.Count, processedSources.Count, "All Sources must be processed.");
-
-            foreach (var source in sources)
-            {
-                bool matchFound = false;
-
-                foreach (var processedSrc in processedSources)
-                {
-                    if (processedSrc.Equals(source))
-                    {
-                        if (matchFound) Assert.Fail("Concurrreny issue detected: Source['{0}'] got processed twice", processedSrc);
-                        matchFound = true;
-                    }
-                }
-
-                Assert.IsTrue(matchFound, "Concurrency issue detected: Source['{0}'] did NOT get processed at all", source);
-            }
-
         }
 
 
         [TestMethod]
         public void StartTestRunWithTestsShouldNotSendCompleteUntilAllTestsAreProcessed()
         {
-            var createdMockManagers = new List<Mock<IProxyExecutionManager>>();
-            Func<IProxyExecutionManager> proxyManagerFunc =
-                () =>
-                {
-                    var manager = new Mock<IProxyExecutionManager>();
-                    createdMockManagers.Add(manager);
-                    return manager.Object;
-                };
+            this.proxyParallelExecutionManager = new ParallelProxyExecutionManager(this.proxyManagerFunc, 3);
 
-            this.proxyParallelExecutionManager = new ParallelProxyExecutionManager(proxyManagerFunc, 3);
-
-            var mockHandler = new Mock<ITestRunEventsHandler>();
-
-            TestCase tc1 = new TestCase("dll1.class1.test1", new Uri("hello://x/"), "1.dll");
-            TestCase tc21 = new TestCase("dll2.class21.test21", new Uri("hello://x/"), "2.dll");
-            TestCase tc22 = new TestCase("dll2.class21.test22", new Uri("hello://x/"), "2.dll");
-            TestCase tc31 = new TestCase("dll3.class31.test31", new Uri("hello://x/"), "3.dll");
-            TestCase tc32 = new TestCase("dll3.class31.test32", new Uri("hello://x/"), "3.dll");
-
-            var tests = new List<TestCase>() { tc1, tc21, tc22, tc31, tc32 };
-
+            var tests = CreateTestCases();
             var testRunCriteria = new TestRunCriteria(tests, 100);
-
             var processedTestCases = new List<TestCase>();
-            var syncObject = new object();
-            foreach (var manager in createdMockManagers)
-            {
-                manager.Setup(m => m.StartTestRun(It.IsAny<TestRunCriteria>(), It.IsAny<ITestRunEventsHandler>())).
-                    Callback<TestRunCriteria, ITestRunEventsHandler>(
-                        (criteria, handler) =>
-                        {
-                            lock (syncObject)
-                            {
-                                processedTestCases.AddRange(criteria.Tests);
-                            }
-
-                            Task.Delay(100).Wait();
-
-                            var completeArgs = new TestRunCompleteEventArgs(new
-                             TestRunStatistics(new Dictionary<TestOutcome, long>()),
-                             false, false, null, null, TimeSpan.FromMilliseconds(1));
-                            handler.HandleTestRunComplete(completeArgs, null, null, null);
-                        });
-            }
+            SetupMockManagersForTestCase(processedTestCases, testRunCriteria);
 
             AutoResetEvent eventHandle = new AutoResetEvent(false);
 
-            mockHandler.Setup(m => m.HandleTestRunComplete(
-                It.IsAny<TestRunCompleteEventArgs>(),
-                It.IsAny<TestRunChangedEventArgs>(),
-                It.IsAny<ICollection<AttachmentSet>>(),
-                It.IsAny<ICollection<string>>())).Callback
-                <TestRunCompleteEventArgs, TestRunChangedEventArgs, ICollection<AttachmentSet>, ICollection<string>>(
-                (completeArgs, runChangedArgs, runAttachments, executorUris) =>
-                {
-                    eventHandle.Set();
-                });
+            SetupHandleTestRunComplete(eventHandle);
 
             Task.Run(() =>
             {
-                this.proxyParallelExecutionManager.StartTestRun(testRunCriteria, mockHandler.Object);
+                this.proxyParallelExecutionManager.StartTestRun(testRunCriteria, this.mockHandler.Object);
             });
 
-            eventHandle.WaitOne();
+            eventHandle.WaitOne(eventTimeout);
 
             Assert.AreEqual(tests.Count, processedTestCases.Count, "All Tests must be processed.");
 
-            foreach (var test in tests)
-            {
-                bool matchFound = false;
-
-                foreach (var processedTest in processedTestCases)
-                {
-                    if (processedTest.FullyQualifiedName.Equals(test.FullyQualifiedName))
-                    {
-                        if (matchFound) Assert.Fail("Concurrreny issue detected: Test['{0}'] got processed twice", test.FullyQualifiedName);
-                        matchFound = true;
-                    }
-                }
-
-                Assert.IsTrue(matchFound, "Concurrency issue detected: Test['{0}'] did NOT get processed at all", test.FullyQualifiedName);
-            }
+            AssertMissingAndDuplicateTestCases(tests, processedTestCases);
 
         }
 
+        [TestMethod]
+        public void ExecutionTestsShouldProcessAllSourcesOnExecutionAbortsForAnySource()
+        {
+            var processedSources = SetupForAbnormalTestCases(isAborted: true);
+            Assert.AreEqual(sources.Count, processedSources.Count, "All Sources must be processed.");
+            AssertMissingAndDuplicateSources(processedSources);
+        }
+
+        [TestMethod]
+        public void ExecutionTestsShouldNotProcessAllSourcesOnExecutionCancelsForAnySource()
+        {
+            var processedSources = SetupForAbnormalTestCases(isCanceled:true);
+            Assert.AreEqual(1, processedSources.Count, "Cancel should stop all sources execution.");
+        }
+
+        private List<string> SetupForAbnormalTestCases(bool isCanceled = false, bool isAborted = false)
+        {
+            var executionManagerMock = new Mock<IProxyExecutionManager>();
+            this.proxyParallelExecutionManager = new ParallelProxyExecutionManager(() => executionManagerMock.Object, 1);
+            this.createdMockManagers.Add(executionManagerMock);
+            var processedSources = new List<string>();
+            this.SetupMockManagers(processedSources, isCanceled: isCanceled, isAborted: isAborted);
+
+            AutoResetEvent eventHandle = new AutoResetEvent(false);
+
+            SetupHandleTestRunComplete(eventHandle);
+
+            Task.Run(() => { this.proxyParallelExecutionManager.StartTestRun(testRunCriteria, this.mockHandler.Object); });
+
+            eventHandle.WaitOne(eventTimeout);
+            return processedSources;
+        }
 
         [TestMethod]
         public void StartTestRunShouldAggregateRunData()
         {
-            var createdMockManagers = new List<Mock<IProxyExecutionManager>>();
-            Func<IProxyExecutionManager> proxyManagerFunc =
-                () =>
-                {
-                    var manager = new Mock<IProxyExecutionManager>();
-                    createdMockManagers.Add(manager);
-                    return manager.Object;
-                };
-
-            this.proxyParallelExecutionManager = new ParallelProxyExecutionManager(proxyManagerFunc, 2);
-
-            var mockHandler = new Mock<ITestRunEventsHandler>();
-
-            var sources = new List<string>() { "1.dll", "2.dll" };
-
-            var testRunCriteria = new TestRunCriteria(sources, 100);
+            this.proxyParallelExecutionManager = new ParallelProxyExecutionManager(this.proxyManagerFunc, 2);
 
             var processedSources = new List<string>();
             var syncObject = new object();
@@ -501,7 +385,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
             AutoResetEvent eventHandle = new AutoResetEvent(false);
 
-            mockHandler.Setup(m => m.HandleTestRunComplete(
+            this.mockHandler.Setup(m => m.HandleTestRunComplete(
                 It.IsAny<TestRunCompleteEventArgs>(),
                 It.IsAny<TestRunChangedEventArgs>(),
                 It.IsAny<ICollection<AttachmentSet>>(),
@@ -526,28 +410,13 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
             Task.Run(() =>
             {
-                this.proxyParallelExecutionManager.StartTestRun(testRunCriteria, mockHandler.Object);
+                this.proxyParallelExecutionManager.StartTestRun(testRunCriteria, this.mockHandler.Object);
             });
 
-            eventHandle.WaitOne();
+            eventHandle.WaitOne(eventTimeout);
 
             Assert.AreEqual(sources.Count, processedSources.Count, "All Sources must be processed.");
-
-            foreach (var source in sources)
-            {
-                bool matchFound = false;
-
-                foreach (var processedSrc in processedSources)
-                {
-                    if (processedSrc.Equals(source))
-                    {
-                        if (matchFound) Assert.Fail("Concurrreny issue detected: Source['{0}'] got processed twice", processedSrc);
-                        matchFound = true;
-                    }
-                }
-
-                Assert.IsTrue(matchFound, "Concurrency issue detected: Source['{0}'] did NOT get processed at all", source);
-            }
+            AssertMissingAndDuplicateSources(processedSources);
         }
 
     }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
@@ -6,6 +6,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
     using System.Collections.Generic;
 
     using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -41,7 +42,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
             this.testDiscoveryManager = new ProxyDiscoveryManager(
                                             this.mockRequestSender.Object,
                                             this.mockTestHostManager.Object,
-                                            this.testableClientConnectionTimeout);
+                                            this.testableClientConnectionTimeout, JsonDataSerializer.Instance);
             this.discoveryCriteria = new DiscoveryCriteria(new[] { "test.dll" }, 1, string.Empty);
 
             // Default setup test host manager as shared (desktop)
@@ -138,7 +139,6 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         [TestMethod]
         public void DiscoverTestsShouldcatchExceptionAndCallHandleDiscoveryComplete()
         {
-            // System.Diagnostics.Debugger.Launch();
             // Setup mocks.
             this.mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
             Mock<ITestDiscoveryEventsHandler> mockTestDiscoveryEventsHandler = new Mock<ITestDiscoveryEventsHandler>();
@@ -147,8 +147,9 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
             this.testDiscoveryManager.DiscoverTests(this.discoveryCriteria, mockTestDiscoveryEventsHandler.Object);
 
             // Verify
-            mockTestDiscoveryEventsHandler.Verify(s => s.HandleDiscoveryComplete(0, It.IsAny<IEnumerable<TestCase>>(), false));
+            mockTestDiscoveryEventsHandler.Verify(s => s.HandleDiscoveryComplete(-1, It.IsAny<IEnumerable<TestCase>>(), true));
             mockTestDiscoveryEventsHandler.Verify(s => s.HandleLogMessage(TestMessageLevel.Error, It.IsAny<string>()));
+            mockTestDiscoveryEventsHandler.Verify(s => s.HandleRawMessage(It.IsAny<string>()), Times.Exactly(2));
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
@@ -10,12 +10,14 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
     using System.Threading.Tasks;
 
     using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     using Moq;
@@ -43,7 +45,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
             this.mockTestHostManager = new Mock<ITestHostManager>();
             this.mockRequestSender = new Mock<ITestRequestSender>();
             this.mockTestRunCriteria = new Mock<TestRunCriteria>(new List<string> { "source.dll" }, 10);
-            this.testExecutionManager = new ProxyExecutionManager(this.mockRequestSender.Object, this.mockTestHostManager.Object, this.clientConnectionTimeout);
+            this.testExecutionManager = new ProxyExecutionManager(this.mockRequestSender.Object, this.mockTestHostManager.Object, this.clientConnectionTimeout, JsonDataSerializer.Instance);
 
             // Default to shared test host
             this.mockTestHostManager.SetupGet(th => th.Shared).Returns(true);
@@ -171,6 +173,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
             this.testExecutionManager.StartTestRun(this.mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
             mockTestRunEventsHandler.Verify(s => s.HandleTestRunComplete(It.IsAny<TestRunCompleteEventArgs>(), null, null, null));
+            mockTestRunEventsHandler.Verify(s => s.HandleLogMessage(TestMessageLevel.Error, It.IsAny<string>()));
+            mockTestRunEventsHandler.Verify(s => s.HandleRawMessage(It.IsAny<string>()), Times.Exactly(2));
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerWithDataCollectionTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerWithDataCollectionTests.cs
@@ -4,8 +4,8 @@
 namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 {
     using TestPlatform.CrossPlatEngine.UnitTests.DataCollection;
-
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client;
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection;
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection.Interfaces;
@@ -37,7 +37,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         {
             this.mockTestHostManager = new Mock<ITestHostManager>();
             this.mockRequestSender = new Mock<ITestRequestSender>();
-            this.testExecutionManager = new ProxyExecutionManager(this.mockRequestSender.Object, this.mockTestHostManager.Object, this.testableClientConnectionTimeout);
+            this.testExecutionManager = new ProxyExecutionManager(this.mockRequestSender.Object, this.mockTestHostManager.Object, this.testableClientConnectionTimeout, JsonDataSerializer.Instance);
             this.mockDataCollectionClient = new Mock<IProxyDataCollectionManager>();
         }
 


### PR DESCRIPTION
- Displays log messages to ide test output window.
- When multiple source passed, If there is abort due to one source, test run/discovery should continue for rest of sources.

Relates issue: #281 

Test Plan:
- Follow the issue repro instructions. able to see error message in IDE test output window.
- Open TestPlatform.sln in patched VS IDE, discover and run all project test.

