### PR TITLE
Fix packaging in unix

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -95,8 +95,7 @@ TPB_VersionSuffix=$VERSION_SUFFIX
 TPB_CIBuild=$CI_BUILD
 TPB_LocalizedBuild=$DISABLE_LOCALIZED_BUILD
 TPB_Verbose=$VERBOSE
-TPB_HasMono=false
-#TPB_HasMono=$(command -v mono > /dev/null && echo true || echo false)
+TPB_HasMono=$(command -v mono > /dev/null && echo true || echo false)
 
 #
 # Logging

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -87,6 +87,7 @@ DOTNET_CLI_VERSION="latest"
 #
 TPB_Solution="TestPlatform.sln"
 TPB_TargetFrameworkCore="netcoreapp2.0"
+TPB_TargetFrameworkCore10="netcoreapp1.0"
 TPB_Configuration=$CONFIGURATION
 TPB_TargetRuntime=$TARGET_RUNTIME
 TPB_Version=$VERSION
@@ -94,7 +95,8 @@ TPB_VersionSuffix=$VERSION_SUFFIX
 TPB_CIBuild=$CI_BUILD
 TPB_LocalizedBuild=$DISABLE_LOCALIZED_BUILD
 TPB_Verbose=$VERBOSE
-TPB_HasMono=$(command -v mono > /dev/null && echo true || echo false)
+TPB_HasMono=false
+#TPB_HasMono=$(command -v mono > /dev/null && echo true || echo false)
 
 #
 # Logging
@@ -261,8 +263,7 @@ function publish_package()
     PROJECTPACKAGEOUTPUTMAP=( \
         $TP_PACKAGE_PROJ_DIR/package.csproj:$coreCLRPackageDir \
         $TP_ROOT_DIR/src/vstest.console/vstest.console.csproj:$coreCLRPackageDir \
-        $TP_ROOT_DIR/src/datacollector/datacollector.csproj:$coreCLRPackageDir \
-        $TP_ROOT_DIR/src/testhost/testhost.csproj:$TP_OUT_DIR/$TPB_Configuration/Microsoft.TestPlatform.TestHost/$TPB_TargetFrameworkCore
+        $TP_ROOT_DIR/src/datacollector/datacollector.csproj:$coreCLRPackageDir
     )
 
     for item in "${PROJECTPACKAGEOUTPUTMAP[@]}" ;
@@ -272,6 +273,12 @@ function publish_package()
         log "Package: Publish $projectToPackage"
         $dotnet publish $projectToPackage --configuration $TPB_Configuration --framework $TPB_TargetFrameworkCore --output $packageOutputPath -v:minimal -p:LocalizedBuild=$TPB_LocalizedBuild
     done
+
+    # Publish TestHost for netcoreapp1.0 target
+    log "Package: Publish testhost.csproj"
+    local projectToPackage=$TP_ROOT_DIR/src/testhost/testhost.csproj
+    local packageOutputPath=$TP_OUT_DIR/$TPB_Configuration/Microsoft.TestPlatform.TestHost/$TPB_TargetFrameworkCore10
+    $dotnet publish $projectToPackage --configuration $TPB_Configuration --framework $TPB_TargetFrameworkCore10 --output $packageOutputPath -v:minimal -p:LocalizedBuild=$TPB_LocalizedBuild
 
     # Copy TestHost for desktop targets if we've built net46
     # packages with mono
@@ -319,10 +326,10 @@ function publishplatformatbstractions()
     log "Publish-PlatfromAbstractions-Internal: Started."
     
     local start=$SECONDS
-    coreCLRPackageDir=$TP_OUT_DIR/$TPB_Configuration/$TPB_TargetFrameworkCore
+    local coreCLRPackageDir=$TP_OUT_DIR/$TPB_Configuration/$TPB_TargetFrameworkCore10
     
-    platformAbstraction="$TP_ROOT_DIR/src/Microsoft.TestPlatform.PlatformAbstractions/bin/$TPB_Configuration"
-    platformAbstractionNetCore=$platformAbstraction/$TPB_TargetFrameworkCore
+    local platformAbstraction="$TP_ROOT_DIR/src/Microsoft.TestPlatform.PlatformAbstractions/bin/$TPB_Configuration"
+    local platformAbstractionNetCore=$platformAbstraction/$TPB_TargetFrameworkCore10
     
     cp -r $platformAbstractionNetCore $coreCLRPackageDir
     

--- a/src/package/nuspec/Microsoft.TestPlatform.Build.csproj
+++ b/src/package/nuspec/Microsoft.TestPlatform.Build.csproj
@@ -4,5 +4,9 @@
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <NuspecFile>TestPlatform.Build.nuspec</NuspecFile>
     <NuspecProperties>version=$(Version)</NuspecProperties>
+
+    <!-- Don't include the output.dll and output.runtimeconfig.json files in nuget package -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 </Project>

--- a/src/package/nuspec/Microsoft.TestPlatform.CLI.csproj
+++ b/src/package/nuspec/Microsoft.TestPlatform.CLI.csproj
@@ -4,5 +4,9 @@
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <NuspecFile>TestPlatform.CLI.nuspec</NuspecFile>
     <NuspecProperties>version=$(Version)</NuspecProperties>
+
+    <!-- Don't include the output.dll and output.runtimeconfig.json files in nuget package -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Ignore build output and runtime configuration for TestPlatform.CLI and TestPlatform.Build packaging projects.

Fix build.sh to use netcoreapp1.0 publish for testhost.