### PR TITLE
Console verbosity

### DIFF
--- a/src/Microsoft.TestPlatform.Common/Logging/TestLoggerManager.cs
+++ b/src/Microsoft.TestPlatform.Common/Logging/TestLoggerManager.cs
@@ -65,11 +65,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Logging
         /// <summary>
         /// Default constructor.
         /// </summary>
-        protected TestLoggerManager()
+        protected TestLoggerManager(TestSessionMessageLogger sessionLogger, InternalTestLoggerEvents loggerEvents)
         {
-            this.messageLogger = TestSessionMessageLogger.Instance;
+            this.messageLogger = sessionLogger;
             this.testLoggerExtensionManager = TestLoggerExtensionManager.Create(messageLogger);
-            this.loggerEvents = new InternalTestLoggerEvents((TestSessionMessageLogger)messageLogger);
+            this.loggerEvents = loggerEvents;
         }
 
         /// <summary>
@@ -85,7 +85,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Logging
                     {
                         if (testLoggerManager == null)
                         {
-                            testLoggerManager = new TestLoggerManager();
+                            testLoggerManager = new TestLoggerManager(TestSessionMessageLogger.Instance,
+                                new InternalTestLoggerEvents(TestSessionMessageLogger.Instance));
                         }
                     }
                 }
@@ -129,6 +130,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Logging
 
         #region Public Methods
 
+        /// <summary>
+        /// Add and initialize the logger with the given parameters
+        /// </summary>
+        /// <param name="logger">The logger that needs to be initialized</param>
+        /// <param name="extensionUri">URI of the logger</param>
+        /// <param name="parameters">Logger parameters</param>
         public void AddLogger(ITestLogger logger, string extensionUri, Dictionary<string, string> parameters)
         {
             this.CheckDisposed();
@@ -392,7 +399,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Logging
         /// <summary>
         /// Populates user supplied and default logger parameters.
         /// </summary>
-        private Dictionary<string, string> UpdateLoggerParamters(Dictionary<string, string> parameters)
+        private Dictionary<string, string> UpdateLoggerParameters(Dictionary<string, string> parameters)
         {
             var loggerParams = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             if (parameters != null)
@@ -441,7 +448,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Logging
         {
             this.loggerEvents.CompleteTestRun(e.TestRunStatistics, e.IsCanceled, e.IsAborted, e.Error, e.AttachmentSets, e.ElapsedTimeInRunningTests);
         }
-
 
         /// <summary>
         /// Called when data collection message is received.

--- a/src/Microsoft.TestPlatform.CoreUtilities/Output/OutputUtilities.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Output/OutputUtilities.cs
@@ -14,6 +14,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
     /// </summary>
     public static class OutputUtilities
     {
+        private static string defaultFormat = "{0}";
+
         /// <summary>
         /// Output an error message.
         /// </summary>
@@ -24,7 +26,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         {
             using (new ConsoleColorHelper(ConsoleColor.Red))
             {
-                Output(output, OutputLevel.Error, Resources.CommandLineError, format, args);
+                Output(output, OutputLevel.Error, defaultFormat, format, args);
             }
         }
 
@@ -38,7 +40,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         {
             using (new ConsoleColorHelper(ConsoleColor.Yellow))
             {
-                Output(output, OutputLevel.Warning, Resources.CommandLineWarning, format, args);
+                Output(output, OutputLevel.Warning, defaultFormat, format, args);
             }
         }
 
@@ -50,7 +52,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         /// <param name="args">Arguments to format into the format string.</param>
         public static void Information(this IOutput output, string format, params object[] args)
         {
-            Output(output, OutputLevel.Information, Resources.CommandLineInformational, format, args);
+            Output(output, OutputLevel.Information, defaultFormat, format, args);
         }
 
         /// <summary>

--- a/src/Microsoft.TestPlatform.CoreUtilities/Output/OutputUtilities.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Output/OutputUtilities.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
     /// </summary>
     public static class OutputUtilities
     {
-        private static string defaultFormat = "{0}";
+        private const string DefaultFormat = "{0}";
 
         /// <summary>
         /// Output an error message.
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         {
             using (new ConsoleColorHelper(ConsoleColor.Red))
             {
-                Output(output, OutputLevel.Error, defaultFormat, format, args);
+                Output(output, OutputLevel.Error, DefaultFormat, format, args);
             }
         }
 
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         {
             using (new ConsoleColorHelper(ConsoleColor.Yellow))
             {
-                Output(output, OutputLevel.Warning, defaultFormat, format, args);
+                Output(output, OutputLevel.Warning, DefaultFormat, format, args);
             }
         }
 
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         /// <param name="args">Arguments to format into the format string.</param>
         public static void Information(this IOutput output, string format, params object[] args)
         {
-            Output(output, OutputLevel.Information, defaultFormat, format, args);
+            Output(output, OutputLevel.Information, DefaultFormat, format, args);
         }
 
         /// <summary>

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -289,8 +289,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
                     Debug.Fail("ConsoleLogger.TestMessageHandler: The test message level is unrecognized: {0}", e.Level.ToString());
                     break;
             }
-
-            Output.WriteLine(string.Empty, (OutputLevel)e.Level);
         }
 
         /// <summary>
@@ -324,9 +322,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
             }
             else if (e.Result.Outcome == TestOutcome.Passed)
             {
-                string output = string.Format(CultureInfo.CurrentCulture, CommandLineResources.PassedTestIndicator, name);
                 if (!this.verbosityLevel.Equals(Verbosity.Minimal))
                 {
+                    string output = string.Format(CultureInfo.CurrentCulture, CommandLineResources.PassedTestIndicator, name);
                     Output.WriteLine(output, OutputLevel.Information);
                 }
                 this.testsPassed++;

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -45,17 +45,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
 
         #endregion
 
-        public class Verbosity
+        internal enum Verbosity
         {
-            public static Verbosity Minimal = new Verbosity("minimal");
-            public static Verbosity Normal = new Verbosity("normal");
-
-            public string level;
-
-            Verbosity(string level)
-            {
-                this.level = level;
-            }
+            Minimal,
+            Normal
         }
 
         #region Fields
@@ -63,7 +56,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
         /// <summary>
         /// Level of verbosity
         /// </summary>
-        private Verbosity verbosityLevel = Verbosity.Normal;
+        private Verbosity verbosityLevel = Verbosity.Minimal;
 
         private TestOutcome testOutcome = TestOutcome.None;
         private int testsTotal = 0;
@@ -103,9 +96,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
             get;
             private set;
         }
+
+        /// <summary>
+        /// Get the verbosity level for the console logger
+        /// </summary>
+        public Verbosity VerbosityLevel => verbosityLevel;
+
         #endregion
 
-        #region ITestLogger
+        #region ITestLoggerWithParameters
 
         /// <summary>
         /// Initializes the Test Logger.
@@ -142,10 +141,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
                 throw new ArgumentException("No default parameters added", nameof(parameters));
             }
 
