### PR TITLE
Show all type of messages( sdtOut, stdErr etc) for passed tests

### DIFF
--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -263,6 +263,19 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
                 }
             }
 
+            var DbgTrcMessagesCollection = GetTestMessages(result.Messages, TestResultMessage.DebugTraceCategory);
+            if (DbgTrcMessagesCollection.Count > 0)
+            {
+                addAdditionalNewLine = false;
+                var dbgTrcMessages = GetFormattedOutput(DbgTrcMessagesCollection);
+
+                if (!string.IsNullOrEmpty(dbgTrcMessages))
+                {
+                    Output.Information(CommandLineResources.DbgTrcMessagesBanner);
+                    Output.Information(dbgTrcMessages);
+                }
+            }
+
             var addnlInfoMessagesCollection = GetTestMessages(result.Messages, TestResultMessage.AdditionalInfoCategory);
             if (addnlInfoMessagesCollection.Count > 0)
             {
@@ -275,6 +288,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
                     Output.Information(addnlInfoMessages);
                 }
             }
+
             if (addAdditionalNewLine)
             {
                 Output.WriteLine(String.Empty, OutputLevel.Information);

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -354,6 +354,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
                 {
                     var output = string.Format(CultureInfo.CurrentCulture, CommandLineResources.PassedTestIndicator, name);
                     Output.Information(output);
+                    DisplayFullInformation(e.Result);
                 }
                 this.testsPassed++;
             }

--- a/src/vstest.console/Resources/Resources.Designer.cs
+++ b/src/vstest.console/Resources/Resources.Designer.cs
@@ -1454,6 +1454,17 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Debug Traces Messages:.
+        /// </summary>
+        public static string DbgTrcMessagesBanner
+        {
+            get
+            {
+                return ResourceManager.GetString("DbgTrcMessagesBanner", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Additionally, you can try specifying &apos;/UseVsixExtensions&apos; command if the test discoverer &amp; executor is installed on the machine as vsix extensions and your installation supports vsix extensions. Example: vstest.console.exe myTests.dll /UseVsixExtensions:true.
         /// </summary>
         public static string SuggestUseVsixExtensionsIfNoTestsIsFound

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -652,4 +652,7 @@
   <data name="DataCollectorFriendlyNameInvalid" xml:space="preserve">
     <value>The Data Collector friendly name '{0}' is not valid.  The Data Collector will be ignored.</value>
   </data>
+  <data name="DbgTrcMessagesBanner" xml:space="preserve">
+    <value>Debug Traces Messages:</value>
+  </data>
 </root>

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -324,7 +324,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
             var testcase = new TestCase("TestName", new Uri("some://uri"), "TestSource");
 
             string message = "Dummy message";
-            TestResultMessage testResultMessage = new TestResultMessage(TestResultMessage.AdditionalInfoCategory, message);
+            TestResultMessage testResultMessage = new TestResultMessage(TestResultMessage.StandardOutCategory, message);
 
             var testresult = new ObjectModel.TestResult(testcase);
             testresult.Outcome = TestOutcome.Passed;
@@ -336,9 +336,36 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
             this.testRunRequest.Raise(m => m.OnRunStatsChange += null, eventArgs);
             this.FlushLoggerMessages();
 
-            this.mockOutput.Verify(o => o.WriteLine(CommandLineResources.AddnlInfoMessagesBanner, OutputLevel.Information), Times.Once());
+            this.mockOutput.Verify(o => o.WriteLine(CommandLineResources.StdOutMessagesBanner, OutputLevel.Information), Times.Once());
             this.mockOutput.Verify(o => o.WriteLine(" " + message, OutputLevel.Information), Times.Once());
         }
+
+        [TestMethod]
+        public void TestResultHandlerShouldShowDbgTrcMsg()
+        {
+            var parameters = new Dictionary<string, string>();
+            parameters.Add("verbosity", "normal");
+            this.consoleLogger.Initialize(this.events.Object, parameters);
+
+            var testcase = new TestCase("TestName", new Uri("some://uri"), "TestSource");
+
+            string message = "Dummy message";
+            TestResultMessage testResultMessage = new TestResultMessage(TestResultMessage.DebugTraceCategory, message);
+
+            var testresult = new ObjectModel.TestResult(testcase);
+            testresult.Outcome = TestOutcome.Passed;
+            testresult.Messages.Add(testResultMessage);
+
+            var eventArgs = new TestRunChangedEventArgs(null, new List<ObjectModel.TestResult> { testresult }, null);
+
+            // Raise an event on mock object
+            this.testRunRequest.Raise(m => m.OnRunStatsChange += null, eventArgs);
+            this.FlushLoggerMessages();
+
+            this.mockOutput.Verify(o => o.WriteLine(CommandLineResources.DbgTrcMessagesBanner, OutputLevel.Information), Times.Once());
+            this.mockOutput.Verify(o => o.WriteLine(" " + message, OutputLevel.Information), Times.Once());
+        }
+
 
         [TestMethod]
         public void TestResultHandlerShouldWriteToConsoleButSkipPassedTestsForMinimalVerbosity()

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -315,6 +315,32 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
         }
 
         [TestMethod]
+        public void TestResultHandlerShouldShowStdOutMsgOfPassedTestIfVerbosityIsNormal()
+        {
+            var parameters = new Dictionary<string, string>();
+            parameters.Add("verbosity", "normal");
+            this.consoleLogger.Initialize(this.events.Object, parameters);
+
+            var testcase = new TestCase("TestName", new Uri("some://uri"), "TestSource");
+
+            string message = "Dummy message";
+            TestResultMessage testResultMessage = new TestResultMessage(TestResultMessage.AdditionalInfoCategory, message);
+
+            var testresult = new ObjectModel.TestResult(testcase);
+            testresult.Outcome = TestOutcome.Passed;
+            testresult.Messages.Add(testResultMessage);
+
+            var eventArgs = new TestRunChangedEventArgs(null, new List<ObjectModel.TestResult> { testresult }, null);
+
+            // Raise an event on mock object
+            this.testRunRequest.Raise(m => m.OnRunStatsChange += null, eventArgs);
+            this.FlushLoggerMessages();
+
+            this.mockOutput.Verify(o => o.WriteLine(CommandLineResources.AddnlInfoMessagesBanner, OutputLevel.Information), Times.Once());
+            this.mockOutput.Verify(o => o.WriteLine(" " + message, OutputLevel.Information), Times.Once());
+        }
+
+        [TestMethod]
         public void TestResultHandlerShouldWriteToConsoleButSkipPassedTestsForMinimalVerbosity()
         {
             var parameters = new Dictionary<string, string>();


### PR DESCRIPTION
Issue: https://github.com/Microsoft/vstest/issues/799 
