### PR TITLE
Use "dotnet test --verbosity" arg for console verbosity

### DIFF
--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
@@ -43,6 +43,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       VSTestCLIRunSettings="$(VSTestCLIRunSettings)"
       VSTestConsolePath="$(VSTestConsolePath)"
       VSTestResultsDirectory="$(VSTestResultsDirectory)"
+      VSTestVerbosity="$(VSTestVerbosity)"
     />
   </Target>
 
@@ -79,6 +80,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Message Text="VSTestCLIRunSettings = $(VSTestCLIRunSettings)" Importance="low" />
     <Message Text="VSTestResultsDirectory = $(VSTestResultsDirectory)" Importance="low" />
     <Message Text="VSTestConsolePath = $(VSTestConsolePath)" Importance="low" />
+    <Message Text="VSTestVerbosity = $(VSTestVerbosity)" Importance="low" />
   </Target>
 
 </Project>

--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask.cs
@@ -82,11 +82,17 @@ namespace Microsoft.TestPlatform.Build.Tasks
         [Required]
         public string VSTestConsolePath
         {
-            get; 
+            get;
             set;
         }
 
         public string VSTestResultsDirectory
+        {
+            get;
+            set;
+        }
+
+        public string VSTestVerbosity
         {
             get;
             set;
@@ -179,6 +185,25 @@ namespace Microsoft.TestPlatform.Build.Tasks
                 {
                     allArgs.Add("--testAdapterPath:" + this.AddDoubleQuotes(Path.GetDirectoryName(this.TestFileFullPath)));
                 }
+            }
+
+            if (!string.IsNullOrWhiteSpace(this.VSTestVerbosity) &&
+                (string.IsNullOrEmpty(this.VSTestLogger) || this.VSTestLogger.IndexOf("console", StringComparison.OrdinalIgnoreCase) < 0))
+            {
+                var normalTestLogging = new List<string>() { "n", "normal", "d", "detailed", "diag", "diagnostic" };
+                var minimalTestLogging = new List<string>() { "m", "minimal" };
+
+                string vsTestVerbosity = "quiet";
+                if (normalTestLogging.Contains(this.VSTestVerbosity))
+                {
+                    vsTestVerbosity = "normal";
+                }
+                else if (minimalTestLogging.Contains(this.VSTestVerbosity))
+                {
+                    vsTestVerbosity = "minimal";
+                }
+
+                allArgs.Add("--logger:Console;Verbosity=" + vsTestVerbosity);
             }
 
             if (this.VSTestCLIRunSettings != null && this.VSTestCLIRunSettings.Length > 0)