-            var verbosityExists = parameters.TryGetValue(ConsoleLogger.VerbosityParam, out string verbosityLevel);
-            if (verbosityExists && verbosityLevel.Equals(Verbosity.Minimal.level))
+            var verbosityExists = parameters.TryGetValue(ConsoleLogger.VerbosityParam, out string verbosity);
+            if (verbosityExists && Enum.TryParse(verbosity, true, out Verbosity verbosityLevel))
             {
-                this.verbosityLevel = Verbosity.Minimal;
+                this.verbosityLevel = verbosityLevel;
             }
 
             this.Initialize(events, String.Empty);

--- a/src/vstest.console/Processors/EnableLoggerArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnableLoggerArgumentProcessor.cs
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
     using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities;
 
     using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;
+    using Microsoft.VisualStudio.TestPlatform.CommandLine.Internal;
 
     /// <summary>
     /// An argument processor that allows the user to enable a specific logger
@@ -154,25 +155,32 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
 
                 if (parseSucceeded)
                 {
-                    // First assume the logger is specified by URI. If that fails try with friendly name.
-                    try
+                    if (loggerIdentifier == "console")
                     {
-                        this.AddLoggerByUri(loggerIdentifier, parameters);
+                        this.loggerManager.AddLogger(new ConsoleLogger(), ConsoleLogger.ExtensionUri, parameters);
                     }
-                    catch (CommandLineException)
+                    else
                     {
-                        string loggerUri;
-                        if (this.loggerManager.TryGetUriFromFriendlyName(loggerIdentifier, out loggerUri))
+                        // First assume the logger is specified by URI. If that fails try with friendly name.
+                        try
                         {
-                            this.AddLoggerByUri(loggerUri, parameters);
+                            this.AddLoggerByUri(loggerIdentifier, parameters);
                         }
-                        else
+                        catch (CommandLineException)
                         {
-                            throw new CommandLineException(
-                            String.Format(
-                            CultureInfo.CurrentUICulture,
-                            CommandLineResources.LoggerNotFound,
-                            argument));
+                            string loggerUri;
+                            if (this.loggerManager.TryGetUriFromFriendlyName(loggerIdentifier, out loggerUri))
+                            {
+                                this.AddLoggerByUri(loggerUri, parameters);
+                            }
+                            else
+                            {
+                                throw new CommandLineException(
+                                String.Format(
+                                CultureInfo.CurrentUICulture,
+                                CommandLineResources.LoggerNotFound,
+                                argument));
+                            }
                         }
                     }
                 }

