### PR TITLE
Datacollector env variables should be given more priority.

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -110,7 +110,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                 }
                 catch (Exception ex)
                 {
-                    throw new TestPlatformException(string.Format(CultureInfo.CurrentUICulture, ex.Message));
+                    EqtTrace.Error("ProxyOperationManager: Failed to launch testhost :{0}", ex);
+                    throw new TestPlatformException(string.Format(CultureInfo.CurrentUICulture, CrossPlatEngineResources.FailedToLaunchTestHost, ex.ToString()));
                 }
 
                 // Warn the user that execution will wait for debugger attach.

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
@@ -115,6 +115,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to launch testhost with error: {0}.
+        /// </summary>
+        internal static string FailedToLaunchTestHost {
+            get {
+                return ResourceManager.GetString("FailedToLaunchTestHost", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Could not find file {0}..
         /// </summary>
         internal static string FileNotFound {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
@@ -177,4 +177,7 @@
   <data name="UnsupportedPropertiesInTestCaseFilter" xml:space="preserve">
     <value>No tests matched the filter because it contains one or more properties that are not valid ({0}). Specify filter expression containing valid properties ({1}).</value>
   </data>
+  <data name="FailedToLaunchTestHost" xml:space="preserve">
+    <value>Failed to launch testhost with error: {0}</value>
+  </data>
 </root>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.cs.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Protokolování diagnostiky TestHost v souboru: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLaunchTestHost">
+        <source>Failed to launch testhost with error: {0}</source>
+        <target state="new">Failed to launch testhost with error: {0}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.de.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Die TestHost-Diagnose wird in der Datei {0} protokolliert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLaunchTestHost">
+        <source>Failed to launch testhost with error: {0}</source>
+        <target state="new">Failed to launch testhost with error: {0}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.es.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Registrando diagnóstico de TestHost en el archivo: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLaunchTestHost">
+        <source>Failed to launch testhost with error: {0}</source>
+        <target state="new">Failed to launch testhost with error: {0}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.fr.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Journalisation des diagnostics TestHost dans le fichier : {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLaunchTestHost">
+        <source>Failed to launch testhost with error: {0}</source>
+        <target state="new">Failed to launch testhost with error: {0}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.it.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Registrazione della diagnostica di TestHost nel file: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLaunchTestHost">
+        <source>Failed to launch testhost with error: {0}</source>
+        <target state="new">Failed to launch testhost with error: {0}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ja.xlf
@@ -172,6 +172,11 @@
         <target state="translated">次のファイルで TestHost 診断をログ記録しています: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLaunchTestHost">
+        <source>Failed to launch testhost with error: {0}</source>
+        <target state="new">Failed to launch testhost with error: {0}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ko.xlf
@@ -172,6 +172,11 @@
         <target state="translated">{0} 파일에 TestHost Diagnostics 로깅 중</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLaunchTestHost">
+        <source>Failed to launch testhost with error: {0}</source>
+        <target state="new">Failed to launch testhost with error: {0}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pl.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Rejestrowanie diagnostyki TestHost w pliku: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLaunchTestHost">
+        <source>Failed to launch testhost with error: {0}</source>
+        <target state="new">Failed to launch testhost with error: {0}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pt-BR.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Registro em log do diagnóstico TestHost no arquivo: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLaunchTestHost">
+        <source>Failed to launch testhost with error: {0}</source>
+        <target state="new">Failed to launch testhost with error: {0}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ru.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Ведение журналов диагностики TestHost в файле: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLaunchTestHost">
+        <source>Failed to launch testhost with error: {0}</source>
+        <target state="new">Failed to launch testhost with error: {0}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.tr.xlf
@@ -172,6 +172,11 @@
         <target state="translated">TestHost Tanılamaları şu dosyadaki günlüğe kaydediliyor: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLaunchTestHost">
+        <source>Failed to launch testhost with error: {0}</source>
+        <target state="new">Failed to launch testhost with error: {0}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf
@@ -83,6 +83,11 @@
         <target state="new">Logging TestHost Diagnostics in file: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="FailedToLaunchTestHost">
+        <source>Failed to launch testhost with error: {0}</source>
+        <target state="new">Failed to launch testhost with error: {0}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hans.xlf
@@ -172,6 +172,11 @@
         <target state="translated">在文件 {0} 中记录 TestHost 诊断</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLaunchTestHost">
+        <source>Failed to launch testhost with error: {0}</source>
+        <target state="new">Failed to launch testhost with error: {0}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hant.xlf
@@ -172,6 +172,11 @@
         <target state="translated">在檔案 {0} 中記錄 TestHost 診斷</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLaunchTestHost">
+        <source>Failed to launch testhost with error: {0}</source>
+        <target state="new">Failed to launch testhost with error: {0}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/ProcessStartInfoExtensions.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/ProcessStartInfoExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         /// <param name="value">Environment Variable value.</param>
         public static void AddEnvironmentVariable(this ProcessStartInfo startInfo, string name, string value)
         {
-            startInfo.EnvironmentVariables.Add(name, value);
+            startInfo.EnvironmentVariables[name] = value;
         }
     }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessStartInfoExtensions.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessStartInfoExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         /// <param name="value">Environment Variable value.</param>
         public static void AddEnvironmentVariable(this ProcessStartInfo startInfo, string name, string value)
         {
-            startInfo.Environment.Add(name, value);
+            startInfo.Environment[name] = value;
         }
     }
 }


### PR DESCRIPTION
- When Datacollector want to set env variables and if same env variable already set in system level. Datacollector value should be given more priority.