--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask.cs
@@ -188,19 +188,19 @@ namespace Microsoft.TestPlatform.Build.Tasks
             }
 
             if (!string.IsNullOrWhiteSpace(this.VSTestVerbosity) &&
-                (string.IsNullOrEmpty(this.VSTestLogger) || this.VSTestLogger.IndexOf("console", StringComparison.OrdinalIgnoreCase) < 0))
+                (string.IsNullOrEmpty(this.VSTestLogger) || this.VSTestLogger.StartsWith("console", StringComparison.OrdinalIgnoreCase)))
             {
                 var normalTestLogging = new List<string>() { "n", "normal", "d", "detailed", "diag", "diagnostic" };
-                var minimalTestLogging = new List<string>() { "m", "minimal" };
+                var quietTestLogging = new List<string>() { "q", "quiet" };
 
-                string vsTestVerbosity = "quiet";
+                string vsTestVerbosity = "minimal";
                 if (normalTestLogging.Contains(this.VSTestVerbosity))
                 {
                     vsTestVerbosity = "normal";
                 }
-                else if (minimalTestLogging.Contains(this.VSTestVerbosity))
+                else if (quietTestLogging.Contains(this.VSTestVerbosity))
                 {
-                    vsTestVerbosity = "minimal";
+                    vsTestVerbosity = "quiet";
                 }
 
                 allArgs.Add("--logger:Console;Verbosity=" + vsTestVerbosity);

--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask.cs
@@ -188,7 +188,7 @@ namespace Microsoft.TestPlatform.Build.Tasks
             }
 
             if (!string.IsNullOrWhiteSpace(this.VSTestVerbosity) &&
-                (string.IsNullOrEmpty(this.VSTestLogger) || this.VSTestLogger.StartsWith("console", StringComparison.OrdinalIgnoreCase)))
+                (string.IsNullOrEmpty(this.VSTestLogger) || !this.VSTestLogger.StartsWith("console", StringComparison.OrdinalIgnoreCase)))
             {
                 var normalTestLogging = new List<string>() { "n", "normal", "d", "detailed", "diag", "diagnostic" };
                 var quietTestLogging = new List<string>() { "q", "quiet" };

--- a/src/vstest.console/Resources/Resources.Designer.cs
+++ b/src/vstest.console/Resources/Resources.Designer.cs
@@ -419,10 +419,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to   To run tests in the same process:
-        ///    &gt;vstest.console.exe tests.dll 
-        ///  To run tests in a separate process:
-        ///    &gt;vstest.console.exe /inIsolation tests.dll
+        ///   Looks up a localized string similar to   To run tests:
+        ///    &gt;vstest.console.exe tests.dll
         ///  To run tests with additional settings such as  data collectors:
         ///    &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings.
         /// </summary>

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -253,10 +253,8 @@
     <value>Error Message:</value>
   </data>
   <data name="Examples" xml:space="preserve">
-    <value>  To run tests in the same process:
+    <value>  To run tests:
     &gt;vstest.console.exe tests.dll 
-  To run tests in a separate process:
-    &gt;vstest.console.exe /inIsolation tests.dll
   To run tests with additional settings such as  data collectors:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</value>
   </data>

--- a/src/vstest.console/Resources/xlf/Resources.cs.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.cs.xlf
@@ -468,19 +468,17 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="Examples">
-        <source>  To run tests in the same process:
+        <source>  To run tests:
     &gt;vstest.console.exe tests.dll 
-  To run tests in a separate process:
-    &gt;vstest.console.exe /inIsolation tests.dll
   To run tests with additional settings such as  data collectors:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</source>
-        <target state="translated">  Spuštění testů ve stejném procesu:
+        <target state="new">  Spuštění testů ve stejném procesu:
     &gt;vstest.console.exe tests.dll 
   Spuštění testů v samostatném procesu:
     &gt;vstest.console.exe /inIsolation tests.dll
   Spuštění testů s dalšími nastaveními, třeba s kolekcemi dat:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Chcete-li spustit testy ve stejném procesu:
     &gt; vstest.console.exe tests.dll Chcete-li spustit testy v samostatném procesu:

--- a/src/vstest.console/Resources/xlf/Resources.de.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.de.xlf
@@ -468,19 +468,17 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="Examples">
-        <source>  To run tests in the same process:
+        <source>  To run tests:
     &gt;vstest.console.exe tests.dll 
-  To run tests in a separate process:
-    &gt;vstest.console.exe /inIsolation tests.dll
   To run tests with additional settings such as  data collectors:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</source>
-        <target state="translated">  So führen Sie Tests im gleichen Prozess aus:
+        <target state="new">  So führen Sie Tests im gleichen Prozess aus:
     &gt;vstest.console.exe tests.dll
   So führen Sie Tests in einem separaten Prozess aus:
     &gt;vstest.console.exe /inIsolation tests.dll
   So führen Sie Tests mit zusätzlichen Einstellungen wie Datensammlern aus:
     &gt;vstest.console.exe tests.dll /Settings:Local.RunSettings</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Tests im gleichen Prozess ausgeführt:
     &gt; vstest.console.exe tests.dll Tests in einem separaten Prozess ausführen:

--- a/src/vstest.console/Resources/xlf/Resources.es.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.es.xlf
@@ -469,20 +469,18 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="Examples">
-        <source>  To run tests in the same process:
+        <source>  To run tests:
     &gt;vstest.console.exe tests.dll 
-  To run tests in a separate process:
-    &gt;vstest.console.exe /inIsolation tests.dll
   To run tests with additional settings such as  data collectors:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</source>
-        <target state="translated">  Para ejecutar pruebas en el mismo proceso:
+        <target state="new">  Para ejecutar pruebas en el mismo proceso:
     &gt;vstest.console.exe tests.dll 
   Para ejecutar pruebas en un proceso aparte:
     &gt;vstest.console.exe /inIsolation tests.dll
   Para ejecutar las pruebas con configuración adicional, como
     recopiladores de datos:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Para ejecutar pruebas en el mismo proceso:
     &gt; vstest.console.exe tests.dll para ejecutar pruebas en un proceso independiente:

--- a/src/vstest.console/Resources/xlf/Resources.fr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.fr.xlf
@@ -468,19 +468,17 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="Examples">
-        <source>  To run tests in the same process:
+        <source>  To run tests:
     &gt;vstest.console.exe tests.dll 
-  To run tests in a separate process:
-    &gt;vstest.console.exe /inIsolation tests.dll
   To run tests with additional settings such as  data collectors:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</source>
-        <target state="translated">  Pour exécuter les tests dans le même processus :
+        <target state="new">  Pour exécuter les tests dans le même processus :
     &gt;vstest.console.exe tests.dll 
   Pour exécuter les tests dans un processus distinct :
     &gt;vstest.console.exe /inIsolation tests.dll
   Pour exécuter les tests avec des paramètres supplémentaires, par exemple des collecteurs de données :
     &gt;vstest.console.exe tests.dll /Settings:Local.RunSettings</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Pour exécuter des tests dans le même processus :
     &gt; tests.dll vstest.console.exe pour exécuter les tests dans un processus distinct :

--- a/src/vstest.console/Resources/xlf/Resources.it.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.it.xlf
@@ -468,19 +468,17 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="Examples">
-        <source>  To run tests in the same process:
+        <source>  To run tests:
     &gt;vstest.console.exe tests.dll 
-  To run tests in a separate process:
-    &gt;vstest.console.exe /inIsolation tests.dll
   To run tests with additional settings such as  data collectors:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</source>
-        <target state="translated">  Per eseguire test nello stesso processo:
+        <target state="new">  Per eseguire test nello stesso processo:
     &gt;vstest.console.exe tests.dll 
   Per eseguire test in un processo separato:
     &gt;vstest.console.exe /inIsolation tests.dll
   Per eseguire test con ulteriori impostazioni, quali agenti di raccolta dati:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Per eseguire i test nello stesso processo:
     &gt; Tests vstest.console.exe per eseguire test in un processo separato:

--- a/src/vstest.console/Resources/xlf/Resources.ja.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ja.xlf
@@ -468,19 +468,17 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="Examples">
-        <source>  To run tests in the same process:
+        <source>  To run tests:
     &gt;vstest.console.exe tests.dll 
-  To run tests in a separate process:
-    &gt;vstest.console.exe /inIsolation tests.dll
   To run tests with additional settings such as  data collectors:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</source>
-        <target state="translated">  同じプロセスでテストを実行する:
+        <target state="new">  同じプロセスでテストを実行する:
     &gt;vstest.console.exe tests.dll 
   個別のプロセスでテストを実行する:
     &gt;vstest.console.exe /inIsolation tests.dll
   データ コレクターなどの追加設定を指定してテストを実行する:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">同じプロセスでテストを実行します。
     &gt; vstest.console.exe tests.dll を別のプロセスでテストを実行します。

--- a/src/vstest.console/Resources/xlf/Resources.ko.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ko.xlf
@@ -468,19 +468,17 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="Examples">
-        <source>  To run tests in the same process:
+        <source>  To run tests:
     &gt;vstest.console.exe tests.dll 
-  To run tests in a separate process:
-    &gt;vstest.console.exe /inIsolation tests.dll
   To run tests with additional settings such as  data collectors:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</source>
-        <target state="translated">  동일한 프로세스에서 테스트를 실행하려면 다음을 사용합니다.
+        <target state="new">  동일한 프로세스에서 테스트를 실행하려면 다음을 사용합니다.
     &gt;vstest.console.exe tests.dll 
   별도의 프로세스에서 테스트를 실행하려면 다음을 사용합니다.
     &gt;vstest.console.exe /inIsolation tests.dll
   데이터 수집기 등의 추가 설정을 사용하여 테스트를 실행하려면 다음을 사용합니다.
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">동일한 프로세스에서 테스트 실행:
     &gt; vstest.console.exe tests.dll는 별도 프로세스에서 테스트를 실행 합니다.

--- a/src/vstest.console/Resources/xlf/Resources.pl.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pl.xlf
@@ -468,19 +468,17 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="Examples">
-        <source>  To run tests in the same process:
+        <source>  To run tests:
     &gt;vstest.console.exe tests.dll 
-  To run tests in a separate process:
-    &gt;vstest.console.exe /inIsolation tests.dll
   To run tests with additional settings such as  data collectors:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</source>
-        <target state="translated">  Aby uruchomić testy w tym samym procesie:
+        <target state="new">  Aby uruchomić testy w tym samym procesie:
     &gt;vstest.console.exe tests.dll 
   Aby uruchomić testy w oddzielnym procesie:
     &gt;vstest.console.exe /inIsolation tests.dll
   Aby uruchomić testy z dodatkowymi ustawieniami, na przykład z modułami zbierającymi dane:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Aby uruchomić testy w tym samym procesie:
     &gt; tests.dll vstest.console.exe, aby uruchomić testy w oddzielnym procesie:

--- a/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
@@ -468,19 +468,17 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="Examples">
-        <source>  To run tests in the same process:
+        <source>  To run tests:
     &gt;vstest.console.exe tests.dll 
-  To run tests in a separate process:
-    &gt;vstest.console.exe /inIsolation tests.dll
   To run tests with additional settings such as  data collectors:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</source>
-        <target state="translated">  Para executar testes no mesmo processo:
+        <target state="new">  Para executar testes no mesmo processo:
     &gt;vstest.console.exe tests.dll 
   Para executar testes em um processo separado:
     &gt;vstest.console.exe /inIsolation tests.dll
   Para executar testes com configurações adicionais, como coletores de dados:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Para executar testes no mesmo processo:
     &gt; vstest.console.exe Tests para executar testes em um processo separado:

--- a/src/vstest.console/Resources/xlf/Resources.ru.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ru.xlf
@@ -468,19 +468,17 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="Examples">
-        <source>  To run tests in the same process:
+        <source>  To run tests:
     &gt;vstest.console.exe tests.dll 
-  To run tests in a separate process:
-    &gt;vstest.console.exe /inIsolation tests.dll
   To run tests with additional settings such as  data collectors:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</source>
-        <target state="translated">  Для запуска тестов в том же процессе:
+        <target state="new">  Для запуска тестов в том же процессе:
     &gt;vstest.console.exe tests.dll 
   Для запуска тестов в отдельном процессе:
     &gt;vstest.console.exe /inIsolation tests.dll
   Для запуска тестов с дополнительными параметрами, например со сборщиками данных:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Для выполнения тестов в том же процессе:
     &gt; tests.dll vstest.console.exe для выполнения тестов в отдельном процессе:

--- a/src/vstest.console/Resources/xlf/Resources.tr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.tr.xlf
@@ -468,19 +468,17 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="Examples">
-        <source>  To run tests in the same process:
+        <source>  To run tests:
     &gt;vstest.console.exe tests.dll 
-  To run tests in a separate process:
-    &gt;vstest.console.exe /inIsolation tests.dll
   To run tests with additional settings such as  data collectors:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</source>
-        <target state="translated">  Testleri aynı işlemde çalıştırmak için:
+        <target state="new">  Testleri aynı işlemde çalıştırmak için:
     &gt;vstest.console.exe tests.dll 
   Testleri ayrı bir işlemde çalıştırmak için:
     &gt;vstest.console.exe /inIsolation tests.dll
   Testleri veri toplayıcılar gibi ek ayarlarla çalıştırmak için:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Aynı işlem içinde testleri çalıştırmak için:
     &gt; vstest.console.exe tests.dll testleri ayrı bir işlemde çalıştırmak için:

--- a/src/vstest.console/Resources/xlf/Resources.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.xlf
@@ -198,10 +198,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="Examples">
-        <source>  To run tests in the same process:
+        <source>  To run tests:
     &gt;vstest.console.exe tests.dll 
-  To run tests in a separate process:
-    &gt;vstest.console.exe /inIsolation tests.dll
   To run tests with additional settings such as  data collectors:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</source>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
@@ -467,19 +467,17 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="Examples">
-        <source>  To run tests in the same process:
+        <source>  To run tests:
     &gt;vstest.console.exe tests.dll 
-  To run tests in a separate process:
-    &gt;vstest.console.exe /inIsolation tests.dll
   To run tests with additional settings such as  data collectors:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</source>
-        <target state="translated">  在同一进程中运行测试:
+        <target state="new">  在同一进程中运行测试:
     &gt;vstest.console.exe tests.dll 
   在单独的进程中运行测试:
     &gt;vstest.console.exe /inIsolation tests.dll
   使用其他设置(如数据收集器)运行测试:
     &gt;vstest.console.exe tests.dll /Settings:Local.RunSettings</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">同一进程中运行测试︰
     &gt; vstest.console.exe tests.dll 若要在单独的进程中运行测试︰

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
@@ -467,19 +467,17 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="Examples">
-        <source>  To run tests in the same process:
+        <source>  To run tests:
     &gt;vstest.console.exe tests.dll 
-  To run tests in a separate process:
-    &gt;vstest.console.exe /inIsolation tests.dll
   To run tests with additional settings such as  data collectors:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</source>
-        <target state="translated">  在相同的處理序中執行測試:
+        <target state="new">  在相同的處理序中執行測試:
     &gt;vstest.console.exe tests.dll 
   在個別的處理序中執行測試:
     &gt;vstest.console.exe /inIsolation tests.dll
   使用像資料收集器之類的其他設定執行測試:
     &gt;vstest.console.exe  tests.dll /Settings:Local.RunSettings</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">同一进程中运行测试︰
     &gt; vstest.console.exe tests.dll 若要在单独的进程中运行测试︰

--- a/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
@@ -44,5 +44,35 @@ namespace Microsoft.TestPlatform.Build.UnitTests
 
             Assert.AreEqual($"--resultsDirectory:\"{resultsDirectoryValue}\"", result[1]);
         }
