### PR TITLE
Updates to unix scripts

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -90,8 +90,7 @@ TPB_TargetFrameworkCore="netcoreapp2.0"
 TPB_TargetFrameworkCore10="netcoreapp1.0"
 TPB_Configuration=$CONFIGURATION
 TPB_TargetRuntime=$TARGET_RUNTIME
-TPB_Version=$VERSION
-TPB_VersionSuffix=$VERSION_SUFFIX
+TPB_Version=$(test -z $VERSION_SUFFIX && echo $VERSION || echo $VERSION-$VERSION_SUFFIX)
 TPB_CIBuild=$CI_BUILD
 TPB_LocalizedBuild=$DISABLE_LOCALIZED_BUILD
 TPB_Verbose=$VERBOSE
@@ -371,8 +370,8 @@ function create_package()
 
 
     for i in ${projectFiles[@]}; do
-        log "$DOTNET_PATH pack --no-build $stagingDir/${i} -o $packageOutputDir -p:Version=$TPB_Version-$TPB_VersionSuffix" \
-        && $DOTNET_PATH pack --no-build $stagingDir/${i} -o $packageOutputDir -p:Version=$TPB_Version-$TPB_VersionSuffix
+        log "$DOTNET_PATH pack --no-build $stagingDir/${i} -o $packageOutputDir -p:Version=$TPB_Version" \
+        && $DOTNET_PATH pack --no-build $stagingDir/${i} -o $packageOutputDir -p:Version=$TPB_Version
     done
 
     log "Create-NugetPackages: Elapsed $(( SECONDS - start ))s."

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -69,7 +69,7 @@ DOTNET_CLI_VERSION="latest"
 # Build configuration
 #
 TPB_Solution="TestPlatform.sln"
-TPB_TargetFrameworkCore="netcoreapp1.0"
+TPB_TargetFrameworkCore="netcoreapp2.0"
 TPB_Configuration=$CONFIGURATION
 TPB_TargetRuntime=$TARGET_RUNTIME
 TPB_Verbose=$VERBOSE
@@ -111,8 +111,9 @@ function usage()
 function invoke_test()
 {
     local dotnet=$(_get_dotnet_path)
+    local vstest=$TP_OUT_DIR/$TPB_Configuration/$TPB_TargetFrameworkCore/vstest.console.dll
 
-    find ./test -path $PROJECT_NAME_PATTERNS | xargs $dotnet vstest --parallel
+    find ./test -path $PROJECT_NAME_PATTERNS | xargs $dotnet $vstest --parallel
 }
 
 #


### PR DESCRIPTION
Use both version and version suffix for informational version in unix builds.
Update test script to use locally built vstest.console.