### PR TITLE
Wait for testhost stderr to be available if connection is broken.

### DIFF
--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
@@ -59,8 +59,11 @@ namespace Microsoft.TestPlatform.TestHostProvider.Hosting
 
             if (exitCode != 0)
             {
-                EqtTrace.Error("Test host exited with error: {0}", testHostProcessStdErrorStr);
-                messageLogger.SendMessage(TestMessageLevel.Error, testHostProcessStdErrorStr);
+                EqtTrace.Error("Test host exited with error: '{0}'", testHostProcessStdErrorStr);
+                if (!string.IsNullOrEmpty(testHostProcessStdErrorStr))
+                {
+                    messageLogger.SendMessage(TestMessageLevel.Error, testHostProcessStdErrorStr);
+                }
             }
 
             onHostExited(new HostProviderEventArgs(testHostProcessStdErrorStr, exitCode, (process as Process).Id));


### PR DESCRIPTION
This allows to provide user information if the test host has crashed.

Don't send stderr to console runner output if it's null or empty.