--- a/src/vstest.console/Processors/EnableLoggerArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnableLoggerArgumentProcessor.cs
@@ -155,7 +155,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
 
                 if (parseSucceeded)
                 {
-                    if (loggerIdentifier == "console")
+                    if (loggerIdentifier.Equals(ConsoleLogger.FriendlyName, StringComparison.OrdinalIgnoreCase))
                     {
                         this.loggerManager.AddLogger(new ConsoleLogger(), ConsoleLogger.ExtensionUri, parameters);
                     }

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
             // TODO: Is this required for design mode
             // Add console logger as a listener to logger events.
             var consoleLogger = new ConsoleLogger();
-            consoleLogger.Initialize(this.testLoggerManager.LoggerEvents, null);
+            this.testLoggerManager.AddLogger(consoleLogger, ConsoleLogger.ExtensionUri, null);
         }
 
         #endregion

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Logging/TestLoggerManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Logging/TestLoggerManagerTests.cs
@@ -431,7 +431,7 @@ namespace TestPlatform.Common.UnitTests.Logging
 
         internal class DummyTestLoggerManager : TestLoggerManager
         {
-            public DummyTestLoggerManager()
+            public DummyTestLoggerManager() : base(TestSessionMessageLogger.Instance, new InternalTestLoggerEvents(TestSessionMessageLogger.Instance))
             {
 
             }

--- a/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Output/OutputUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Output/OutputUtilitiesTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.TestPlatform.CoreUtilities.UnitTests.Output
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.VisualStudio.TestPlatform.Utilities;
+    using Moq;
+
+    [TestClass]
+    public class OutputUtilitiesTests
+    {
+        private Mock<IOutput> mockOutput;
+
+        [TestInitialize]
+        public void TestInit()
+        {
+            mockOutput = new Mock<IOutput>();
+        }
+
+        [TestMethod]
+        public void OutputErrorForSimpleMessageShouldOutputTheMessageString()
+        {
+            mockOutput.Object.Error("HelloError", null);
+            mockOutput.Verify(o => o.WriteLine("HelloError", OutputLevel.Error), Times.Once());
+        }
+
+        [TestMethod]
+        public void OutputErrorForMessageWithParamsShouldOutputFormattedMessage()
+        {
+            mockOutput.Object.Error("HelloError {0} {1}", "Foo", "Bar");
+            mockOutput.Verify(o => o.WriteLine("HelloError Foo Bar", OutputLevel.Error), Times.Once());
+        }
+
+        [TestMethod]
+        public void OutputWarningForSimpleMessageShouldOutputTheMessageString()
+        {
+            mockOutput.Object.Warning("HelloWarning", null);
+            mockOutput.Verify(o => o.WriteLine("HelloWarning", OutputLevel.Warning), Times.Once());
+        }
+
+        [TestMethod]
+        public void OutputWarningForMessageWithParamsShouldOutputFormattedMessage()
+        {
+            mockOutput.Object.Warning("HelloWarning {0} {1}", "Foo", "Bar");
+            mockOutput.Verify(o => o.WriteLine("HelloWarning Foo Bar", OutputLevel.Warning), Times.Once());
+        }
+
+        [TestMethod]
+        public void OutputInformationForSimpleMessageShouldOutputTheMessageString()
+        {
+            mockOutput.Object.Information("HelloInformation", null);
+            mockOutput.Verify(o => o.WriteLine("HelloInformation", OutputLevel.Information), Times.Once());
+        }
+
+        [TestMethod]
+        public void OutputInformationForMessageWithParamsShouldOutputFormattedMessage()
+        {
+            mockOutput.Object.Information("HelloInformation {0} {1}", "Foo", "Bar");
+            mockOutput.Verify(o => o.WriteLine("HelloInformation Foo Bar", OutputLevel.Information), Times.Once());
+        }
+    }
+}

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -51,14 +51,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
         {
             Assert.ThrowsException<ArgumentNullException>(() =>
             {
-                this.consoleLogger.Initialize(null, null);
+                this.consoleLogger.Initialize(null, string.Empty);
             });
         }
 
         [TestMethod]
         public void InitializeShouldNotThrowExceptionIfEventsIsNotNull()
         {
-            this.consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, null);
+            this.consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, string.Empty);
         }
 
         [TestMethod]
