### PR TITLE
Clean up test host before Discovery/execution cleanup.

### DIFF
--- a/src/Microsoft.TestPlatform.Client/Discovery/DiscoveryRequest.cs
+++ b/src/Microsoft.TestPlatform.Client/Discovery/DiscoveryRequest.cs
@@ -211,6 +211,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.Discovery
                     return;
                 }
 
+                // Close the discovery session and terminate any test host processes. This operation should never
+                // throw.
+                this.DiscoveryManager?.Close();
+
                 try
                 {
                     // Raise onDiscoveredTests event if there are some tests in the last chunk. 
@@ -225,12 +229,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.Discovery
                 }
                 finally
                 {
-                    ManualResetEvent discoveryComplete = this.discoveryCompleted;
-
                     // Notify the waiting handle that discovery is complete
-                    if (discoveryComplete != null)
+                    if (this.discoveryCompleted != null)
                     {
-                        discoveryComplete.Set();
+                        this.discoveryCompleted.Set();
                         if (EqtTrace.IsVerboseEnabled)
                         {
                             EqtTrace.Verbose("DiscoveryRequest.DiscoveryComplete: Notified the discovery complete event.");
@@ -245,9 +247,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.Discovery
                     }
 
                     this.discoveryInProgress = false;
-
-                    // Close the discovery session
-                    this.DiscoveryManager?.Close();
                 }
             }
 

--- a/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
+++ b/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
@@ -276,6 +276,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.Execution
                     return;
                 }
 
+                // Disposing off the resources held by the execution manager so that the test host process can shut down.
+                this.ExecutionManager?.Close();
+
                 try
                 {
                     this.runRequestTimeTracker.Stop();
@@ -317,9 +320,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.Execution
 
                     // Notify the waiting handle that run is complete
                     this.runCompletionEvent.Set();
-
-                    // Disposing off the resources held by the execution manager so that the test host process can shut down.
-                    this.ExecutionManager?.Close();
                 }
 
                 EqtTrace.Info("TestRunRequest:TestRunComplete: Completed.");

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -21,7 +21,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
     using CrossPlatEngineResources = Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources.Resources;
     using System.Reflection;
     using System.Linq;
-    using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
 
     /// <summary>
     /// Base class for any operations that the client needs to drive through the engine.
@@ -31,10 +30,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         private readonly ITestRuntimeProvider testHostManager;
         private readonly IProcessHelper processHelper;
         private readonly int connectionTimeout;
+        private readonly string versionCheckPropertyName = "IsVersionCheckRequired";
+        private readonly ManualResetEventSlim testHostExited = new ManualResetEventSlim(false);
 
         private bool initialized;
         private string testHostProcessStdError;
-        private readonly string versionCheckPropertyName = "IsVersionCheckRequired";
+        private int testHostId;
+
         #region Constructors
 
         /// <summary>
@@ -50,6 +52,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             this.testHostManager = testHostManager;
             this.processHelper = new ProcessHelper();
             this.initialized = false;
+            this.testHostId = -1;
         }
 
         #endregion
@@ -85,14 +88,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
 
                 var connectionInfo = new TestRunnerConnectionInfo { Port = portNumber, RunnerProcessId = processId, LogFile = this.GetTimestampedLogFile(EqtTrace.LogFile) };
 
-                // Get the test process start info
-                var testHostStartInfo = this.testHostManager.GetTestHostProcessStartInfo(sources, null, connectionInfo);
-
                 // Subscribe to TestHost Event
                 this.testHostManager.HostLaunched += this.TestHostManagerHostLaunched;
                 this.testHostManager.HostExited += this.TestHostManagerHostExited;
 
-                this.UpdateTestProcessStartInfo(testHostStartInfo);
+                // Get the test process start info
+                var testHostStartInfo = this.UpdateTestProcessStartInfo(this.testHostManager.GetTestHostProcessStartInfo(sources, null, connectionInfo));
 
                 // Launch the test host.
                 CancellationTokenSource hostLaunchCts = new CancellationTokenSource();
