### PR TITLE
15.3-rtm Vstest.console should exit on parent process exit in design mode (#870)

### DIFF
--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -6,8 +6,8 @@
     <!-- Name of the elements must be in sync with test\Microsoft.TestPlatform.TestUtilities\IntegrationTestBase.cs -->
     <NETTestSdkPreviousVersion>15.0.0</NETTestSdkPreviousVersion>
 
-    <MSTestFrameworkVersion>1.1.14</MSTestFrameworkVersion>
-    <MSTestAdapterVersion>1.1.14</MSTestAdapterVersion>
+    <MSTestFrameworkVersion>1.1.18</MSTestFrameworkVersion>
+    <MSTestAdapterVersion>1.1.18</MSTestAdapterVersion>
     <MSTestAssertExtensionVersion>1.0.3-preview</MSTestAssertExtensionVersion>
     
     <XUnitFrameworkVersion>2.2.0</XUnitFrameworkVersion>

--- a/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
+++ b/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
@@ -13,8 +13,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.DesignMode
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-    using System.Linq;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+    using System.Linq;
 
     /// <summary>
     /// The design mode client.
@@ -105,6 +106,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.DesignMode
             // Dispose off the communications to end the session
             // this should end the "ProcessRequests" loop with an exception
             this.Dispose();
+
+            EqtTrace.Info("DesignModeClient: Parent process exited, Exiting myself..");
+            Environment.Exit(1);
         }
 
         /// <summary>
@@ -144,7 +148,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.DesignMode
                         case MessageType.StartDiscovery:
                             {
                                 var discoveryPayload = message.Payload.ToObject<DiscoveryRequestPayload>();
-                                testRequestManager.DiscoverTests(discoveryPayload, new DesignModeTestEventsRegistrar(this), this.protocolConfig);
+                                this.StartDiscovery(discoveryPayload, testRequestManager);
                                 break;
                             }
 
@@ -277,19 +281,56 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.DesignMode
                 }
                 catch(Exception ex)
                 {
+                    EqtTrace.Error("DesignModeClient: Exception in StartTestRun: " + ex);
                     // If there is an exception during test run request creation or some time during the process
                     // In such cases, TestPlatform will never send a TestRunComplete event and IDE need to be sent a run complete message
-                    // We need recoverability in translationlayer-designmode scenarios 
+                    // We need recoverability in translationlayer-designmode scenarios
+
+                    var testMessagePayload = new TestMessagePayload { MessageLevel = TestMessageLevel.Error, Message = ex.ToString() };
+                    this.communicationManager.SendMessage(MessageType.TestMessage, testMessagePayload);
                     var runCompletePayload = new TestRunCompletePayload()
                     {
                         TestRunCompleteArgs = new TestRunCompleteEventArgs(null, false, true, ex, null, TimeSpan.MinValue),
                         LastRunTests = null
                     };
-
                     // Send run complete to translation layer
                     this.communicationManager.SendMessage(MessageType.ExecutionComplete, runCompletePayload);
                 }
             });
+        }
+
+        private void StartDiscovery(DiscoveryRequestPayload discoveryRequestPayload, ITestRequestManager testRequestManager)
+        {
+            Task.Run(
+                delegate
+                {
+                    try
+                    {
+                        testRequestManager.ResetOptions();
+                        testRequestManager.DiscoverTests(discoveryRequestPayload, new DesignModeTestEventsRegistrar(this), this.protocolConfig);
+                    }
+                    catch (Exception ex)
+                    {
+                        EqtTrace.Error("DesignModeClient: Exception in StartDiscovery: " + ex);
+
+                        // If there is an exception during test discovery request creation or some time during the process
+                        // In such cases, TestPlatform will never send a DiscoveryComplete event and IDE need to be sent a discovery complete message
+                        // We need recoverability in translationlayer-designmode scenarios
+
+                        var testMessagePayload = new TestMessagePayload { MessageLevel = TestMessageLevel.Error, Message = ex.ToString() };
+                        this.communicationManager.SendMessage(MessageType.TestMessage, testMessagePayload);
+
+                        var payload = new DiscoveryCompletePayload()
+                        {
+                            IsAborted = true,
+                            LastDiscoveredTests = null,
+                            TotalTests = -1
+                        };
+
+                        // Send run complete to translation layer
+                        this.communicationManager.SendMessage(MessageType.DiscoveryComplete, payload);
+                    }
+                });
         }
 
         #region IDisposable Support

