### PR TITLE
Added double quotes to handle space in data collector name.

### DIFF
--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask.cs
@@ -227,7 +227,7 @@ namespace Microsoft.TestPlatform.Build.Tasks
             {
                 foreach(var arg in this.VSTestCollect)
                 {
-                    allArgs.Add("--collect:" + arg);
+                    allArgs.Add("--collect:" + arg.AddDoubleQuote());
                 }
             }
 

--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask.cs
@@ -159,7 +159,7 @@ namespace Microsoft.TestPlatform.Build.Tasks
 
             if (!string.IsNullOrEmpty(this.VSTestLogger))
             {
-                allArgs.Add("--logger:" + this.VSTestLogger);
+                allArgs.Add("--logger:" + this.VSTestLogger.AddDoubleQuote());
             }
 
             if (!string.IsNullOrEmpty(this.VSTestResultsDirectory))

--- a/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
@@ -57,8 +57,8 @@ namespace Microsoft.TestPlatform.Build.UnitTests
 
             var allArguments = vstestTask.CreateArgument().ToArray();
 
-            Assert.IsNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=normal")));
-            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=quiet")));
+            Assert.IsNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:\"Console;Verbosity=normal\"")));
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:\"Console;Verbosity=quiet\"")));
         }
 
         [TestMethod]
@@ -144,8 +144,8 @@ namespace Microsoft.TestPlatform.Build.UnitTests
 
             Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=normal")));
         }
-        [TestMethod]
 
+        [TestMethod]
         public void CreateArgumentShouldSetConsoleLoggerVerbosityToQuietIfConsoleLoggerIsNotGivenInArgsAndVerbosityIsq()
         {
             var vstestTask = new VSTestTask { VSTestVerbosity = "q" };
@@ -199,6 +199,22 @@ namespace Microsoft.TestPlatform.Build.UnitTests
             var allArguments = vstestTask.CreateArgument().ToArray();
 
             Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:Console;Verbosity=minimal")));
+        }
+
+        [TestMethod]
+        public void CreateArgumentShouldPreserveWhiteSpaceInLogger()
+        {
+            var vstestTask = new VSTestTask();
+            
+            // Add values for required properties.
+            vstestTask.TestFileFullPath = "abc";
+            vstestTask.VSTestFramework = "abc";
+            vstestTask.VSTestLogger = "trx;LogFileName=foo bar.trx";
+
+
+            var allArguments = vstestTask.CreateArgument().ToArray();
+
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:\"trx;LogFileName=foo bar.trx\"")));
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
@@ -211,12 +211,12 @@ namespace Microsoft.TestPlatform.Build.UnitTests
             vstestTask.VSTestFramework = "abc";
 
             vstestTask.VSTestCollect[0] = "name1";
-            vstestTask.VSTestCollect[1] = "name2";
+            vstestTask.VSTestCollect[1] = "name 2";
 
             var allArguments = vstestTask.CreateArgument().ToArray();
 
-            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--collect:name1")));
-            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--collect:name2")));
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--collect:\"name1\"")));
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--collect:\"name 2\"")));
         }
     }
 }


### PR DESCRIPTION
Added double quotes to handle space in data collector name.
E.g. 
>dotnet test --collect "FriendlyName WithSpace"