### PR TITLE
Fix for #657, where dotnet vstest fails after publish and deploy

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Hosting/DotnetTestHostManager.cs
@@ -363,6 +363,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
                         }
                     }
                 }
+                
+                // Probing failed to find full path. Fallback to alternative options.
+                testHostPath = string.Empty;
             }
 
             if (string.IsNullOrEmpty(testHostPath))


### PR DESCRIPTION
Fixes #657 