### PR TITLE
Fix errors during package restore

### DIFF
--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -18,5 +18,7 @@
     <NUnitAdapterVersion>2.0.0</NUnitAdapterVersion>
 
     <ChutzpahAdapterVersion>4.2.4</ChutzpahAdapterVersion>
+
+    <MoqVersion>4.7.25</MoqVersion>
   </PropertyGroup>
 </Project>

--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -83,10 +83,15 @@
           <Version>$(MSTestAdapterVersion)</Version>
         </PackageReference>
         <PackageReference Include="Moq">
-          <Version>4.6.38-*</Version>
+          <Version>$(MoqVersion)</Version>
         </PackageReference>
         <PackageReference Include="MSTest.Assert.Extensions">
           <Version>$(MSTestAssertExtensionVersion)</Version>
+        </PackageReference>
+
+        <!-- Workaround for https://github.com/castleproject/Core/issues/239 -->
+        <PackageReference Include="System.ComponentModel.TypeConverter">
+          <Version>4.3.0</Version>
         </PackageReference>
       </ItemGroup>
     </When>


### PR DESCRIPTION
Make Moq an external dependency
Add a workaround for castle.core dependency on non-existent TypeConverter package.