### PR TITLE
Create config file for test project targeting .NET Framework

### DIFF
--- a/src/package/nuspec/Microsoft.NET.Test.Sdk.targets
+++ b/src/package/nuspec/Microsoft.NET.Test.Sdk.targets
@@ -43,8 +43,9 @@
   </PropertyGroup>
  
   <!--
-     Generate config file for test project targeting .NET Framework. This config file has have binding redirect which
-	 is needed at time of running tests.
+     Generate config file for test project targeting .NET Framework. This config file has have binding redirect which is needed at time of running tests.
+     Added below two lines because msbuild has following check:
+     https://github.com/Microsoft/msbuild/blob/dd5e8bc3f86ac98bd77d8971b00a6ad14f122f1a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets#L2027 
    -->
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/src/package/nuspec/Microsoft.NET.Test.Sdk.targets
+++ b/src/package/nuspec/Microsoft.NET.Test.Sdk.targets
@@ -41,6 +41,15 @@
   <PropertyGroup>
     <DebugType Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">Full</DebugType>
   </PropertyGroup>
+ 
+  <!--
+     Generate config file for test project targeting .NET Framework. This config file has have binding redirect which
+	 is needed at time of running tests.
+   -->
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
 
   <!--
      Note that this must run before every invocation of CoreCompile to ensure that all


### PR DESCRIPTION
Issue:
1) https://github.com/Microsoft/vstest/issues/428
2) https://github.com/Microsoft/vstest/issues/595

Fix:
Generate config file for test project targeting .NET Framework. This config file has have binding redirect which is needed at time of running tests.