### PR TITLE
Use netcoreapp 1.0.5 shared runtime.

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft. All rights reserved.
+﻿# Copyright (c) Microsoft. All rights reserved.
 # Build script for Test Platform.
 
 [CmdletBinding()]
@@ -134,7 +134,7 @@ function Install-DotNetCli
 
     # Pull in additional shared frameworks.
     # Get netcoreapp1.0 shared components.
-    & $dotnetInstallScript -InstallDir $dotnetInstallPath -SharedRuntime -Version '1.0.4' -Channel 'preview'
+    & $dotnetInstallScript -InstallDir $dotnetInstallPath -SharedRuntime -Version '1.0.5-servicing-004880-00' -Channel 'preview'
     
     # Get netcoreapp1.1 shared components.
     & $dotnetInstallScript -InstallDir $dotnetInstallPath -SharedRuntime -Version '1.1.1' -Channel 'release/1.1.0'

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -137,7 +137,7 @@ function Install-DotNetCli
     & $dotnetInstallScript -InstallDir $dotnetInstallPath -SharedRuntime -Version '1.0.5' -Channel 'preview'
     
     # Get netcoreapp1.1 shared components.
-    & $dotnetInstallScript -InstallDir $dotnetInstallPath -SharedRuntime -Version '1.1.1' -Channel 'release/1.1.0'
+    & $dotnetInstallScript -InstallDir $dotnetInstallPath -SharedRuntime -Version '1.1.2' -Channel 'release/1.1.0'
     
     Write-Log "Install-DotNetCli: Complete. {$(Get-ElapsedTime($timer))}"
 }

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -134,7 +134,7 @@ function Install-DotNetCli
 
     # Pull in additional shared frameworks.
     # Get netcoreapp1.0 shared components.
-    & $dotnetInstallScript -InstallDir $dotnetInstallPath -SharedRuntime -Version '1.0.5-servicing-004880-00' -Channel 'preview'
+    & $dotnetInstallScript -InstallDir $dotnetInstallPath -SharedRuntime -Version '1.0.5' -Channel 'preview'
     
     # Get netcoreapp1.1 shared components.
     & $dotnetInstallScript -InstallDir $dotnetInstallPath -SharedRuntime -Version '1.1.1' -Channel 'release/1.1.0'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -158,7 +158,7 @@ function install_cli()
     log "install_cli: Get the shared netcoreapp1.0 runtime..."
     $install_script --install-dir "$TP_TOOLS_DIR/dotnet" --no-path --channel "preview" --version "1.0.5" --shared-runtime
     log "install_cli: Get the shared netcoreapp1.1 runtime..."
-    $install_script --install-dir "$TP_TOOLS_DIR/dotnet" --no-path --channel "release/1.1.0" --version "1.1.1" --shared-runtime
+    $install_script --install-dir "$TP_TOOLS_DIR/dotnet" --no-path --channel "release/1.1.0" --version "1.1.2" --shared-runtime
 
     log "install_cli: Complete. Elapsed $(( SECONDS - start ))s."
     return 0

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -156,7 +156,7 @@ function install_cli()
 
     # Get netcoreapp1.1 shared components
     log "install_cli: Get the shared netcoreapp1.0 runtime..."
-    $install_script --install-dir "$TP_TOOLS_DIR/dotnet" --no-path --channel "preview" --version "1.0.5-servicing-004880-00" --shared-runtime
+    $install_script --install-dir "$TP_TOOLS_DIR/dotnet" --no-path --channel "preview" --version "1.0.5" --shared-runtime
     log "install_cli: Get the shared netcoreapp1.1 runtime..."
     $install_script --install-dir "$TP_TOOLS_DIR/dotnet" --no-path --channel "release/1.1.0" --version "1.1.1" --shared-runtime
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -89,8 +89,7 @@ TPB_Solution="TestPlatform.sln"
 TPB_TargetFrameworkCore="netcoreapp2.0"
 TPB_Configuration=$CONFIGURATION
 TPB_TargetRuntime=$TARGET_RUNTIME
-TPB_Version=$VERSION
-TPB_VersionSuffix=$VERSION_SUFFIX
+TPB_Version=$(test -z $VERSION_SUFFIX && echo $VERSION || echo "$VERSION-$VERSION_SUFFIX")
 TPB_CIBuild=$CI_BUILD
 TPB_LocalizedBuild=$DISABLE_LOCALIZED_BUILD
 TPB_Verbose=$VERBOSE