+
+        [TestMethod]
+        public void CreateArgumentShouldSetConsoleLoggerVerbosityIfConsoleLoggerIsNotGivenInArgs()
+        {
+            var vstestTask = new VSTestTask { VSTestVerbosity = "diag" };
+
+            // Add values for required properties.
+            vstestTask.TestFileFullPath = "abc";
+            vstestTask.VSTestFramework = "abc";
+
+            var allArguments = vstestTask.CreateArgument().ToArray();
+
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=normal")));
+        }
+
+        [TestMethod]
+        public void CreateArgumentShouldNotSetConsoleLoggerVerbosityIfConsoleLoggerIsGivenInArgs()
+        {
+            var vstestTask = new VSTestTask { VSTestVerbosity = "diag" };
+
+            // Add values for required properties.
+            vstestTask.TestFileFullPath = "abc";
+            vstestTask.VSTestFramework = "abc";
+            vstestTask.VSTestLogger = "Console;Verbosity=quiet";
+
+            var allArguments = vstestTask.CreateArgument().ToArray();
+
+            Assert.IsNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=normal")));
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=quiet")));
+        }
     }
 }

--- a/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
@@ -46,20 +46,6 @@ namespace Microsoft.TestPlatform.Build.UnitTests
         }
 
         [TestMethod]
