### PR TITLE
Dont pick package from fallbackPackageFolders as we want all the packages in vstest\package folder

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -11,6 +11,9 @@
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />
   </activePackageSource>
+  <fallbackPackageFolders>
+    <clear />
+  </fallbackPackageFolders>
   <config>
     <!-- This path is relative as a workaround to https://github.com/NuGet/Home/issues/2831 -->
     <add key="globalPackagesFolder" value="packages" />

--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
@@ -13,7 +13,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Load Microsoft.TestPlatform.Build.Tasks.dll, this can be overridden to use a different version with $(VSTestTaskAssemblyFile) -->
   <PropertyGroup>
     <VSTestTaskAssemblyFile Condition="$(VSTestTaskAssemblyFile) == ''">Microsoft.TestPlatform.Build.dll</VSTestTaskAssemblyFile>
-    <VSTestConsolePath Condition="$(VSTestConsoleFile) == ''">$([System.IO.Path]::Combine($(MSBuildThisFileDirectory),"vstest.console.dll"))</VSTestConsolePath>
+    <VSTestConsolePath Condition="$(VSTestConsolePath) == ''">$([System.IO.Path]::Combine($(MSBuildThisFileDirectory),"vstest.console.dll"))</VSTestConsolePath>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <UsingTask TaskName="Microsoft.TestPlatform.Build.Tasks.VSTestTask" AssemblyFile="$(VSTestTaskAssemblyFile)" />


### PR DESCRIPTION
In our build.ps1 we are explicitly looking for newtonsoft.json in vstest\packages. If newtonsoft.json exist in fallbackPackageFolders then it will not be restored in vstest\package, hence build.ps1 will fail in search of newtonsoft.json