### PR TITLE
Create new RuntimeProvider to be associated with each ProxyOperationManager

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -146,8 +146,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             finally
             {
                 this.initialized = false;
-                this.testHostManager.HostExited -= this.TestHostManagerHostExited;
-                this.testHostManager.HostLaunched -= this.TestHostManagerHostLaunched;
             }
         }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -146,6 +146,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             finally
             {
                 this.initialized = false;
+                this.testHostManager.HostExited -= this.TestHostManagerHostExited;
+                this.testHostManager.HostLaunched -= this.TestHostManagerHostLaunched;
             }
         }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Hosting/DefaultTestHostManager.cs
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
             var exitCode = 0;
             this.processHelper.TryGetExitCode(process, out exitCode);
 
-            this.OnHostExited(new HostProviderEventArgs(this.testHostProcessStdError.ToString(), exitCode));
+            this.OnHostExited(new HostProviderEventArgs(this.testHostProcessStdError.ToString(), exitCode, process.Id));
         });
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
             if (this.processHelper.TryGetExitCode(process, out exitCode))
             {
                 EqtTrace.Error("Test host exited with error: {0}", this.testHostProcessStdError);
-                this.OnHostExited(new HostProviderEventArgs(this.testHostProcessStdError.ToString(), exitCode));
+                this.OnHostExited(new HostProviderEventArgs(this.testHostProcessStdError.ToString(), exitCode, process.Id));
             }
         });
 
@@ -258,7 +258,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
             }
             catch (OperationCanceledException ex)
             {
-                this.OnHostExited(new HostProviderEventArgs(ex.Message, -1));
+                this.OnHostExited(new HostProviderEventArgs(ex.Message, -1, 0));
                 return -1;
             }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Hosting/DotnetTestHostManager.cs
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
             var exitCode = 0;
             this.processHelper.TryGetExitCode(process, out exitCode);
 
-            this.OnHostExited(new HostProviderEventArgs(this.testHostProcessStdError.ToString(), exitCode));
+            this.OnHostExited(new HostProviderEventArgs(this.testHostProcessStdError.ToString(), exitCode, process.Id));
         });
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
             if (this.processHelper.TryGetExitCode(process, out exitCode))
             {
                 EqtTrace.Error("Test host exited with error: {0}", this.testHostProcessStdError);
-                this.OnHostExited(new HostProviderEventArgs(this.testHostProcessStdError.ToString(), exitCode));
+                this.OnHostExited(new HostProviderEventArgs(this.testHostProcessStdError.ToString(), exitCode, process.Id));
             }
         };
 

--- a/src/Microsoft.TestPlatform.ObjectModel/Host/ITestRunTimeProvider.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Host/ITestRunTimeProvider.cs
@@ -126,14 +126,17 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Host
             this.ErrroCode = 0;
         }
 
-        public HostProviderEventArgs(string message, int errorCode)
+        public HostProviderEventArgs(string message, int errorCode, int processId)
         {
             this.Data = message;
             this.ErrroCode = errorCode;
+            this.ProcessId = processId;
         }
 
         public string Data { get; set; }
 
         public int ErrroCode { get; set; }
+
+        public int ProcessId { get; set; }
     }
 }


### PR DESCRIPTION
Since RuntimeProvider manages individual testruntime & also has state w.r.t a runtime's errorstream, & raises events w.r.t that runtime. It is better to associate a new runtimeprovider with each ProxyOperationManager(in parallel scenario)