-        public void CreateArgumentShouldSetConsoleLoggerVerbosityIfConsoleLoggerIsNotGivenInArgs()
-        {
-            var vstestTask = new VSTestTask { VSTestVerbosity = "diag" };
-
-            // Add values for required properties.
-            vstestTask.TestFileFullPath = "abc";
-            vstestTask.VSTestFramework = "abc";
-
-            var allArguments = vstestTask.CreateArgument().ToArray();
-
-            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=normal")));
-        }
-
-        [TestMethod]
         public void CreateArgumentShouldNotSetConsoleLoggerVerbosityIfConsoleLoggerIsGivenInArgs()
         {
             var vstestTask = new VSTestTask { VSTestVerbosity = "diag" };
@@ -73,6 +59,146 @@ namespace Microsoft.TestPlatform.Build.UnitTests
 
             Assert.IsNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=normal")));
             Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=quiet")));
+        }
+
+        [TestMethod]
+        public void CreateArgumentShouldSetConsoleLoggerVerbosityToNormalIfConsoleLoggerIsNotGivenInArgsAndVerbosityIsn()
+        {
+            var vstestTask = new VSTestTask { VSTestVerbosity = "n" };
+
+            // Add values for required properties.
+            vstestTask.TestFileFullPath = "abc";
+            vstestTask.VSTestFramework = "abc";
+
+            var allArguments = vstestTask.CreateArgument().ToArray();
+
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=normal")));
+        }
+
+        [TestMethod]
+        public void CreateArgumentShouldSetConsoleLoggerVerbosityToNormalIfConsoleLoggerIsNotGivenInArgsAndVerbosityIsnormal()
+        {
+            var vstestTask = new VSTestTask { VSTestVerbosity = "normal" };
+
+            // Add values for required properties.
+            vstestTask.TestFileFullPath = "abc";
+            vstestTask.VSTestFramework = "abc";
+
+            var allArguments = vstestTask.CreateArgument().ToArray();
+
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=normal")));
+        }
+
+        [TestMethod]
+        public void CreateArgumentShouldSetConsoleLoggerVerbosityToNormalIfConsoleLoggerIsNotGivenInArgsAndVerbosityIsd()
+        {
+            var vstestTask = new VSTestTask { VSTestVerbosity = "d" };
+
+            // Add values for required properties.
+            vstestTask.TestFileFullPath = "abc";
+            vstestTask.VSTestFramework = "abc";
+
+            var allArguments = vstestTask.CreateArgument().ToArray();
+
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=normal")));
+        }
+
+        [TestMethod]
+        public void CreateArgumentShouldSetConsoleLoggerVerbosityToNormalIfConsoleLoggerIsNotGivenInArgsAndVerbosityIsdetailed()
+        {
+            var vstestTask = new VSTestTask { VSTestVerbosity = "detailed" };
+
+            // Add values for required properties.
+            vstestTask.TestFileFullPath = "abc";
+            vstestTask.VSTestFramework = "abc";
+
+            var allArguments = vstestTask.CreateArgument().ToArray();
+
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=normal")));
+        }
+
+        [TestMethod]
+        public void CreateArgumentShouldSetConsoleLoggerVerbosityToNormalIfConsoleLoggerIsNotGivenInArgsAndVerbosityIsdiag()
+        {
+            var vstestTask = new VSTestTask { VSTestVerbosity = "diag" };
+
+            // Add values for required properties.
+            vstestTask.TestFileFullPath = "abc";
+            vstestTask.VSTestFramework = "abc";
+
+            var allArguments = vstestTask.CreateArgument().ToArray();
+
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=normal")));
+        }
+
+        [TestMethod]
+        public void CreateArgumentShouldSetConsoleLoggerVerbosityToNormalIfConsoleLoggerIsNotGivenInArgsAndVerbosityIsdiagnostic()
+        {
+            var vstestTask = new VSTestTask { VSTestVerbosity = "diagnostic" };
+
+            // Add values for required properties.
+            vstestTask.TestFileFullPath = "abc";
+            vstestTask.VSTestFramework = "abc";
+
+            var allArguments = vstestTask.CreateArgument().ToArray();
+
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=normal")));
+        }
+        [TestMethod]
+
+        public void CreateArgumentShouldSetConsoleLoggerVerbosityToQuietIfConsoleLoggerIsNotGivenInArgsAndVerbosityIsq()
+        {
+            var vstestTask = new VSTestTask { VSTestVerbosity = "q" };
+
+            // Add values for required properties.
+            vstestTask.TestFileFullPath = "abc";
+            vstestTask.VSTestFramework = "abc";
+
+            var allArguments = vstestTask.CreateArgument().ToArray();
+
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=quiet")));
+        }
+
+        [TestMethod]
+        public void CreateArgumentShouldSetConsoleLoggerVerbosityToQuietIfConsoleLoggerIsNotGivenInArgsAndVerbosityIsquiet()
+        {
+            var vstestTask = new VSTestTask { VSTestVerbosity = "quiet" };
+
+            // Add values for required properties.
+            vstestTask.TestFileFullPath = "abc";
+            vstestTask.VSTestFramework = "abc";
+
+            var allArguments = vstestTask.CreateArgument().ToArray();
+
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=quiet")));
+        }
+
+        [TestMethod]
+        public void CreateArgumentShouldSetConsoleLoggerVerbosityToMinimalIfConsoleLoggerIsNotGivenInArgsAndVerbosityIsm()
+        {
+            var vstestTask = new VSTestTask { VSTestVerbosity = "m" };
+
+            // Add values for required properties.
+            vstestTask.TestFileFullPath = "abc";
+            vstestTask.VSTestFramework = "abc";
+
+            var allArguments = vstestTask.CreateArgument().ToArray();
+
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=minimal")));
+        }
+
+        [TestMethod]
+        public void CreateArgumentShouldSetConsoleLoggerVerbosityToMinimalIfConsoleLoggerIsNotGivenInArgsAndVerbosityIsminimal()
+        {
+            var vstestTask = new VSTestTask { VSTestVerbosity = "minimal" };
+
+            // Add values for required properties.
+            vstestTask.TestFileFullPath = "abc";
+            vstestTask.VSTestFramework = "abc";
+
+            var allArguments = vstestTask.CreateArgument().ToArray();
+
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=minimal")));
         }
     }
 }

--- a/test/vstest.console.UnitTests/Processors/HelpArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/HelpArgumentProcessorTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.IsTrue(output.Lines.Contains("Arguments:"));
             Assert.IsTrue(output.Lines.Contains("Options:"));
             Assert.IsTrue(output.Lines.Contains("Description: Runs tests from the specified files."));
-            Assert.IsTrue(output.Lines.Contains("  To run tests in the same process:\n    >vstest.console.exe tests.dll \n  To run tests in a separate process:\n    >vstest.console.exe /inIsolation tests.dll\n  To run tests with additional settings such as  data collectors:\n    >vstest.console.exe  tests.dll /Settings:Local.RunSettings"));
+            Assert.IsTrue(output.Lines.Contains("  To run tests:\n    >vstest.console.exe tests.dll \n  To run tests with additional settings such as  data collectors:\n    >vstest.console.exe  tests.dll /Settings:Local.RunSettings"));
         }
     }
 


### PR DESCRIPTION
1) Add support to use "dotnet test --verbosity" args for console verbosity
2) Remove invalid help message