### PR TITLE
Wait for testhost stderr to be available if connection is broken. (#772)

### DIFF
--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
@@ -60,10 +60,6 @@ namespace Microsoft.TestPlatform.TestHostProvider.Hosting
             if (exitCode != 0)
             {
                 EqtTrace.Error("Test host exited with error: '{0}'", testHostProcessStdErrorStr);
-                if (!string.IsNullOrEmpty(testHostProcessStdErrorStr))
-                {
-                    messageLogger.SendMessage(TestMessageLevel.Error, testHostProcessStdErrorStr);
-                }
             }
 
             onHostExited(new HostProviderEventArgs(testHostProcessStdErrorStr, exitCode, (process as Process).Id));

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
@@ -59,8 +59,11 @@ namespace Microsoft.TestPlatform.TestHostProvider.Hosting
 
             if (exitCode != 0)
             {
-                EqtTrace.Error("Test host exited with error: {0}", testHostProcessStdErrorStr);
-                messageLogger.SendMessage(TestMessageLevel.Error, testHostProcessStdErrorStr);
+                EqtTrace.Error("Test host exited with error: '{0}'", testHostProcessStdErrorStr);
+                if (!string.IsNullOrEmpty(testHostProcessStdErrorStr))
+                {
+                    messageLogger.SendMessage(TestMessageLevel.Error, testHostProcessStdErrorStr);
+                }
             }
 
             onHostExited(new HostProviderEventArgs(testHostProcessStdErrorStr, exitCode, (process as Process).Id));

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -180,7 +180,6 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
             await this.testableTestHostManager.LaunchTestHostAsync(this.GetDefaultStartInfo());
 
             Assert.AreEqual(errorData, this.errorMessage);
-            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Error, this.errorMessage + Environment.NewLine));
         }
 
         [TestMethod]
@@ -194,7 +193,6 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
             // Ignore new line chars
             Assert.AreEqual(this.maxStdErrStringLength - Environment.NewLine.Length, this.errorMessage.Length);
             Assert.AreEqual(errorData.Substring(5), this.errorMessage);
-            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Error, this.errorMessage + Environment.NewLine));
         }
 
         [TestMethod]
@@ -206,7 +204,6 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
             await this.testableTestHostManager.LaunchTestHostAsync(this.GetDefaultStartInfo());
 
             Assert.AreEqual(null, this.errorMessage);
-            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Error, this.errorMessage + Environment.NewLine), Times.Never);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -504,7 +504,6 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
             await this.dotnetHostManager.LaunchTestHostAsync(this.defaultTestProcessStartInfo);
 
             Assert.AreEqual(errorData, this.errorMessage);
-            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Error, this.errorMessage + Environment.NewLine));
         }
 
         [TestMethod]
@@ -518,7 +517,6 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
             // Ignore new line chars
             Assert.AreEqual(this.maxStdErrStringLength - Environment.NewLine.Length, this.errorMessage.Length);
             Assert.AreEqual(errorData.Substring(5), this.errorMessage);
-            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Error, this.errorMessage + Environment.NewLine));
         }
 
         [TestMethod]
@@ -530,7 +528,6 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
             await this.dotnetHostManager.LaunchTestHostAsync(this.defaultTestProcessStartInfo);
 
             Assert.IsNull(this.errorMessage);
-            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Error, this.errorMessage + Environment.NewLine), Times.Never);
         }
 
         [TestMethod]


### PR DESCRIPTION
This allows to provide user information if the test host has crashed.

Don't send stderr to console runner output if it's null or empty.