### PR TITLE
Dont send any adapter other than from source directory for netcoreapp

### DIFF
--- a/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
+++ b/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
@@ -3,17 +3,19 @@
 
 namespace Microsoft.VisualStudio.TestPlatform.Client.Execution
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading;
+
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
     using Microsoft.VisualStudio.TestPlatform.Utilities;
-    using System;
-    using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.Diagnostics;
-    using System.Threading;
+
     using ClientResources = Microsoft.VisualStudio.TestPlatform.Client.Resources.Resources;
+    using System.Collections.ObjectModel;
 
     public class TestRunRequest : ITestRunRequest, ITestRunEventsHandler
     {

--- a/src/Microsoft.TestPlatform.Client/TestPlatform.cs
+++ b/src/Microsoft.TestPlatform.Client/TestPlatform.cs
@@ -159,14 +159,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Client
         }
 
         /// <summary>
-        /// Clear test plugin cache
-        /// </summary>
-        public void ClearExtensions()
-        {
-            TestPluginCache.Instance.ClearExtensions();
-        }
-
-        /// <summary>
         /// Update the test adapter paths provided through run settings to be used by the test service
         /// </summary>
         /// <param name="runSettings">

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginCache.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginCache.cs
@@ -306,20 +306,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
             }
         }
 
-        /// <summary>
-        /// Clear test plugin cache
-        /// </summary>
-        public void ClearExtensions()
-        {
-            this.pathToExtensions = null;
-            this.TestExtensions?.InvalidateCache();
-
-            if (EqtTrace.IsVerboseEnabled)
-            {
-                EqtTrace.Verbose("TestPluginCache: Clearing test plugin cache");
-            }
-        }
-
         #endregion
 
         #region Utility methods

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
 
         private void InitializeExtensions(IEnumerable<string> sources)
         {
-            List<string> extensions = new List<string>();
+            var extensions = new List<string>();
 
             if (TestPluginCache.Instance.PathToExtensions != null)
             {
@@ -139,17 +139,16 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                 extensions.AddRange(TestPluginCache.Instance.PathToExtensions.Where(ext => regex.IsMatch(ext)));
             }
 
-            // Concatenate adapters with default extensions
             extensions.AddRange(TestPluginCache.Instance.DefaultExtensionPaths);
             var sourceList = sources.ToList();
-            var extensionsToInitialize = this.testHostManager.GetTestPlatformExtensions(sourceList, extensions).ToList();
+            var platformExtensions = this.testHostManager.GetTestPlatformExtensions(sourceList, extensions).ToList();
 
             // Only send this if needed.
-            if (extensionsToInitialize.Count() > 0)
+            if (platformExtensions.Any())
             {
                 this.SetupChannel(sourceList);
 
-                this.RequestSender.InitializeDiscovery(extensionsToInitialize, TestPluginCache.Instance.LoadOnlyWellKnownExtensions);
+                this.RequestSender.InitializeDiscovery(platformExtensions, TestPluginCache.Instance.LoadOnlyWellKnownExtensions);
             }
         }
     }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
