### PR TITLE
Revert "Add Microsoft.Extensions.DependencyModel dependency to test host nuspec"

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Microsoft.TestPlatform.CrossPlatEngine.csproj
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Microsoft.TestPlatform.CrossPlatEngine.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TestPlatformRoot Condition="$(TestPlatformRoot) == ''">..\..\</TestPlatformRoot>
@@ -11,7 +11,7 @@
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.5' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Resources\Resources.resx" />
+    <EmbeddedResource Include="Resources\Resources.resx"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.TestPlatform.CommunicationUtilities\Microsoft.TestPlatform.CommunicationUtilities.csproj" />
@@ -23,7 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyModel">
-      <Version>1.1.0</Version>
+      <Version>1.0.1-beta-000933</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">

--- a/src/TestPlatform.TestHost.nuspec
+++ b/src/TestPlatform.TestHost.nuspec
@@ -18,7 +18,6 @@
         
       <!-- CommunicationUtilities requires 8.0.3, but 8.0.3 doesn't provide a netcoreapp1.0 target -->
       <dependency id="Newtonsoft.Json" version="9.0.1"/>
-      <dependency id="Microsoft.Extensions.DependencyModel" version="1.1.0"/>
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
- Related bug #433 can be fixed by upgrading `xunit.runner.visualstudio >=2.2.0-rc1-build1247`
- Not taking this change for rtm. As it is not compatibility with `xunit.runner.visualstudio <=2.2.0-beta5-build1225`
