### PR TITLE
Testhost crash info is not coming to Testwindow.

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
     using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
+    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine;
@@ -24,6 +25,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
     public class ProxyDiscoveryManager : ProxyOperationManager, IProxyDiscoveryManager
     {
         private readonly ITestRuntimeProvider testHostManager;
+        private IDataSerializer dataSerializer;
 
         #region Constructors
 
@@ -33,7 +35,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         /// <param name="testRequestSender">Test request sender instance.</param>
         /// <param name="testHostManager">Test host manager instance.</param>
         public ProxyDiscoveryManager(ITestRequestSender testRequestSender, ITestRuntimeProvider testHostManager)
-            : this(testRequestSender, testHostManager, CrossPlatEngine.Constants.ClientConnectionTimeout)
+            : this(testRequestSender, testHostManager, JsonDataSerializer.Instance, CrossPlatEngine.Constants.ClientConnectionTimeout)
         {
             this.testHostManager = testHostManager;
         }
@@ -54,9 +56,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         internal ProxyDiscoveryManager(
             ITestRequestSender requestSender,
             ITestRuntimeProvider testHostManager,
+            IDataSerializer dataSerializer,
             int clientConnectionTimeout)
             : base(requestSender, testHostManager, clientConnectionTimeout)
         {
+            this.dataSerializer = dataSerializer;
             this.testHostManager = testHostManager;
         }
 
@@ -99,6 +103,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             catch (Exception exception)
             {
                 EqtTrace.Error("ProxyDiscoveryManager.DiscoverTests: Failed to discover tests: {0}", exception);
+
+                // Log to vs ide test output
+                var testMessagePayload = new TestMessagePayload { MessageLevel = TestMessageLevel.Error, Message = exception.Message };
+                var rawMessage = this.dataSerializer.SerializePayload(MessageType.TestMessage, testMessagePayload);
+                eventHandler.HandleRawMessage(rawMessage);
+
+                // Log to vstest.console
                 eventHandler.HandleLogMessage(TestMessageLevel.Error, exception.Message);
                 eventHandler.HandleDiscoveryComplete(0, new List<ObjectModel.TestCase>(), false);
             }

--- a/src/testhost.x86/Program.cs
+++ b/src/testhost.x86/Program.cs
@@ -36,6 +36,9 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
             catch (Exception ex)
             {
                 EqtTrace.Error("TestHost: Error occured during initialization of TestHost : {0}", ex);
+
+                // Throw exception so that vstest.console get the exception message.
+                throw ex;
             }
             finally
             {

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
@@ -27,6 +27,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
         private Mock<ITestRequestSender> mockRequestSender;
 
+        private Mock<IDataSerializer> mockDataSerializer;
+
         /// <summary>
         /// The client connection timeout in milliseconds for unit tests.
         /// </summary>
@@ -38,9 +40,11 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         {
             this.mockTestHostManager = new Mock<ITestRuntimeProvider>();
             this.mockRequestSender = new Mock<ITestRequestSender>();
+            this.mockDataSerializer = new Mock<IDataSerializer>();
             this.testDiscoveryManager = new ProxyDiscoveryManager(
                                             this.mockRequestSender.Object,
                                             this.mockTestHostManager.Object,
+                                            this.mockDataSerializer.Object,
                                             this.testableClientConnectionTimeout);
             this.discoveryCriteria = new DiscoveryCriteria(new[] { "test.dll" }, 1, string.Empty);
 
@@ -148,6 +152,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
             // Verify
             mockTestDiscoveryEventsHandler.Verify(s => s.HandleDiscoveryComplete(0, It.IsAny<IEnumerable<TestCase>>(), false));
+            mockTestDiscoveryEventsHandler.Verify(s => s.HandleRawMessage(It.IsAny<string>()));
             mockTestDiscoveryEventsHandler.Verify(s => s.HandleLogMessage(TestMessageLevel.Error, It.IsAny<string>()));
         }
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerWithDataCollectionTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerWithDataCollectionTests.cs
@@ -34,6 +34,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
         private ProxyExecutionManagerWithDataCollection proxyExecutionManager;
 
+        private Mock<IDataSerializer> mockDataSerializer;
+
         /// <summary>
         /// The client connection timeout in milliseconds for unit tests.
         /// </summary>
@@ -44,7 +46,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         {
             this.mockTestHostManager = new Mock<ITestRuntimeProvider>();
             this.mockRequestSender = new Mock<ITestRequestSender>();
-            this.testExecutionManager = new ProxyExecutionManager(this.mockRequestSender.Object, this.mockTestHostManager.Object, this.testableClientConnectionTimeout);
+            this.mockDataSerializer = new Mock<IDataSerializer>();
+            this.testExecutionManager = new ProxyExecutionManager(this.mockRequestSender.Object, this.mockTestHostManager.Object, this.mockDataSerializer.Object, this.testableClientConnectionTimeout);
             this.mockDataCollectionManager = new Mock<IProxyDataCollectionManager>();
             this.mockProcessHelper = new Mock<IProcessHelper>();
             this.proxyExecutionManager = new ProxyExecutionManagerWithDataCollection(this.mockRequestSender.Object, this.mockTestHostManager.Object, this.mockDataCollectionManager.Object);


### PR DESCRIPTION
Issue: When testhost is crashing before setting up channel with vstest.console, vstest.console should log error message in TestWindow. https://github.com/Microsoft/vstest/issues/832 

Fix: Send error message to Test hub of output window.

Testing: Added UT and done manual testing
