### PR TITLE
Initialize testhostprovider

### DIFF
--- a/src/Microsoft.TestPlatform.Client/TestPlatform.cs
+++ b/src/Microsoft.TestPlatform.Client/TestPlatform.cs
@@ -79,7 +79,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Client
             this.UpdateTestAdapterPaths(discoveryCriteria.RunSettings);
 
             var testHostManager = this.testHostProviderManager.GetTestHostManagerByRunConfiguration(discoveryCriteria.RunSettings);
-            
+            testHostManager.Initialize(TestSessionMessageLogger.Instance, discoveryCriteria.RunSettings);
+
             var discoveryManager = this.TestEngine.GetDiscoveryManager(testHostManager, discoveryCriteria, protocolConfig);
             discoveryManager.Initialize();
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DiscoveryTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DiscoveryTests.cs
@@ -19,5 +19,26 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             var listOfTests = new string[] { "SampleUnitTestProject.UnitTest1.PassingTest", "SampleUnitTestProject.UnitTest1.FailingTest", "SampleUnitTestProject.UnitTest1.SkippingTest" };
             this.ValidateDiscoveredTests(listOfTests);
         }
+
+        [CustomDataTestMethod]
+        [NET46TargetFramework]
+        [NETCORETargetFramework]
+        public void MultipleSourcesDiscoverAllTests(string runnerFramework, string targetFramework, string targetRuntime)
+        {
+            AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerFramework, targetFramework, targetRuntime);
+
+            var assemblyPaths =
+                this.BuildMultipleAssemblyPath("SimpleTestProject.dll", "SimpleTestProject2.dll").Trim('\"');
+            this.InvokeVsTestForDiscovery(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue);
+            var listOfTests = new string[] {
+                "SampleUnitTestProject.UnitTest1.PassingTest",
+                "SampleUnitTestProject.UnitTest1.FailingTest",
+                "SampleUnitTestProject.UnitTest1.SkippingTest",
+                "SampleUnitTestProject.UnitTest1.PassingTest2",
+                "SampleUnitTestProject.UnitTest1.FailingTest2",
+                "SampleUnitTestProject.UnitTest1.SkippingTest2"
+            };
+            this.ValidateDiscoveredTests(listOfTests);
+        }
     }
 }

--- a/test/Microsoft.TestPlatform.Client.UnitTests/TestPlatformTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/TestPlatformTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests
         }
 
         [TestMethod]
-        public void CreateDiscoveryRequestShouldCreateDiscoveryRequestWithGivenCriteriaAndReturnIt()
+        public void CreateDiscoveryRequestShouldInitializeManagersAndCreateDiscoveryRequestWithGivenCriteriaAndReturnIt()
         {
             this.discoveryManager.Setup(dm => dm.Initialize()).Verifiable();
             this.testEngine.Setup(te => te.GetDiscoveryManager(this.hostManager.Object, It.IsAny<DiscoveryCriteria>(), It.IsAny<ProtocolConfig>())).Returns(this.discoveryManager.Object);
@@ -51,6 +51,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests
 
             var discoveryRequest = tp.CreateDiscoveryRequest(discoveryCriteria, It.IsAny<ProtocolConfig>());
 
+            this.hostManager.Verify(hm => hm.Initialize(It.IsAny<TestSessionMessageLogger>(), It.IsAny<string>()), Times.Once);
+            this.discoveryManager.Verify(dm => dm.Initialize(), Times.Once);
             Assert.AreEqual(discoveryCriteria, discoveryRequest.DiscoveryCriteria);
         }
 
@@ -127,7 +129,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests
         }
 
         [TestMethod]
-        public void CreateTestRunRequestShouldCreateTestRunRequestWithSpecifiedCriteria()
+        public void CreateTestRunRequestShouldInitializeManagersAndCreateTestRunRequestWithSpecifiedCriteria()
         {
             this.executionManager.Setup(dm => dm.Initialize()).Verifiable();
             this.testEngine.Setup(te => te.GetExecutionManager(this.hostManager.Object, It.IsAny<TestRunCriteria>(), It.IsAny<ProtocolConfig>())).Returns(this.executionManager.Object);
@@ -138,6 +140,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests
             var testRunRequest = tp.CreateTestRunRequest(testRunCriteria, It.IsAny<ProtocolConfig>());
 
             var actualTestRunRequest = testRunRequest as TestRunRequest;
+
+            this.hostManager.Verify(hm => hm.Initialize(It.IsAny<TestSessionMessageLogger>(), It.IsAny<string>()), Times.Once);
+            this.executionManager.Verify(em => em.Initialize(), Times.Once);
             Assert.AreEqual(testRunCriteria, actualTestRunRequest.TestRunCriteria);
         }
 

--- a/test/TestAssets/SimpleTestProject2/UnitTest1.cs
+++ b/test/TestAssets/SimpleTestProject2/UnitTest1.cs
@@ -14,7 +14,7 @@ namespace SampleUnitTestProject2
         /// The passing test.
         /// </summary>
         [TestMethod]
-        public void PassingTest()
+        public void PassingTest2()
         {
             Assert.AreEqual(2, 2);
         }
@@ -23,7 +23,7 @@ namespace SampleUnitTestProject2
         /// The failing test.
         /// </summary>
         [TestMethod]
-        public void FailingTest()
+        public void FailingTest2()
         {
             Assert.AreEqual(2, 3);
         }
@@ -33,7 +33,7 @@ namespace SampleUnitTestProject2
         /// </summary>
         [Ignore]
         [TestMethod]
-        public void SkippingTest()
+        public void SkippingTest2()
         {
         }
     }


### PR DESCRIPTION
Initialize testhostprovider to specify whether is it shared or not during discovery as well

Issue: https://github.com/Microsoft/vstest/issues/711