@@ -101,6 +102,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                 try
                 {
                     hostLaunchedTask.Wait(hostLaunchCts.Token);
+                    this.testHostId = hostLaunchedTask.Result;
                 }
                 catch (OperationCanceledException ex)
                 {
@@ -158,14 +160,26 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         /// </summary>
         public virtual void Close()
         {
-            // TODO dispose the testhost process
             try
             {
                 this.RequestSender.EndSession();
             }
+            catch (Exception ex)
+            {
+                // Sending an end session is not necessarily a failure. Discovery and execution should be already
+                // complete at this time.
+                EqtTrace.Warning("ProxyOperationManager: Failed to end session: " + ex);
+            }
             finally
             {
                 this.initialized = false;
+
+                if (!this.testHostExited.Wait(1000) && this.testHostId != -1)
+                {
+                    EqtTrace.Warning("ProxyOperationManager: Timed out waiting for test host to exit. Will terminate process.");
+                    this.testHostManager.TerminateAsync(this.testHostId, CancellationToken.None).Wait();
+                }
+
                 this.testHostManager.HostExited -= this.TestHostManagerHostExited;
                 this.testHostManager.HostLaunched -= this.TestHostManagerHostLaunched;
             }

--- a/src/Microsoft.TestPlatform.ObjectModel/Host/ITestRunTimeProvider.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Host/ITestRunTimeProvider.cs
@@ -10,6 +10,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Host
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+    using System.Threading;
 
     /// <summary>
     /// Interface for TestRuntimeProvider which manages test host processes for test engine.
@@ -84,6 +85,13 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Host
         /// <param name="sources">List of test sources.</param>
         /// <returns>List of paths to extension assemblies.</returns>
         IEnumerable<string> GetTestPlatformExtensions(IEnumerable<string> sources, IEnumerable<string> extensions);
+
+        /// <summary>
+        /// Terminate the test host process.
+        /// </summary>
+        /// <param name="processId">Process identifier for the test host.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task TerminateAsync(int processId, CancellationToken cancellationToken);
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/IProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/IProcessHelper.cs
@@ -66,5 +66,11 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces
         /// Callback on process exit.
         /// </param>
         void SetExitCallback(int processId, Action callbackAction);
+
+        /// <summary>
+        /// Terminates a process.
+        /// </summary>
+        /// <param name="processId">Id of the process to terminate.</param>
+        void TerminateProcess(int processId);
     }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -125,5 +125,12 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
                     callbackAction.Invoke();
                 };
         }
+
+        /// <inheritdoc/>
+        public void TerminateProcess(int processId)
+        {
+            var process = Process.GetProcessById(processId);
+            process.Kill();
+        }
     }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard1.0/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard1.0/System/ProcessHelper.cs
@@ -60,5 +60,11 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         {
             throw new NotImplementedException();
         }
+
+        /// <inheritdoc/>
+        public void TerminateProcess(int processId)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -194,28 +194,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
             return true;
         }
 
-        /// <summary>
-        /// Raises HostLaunched event
-        /// </summary>
-        /// <param name="e">hostprovider event args</param>
-        public void OnHostLaunched(HostProviderEventArgs e)
-        {
-            this.HostLaunched.SafeInvoke(this, e, "HostProviderEvents.OnHostLaunched");
-        }
-
-        /// <summary>
-        /// Raises HostExited event
-        /// </summary>
-        /// <param name="e">hostprovider event args</param>
-        public void OnHostExited(HostProviderEventArgs e)
-        {
-            if (!this.hostExitedEventRaised)
-            {
-                this.hostExitedEventRaised = true;
-                this.HostExited.SafeInvoke(this, e, "HostProviderEvents.OnHostError");
-            }
-        }
-
         /// <inheritdoc/>
         public void Initialize(IMessageLogger logger, string runsettingsXml)
         {
@@ -227,6 +205,43 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
 
             this.Shared = !runConfiguration.DisableAppDomain;
             this.hostExitedEventRaised = false;
+        }
+
+        /// <inheritdoc/>
+        public Task TerminateAsync(int processId, CancellationToken cancellationToken)
+        {
+            try
+            {
+                this.processHelper.TerminateProcess(processId);
+            }
+            catch (Exception ex)
+            {
+                EqtTrace.Warning("DefaultTestHostManager: Unable to terminate test host process: " + ex);
+            }
+
+            return Task.FromResult(true);
+        }
+
+        /// <summary>
+        /// Raises HostLaunched event
+        /// </summary>
+        /// <param name="e">hostprovider event args</param>
+        private void OnHostLaunched(HostProviderEventArgs e)
+        {
+            this.HostLaunched.SafeInvoke(this, e, "HostProviderEvents.OnHostLaunched");
+        }
+
+        /// <summary>
+        /// Raises HostExited event
+        /// </summary>
+        /// <param name="e">hostprovider event args</param>
+        private void OnHostExited(HostProviderEventArgs e)
+        {
+            if (!this.hostExitedEventRaised)
+            {
+                this.hostExitedEventRaised = true;
+                this.HostExited.SafeInvoke(this, e, "HostProviderEvents.OnHostError");
+            }
         }
 
         private CancellationTokenSource GetCancellationTokenSource()

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -274,11 +274,26 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
             return false;
         }
 
