### PR TITLE
Using environment variables in test results directory path in run settings throws error

### DIFF
--- a/src/Microsoft.TestPlatform.Utilities/ClientUtilities.cs
+++ b/src/Microsoft.TestPlatform.Utilities/ClientUtilities.cs
@@ -51,6 +51,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         private static void FixNodeFilePath(XmlNode node, string root)
         {
             string fileName = node.InnerXml;
+            fileName = Environment.ExpandEnvironmentVariables(fileName);
 
             if (!string.IsNullOrEmpty(fileName)
                     && !Path.IsPathRooted(fileName))
@@ -58,9 +59,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
                 // We have a relative file path...
                 fileName = Path.Combine(root, fileName);
                 fileName = Path.GetFullPath(fileName);
-
-                node.InnerXml = fileName;
             }
+
+            node.InnerXml = fileName;
         }
     }
 }

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/ClientUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/ClientUtilitiesTests.cs
@@ -159,5 +159,29 @@ namespace Microsoft.TestPlatform.Utilities.Tests
 
             Assert.AreEqual(runSettingsXML, finalSettingsXml);
         }
+
+        [TestMethod]
+        public void FixRelativePathsInRunSettingsShouldExpandEnvironmentVariable()
+        {
+            var runSettingsXML = "<RunSettings><RunConfiguration><ResultsDirectory>%temp%\\results</ResultsDirectory></RunConfiguration></RunSettings>";
+
+            var doc = new XmlDocument();
+            doc.LoadXml(runSettingsXML);
+
+            var currentAssemblyLocation = typeof(ClientUtilitiesTests).GetTypeInfo().Assembly.Location;
+
+            ClientUtilities.FixRelativePathsInRunSettings(doc, currentAssemblyLocation);
+
+            var finalSettingsXml = doc.OuterXml;
+
+            var expectedPath = Environment.ExpandEnvironmentVariables("%temp%\\results");
+
+            var expectedSettingsXml = string.Concat(
+                "<RunSettings><RunConfiguration><ResultsDirectory>",
+                expectedPath,
+                "</ResultsDirectory></RunConfiguration></RunSettings>");
+
+            Assert.AreEqual(expectedSettingsXml, finalSettingsXml);
+        }
     }
 }


### PR DESCRIPTION
Issue: https://devdiv.visualstudio.com/DevDiv/_workitems?id=438724&_a=edit

Root Cause: We missed to expand environment variable before checking Path.IsPathRooted. Path.IsPathRooted returns false if path name has environment variable at the beginning and we end up adding base directory before file name.

Fix: Expand environment variable before checking Path.IsPathRooted.

Test: Added unit test and verified scenario manually