@@ -131,20 +131,25 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
 
         private void InitializeExtensions(IEnumerable<string> sources)
         {
-            var sourceList = sources.ToList();
-            var extensions = this.testHostManager.GetTestPlatformExtensions(sourceList, TestPluginCache.Instance.DefaultExtensionPaths).ToList();
+            List<string> extensions = new List<string>();
+
             if (TestPluginCache.Instance.PathToExtensions != null)
             {
                 var regex = new Regex(TestPlatformConstants.TestAdapterRegexPattern, RegexOptions.IgnoreCase);
                 extensions.AddRange(TestPluginCache.Instance.PathToExtensions.Where(ext => regex.IsMatch(ext)));
             }
 
+            // Concatenate adapters with default extensions
+            extensions.AddRange(TestPluginCache.Instance.DefaultExtensionPaths);
+            var sourceList = sources.ToList();
+            var extensionsToInitialize = this.testHostManager.GetTestPlatformExtensions(sourceList, extensions).ToList();
+
             // Only send this if needed.
-            if (extensions.Count() > 0)
+            if (extensionsToInitialize.Count() > 0)
             {
                 this.SetupChannel(sourceList);
 
-                this.RequestSender.InitializeDiscovery(extensions, TestPluginCache.Instance.LoadOnlyWellKnownExtensions);
+                this.RequestSender.InitializeDiscovery(extensionsToInitialize, TestPluginCache.Instance.LoadOnlyWellKnownExtensions);
             }
         }
     }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -176,7 +176,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
 
         private void InitializeExtensions(IEnumerable<string> sources)
         {
-            List<string> extensions = new List<string>();
+            var extensions = new List<string>();
 
             if (TestPluginCache.Instance.PathToExtensions != null)
             {
@@ -184,17 +184,16 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                 extensions.AddRange(TestPluginCache.Instance.PathToExtensions.Where(ext => regex.IsMatch(ext)));
             }
 
-            // Concatenate adapters with default extensions
             extensions.AddRange(TestPluginCache.Instance.DefaultExtensionPaths);
             var sourceList = sources.ToList();
-            var extensionsToInitialize = this.testHostManager.GetTestPlatformExtensions(sourceList, extensions).ToList();
+            var platformExtensions = this.testHostManager.GetTestPlatformExtensions(sourceList, extensions).ToList();
 
             // Only send this if needed.
-            if (extensionsToInitialize.Count() > 0)
+            if (platformExtensions.Any())
             {
                 this.SetupChannel(sourceList);
 
-                this.RequestSender.InitializeExecution(extensionsToInitialize, TestPluginCache.Instance.LoadOnlyWellKnownExtensions);
+                this.RequestSender.InitializeExecution(platformExtensions, TestPluginCache.Instance.LoadOnlyWellKnownExtensions);
             }
         }
     }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -176,20 +176,25 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
 
         private void InitializeExtensions(IEnumerable<string> sources)
         {
-            var sourceList = sources.ToList();
-            var extensions = this.testHostManager.GetTestPlatformExtensions(sourceList, TestPluginCache.Instance.DefaultExtensionPaths).ToList();
+            List<string> extensions = new List<string>();
+
             if (TestPluginCache.Instance.PathToExtensions != null)
             {
                 var regex = new Regex(TestPlatformConstants.TestAdapterRegexPattern, RegexOptions.IgnoreCase);
-                extensions.AddRange(TestPluginCache.Instance.PathToExtensions.Where(ext => (regex.IsMatch(ext))));
+                extensions.AddRange(TestPluginCache.Instance.PathToExtensions.Where(ext => regex.IsMatch(ext)));
             }
 
+            // Concatenate adapters with default extensions
+            extensions.AddRange(TestPluginCache.Instance.DefaultExtensionPaths);
+            var sourceList = sources.ToList();
+            var extensionsToInitialize = this.testHostManager.GetTestPlatformExtensions(sourceList, extensions).ToList();
+
             // Only send this if needed.
-            if (extensions.Count() > 0)
+            if (extensionsToInitialize.Count() > 0)
             {
                 this.SetupChannel(sourceList);
 
-                this.RequestSender.InitializeExecution(extensions, TestPluginCache.Instance.LoadOnlyWellKnownExtensions);
+                this.RequestSender.InitializeExecution(extensionsToInitialize, TestPluginCache.Instance.LoadOnlyWellKnownExtensions);
             }
         }
     }

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestPlatform.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestPlatform.cs
@@ -19,11 +19,6 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Client
         void UpdateExtensions(IEnumerable<string> pathToAdditionalExtensions, bool loadOnlyWellKnownExtensions);
 
         /// <summary>
-        /// Clear the extension
-        /// </summary>
-        void ClearExtensions();
-
-        /// <summary>
         /// Creates a discovery request
         /// </summary>
         /// <param name="discoveryCriteria">Specifies the discovery parameters</param>

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -180,9 +180,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
                 {
                     this.testLoggerManager?.UnregisterDiscoveryEvents(discoveryRequest);
                     discoveryEventsRegistrar?.UnregisterDiscoveryEvents(discoveryRequest);
-
-                    // Clear the extensions once request is complete, so that new request will not use extension from last request.
-                    this.testPlatform.ClearExtensions();
                 }
             }
 
@@ -343,9 +340,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
                         this.testLoggerManager.UnregisterTestRunEvents(testRunRequest);
                         this.testRunResultAggregator.UnregisterTestRunEvents(testRunRequest);
                         testRunEventsRegistrar?.UnregisterTestRunEvents(testRunRequest);
-
-                        // Clear the extensions once request is complete, so that new request will not use extension from last request.
-                        this.testPlatform.ClearExtensions();
                     }
                 }
 

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginCacheTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginCacheTests.cs
@@ -127,46 +127,10 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             Assert.AreEqual(1, updatedExtensions.Count());
         }
 