+        /// <inheritdoc/>
+        public Task TerminateAsync(int processId, CancellationToken cancellationToken)
+        {
+            try
+            {
+                this.processHelper.TerminateProcess(processId);
+            }
+            catch (Exception ex)
+            {
+                EqtTrace.Warning("DotnetTestHostManager: Unable to terminate test host process: " + ex);
+            }
+
+            return Task.FromResult(true);
+        }
+
         /// <summary>
         /// Raises HostLaunched event
         /// </summary>
         /// <param name="e">hostprovider event args</param>
-        public void OnHostLaunched(HostProviderEventArgs e)
+        private void OnHostLaunched(HostProviderEventArgs e)
         {
             this.HostLaunched.SafeInvoke(this, e, "HostProviderEvents.OnHostLaunched");
         }
@@ -287,7 +302,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
         /// Raises HostExited event
         /// </summary>
         /// <param name="e">hostprovider event args</param>
-        public void OnHostExited(HostProviderEventArgs e)
+        private void OnHostExited(HostProviderEventArgs e)
         {
             if (!this.hostExitedEventRaised)
             {

--- a/test/Microsoft.TestPlatform.Client.UnitTests/Discovery/DiscoveryRequestTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/Discovery/DiscoveryRequestTests.cs
@@ -87,11 +87,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.Discovery
             this.discoveryManager.Verify(dm => dm.Abort(), Times.Once);
         }
 
-
         [TestMethod]
         public void AbortIfDiscoveryIsNotInProgressShouldNotCallDiscoveryManagerAbort()
         {
-            // DiscoveryAsyn has not been called, discoveryInProgress should be false
+            // DiscoveryAsync has not been called, discoveryInProgress should be false
             this.discoveryRequest.Abort();
             this.discoveryManager.Verify(dm => dm.Abort(), Times.Never);
         }
@@ -111,6 +110,21 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.Discovery
             eventsHandler.HandleDiscoveryComplete(1, Enumerable.Empty<TestCase>(), false);
 
             this.discoveryManager.Verify(dm => dm.Close(), Times.Once);
+        }
+
+        [TestMethod]
+        public void HandleDiscoveryCompleteShouldCloseDiscoveryManagerBeforeRaiseDiscoveryComplete()
+        {
+            var events = new List<string>();
+            this.discoveryManager.Setup(dm => dm.Close()).Callback(() => events.Add("close"));
+            this.discoveryRequest.OnDiscoveryComplete += (s, e) => events.Add("complete");
+            var eventsHandler = this.discoveryRequest as ITestDiscoveryEventsHandler;
+
+            eventsHandler.HandleDiscoveryComplete(1, Enumerable.Empty<TestCase>(), false);
+
+            Assert.AreEqual(2, events.Count);
+            Assert.AreEqual("close", events[0]);
+            Assert.AreEqual("complete", events[1]);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Hosting/TestHostProviderManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Hosting/TestHostProviderManagerTests.cs
@@ -24,8 +24,7 @@ namespace TestPlatform.Common.UnitTests.Logging
     [TestClass]
     public class TestHostProviderManagerTests
     {
-        [TestInitialize]
-        public void Initialize()
+        public TestHostProviderManagerTests()
         {
             TestPluginCacheTests.SetupMockExtensions();
         }
@@ -34,7 +33,7 @@ namespace TestPlatform.Common.UnitTests.Logging
         public void TestHostProviderManagerShouldReturnTestHostWhenAppropriateCustomUriProvided()
         {
             var manager = TestRuntimeProviderManager.Instance;
-            Assert.IsNotNull(manager.GetTestHostManagerByUri("executor://CustomTestHost/"));
+            Assert.IsNotNull(manager.GetTestHostManagerByUri("executor://DesktopTestHost/"));
         }
 
         [TestMethod]
@@ -98,7 +97,7 @@ namespace TestPlatform.Common.UnitTests.Logging
 
             var testHostManager = TestRuntimeProviderManager.Instance.GetTestHostManagerByRunConfiguration(runSettingsXml);
 
-            Assert.AreEqual(typeof(DotnetTestHostManager), testHostManager.GetType());
+            Assert.AreEqual(typeof(TestableTestHostManager), testHostManager.GetType());
         }
 
         [TestMethod]
@@ -135,8 +134,8 @@ namespace TestPlatform.Common.UnitTests.Logging
 
         #region implementations
 
-        [ExtensionUri("executor://CustomTestHost")]
-        [FriendlyName("CustomHost")]
+        [ExtensionUri("executor://DesktopTestHost")]
+        [FriendlyName("DesktopTestHost")]
         private class CustomTestHost : ITestRuntimeProvider
         {
             public event EventHandler<HostProviderEventArgs> HostLaunched;
@@ -162,16 +161,6 @@ namespace TestPlatform.Common.UnitTests.Logging
                 return true;
             }
 
-            public void DeregisterForExitNotification()
-            {
-                throw new NotImplementedException();
-            }
-
-            public CancellationTokenSource GetCancellationTokenSource()
-            {
-                throw new NotImplementedException();
-            }
-
             public TestProcessStartInfo GetTestHostProcessStartInfo(IEnumerable<string> sources, IDictionary<string, string> environmentVariables, TestRunnerConnectionInfo connectionInfo)
             {
                 throw new NotImplementedException();
@@ -203,27 +192,26 @@ namespace TestPlatform.Common.UnitTests.Logging
                 this.HostLaunched.Invoke(this, new HostProviderEventArgs("Error"));
             }
 
-            public void RegisterForExitNotification(Action abortCallback)
+            public void SetCustomLauncher(ITestHostLauncher customLauncher)
             {
                 throw new NotImplementedException();
             }
 
-            public void SetCustomLauncher(ITestHostLauncher customLauncher)
+            public Task TerminateAsync(int testHostId, CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();
             }
         }
 
