### PR TITLE
Use vswhere for building vsix

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -6,7 +6,6 @@
     <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="vstest" value="https://dotnet.myget.org/F/vstest/api/v3/index.json" />
-    <add key="dotnet.myget.org roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
   </packageSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -504,7 +504,7 @@ function Locate-VsInstallPath
 
    Write-Verbose "Using '$vswhere' to locate VS installation path."
 
-   $requiredPackageIds = @("Microsoft.Component.MSBuild", "Microsoft.Net.Component.4.6.TargetingPack", "Microsoft.VisualStudio.Component.Roslyn.Compiler", "Microsoft.VisualStudio.Component.VSSDK")
+   $requiredPackageIds = @("Microsoft.Component.MSBuild", "Microsoft.Net.Component.4.6.TargetingPack", "Microsoft.VisualStudio.Component.VSSDK")
    Write-Verbose "VSInstallation requirements : $requiredPackageIds"
 
    Try

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -63,7 +63,7 @@ $env:NUGET_PACKAGES = $env:TP_PACKAGES_DIR
 $env:NUGET_EXE_Version = "3.4.3"
 $env:DOTNET_CLI_VERSION = "2.1.0-preview1-006329"
 $env:DOTNET_RUNTIME_VERSION = "2.0.0-preview2-25331-01"
-$env:LOCATE_VS_API_VERSION = "0.2.4-beta"
+$env:VSWHERE_VERSION = "2.0.2"
 $env:MSBUILD_VERSION = "15.0"
 
 #
@@ -338,7 +338,7 @@ function Create-VsixPackage
     }
     else
     {
-        Write-Log ".. Create-VsixPackage: Cannot generate vsix as msbuild.exe not found"
+        Write-Log ".. Create-VsixPackage: Cannot generate vsix as msbuild.exe not found at '$msbuildPath'."
     }
 
     Write-Log "Create-VsixPackage: Complete. {$(Get-ElapsedTime($timer))}"
@@ -485,7 +485,7 @@ function Locate-MSBuildPath
 
     if([string]::IsNullOrEmpty($vsInstallPath))
     {
-      return $null
+        return $null
     }
 
     $vsInstallPath = Resolve-Path -path $vsInstallPath
@@ -497,37 +497,34 @@ function Locate-MSBuildPath
 
 function Locate-VsInstallPath
 {
-   $locateVsApi = Locate-LocateVsApi
+   $vswhere = Join-Path -path $env:TP_PACKAGES_DIR -ChildPath "vswhere\$env:VSWHERE_VERSION\tools\vswhere.exe"
+   if (!(Test-Path -path $vswhere)) {
+       throw "Unable to locate vswhere in path '$vswhere'."
+   }
+
+   Write-Verbose "Using '$vswhere' to locate VS installation path."
 
    $requiredPackageIds = @("Microsoft.Component.MSBuild", "Microsoft.Net.Component.4.6.TargetingPack", "Microsoft.VisualStudio.Component.Roslyn.Compiler", "Microsoft.VisualStudio.Component.VSSDK")
-
    Write-Verbose "VSInstallation requirements : $requiredPackageIds"
 
-   Add-Type -path $locateVsApi
    Try
    {
-     $vsInstallPath = [LocateVS.Instance]::GetInstallPath($env:MSBUILD_VERSION, $requiredPackageIds)
+       Write-Verbose "VSWhere command line: $vswhere -latest -prerelease -products * -requires $requiredPackageIds -property installationPath"
+       if ($TPB_CIBuild) {
+           $vsInstallPath = & $vswhere -latest -products * -requires $requiredPackageIds -property installationPath
+       }
+       else {
+           # Allow using pre release versions of VS for dev builds
+           $vsInstallPath = & $vswhere -latest -prerelease -products * -requires $requiredPackageIds -property installationPath
+       }
    }
    Catch [System.Management.Automation.MethodInvocationException]
    {
-      Write-Verbose "Failed to find VS installation with requirements : $requiredPackageIds"
+       Write-Verbose "Failed to find VS installation with requirements : $requiredPackageIds"
    }
 
    Write-Verbose "VSInstallPath is : $vsInstallPath"
-
    return $vsInstallPath
-}
-
-function Locate-LocateVsApi
-{
-  $locateVsApi = Join-Path -path $env:TP_PACKAGES_DIR -ChildPath "RoslynTools.Microsoft.LocateVS\$env:LOCATE_VS_API_VERSION\tools\LocateVS.dll"
-
-  if (!(Test-Path -path $locateVsApi)) {
-    throw "The specified LocateVS API version ($env:LOCATE_VS_API_VERSION) could not be located."
-  }
-
-  Write-Verbose "locateVsApi is : $locateVsApi"
-  return $locateVsApi
 }
 
 function Update-VsixVersion($vsixProjectDir)

--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -6,8 +6,8 @@
     <!-- Name of the elements must be in sync with test\Microsoft.TestPlatform.TestUtilities\IntegrationTestBase.cs -->
     <NETTestSdkPreviousVersion>15.0.0</NETTestSdkPreviousVersion>
 
-    <MSTestFrameworkVersion>1.1.18</MSTestFrameworkVersion>
-    <MSTestAdapterVersion>1.1.18</MSTestAdapterVersion>
+    <MSTestFrameworkVersion>1.2.0-beta</MSTestFrameworkVersion>
+    <MSTestAdapterVersion>1.2.0-beta</MSTestAdapterVersion>
     <MSTestAssertExtensionVersion>1.0.3-preview</MSTestAssertExtensionVersion>
     
     <XUnitFrameworkVersion>2.2.0</XUnitFrameworkVersion>
@@ -20,6 +20,6 @@
     <ChutzpahAdapterVersion>4.2.4</ChutzpahAdapterVersion>
 
     <JsonNetVersion>9.0.1</JsonNetVersion>
-    <MoqVersion>4.7.25</MoqVersion>
+    <MoqVersion>4.7.63</MoqVersion>
   </PropertyGroup>
 </Project>

--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -88,11 +88,6 @@
         <PackageReference Include="MSTest.Assert.Extensions">
           <Version>$(MSTestAssertExtensionVersion)</Version>
         </PackageReference>
-
-        <!-- Workaround for https://github.com/castleproject/Core/issues/239 -->
-        <PackageReference Include="System.ComponentModel.TypeConverter">
-          <Version>4.3.0</Version>
-        </PackageReference>
       </ItemGroup>
     </When>
   </Choose>

--- a/src/package/external/external.csproj
+++ b/src/package/external/external.csproj
@@ -41,8 +41,8 @@
       <Version>14.0.12-pre</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="RoslynTools.Microsoft.LocateVS">
-      <Version>0.2.4-beta</Version>
+    <PackageReference Include="vswhere">
+      <Version>2.0.2</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Internal.TestPlatform.Extensions">


### PR DESCRIPTION
Remove dependency on locate-vs package. Allow lookup for prerelease VS
when building dev packages.

Upgrade to latest Moq, this fixes an issue with TypeConverter dependency.
Upgrade to latest MSTest beta package.