### PR TITLE
Allow assemblies to specify default resource

### DIFF
--- a/src/Microsoft.TestPlatform.Client/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.TestPlatform.Client/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -12,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Microsoft.VisualStudio.TestPlatform.Client")]
 [assembly: AssemblyTrademark("")]
+[assembly: NeutralResourcesLanguage("en-US")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Microsoft.TestPlatform.Common/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.TestPlatform.Common/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -12,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Microsoft.TestPlatform.Common")]
 [assembly: AssemblyTrademark("")]
+[assembly: NeutralResourcesLanguage("en-US")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -12,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Microsoft.VisualStudio.TestPlatform.CommunicationUtilities")]
 [assembly: AssemblyTrademark("")]
+[assembly: NeutralResourcesLanguage("en-US")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Microsoft.TestPlatform.CoreUtilities/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -12,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Microsoft.TestPlatform.CoreUtilities")]
 [assembly: AssemblyTrademark("")]
+[assembly: NeutralResourcesLanguage("en-US")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -12,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Microsoft.VisualStudio.TestPlatform.CrossPlatEngine")]
 [assembly: AssemblyTrademark("")]
+[assembly: NeutralResourcesLanguage("en-US")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Microsoft.TestPlatform.ObjectModel/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Properties/AssemblyInfo.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -15,6 +16,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Microsoft.TestPlatfrom.ObjectModel")]
 [assembly: AssemblyTrademark("")]
+[assembly: NeutralResourcesLanguage("en-US")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Microsoft.TestPlatform.Utilities/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.TestPlatform.Utilities/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -12,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Microsoft.TestPlatform.Utilities")]
 [assembly: AssemblyTrademark("")]
+[assembly: NeutralResourcesLanguage("en-US")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/testhost.x86/DefaultEngineInvoker.cs
+++ b/src/testhost.x86/DefaultEngineInvoker.cs
@@ -23,8 +23,9 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
     {
         /// <summary>
         /// The timeout for the client to connect to the server.
+        /// Increasing Timeout to allow client to connect, not always the client can connect within 5 seconds
         /// </summary>
-        private const int ClientListenTimeOut = 5 * 1000;
+        private const int ClientListenTimeOut = 30 * 1000;
 
         private const string EndpointArgument = "--endpoint";
 

--- a/src/testhost.x86/Properties/AssemblyInfo.cs
+++ b/src/testhost.x86/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -12,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Microsoft.TestHost.x86")]
 [assembly: AssemblyTrademark("")]
+[assembly: NeutralResourcesLanguage("en-US")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/testhost/Properties/AssemblyInfo.cs
+++ b/src/testhost/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -12,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Microsoft.TestHost")]
 [assembly: AssemblyTrademark("")]
+[assembly: NeutralResourcesLanguage("en-US")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from


### PR DESCRIPTION
UWP release does not pick resources if this attribute is not specified.