+        [Ignore]
         [TestMethod]
         public void UpdateAdditionalExtensionsShouldResetExtensionsDiscoveredFlag()
         {
-            SetupMockAdditionalPathExtensions();
-
-            TestPluginCache.Instance.DiscoverTestExtensions<TestDiscovererPluginInformation, ITestDiscoverer>(TestPlatformConstants.TestAdapterRegexPattern);
-
-            Assert.IsTrue(TestPluginCache.Instance.TestExtensions.AreTestDiscoverersCached);
-
-            // update extensions
-            var additionalExtensions = new List<string> { "foo.dll" };
-            TestPluginCache.Instance.UpdateExtensions(additionalExtensions, true);
-
-            Assert.IsFalse(TestPluginCache.Instance.TestExtensions.AreTestDiscoverersCached);
-        }
-
-        [TestMethod]
-        public void ClearExtensionsShouldClearExtensionPath()
-        {
-            var additionalExtensions = new List<string> { "foo.dll" };
-            TestPluginCache.Instance.UpdateExtensions(additionalExtensions, true);
-
-            TestPluginCache.Instance.ClearExtensions();
-
-            Assert.IsNull(TestPluginCache.Instance.PathToExtensions);
-        }
-
-        [TestMethod]
-        public void ClearExtensionsShouldClearTestExtensionsCache()
-        {
-            SetupMockAdditionalPathExtensions();
-
-            TestPluginCache.Instance.DiscoverTestExtensions<TestDiscovererPluginInformation, ITestDiscoverer>(TestPlatformConstants.TestAdapterRegexPattern);
-
-            Assert.IsTrue(TestPluginCache.Instance.TestExtensions.AreTestDiscoverersCached);
-
-            // Clear cache
-            TestPluginCache.Instance.ClearExtensions();
-
-            Assert.IsFalse(TestPluginCache.Instance.TestExtensions.AreTestDiscoverersCached);
         }
 
         #endregion

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
@@ -113,6 +113,29 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         }
 
         [TestMethod]
+        public void InitializeShouldPassAdapterToTestHostManagerFromTestPluginCacheExtensions()
+        {
+            TestPluginCache.Instance.UpdateExtensions(new List<string> { "abc.TestAdapter.dll", "xyz.TestAdapter.dll" }, false);
+            try
+            {
+                this.mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(true);
+
+                var expectedResult = new List<string>();
+                expectedResult.AddRange(TestPluginCache.Instance.PathToExtensions);
+                expectedResult.AddRange(TestPluginCache.Instance.DefaultExtensionPaths);
+
+                this.testDiscoveryManager.Initialize();
+
+
+                this.mockTestHostManager.Verify(th => th.GetTestPlatformExtensions(It.IsAny<IEnumerable<string>>(), expectedResult), Times.Once);
+            }
+            finally
+            {
+                TestPluginCache.Instance = null;
+            }
+        }
+
+        [TestMethod]
         public void DiscoverTestsShouldNotIntializeIfDoneSoAlready()
         {
             this.testDiscoveryManager.Initialize();

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
@@ -115,6 +115,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         [TestMethod]
         public void InitializeShouldPassAdapterToTestHostManagerFromTestPluginCacheExtensions()
         {
+            // We are updating extension with testadapter only to make it easy to test.
+            // In product code it filter out testadapter from extension
             TestPluginCache.Instance.UpdateExtensions(new List<string> { "abc.TestAdapter.dll", "xyz.TestAdapter.dll" }, false);
             try
             {
@@ -125,7 +127,6 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
                 expectedResult.AddRange(TestPluginCache.Instance.DefaultExtensionPaths);
 
                 this.testDiscoveryManager.Initialize();
-
 
                 this.mockTestHostManager.Verify(th => th.GetTestPlatformExtensions(It.IsAny<IEnumerable<string>>(), expectedResult), Times.Once);
             }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
@@ -119,6 +119,31 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         }
 
         [TestMethod]
+        public void InitializeShouldPassAdapterToTestHostManagerFromTestPluginCacheExtensions()
+        {
+            // We are updating extension with testadapter only to make it easy to test.
+            // In product code it filter out testadapter from extension
+            TestPluginCache.Instance.UpdateExtensions(new List<string> { "abc.TestAdapter.dll", "xyz.TestAdapter.dll"}, false);
+            try
+            {
+                this.mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(true);
+
+                var expectedResult = new List<string>();
+                expectedResult.AddRange(TestPluginCache.Instance.PathToExtensions);
+                expectedResult.AddRange(TestPluginCache.Instance.DefaultExtensionPaths);
+
+                this.testExecutionManager.Initialize();
+
+
+                this.mockTestHostManager.Verify(th => th.GetTestPlatformExtensions(It.IsAny<IEnumerable<string>>(), expectedResult), Times.Once);
+            }
+            finally
+            {
+                TestPluginCache.Instance = null;
+            }
+        }
+
+        [TestMethod]
         public void StartTestRunShouldNotIntializeIfDoneSoAlready()
         {
             this.testExecutionManager.Initialize();

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
@@ -134,7 +134,6 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
                 this.testExecutionManager.Initialize();
 
-
                 this.mockTestHostManager.Verify(th => th.GetTestPlatformExtensions(It.IsAny<IEnumerable<string>>(), expectedResult), Times.Once);
             }
             finally

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -138,23 +138,6 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
         }
 
         [TestMethod]