@@ -252,7 +252,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
             this.mockOutput = new Mock<IOutput>();
 
             this.consoleLogger = new ConsoleLogger(this.mockOutput.Object);
-            this.consoleLogger.Initialize(this.events.Object, null);
+            this.consoleLogger.Initialize(this.events.Object, string.Empty);
 
             DummyTestLoggerManager.Cleanup();
 

--- a/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
@@ -6,10 +6,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
     using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
     using Microsoft.VisualStudio.TestPlatform.Common.Logging;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using System;
-    using System.Collections.Generic;
-
-    using Castle.DynamicProxy.Contributors;
+    using vstest.console.UnitTests.TestDoubles;
 
     [TestClass]
     public class EnableLoggersArgumentProcessorTests
@@ -50,7 +47,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual(false, capabilities.IsSpecialCommand);
         }
 
-
         [TestMethod]
         public void ExecutorInitializeWithNullOrEmptyArgumentsShouldThrowException()
         {
@@ -77,6 +73,17 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         }
 
         [TestMethod]
+        public void ExecutorInitializeWithValidArgumentsShouldAddConsoleloggerToTestLoggerManager()
+        {
+            RunTestsArgumentProcessorTests.SetupMockExtensions();
+            var testloggerManager = new DummyTestLoggerManager();
+            var executor = new EnableLoggerArgumentExecutor(testloggerManager);
+
+            executor.Initialize("console;verbosity=minimal");
+            Assert.IsTrue(testloggerManager.GetInitializedLoggers.Contains("logger://Microsoft/TestPlatform/ConsoleLogger/v2"));
+        }
+
+        [TestMethod]
         public void ExectorInitializeShouldThrowExceptionIfInvalidArgumentIsPassed()
         {
             var executor = new EnableLoggerArgumentExecutor(TestLoggerManager.Instance);
@@ -92,27 +99,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             var executor = new EnableLoggerArgumentExecutor(null);
             var result = executor.Execute();
             Assert.AreEqual(ArgumentProcessorResult.Success, result);
-        }
-    }
-
-    internal class DummyTestLoggerManager : TestLoggerManager
-    {
-        public DummyTestLoggerManager()
-        {
-
-        }
-
-        public HashSet<String> GetInitializedLoggers
-        {
-            get
-            {
-                return InitializedLoggers;
-            }
-        }
-
-        public static void Cleanup()
-        {
-            Instance = null;
         }
     }
 }

--- a/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
@@ -37,6 +37,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         {
             this.mockFileHelper = new Mock<IFileHelper>();
             this.mockFileHelper.Setup(fh => fh.Exists(this.dummyTestFilePath)).Returns(true);
+            this.mockFileHelper.Setup(x => x.GetCurrentDirectory()).Returns("");
             this.mockTestPlatformEventSource = new Mock<ITestPlatformEventSource>();
         }
 

