### PR TITLE
Fix setting of json serializer to ignore self referencing loop

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -11,6 +11,9 @@
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />
   </activePackageSource>
+  <fallbackPackageFolders>
+    <clear />
+  </fallbackPackageFolders>
   <config>
     <!-- This path is relative as a workaround to https://github.com/NuGet/Home/issues/2831 -->
     <add key="globalPackagesFolder" value="packages" />

--- a/samples/Microsoft.TestPlatform.Protocol/Communication/JsonDataSerializer.cs
+++ b/samples/Microsoft.TestPlatform.Protocol/Communication/JsonDataSerializer.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.TestPlatform.Protocol
 {
     using System.IO;
-    
+
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
     using Newtonsoft.Json.Serialization;
@@ -25,12 +25,13 @@ namespace Microsoft.TestPlatform.Protocol
         {
             serializer = JsonSerializer.Create(
                             new JsonSerializerSettings
-                                {
-                                    DateFormatHandling = DateFormatHandling.IsoDateFormat,
-                                    DateParseHandling = DateParseHandling.DateTimeOffset,
-                                    DateTimeZoneHandling = DateTimeZoneHandling.Utc,
-                                    TypeNameHandling = TypeNameHandling.None
-                                });
+                            {
+                                DateFormatHandling = DateFormatHandling.IsoDateFormat,
+                                DateParseHandling = DateParseHandling.DateTimeOffset,
+                                DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                                TypeNameHandling = TypeNameHandling.None,
+                                ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+                            });
 #if DEBUG
             // MemoryTraceWriter can help diagnose serialization issues. Enable it for
             // debug builds only.
@@ -68,7 +69,7 @@ namespace Microsoft.TestPlatform.Protocol
         public T DeserializePayload<T>(Message message)
         {
             T retValue = default(T);
-            
+
             // TODO: Currently we use json serializer auto only for non-testmessage types
             // CHECK: Can't we just use auto for everything
             if (Microsoft.TestPlatform.Protocol.MessageType.TestMessage.Equals(message.MessageType))
@@ -117,7 +118,7 @@ namespace Microsoft.TestPlatform.Protocol
         public string SerializePayload(string messageType, object payload)
         {
             JToken serializedPayload = null;
-            
+
             // TODO: Currently we use json serializer auto only for non-testmessage types
             // CHECK: Can't we just use auto for everything
             if (MessageType.TestMessage.Equals(messageType))

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.cs
@@ -32,7 +32,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 DateFormatHandling = DateFormatHandling.IsoDateFormat,
                 DateParseHandling = DateParseHandling.DateTimeOffset,
                 DateTimeZoneHandling = DateTimeZoneHandling.Utc,
-                TypeNameHandling = TypeNameHandling.None
+                TypeNameHandling = TypeNameHandling.None,
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore
             };
 
             payloadSerializer = JsonSerializer.Create(jsonSettings);

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Events/TestRunCompleteEventArgs.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Events/TestRunCompleteEventArgs.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Client
             this.TestRunStatistics = stats;
             this.IsCanceled = isCanceled;
             this.IsAborted = isAborted;
-            this.Error = null; // Passing error value as null, should be pass exception. Issue: https://github.com/Microsoft/vstest/issues/618
+            this.Error = error;
             this.AttachmentSets = attachmentSets;
             this.ElapsedTimeInRunningTests = elapsedTime;
         }

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/JsonDataSerializerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/JsonDataSerializerTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
+{
+    using System;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class JsonDataSerializerTests
+    {
+        [TestMethod]
+        public void SerializePayloadShouldSerializeAnObjectWithSelfReferencingLoop()
+        {
+            var classWithSelfReferencingLoop = new ClassWithSelfReferencingLoop(null);
+            classWithSelfReferencingLoop = new ClassWithSelfReferencingLoop(classWithSelfReferencingLoop);
+            classWithSelfReferencingLoop.InfiniteRefernce.InfiniteRefernce = classWithSelfReferencingLoop;
+
+            var sut = JsonDataSerializer.Instance;
+
+            // this line should not throw exception
+            sut.SerializePayload("dummy", classWithSelfReferencingLoop);
+        }
+
+        public class ClassWithSelfReferencingLoop
+        {
+            public ClassWithSelfReferencingLoop(ClassWithSelfReferencingLoop ir)
+            {
+                this.InfiniteRefernce = ir;
+            }
+
+            public ClassWithSelfReferencingLoop InfiniteRefernce
+            {
+                get;
+                set;
+            }
+        }
+    }
+}

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/JsonDataSerializerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/JsonDataSerializerTests.cs
@@ -19,8 +19,26 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
 
             var sut = JsonDataSerializer.Instance;
 
-            // this line should not throw exception
+            // This line should not throw exception
             sut.SerializePayload("dummy", classWithSelfReferencingLoop);
+        }
+
+        [TestMethod]
+        public void DeserializeShouldDeserializeAnObjectWhichHadSelfReferencingLoopBeforeSerialization()
+        {
+            var classWithSelfReferencingLoop = new ClassWithSelfReferencingLoop(null);
+            classWithSelfReferencingLoop = new ClassWithSelfReferencingLoop(classWithSelfReferencingLoop);
+            classWithSelfReferencingLoop.InfiniteRefernce.InfiniteRefernce = classWithSelfReferencingLoop;
+
+            var sut = JsonDataSerializer.Instance;
+
+            var json = sut.SerializePayload("dummy", classWithSelfReferencingLoop);
+
+            // This line should deserialize properly
+            var result = sut.Deserialize<ClassWithSelfReferencingLoop>(json, 1);
+
+            Assert.AreEqual(typeof(ClassWithSelfReferencingLoop), result.GetType());
+            Assert.IsNull(result.InfiniteRefernce);
         }
 
         public class ClassWithSelfReferencingLoop


### PR DESCRIPTION
Issue: 
1) https://github.com/Microsoft/vstest/issues/706
2) https://github.com/Microsoft/vstest/issues/618

Fix: 
Don’t serialize the type if that have self-referencing loop
