### PR TITLE
LUT is throwing exception when environmental variable LiveUnitTesting_TestPlatformLog is set to 1

### DIFF
--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/ConsoleParameters.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/ConsoleParameters.cs
@@ -17,12 +17,13 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         internal static readonly ConsoleParameters Default = new ConsoleParameters();
 
         private string logFilePath = null;
-        private IFileHelper fileHelper = new FileHelper();
+        private IFileHelper fileHelper;
 
         /// <summary>
         /// Create instance of <see cref="ConsoleParameters"/>
         /// </summary>
-        public ConsoleParameters() { }
+        public ConsoleParameters() : this(new FileHelper())
+        { }
 
         /// <summary>
         /// Create instance of <see cref="ConsoleParameters"/>
@@ -52,14 +53,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
                 }
 
                 // Ensure path is double quoted. if path has white space then it can create problem.
-                if (!value.StartsWith("\""))
-                {
-                    this.logFilePath = "\"" + value + "\"";
-                }
-                else
-                {
-                    this.logFilePath = value;
-                }
+                this.logFilePath = "\"" + value + "\"";
             }
         }
 

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/ConsoleParameters.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/ConsoleParameters.cs
@@ -4,6 +4,8 @@
 namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
 {
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+    using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
+    using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
     using System;
     using System.IO;
 
@@ -15,6 +17,21 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         internal static readonly ConsoleParameters Default = new ConsoleParameters();
 
         private string logFilePath = null;
+        private IFileHelper fileHelper = new FileHelper();
+
+        /// <summary>
+        /// Create instance of <see cref="ConsoleParameters"/>
+        /// </summary>
+        public ConsoleParameters() { }
+
+        /// <summary>
+        /// Create instance of <see cref="ConsoleParameters"/>
+        /// </summary>
+        /// <param name="fileHelper"> Object of type <see cref="IFileHelper"/></param>
+        public ConsoleParameters(IFileHelper fileHelper)
+        {
+            this.fileHelper = fileHelper;
+        }
 
         /// <summary>
         /// Full path for the log file
@@ -29,7 +46,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
             set
             {
                 ValidateArg.NotNullOrEmpty(value, "LogFilePath");
-                if(!Directory.Exists(Path.GetDirectoryName(value)))
+                if (!fileHelper.DirectoryExists(Path.GetDirectoryName(value)))
                 {
                     throw new ArgumentException("LogFilePath must point to a valid directory for logging!");
                 }

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/ConsoleParameters.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/ConsoleParameters.cs
@@ -34,7 +34,15 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
                     throw new ArgumentException("LogFilePath must point to a valid directory for logging!");
                 }
 
-                this.logFilePath = value;
+                // Ensure path is double quoted. if path has white space then it can create problem.
+                if (!value.StartsWith("\""))
+                {
+                    this.logFilePath = "\"" + value + "\"";
+                }
+                else
+                {
+                    this.logFilePath = value;
+                }
             }
         }
 

--- a/test/TranslationLayer.UnitTests/ConsoleParametersTests.cs
+++ b/test/TranslationLayer.UnitTests/ConsoleParametersTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
+{
+    using Microsoft.TestPlatform.VsTestConsole.TranslationLayer;
+    using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using Moq;
+
+    [TestClass]
+    public class ConsoleParametersTests
+    {
+        [TestMethod]
+        public void LogFilePathShouldEnsureDoubleQuote()
+        {
+            var moqFileHelper = new Mock<IFileHelper>();
+            moqFileHelper.Setup(fh => fh.DirectoryExists(It.IsAny<string>())).Returns(true);
+
+            var sut = new ConsoleParameters(moqFileHelper.Object);
+
+            sut.LogFilePath = "c:\\users\\file location\\o.txt";
+
+            string result = sut.LogFilePath;
+
+            Assert.IsTrue(result.StartsWith("\""));
+        }
+
+    }
+
+
+
+}

--- a/test/TranslationLayer.UnitTests/ConsoleParametersTests.cs
+++ b/test/TranslationLayer.UnitTests/ConsoleParametersTests.cs
@@ -26,9 +26,5 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
 
             Assert.IsTrue(result.StartsWith("\""));
         }
-
     }
-
-
-
 }


### PR DESCRIPTION
Issue: https://github.com/Microsoft/vstest/issues/734
Root Cause:
When LiveUnitTesting_TestPlatformLog is set 1, LUT is passing argument `/diag=Some-Path-Of-Log-File` to vstest.console.exe. Due to space in path vstest.console.exe is exiting with error.

Fix: Make sure given path has double quote 