--- a/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
@@ -33,6 +33,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         {
             this.mockFileHelper = new Mock<IFileHelper>();
             this.mockFileHelper.Setup(fh => fh.Exists(this.dummyTestFilePath)).Returns(true);
+            this.mockFileHelper.Setup(x => x.GetCurrentDirectory()).Returns("");
             this.mockTestPlatformEventSource = new Mock<ITestPlatformEventSource>();
         }
 

--- a/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
@@ -40,6 +40,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         {
             this.mockFileHelper = new Mock<IFileHelper>();
             this.mockFileHelper.Setup(fh => fh.Exists(this.dummyTestFilePath)).Returns(true);
+            this.mockFileHelper.Setup(x => x.GetCurrentDirectory()).Returns("");
             this.mockTestPlatformEventSource = new Mock<ITestPlatformEventSource>();
             SetupMockExtensions();
         }

--- a/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
@@ -187,7 +187,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
                 o =>
                 o.WriteLine(
                     string.Format(
-                        "Warning: The path '{0}' specified in the 'TestAdapterPath' does not contain any test adapters, provide a valid path and try again.",
+                        "The path '{0}' specified in the 'TestAdapterPath' does not contain any test adapters, provide a valid path and try again.",
                         currentFolder),
                     OutputLevel.Warning));
 

--- a/test/vstest.console.UnitTests/Processors/TestSourceArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestSourceArgumentProcessorTests.cs
@@ -86,6 +86,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             var testFilePath = "DummyTestFile.txt";
             var mockFileHelper = new Mock<IFileHelper>();
             mockFileHelper.Setup(fh => fh.Exists(testFilePath)).Returns(true);
+            mockFileHelper.Setup(x => x.GetCurrentDirectory()).Returns("");
             var options = CommandLineOptions.Instance;
             options.Reset();
             options.FileHelper = mockFileHelper.Object;

--- a/test/vstest.console.UnitTests/TestDoubles/DummyLoggerEvents.cs
+++ b/test/vstest.console.UnitTests/TestDoubles/DummyLoggerEvents.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace vstest.console.UnitTests.TestDoubles
+{
+    using System;
+    using Microsoft.VisualStudio.TestPlatform.Common.Logging;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+
+    internal class DummyLoggerEvents : InternalTestLoggerEvents
+    {
+        public DummyLoggerEvents(TestSessionMessageLogger testSessionMessageLogger) : base(testSessionMessageLogger)
+        {
+        }
+
+        public override event EventHandler<TestResultEventArgs> TestResult;
+        public override event EventHandler<TestRunCompleteEventArgs> TestRunComplete;
+        public override event EventHandler<TestRunMessageEventArgs> TestRunMessage;
+
+        public bool EventsSubscribed()
+        {
+            return TestResult != null && TestRunComplete != null && TestRunMessage != null;
+        }
+    }
+}

--- a/test/vstest.console.UnitTests/TestDoubles/DummyTestLoggerManager.cs
+++ b/test/vstest.console.UnitTests/TestDoubles/DummyTestLoggerManager.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace vstest.console.UnitTests.TestDoubles
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.VisualStudio.TestPlatform.Common.Logging;
+
+    internal class DummyTestLoggerManager : TestLoggerManager
+    {
+        public DummyTestLoggerManager() : this(new DummyLoggerEvents(TestSessionMessageLogger.Instance))
+        {
+        }
+
+        public DummyTestLoggerManager(InternalTestLoggerEvents loggerEvents)
+            : base(TestSessionMessageLogger.Instance, loggerEvents)
+        {
+        }
+
+        public HashSet<String> GetInitializedLoggers
+        {
+            get
+            {
+                return InitializedLoggers;
+            }
+        }
+
+        public static void Cleanup()
+        {
+            Instance = null;
+        }
+    }
+}


### PR DESCRIPTION
 Code changes for adding verbosity parameter for console logger.  
 Making Verbosity minimal by default and Adding the tests 

Fix for https://github.com/Microsoft/vstest/issues/478 & https://github.com/Microsoft/vstest/issues/301

TestPlan:
Default behavior is minimal.
Minimal should not show passing test information.
Other commandline args to be verified (for both vstest.console.exe, dotnet test)
1.  /logger:console;verbosity=minimal should show minimal
2.  /logger:console;verbosity=normal should show normal i.e. along with passing tests
3.  /logger:console;verbosity=randomString should show minimal.