--- a/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
@@ -1,19 +1,34 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.VisualStudio.TestPlatform.Client.DesignMode;
-using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
-using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
-using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
-using System;
-
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
 {
+    using Microsoft.VisualStudio.TestPlatform.Client.DesignMode;
+    using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
+    using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
+    using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
+    using Moq;
+    using System;
+    using System.Diagnostics;
+
     [TestClass]
     public class PortArgumentProcessorTests
     {
+        private Mock<IProcessHelper> mockProcessHelper;
+        private Mock<IDesignModeClient> testDesignModeClient;
+        private Mock<ITestRequestManager> testRequestManager;
+        private PortArgumentExecutor executor;
+
+        public PortArgumentProcessorTests()
+        {
+            this.mockProcessHelper = new Mock<IProcessHelper>();
+            this.testDesignModeClient = new Mock<IDesignModeClient>();
+            this.testRequestManager = new Mock<ITestRequestManager>();
+            this.executor = new PortArgumentExecutor(CommandLineOptions.Instance, this.testRequestManager.Object);
+        }
+
         [TestMethod]
         public void GetMetadataShouldReturnPortArgumentProcessorCapabilities()
         {
@@ -51,7 +66,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         [TestMethod]
         public void ExecutorInitializeWithNullOrEmptyPortShouldThrowCommandLineException()
         {
-            var executor = new PortArgumentExecutor(CommandLineOptions.Instance, TestRequestManager.Instance);
             try
             {
                 executor.Initialize(null);
@@ -66,10 +80,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         [TestMethod]
         public void ExecutorInitializeWithInvalidPortShouldThrowCommandLineException()
         {
-            var executor = new PortArgumentExecutor(CommandLineOptions.Instance, TestRequestManager.Instance);
             try
             {
-                executor.Initialize("Foo");
+                this.executor.Initialize("Foo");
             }
             catch (Exception ex)
             {
@@ -81,11 +94,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         [TestMethod]
         public void ExecutorInitializeWithValidPortShouldAddPortToCommandLineOptionsAndInitializeDesignModeManager()
         {
-            var executor = new PortArgumentExecutor(CommandLineOptions.Instance, TestRequestManager.Instance);
             int port = 2345;
             CommandLineOptions.Instance.ParentProcessId = 0;
 
-            executor.Initialize(port.ToString());
+            this.executor.Initialize(port.ToString());
 
             Assert.AreEqual(port, CommandLineOptions.Instance.Port);
             Assert.IsNotNull(DesignModeClient.Instance);
@@ -94,30 +106,39 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         [TestMethod]
         public void ExecutorInitializeShouldSetDesignMode()
         {
-            var executor = new PortArgumentExecutor(CommandLineOptions.Instance, TestRequestManager.Instance);
             int port = 2345;
             CommandLineOptions.Instance.ParentProcessId = 0;
 
-            executor.Initialize(port.ToString());
+            this.executor.Initialize(port.ToString());
 
             Assert.IsTrue(CommandLineOptions.Instance.IsDesignMode);
         }
 
         [TestMethod]
+        public void ExecutorInitializeShouldSetProcessExitCallback()
+        {
+            this.executor = new PortArgumentExecutor(CommandLineOptions.Instance, this.testRequestManager.Object, this.mockProcessHelper.Object);
+            int port = 2345;
+            int processId = Process.GetCurrentProcess().Id;
+            CommandLineOptions.Instance.ParentProcessId = processId;
+
+            this.executor.Initialize(port.ToString());
+
+            this.mockProcessHelper.Verify(ph => ph.SetExitCallback(processId, It.IsAny<Action>()), Times.Once);
+        }
+
+        [TestMethod]
         public void ExecutorExecuteForValidConnectionReturnsArgumentProcessorResultSuccess()
         {
-            var testDesignModeClient = new Mock<IDesignModeClient>();
-            var testRequestManager = new Mock<ITestRequestManager>();
-
-            var executor = new PortArgumentExecutor(CommandLineOptions.Instance, testRequestManager.Object,
-                (parentProcessId) => testDesignModeClient.Object);
+            this.executor = new PortArgumentExecutor(CommandLineOptions.Instance, this.testRequestManager.Object,
+                (parentProcessId, ph) => this.testDesignModeClient.Object, this.mockProcessHelper.Object);
 
             int port = 2345;
-            executor.Initialize(port.ToString());
+            this.executor.Initialize(port.ToString());
             var result = executor.Execute();
 
-            testDesignModeClient.Verify(td =>
-                td.ConnectToClientAndProcessRequests(port, testRequestManager.Object), Times.Once);
+            this.testDesignModeClient.Verify(td =>
+                td.ConnectToClientAndProcessRequests(port, this.testRequestManager.Object), Times.Once);
 
             Assert.AreEqual(ArgumentProcessorResult.Success, result);
         }
@@ -125,43 +146,40 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         [TestMethod]
         public void ExecutorExecuteForFailedConnectionShouldThrowCommandLineException()
         {
-            var testRequestManager = new Mock<ITestRequestManager>();
-            var testDesignModeClient = new Mock<IDesignModeClient>();
-
-            var executor = new PortArgumentExecutor(CommandLineOptions.Instance, testRequestManager.Object,
-                (parentProcessId) => testDesignModeClient.Object);
+            this.executor = new PortArgumentExecutor(CommandLineOptions.Instance, this.testRequestManager.Object,
+                (parentProcessId, ph) => testDesignModeClient.Object, this.mockProcessHelper.Object);
 
             testDesignModeClient.Setup(td => td.ConnectToClientAndProcessRequests(It.IsAny<int>(),
                 It.IsAny<ITestRequestManager>())).Callback(() => { throw new TimeoutException(); });
 
             int port = 2345;
-            executor.Initialize(port.ToString());
+            this.executor.Initialize(port.ToString());
             Assert.ThrowsException<CommandLineException>(() => executor.Execute());
 
-            testDesignModeClient.Verify(td => td.ConnectToClientAndProcessRequests(port, testRequestManager.Object), Times.Once);
+            testDesignModeClient.Verify(td => td.ConnectToClientAndProcessRequests(port, this.testRequestManager.Object), Times.Once);
         }
 
 
         [TestMethod]
         public void ExecutorExecuteSetsParentProcessIdOnDesignModeInitializer()
         {
-            var testDesignModeClient = new Mock<IDesignModeClient>();
-            var testRequestManager = new Mock<ITestRequestManager>();
-
             var parentProcessId = 2346;
             var parentProcessIdArgumentExecutor = new ParentProcessIdArgumentExecutor(CommandLineOptions.Instance);
             parentProcessIdArgumentExecutor.Initialize(parentProcessId.ToString());
 
             int actualParentProcessId = -1;
-            var executor = new PortArgumentExecutor(CommandLineOptions.Instance, testRequestManager.Object,
-                (ppid) =>
+            this.executor = new PortArgumentExecutor(CommandLineOptions.Instance,
+                this.testRequestManager.Object,
+                (ppid, ph) =>
                 {
                     actualParentProcessId = ppid;
                     return testDesignModeClient.Object;
-                });
+                },
+                this.mockProcessHelper.Object
+                );
 
             int port = 2345;
-            executor.Initialize(port.ToString());
+            this.executor.Initialize(port.ToString());
             var result = executor.Execute();
 
             testDesignModeClient.Verify(td =>


### PR DESCRIPTION
Porting https://github.com/Microsoft/vstest/pull/870 to 15.3-rtm