### PR TITLE
Fix buffer size for socket send/receive.

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketClient.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketClient.cs
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 throw connectAsyncTask.Exception;
             }
 
-            this.channel = this.channelFactory(this.tcpClient.GetStream());
+            this.channel = this.channelFactory(new BufferedStream(this.tcpClient.GetStream(), 64 * 1024));
             if (this.ServerConnected != null)
             {
                 this.ServerConnected.SafeInvoke(this, new ConnectedEventArgs(this.channel), "SocketClient: ServerConnected");

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketClient.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketClient.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             this.cancellation = new CancellationTokenSource();
             this.stopped = false;
 
-            this.tcpClient = new TcpClient();
+            this.tcpClient = new TcpClient { NoDelay = true };
             this.channelFactory = channelFactory;
         }
 
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 throw connectAsyncTask.Exception;
             }
 
-            this.stream = new BufferedStream(this.tcpClient.GetStream(), 64 * 1024);
+            this.stream = new BufferedStream(this.tcpClient.GetStream(), 8 * 1024);
             this.channel = this.channelFactory(this.stream);
             if (this.ServerConnected != null)
             {

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketClient.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketClient.cs
@@ -93,9 +93,16 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 this.stopped = true;
 
                 // Close the client and dispose the underlying stream
+                // Depending on implementation order of dispose may be important.
+                // 1. Channel dispose -> disposes reader/writer which call a Flush on the Stream. Stream shouldn't
+                // be disposed at this time.
+                // 2. Stream's dispose may Flush the underlying base stream (if it's a BufferedStream). We should try
+                // dispose it next.
+                // 3. TcpClient's dispose will clean up the network stream and close any sockets. NetworkStream's dispose
+                // is a no-op if called a second time.
+                this.channel?.Dispose();
                 this.stream?.Dispose();
                 this.tcpClient?.Dispose();
-                this.channel?.Dispose();
 
                 this.cancellation.Dispose();
 

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketCommunicationManager.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketCommunicationManager.cs
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         /// <summary>
         /// Stream to use read timeout
         /// </summary>
-        private NetworkStream stream;
+        private Stream stream;
 
         private Socket socket;
 
@@ -115,7 +115,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
                 var client = await this.tcpListener.AcceptTcpClientAsync();
                 this.socket = client.Client;
-                this.stream = client.GetStream();
+                this.stream = new BufferedStream(client.GetStream(), 64 * 1024);
                 this.binaryReader = new BinaryReader(this.stream);
                 this.binaryWriter = new BinaryWriter(this.stream);
 
@@ -162,7 +162,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             this.tcpClient = new TcpClient();
             this.socket = this.tcpClient.Client;
             await this.tcpClient.ConnectAsync(IPAddress.Loopback, portNumber);
-            this.stream = this.tcpClient.GetStream();
+            this.stream = new BufferedStream(this.tcpClient.GetStream(), 64 * 1024);
             this.binaryReader = new BinaryReader(this.stream);
             this.binaryWriter = new BinaryWriter(this.stream);
             this.clientConnectionAcceptedEvent.Set();

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketCommunicationManager.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketCommunicationManager.cs
@@ -22,6 +22,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         /// The server stream read timeout constant (in microseconds).
         /// </summary>
         private const int STREAMREADTIMEOUT = 1000 * 1000;
+        private const int BUFFERSIZE = 8 * 1024;
 
         /// <summary>
         /// TCP Listener to host TCP channel and listen
@@ -94,7 +95,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         {
             var endpoint = new IPEndPoint(IPAddress.Loopback, 0);
             this.tcpListener = new TcpListener(endpoint);
-
             this.tcpListener.Start();
 
             var portNumber = ((IPEndPoint)this.tcpListener.LocalEndpoint).Port;
@@ -115,7 +115,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
                 var client = await this.tcpListener.AcceptTcpClientAsync();
                 this.socket = client.Client;
-                this.stream = new BufferedStream(client.GetStream(), 64 * 1024);
+                this.socket.NoDelay = true;
+                this.stream = new BufferedStream(client.GetStream(), BUFFERSIZE);
                 this.binaryReader = new BinaryReader(this.stream);
                 this.binaryWriter = new BinaryWriter(this.stream);
 
@@ -159,10 +160,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         {
             this.clientConnectionAcceptedEvent.Reset();
             EqtTrace.Info("Trying to connect to server on port : {0}", portNumber);
-            this.tcpClient = new TcpClient();
+            this.tcpClient = new TcpClient { NoDelay = true };
             this.socket = this.tcpClient.Client;
             await this.tcpClient.ConnectAsync(IPAddress.Loopback, portNumber);
-            this.stream = new BufferedStream(this.tcpClient.GetStream(), 64 * 1024);
+            this.stream = new BufferedStream(this.tcpClient.GetStream(), BUFFERSIZE);
             this.binaryReader = new BinaryReader(this.stream);
             this.binaryWriter = new BinaryWriter(this.stream);
             this.clientConnectionAcceptedEvent.Set();
@@ -324,8 +325,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                         && socketException.SocketErrorCode == SocketError.TimedOut)
                     {
                         EqtTrace.Info(
-                            "SocketCommunicationManager ReceiveMessage: failed to receive message because read timeout {0}",
-                            ioException);
+                        "SocketCommunicationManager ReceiveMessage: failed to receive message because read timeout {0}",
+                        ioException);
                     }
                     else
                     {

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
@@ -92,6 +92,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             if (this.ClientConnected != null)
             {
                 this.channel = this.channelFactory(client.GetStream());
+                this.channel = this.channelFactory(new BufferedStream(client.GetStream(), 64 * 1024));
                 this.ClientConnected.SafeInvoke(this, new ConnectedEventArgs(this.channel), "SocketServer: ClientConnected");
 
                 // Start the message loop

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
@@ -29,6 +29,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         private TcpClient tcpClient;
 
+        private Stream stream;
+
         private bool stopped;
 
         /// <summary>
@@ -91,8 +93,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
             if (this.ClientConnected != null)
             {
-                this.channel = this.channelFactory(client.GetStream());
-                this.channel = this.channelFactory(new BufferedStream(client.GetStream(), 64 * 1024));
+                this.stream = new BufferedStream(client.GetStream(), 64 * 1024);
+                this.channel = this.channelFactory(this.stream);
                 this.ClientConnected.SafeInvoke(this, new ConnectedEventArgs(this.channel), "SocketServer: ClientConnected");
 
                 // Start the message loop
@@ -111,8 +113,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 this.tcpListener.Stop();
 
                 // Close the client and dispose the underlying stream
+                this.stream?.Dispose();
                 this.tcpClient?.Dispose();
-                this.channel.Dispose();
+                this.channel?.Dispose();
 
                 this.cancellation.Dispose();
 

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
@@ -113,10 +113,17 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 // Stop accepting any other connections
                 this.tcpListener.Stop();
 
-                // Close the client and dispose the underlying stream
+                // Close the client and dispose the underlying stream.
+                // Depending on implementation order of dispose may be important.
+                // 1. Channel dispose -> disposes reader/writer which call a Flush on the Stream. Stream shouldn't
+                // be disposed at this time.
+                // 2. Stream's dispose may Flush the underlying base stream (if it's a BufferedStream). We should try
+                // dispose it next.
+                // 3. TcpClient's dispose will clean up the network stream and close any sockets. NetworkStream's dispose
+                // is a no-op if called a second time.
+                this.channel?.Dispose();
                 this.stream?.Dispose();
                 this.tcpClient?.Dispose();
-                this.channel?.Dispose();
 
                 this.cancellation.Dispose();
 

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
@@ -90,10 +90,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         private void OnClientConnected(TcpClient client)
         {
             this.tcpClient = client;
+            this.tcpClient.Client.NoDelay = true;
 
             if (this.ClientConnected != null)
             {
-                this.stream = new BufferedStream(client.GetStream(), 64 * 1024);
+                this.stream = new BufferedStream(client.GetStream(), 8 * 1024);
                 this.channel = this.channelFactory(this.stream);
                 this.ClientConnected.SafeInvoke(this, new ConnectedEventArgs(this.channel), "SocketServer: ClientConnected");
 

--- a/test/Microsoft.TestPlatform.PerformanceTests/SocketTests.cs
+++ b/test/Microsoft.TestPlatform.PerformanceTests/SocketTests.cs
@@ -18,6 +18,8 @@ namespace Microsoft.TestPlatform.PerformanceTests
         [TestMethod]
         public void SocketThroughput2()
         {
+            // Measure the throughput with socket communication v2 (SocketServer, SocketClient)
+            // implementation.
             var server = new SocketServer();
             var client = new SocketClient();
             ICommunicationChannel serverChannel = null;
@@ -71,6 +73,8 @@ namespace Microsoft.TestPlatform.PerformanceTests
         [TestMethod]
         public void SocketThroughput1()
         {
+            // Measure the throughput with socket communication v1 (SocketCommunicationManager)
+            // implementation.
             var server = new SocketCommunicationManager();
             var client = new SocketCommunicationManager();
             var watch = new Stopwatch();

--- a/test/Microsoft.TestPlatform.PerformanceTests/SocketTests.cs
+++ b/test/Microsoft.TestPlatform.PerformanceTests/SocketTests.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.TestPlatform.PerformanceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Text;
+    using System.Threading;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class SocketTests
+    {
+        [TestMethod]
+        public void SocketThroughput2()
+        {
+            var server = new SocketServer();
+            var client = new SocketClient();
+            ICommunicationChannel serverChannel = null;
+            ICommunicationChannel clientChannel = null;
+            ManualResetEventSlim dataTransferred = new ManualResetEventSlim(false);
+            ManualResetEventSlim clientConnected = new ManualResetEventSlim(false);
+            ManualResetEventSlim serverConnected = new ManualResetEventSlim(false);
+            int dataReceived = 0;
+            var watch = new Stopwatch();
+            var thread = new Thread(() => SendData(clientChannel, watch));
+
+            // Setup server
+            server.ClientConnected += (sender, args) =>
+            {
+                serverChannel = args.Channel;
+                serverChannel.MessageReceived += (channel, messageReceived) =>
+                {
+                    // Keep count of bytes
+                    dataReceived += messageReceived.Data.Length;
+
+                    if (dataReceived >= 65536 * 20000)
+                    {
+                        dataTransferred.Set();
+                        watch.Stop();
+                    }
+                };
+
+                clientConnected.Set();
+            };
+
+            client.ServerConnected += (sender, args) =>
+            {
+                clientChannel = args.Channel;
+
+                thread.Start();
+
+                serverConnected.Set();
+            };
+
+            var port = server.Start();
+            client.Start(port);
+
+            clientConnected.Wait();
+            serverConnected.Wait();
+            thread.Join();
+            dataTransferred.Wait();
+
+            Assert.IsTrue(watch.Elapsed < TimeSpan.FromSeconds(4), "Elapsed: " + watch.Elapsed);
+        }
+
+        [TestMethod]
+        public void SocketThroughput1()
+        {
+            var server = new SocketCommunicationManager();
+            var client = new SocketCommunicationManager();
+            var watch = new Stopwatch();
+
+            int port = server.HostServer();
+            client.SetupClientAsync(port).Wait();
+            server.AcceptClientAsync().Wait();
+
+            server.WaitForClientConnection(1000);
+            client.WaitForServerConnection(1000);
+
+            var clientThread = new Thread(() => SendData2(client, watch));
+            clientThread.Start();
+
+            var dataReceived = 0;
+            while (dataReceived < 65536 * 20000)
+            {
+                dataReceived += server.ReceiveRawMessage().Length;
+            }
+
+            watch.Stop();
+            clientThread.Join();
+
+            Assert.IsTrue(watch.Elapsed < TimeSpan.FromSeconds(4), "Elapsed: " + watch.Elapsed);
+        }
+
+        private static void SendData(ICommunicationChannel channel, Stopwatch watch)
+        {
+            var dataBytes = new byte[65536];
+            for (int i = 0; i < dataBytes.Length; i++)
+            {
+                dataBytes[i] = 0x65;
+            }
+
+            var dataBytesStr = System.Text.Encoding.UTF8.GetString(dataBytes);
+
+            watch.Start();
+            for (int i = 0; i < 20000; i++)
+            {
+                channel.Send(dataBytesStr);
+            }
+        }
+
+        private static void SendData2(ICommunicationManager communicationManager, Stopwatch watch)
+        {
+            var dataBytes = new byte[65536];
+            for (int i = 0; i < dataBytes.Length; i++)
+            {
+                dataBytes[i] = 0x65;
+            }
+
+            var dataBytesStr = System.Text.Encoding.UTF8.GetString(dataBytes);
+
+            watch.Start();
+            for (int i = 0; i < 20000; i++)
+            {
+                communicationManager.SendRawMessage(dataBytesStr);
+            }
+        }
+    }
+}


### PR DESCRIPTION
By default, BinaryWriter and Reader use a very small bufer size, which leads to multiple
sends through the network. Increasing the buffer speeds it up by magnitudes.