### PR TITLE
Changed vstest log file path to absolute in TranslationLayer.E2ETest …

### DIFF
--- a/samples/Microsoft.TestPlatform.TranslationLayer.E2ETest/Program.cs
+++ b/samples/Microsoft.TestPlatform.TranslationLayer.E2ETest/Program.cs
@@ -51,8 +51,6 @@ namespace Microsoft.TestPlatform.TranslationLayer.E2ETest
                 }
             }
 
-            Console.WriteLine(Directory.GetCurrentDirectory());
-
             Console.WriteLine("Parameters:");
             Console.WriteLine("Runner Path: " + runnerLocation);
             Console.WriteLine("Test Assembly Path: " + testAssembly);

--- a/samples/Microsoft.TestPlatform.TranslationLayer.E2ETest/Program.cs
+++ b/samples/Microsoft.TestPlatform.TranslationLayer.E2ETest/Program.cs
@@ -21,7 +21,7 @@ namespace Microsoft.TestPlatform.TranslationLayer.E2ETest
     {
         public static int Main(string[] args)
         {
-            if(args == null || args.Length < 1)
+            if (args == null || args.Length < 1)
             {
                 Console.WriteLine(@"Please provide appropriate arguments. Arguments can be passed as following:");
                 Console.WriteLine(@"Microsoft.TestPlatform.TranslationLayer.E2ETest.exe --runner:'[vstest.console path]' --testassembly:'[assemblyPath]' --testadapterpath:'[path]'");
@@ -51,13 +51,16 @@ namespace Microsoft.TestPlatform.TranslationLayer.E2ETest
                 }
             }
 
+            Console.WriteLine(Directory.GetCurrentDirectory());
+
             Console.WriteLine("Parameters:");
             Console.WriteLine("Runner Path: " + runnerLocation);
             Console.WriteLine("Test Assembly Path: " + testAssembly);
             Console.WriteLine("Test Adapter Path: " + testadapterPath);
             Console.WriteLine("-------------------------------------------------------");
 
-            IVsTestConsoleWrapper consoleWrapper = new VsTestConsoleWrapper(runnerLocation, new ConsoleParameters { LogFilePath = @"log.txt" });
+            var logFilePath = Path.Combine(Directory.GetCurrentDirectory(), @"log.txt");
+            IVsTestConsoleWrapper consoleWrapper = new VsTestConsoleWrapper(runnerLocation, new ConsoleParameters { LogFilePath = logFilePath });
 
             consoleWrapper.StartSession();
             consoleWrapper.InitializeExtensions(new List<string>() { testadapterPath });

--- a/samples/Microsoft.TestPlatform.TranslationLayer.E2ETest/Properties/launchSettings.json
+++ b/samples/Microsoft.TestPlatform.TranslationLayer.E2ETest/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Microsoft.TestPlatform.TranslationLayer.E2ETest": {
+      "commandName": "Project",
+      "commandLineArgs": "--runner:\"bin\\Debug\\net46\\win7-x64\\vstest.console.exe\" --testadapterpath:\"bin\\Debug\\net46\\win7-x64\\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll\" --testassembly:\"bin\\Debug\\net46\\win7-x64\\UnitTestProject.dll\""
+    }
+  }
+}

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/ConsoleParameters.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/ConsoleParameters.cs
@@ -49,7 +49,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
             {
                 ValidateArg.NotNullOrEmpty(value, "LogFilePath");
                 var directoryPath = Path.GetDirectoryName(value);
-                if ((directoryPath != string.Empty) && !fileHelper.DirectoryExists(Path.GetDirectoryName(value)))
+                if (!string.IsNullOrEmpty(directoryPath) && !fileHelper.DirectoryExists(Path.GetDirectoryName(value)))
                 {
                     throw new ArgumentException("LogFilePath must point to a valid directory for logging!");
                 }

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/ConsoleParameters.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/ConsoleParameters.cs
@@ -48,7 +48,8 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
             set
             {
                 ValidateArg.NotNullOrEmpty(value, "LogFilePath");
-                if (!fileHelper.DirectoryExists(Path.GetDirectoryName(value)))
+                var directoryPath = Path.GetDirectoryName(value);
+                if ((directoryPath != string.Empty) && !fileHelper.DirectoryExists(Path.GetDirectoryName(value)))
                 {
                     throw new ArgumentException("LogFilePath must point to a valid directory for logging!");
                 }


### PR DESCRIPTION
> …sample program.
> 
> Added default run parameters to TranslationLayer.E2ETest sample program.
>
> Modified TranslationLayer.ConsoleParameters.LogFilePath to properly handle relative paths, or absolute paths.

This is a fix for #872, including a direct fix for the sample program's incorrect usage of the API, and an improvement to the API itself to allow usage of relative paths.