@@ -156,7 +155,7 @@ function install_cli()
 
     # Get netcoreapp1.1 shared components
     log "install_cli: Get the shared netcoreapp1.0 runtime..."
-    $install_script --install-dir "$TP_TOOLS_DIR/dotnet" --no-path --channel "preview" --version "1.0.4" --shared-runtime
+    $install_script --install-dir "$TP_TOOLS_DIR/dotnet" --no-path --channel "preview" --version "1.0.5-servicing-004880-00" --shared-runtime
     log "install_cli: Get the shared netcoreapp1.1 runtime..."
     $install_script --install-dir "$TP_TOOLS_DIR/dotnet" --no-path --channel "release/1.1.0" --version "1.1.1" --shared-runtime
 
@@ -365,8 +364,8 @@ function create_package()
 
 
     for i in ${projectFiles[@]}; do
-        log "$DOTNET_PATH pack --no-build $stagingDir/${i} -o $packageOutputDir -p:Version=$TPB_Version-$TPB_VersionSuffix" \
-        && $DOTNET_PATH pack --no-build $stagingDir/${i} -o $packageOutputDir -p:Version=$TPB_Version-$TPB_VersionSuffix
+        log "$DOTNET_PATH pack --no-build $stagingDir/${i} -o $packageOutputDir -p:Version=$TPB_Version" \
+        && $DOTNET_PATH pack --no-build $stagingDir/${i} -o $packageOutputDir -p:Version=$TPB_Version
     done
 
     log "Create-NugetPackages: Elapsed $(( SECONDS - start ))s."

--- a/src/Microsoft.TestPlatform.Common/DataCollection/Interfaces/IDataCollectionAttachmentManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/Interfaces/IDataCollectionAttachmentManager.cs
@@ -49,13 +49,13 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.Interfaces
         /// <param name="sendFileCompletedCallback">
         /// The send File Completed Callback.
         /// </param>
-        /// <param name="typeUri">
-        /// The type Uri.
+        /// <param name="dataCollectorUri">
+        /// Uri of the data collector.
         /// </param>
         /// <param name="friendlyName">
         /// The friendly Name.
         /// </param>
-        void AddAttachment(FileTransferInformation fileTransferInfo, AsyncCompletedEventHandler sendFileCompletedCallback, Uri typeUri, string friendlyName);
+        void AddAttachment(FileTransferInformation fileTransferInfo, AsyncCompletedEventHandler sendFileCompletedCallback, Uri dataCollectorUri, string friendlyName);
 
         /// <summary>
         /// Stops processing further transfer requests as test run is cancelled.

--- a/src/Microsoft.TestPlatform.CoreUtilities/Helpers/FileHelper.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Helpers/FileHelper.cs
@@ -58,5 +58,17 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities.Helpers
         {
             return new FileInfo(path).Attributes;
         }
+
+        /// <inheritdoc/>
+        public void CopyFile(string sourcePath, string destinationPath)
+        {
+            File.Copy(sourcePath, destinationPath);
+        }
+
+        /// <inheritdoc/>
+        public void MoveFile(string sourcePath, string destinationPath)
+        {
+            File.Move(sourcePath, destinationPath);
+        }
     }
 }

--- a/src/Microsoft.TestPlatform.CoreUtilities/Helpers/Interfaces/IFileHelper.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Helpers/Interfaces/IFileHelper.cs
@@ -62,5 +62,19 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces
         /// <param name="path">Full path of the file.</param>
         /// <returns>Attributes of the file.</returns>
         FileAttributes GetFileAttributes(string path);
+
+        /// <summary>
+        /// Copy a file in the file system.
+        /// </summary>
+        /// <param name="sourcePath">Full path of the file.</param>
+        /// <param name="destinationPath">Target path for the file.</param>
+        void CopyFile(string sourcePath, string destinationPath);
+
+        /// <summary>
+        /// Moves a file in the file system.
+        /// </summary>
+        /// <param name="sourcePath">Full path of the file.</param>
+        /// <param name="destinationPath">Target path for the file.</param>
+        void MoveFile(string sourcePath, string destinationPath);
     }
 }


### PR DESCRIPTION
Fixes an issue in case-sensitive OS where packages are not located
with netcoreapp2.0 sdk and 1.0.4 runtime. See dotnet/cli#6390.