-        public void DiscoverTestsShouldClearCacheAfterDiscovery()
-        {
-            var payload = new DiscoveryRequestPayload()
-            {
-                Sources = new List<string>() { "a" },
-            };
-
-            var mockDiscoveryRequest = new Mock<IDiscoveryRequest>();
-            this.mockTestPlatform.Setup(mt => mt.CreateDiscoveryRequest(It.IsAny<DiscoveryCriteria>(), It.IsAny<ProtocolConfig>())).Callback(
-                (DiscoveryCriteria discoveryCriteria, ProtocolConfig config) => { }).Returns(mockDiscoveryRequest.Object);
-
-            var success = this.testRequestManager.DiscoverTests(payload, new Mock<ITestDiscoveryEventsRegistrar>().Object, It.IsAny<ProtocolConfig>());
-
-            this.mockTestPlatform.Verify(tp => tp.ClearExtensions(), Times.Once);
-        }
-
-        [TestMethod]
         public void DiscoverTestsShouldCallTestPlatformAndSucceed()
         {
             var payload = new DiscoveryRequestPayload()
@@ -215,10 +198,10 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
             this.mockTestPlatform.Setup(mt => mt.CreateTestRunRequest(It.IsAny<TestRunCriteria>(), It.IsAny<ProtocolConfig>())).Callback(
                (TestRunCriteria runCriteria, ProtocolConfig config) =>
                {
-                   Thread.Sleep(1);
-                   createRunRequestTime = sw.ElapsedMilliseconds;
-                   observedCriteria = runCriteria;
-               }).Returns(mockRunRequest.Object);
+                    Thread.Sleep(1);
+                    createRunRequestTime = sw.ElapsedMilliseconds;
+                    observedCriteria = runCriteria;
+                }).Returns(mockRunRequest.Object);
 
             mockRunRequest.Setup(mr => mr.CancelAsync()).Callback(() =>
             {
@@ -305,22 +288,6 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
 
             var success = this.testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, It.IsAny<ProtocolConfig>());
             Assert.AreEqual(15, actualTestRunCriteria.FrequencyOfRunStatsChangeEvent);
-        }
-
-        [TestMethod]
-        public void RunTestsShouldCallClearExtensionsAfterRun()
-        {
-            var payload = new TestRunRequestPayload()
-            {
-                Sources = new List<string>() { "a" },
-            };
-
-            var mockDiscoveryRequest = new Mock<ITestRunRequest>();
-            this.mockTestPlatform.Setup(mt => mt.CreateTestRunRequest(It.IsAny<TestRunCriteria>(), It.IsAny<ProtocolConfig>())).Callback(
-                (TestRunCriteria runCriteria, ProtocolConfig config) => { }).Returns(mockDiscoveryRequest.Object);
-
-            var success = this.testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, It.IsAny<ProtocolConfig>());
-            this.mockTestPlatform.Verify(tp => tp.ClearExtensions(), Times.Once);
         }
 
         [TestMethod]
@@ -630,7 +597,7 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
             var payload = new TestRunRequestPayload
             {
                 RunSettings = runsettings,
-                Sources = new List<string> { "c:\\testproject.dll" }
+                Sources = new List<string> {"c:\\testproject.dll"}
             };
             this.commandLineOptions.IsDesignMode = designModeValue;
 
@@ -645,7 +612,7 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
             var discoveryPayload = new DiscoveryRequestPayload
             {
                 RunSettings = runsettings,
-                Sources = new[] { "c:\\testproject.dll" }
+                Sources = new[] {"c:\\testproject.dll"}
             };
             return discoveryPayload;
         }


### PR DESCRIPTION
1) Reverted changes which were clearing extension cache after each request complete as it was breaking  LUT
2) Sending adapter from source directory so that net46 adapter will not get used to run netcoreapp tests