-        [ExtensionUri("executor://DotnetTestHostManager")]
-        [FriendlyName("DotnetTestHostManager")]
-        private class DotnetTestHostManager : ITestRuntimeProvider
+        [ExtensionUri("executor://NetCoreTestHost")]
+        [FriendlyName("NetCoreTestHost")]
+        private class TestableTestHostManager : ITestRuntimeProvider
         {
             public event EventHandler<HostProviderEventArgs> HostLaunched;
 
             public event EventHandler<HostProviderEventArgs> HostExited;
 
             public bool Shared { get; private set; }
-
 
             public bool CanExecuteCurrentRunConfiguration(string runsettingsXml)
             {
@@ -241,16 +229,6 @@ namespace TestPlatform.Common.UnitTests.Logging
                 return false;
             }
 
-            public void DeregisterForExitNotification()
-            {
-                throw new NotImplementedException();
-            }
-
-            public CancellationTokenSource GetCancellationTokenSource()
-            {
-                throw new NotImplementedException();
-            }
-
             public TestProcessStartInfo GetTestHostProcessStartInfo(IEnumerable<string> sources, IDictionary<string, string> environmentVariables, TestRunnerConnectionInfo connectionInfo)
             {
                 throw new NotImplementedException();
@@ -282,12 +260,12 @@ namespace TestPlatform.Common.UnitTests.Logging
                 this.HostLaunched.Invoke(this, new HostProviderEventArgs("Error"));
             }
 
-            public void RegisterForExitNotification(Action abortCallback)
+            public void SetCustomLauncher(ITestHostLauncher customLauncher)
             {
                 throw new NotImplementedException();
             }
 
-            public void SetCustomLauncher(ITestHostLauncher customLauncher)
+            public Task TerminateAsync(int testHostId, CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();
             }

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -10,8 +10,8 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
     using System.Linq;
     using System.Runtime.InteropServices;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
-
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Helpers;
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Helpers.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting;
@@ -19,11 +19,9 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Host;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-    using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
     using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     using Moq;
 
 #pragma warning disable SA1600
@@ -625,6 +623,24 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
 
             Assert.AreEqual(this.errorMessage, string.Empty);
             Assert.AreEqual(this.exitCode, exitCode);
+        }
+
+        [TestMethod]
+        public async Task TerminateAsyncShouldKillTestHostProcess()
+        {
+            await this.dotnetHostManager.TerminateAsync(123, CancellationToken.None);
+
+            this.mockProcessHelper.Verify(ph => ph.TerminateProcess(123), Times.Once);
+        }
+
+        [TestMethod]
+        public void TerminateAsyncShouldNotThrowIfTestHostIsNotStarted()
+        {
+            this.mockProcessHelper.Setup(ph => ph.TerminateProcess(It.IsAny<int>())).Throws<Exception>();
+
+            this.dotnetHostManager.TerminateAsync(123, CancellationToken.None).Wait();
+
+            this.mockProcessHelper.Verify(ph => ph.TerminateProcess(123), Times.Once);
         }
 
         private void DotnetHostManagerExitCodeTesterHostExited(object sender, HostProviderEventArgs e)


### PR DESCRIPTION
Fix the sequence of ProxyExecutionManager.Close and the run request
completion event. Ensure that the test host is terminated before
discovery/execution completion is raised.

This fixes an issue where an IDE/Editor can call discovery successively,
but the testhost running for first request could still be running. The fix
also allows callers to cleanup resources once they receive execution/discovery
events.