### PR TITLE
make testplatform compatible with old testhost

### DIFF
--- a/TestPlatform.sln
+++ b/TestPlatform.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26605.1
+VisualStudioVersion = 15.0.26507.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{ED0C35EB-7F31-4841-A24F-8EB708FFA959}"
 EndProject
@@ -156,6 +156,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests", "test\Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests\Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests.csproj", "{488675EC-C8BB-40E0-AD4F-91F623D548B3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlameUnitTestProject", "test\TestAssets\BlameUnitTestProject\BlameUnitTestProject.csproj", "{6B2B841C-CCFF-469A-9939-EB07EA0401AE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleProjectWithOldTestHost", "test\TestAssets\SampleProjectWithOldTestHost\SampleProjectWithOldTestHost.csproj", "{DFF82C76-9498-4E8B-8B5E-D12E2B92FA46}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -827,6 +829,18 @@ Global
 		{6B2B841C-CCFF-469A-9939-EB07EA0401AE}.Release|x64.Build.0 = Release|Any CPU
 		{6B2B841C-CCFF-469A-9939-EB07EA0401AE}.Release|x86.ActiveCfg = Release|Any CPU
 		{6B2B841C-CCFF-469A-9939-EB07EA0401AE}.Release|x86.Build.0 = Release|Any CPU
+		{DFF82C76-9498-4E8B-8B5E-D12E2B92FA46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DFF82C76-9498-4E8B-8B5E-D12E2B92FA46}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DFF82C76-9498-4E8B-8B5E-D12E2B92FA46}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DFF82C76-9498-4E8B-8B5E-D12E2B92FA46}.Debug|x64.Build.0 = Debug|Any CPU
+		{DFF82C76-9498-4E8B-8B5E-D12E2B92FA46}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DFF82C76-9498-4E8B-8B5E-D12E2B92FA46}.Debug|x86.Build.0 = Debug|Any CPU
+		{DFF82C76-9498-4E8B-8B5E-D12E2B92FA46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DFF82C76-9498-4E8B-8B5E-D12E2B92FA46}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DFF82C76-9498-4E8B-8B5E-D12E2B92FA46}.Release|x64.ActiveCfg = Release|Any CPU
+		{DFF82C76-9498-4E8B-8B5E-D12E2B92FA46}.Release|x64.Build.0 = Release|Any CPU
+		{DFF82C76-9498-4E8B-8B5E-D12E2B92FA46}.Release|x86.ActiveCfg = Release|Any CPU
+		{DFF82C76-9498-4E8B-8B5E-D12E2B92FA46}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -896,5 +910,6 @@ Global
 		{76D4BB7E-D981-42D5-BE96-6FAD8DEF9A4A} = {ED0C35EB-7F31-4841-A24F-8EB708FFA959}
 		{488675EC-C8BB-40E0-AD4F-91F623D548B3} = {B27FAFDF-2DBA-4AB0-BA85-FD5F21D359D6}
 		{6B2B841C-CCFF-469A-9939-EB07EA0401AE} = {8DA7CBD9-F17E-41B6-90C4-CFF55848A25A}
+		{DFF82C76-9498-4E8B-8B5E-D12E2B92FA46} = {8DA7CBD9-F17E-41B6-90C4-CFF55848A25A}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -6,11 +6,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using System.IO;
     using System.Linq;
     using System.Reflection;
     using System.Threading;
-    using System.Xml;
     using Microsoft.VisualStudio.TestPlatform.Common;
     using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
@@ -22,7 +20,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine.ClientProtocol;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Host;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
     using Microsoft.VisualStudio.TestPlatform.Utilities;
     using Constants = Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Constants;
 
@@ -227,23 +224,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             {
                 if ((bool)property.GetValue(this.testHostManager))
                 {
-                    if (!string.IsNullOrWhiteSpace(runsettingsXml))
-                    {
-                        using (var stream = new StringReader(runsettingsXml))
-                        using (var reader = XmlReader.Create(stream, XmlRunSettingsUtilities.ReaderSettings))
-                        {
-                            var document = new XmlDocument();
-                            document.Load(reader);
-
-                            var navigator = document.CreateNavigator();
-
-                            InferRunSettingsHelper.RemoveCollectSourceInformation(navigator);
-                            InferRunSettingsHelper.RemoveDesignMode(navigator);
-                            InferRunSettingsHelper.RemoveTestSessionTimeout(navigator);
-
-                            updatedRunSettingsXml = navigator.OuterXml;
-                        }
-                    }
+                    updatedRunSettingsXml = InferRunSettingsHelper.MakeRunsettingsCompatible(runsettingsXml);
                 }
             }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -10,12 +10,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
     using System.Linq;
     using System.Reflection;
     using System.Threading;
-    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
-    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Extensions;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Host;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
     using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
@@ -33,7 +30,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         private readonly IProcessHelper processHelper;
         private readonly int connectionTimeout;
         private readonly string versionCheckPropertyName = "IsVersionCheckRequired";
-        private readonly string oldTestHostPropertyName = "TestHostCannotHandleNewRunSettingsNode";
+        private readonly string makeRunsettingsCompatiblePropertyName = "MakeRunsettingsCompatible";
+        private bool versionCheckRequired = true;
+        private bool makeRunsettingsCompatible;
+        private bool makeRunsettingsCompatibleSet;
         private readonly ManualResetEventSlim testHostExited = new ManualResetEventSlim(false);
 
         private int testHostProcessId;
@@ -161,14 +161,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                 // Handling special case for dotnet core projects with older test hosts
                 // Older test hosts are not aware of protocol version check
                 // Hence we should not be sending VersionCheck message to these test hosts
-                bool checkRequired = true;
-                var property = this.testHostManager.GetType().GetRuntimeProperties().FirstOrDefault(p => string.Equals(p.Name, versionCheckPropertyName, StringComparison.OrdinalIgnoreCase));
-                if (property != null)
-                {
-                    checkRequired = (bool)property.GetValue(this.testHostManager);
-                }
+                this.CompatIssueWithVersionCheckAndRunsettings();
 
-                if (checkRequired)
+                if (this.versionCheckRequired)
                 {
                     this.RequestSender.CheckVersionWithTestHost();
                 }
@@ -207,7 +202,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                 this.initialized = false;
 
                 EqtTrace.Warning("ProxyOperationManager: Timed out waiting for test host to exit. Will terminate process.");
-                
+
                 // please clean up test host. 
                 this.testHostManager.CleanTestHostAsync(CancellationToken.None).Wait();
 
@@ -254,25 +249,39 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         /// </summary>
         /// <param name="runsettingsXml">runsettings string</param>
         /// <returns>runsetting after removing unrequired nodes</returns>
-        protected string RemoveNodesFromRunsettingsIfRequired(string runsettingsXml, ITestRunEventsHandler eventHandler)
+        protected string RemoveNodesFromRunsettingsIfRequired(string runsettingsXml, Action<TestMessageLevel, string> logMessage)
         {
             var updatedRunSettingsXml = runsettingsXml;
-
-            var property = this.testHostManager.GetType().GetRuntimeProperties().FirstOrDefault(p => string.Equals(p.Name, oldTestHostPropertyName, StringComparison.OrdinalIgnoreCase));
-            if (property != null)
+            if (!this.makeRunsettingsCompatibleSet)
             {
-                if ((bool)property.GetValue(this.testHostManager))
-                {
-                    var testMessagePayload = new TestMessagePayload { MessageLevel = TestMessageLevel.Warning, Message = CrossPlatEngineResources.OldTestHostIsGettingUsed };
-                    var rawMessage = JsonDataSerializer.Instance.SerializePayload(MessageType.TestMessage, testMessagePayload);
-                    eventHandler.HandleLogMessage(TestMessageLevel.Warning, CrossPlatEngineResources.OldTestHostIsGettingUsed);
-                    eventHandler.HandleRawMessage(rawMessage);
+                this.CompatIssueWithVersionCheckAndRunsettings();
+            }
 
-                    updatedRunSettingsXml = InferRunSettingsHelper.MakeRunsettingsCompatible(runsettingsXml);
-                }
+            if (this.makeRunsettingsCompatible)
+            {
+                logMessage.Invoke(TestMessageLevel.Warning, CrossPlatEngineResources.OldTestHostIsGettingUsed);
+                updatedRunSettingsXml = InferRunSettingsHelper.MakeRunsettingsCompatible(runsettingsXml);
             }
 
             return updatedRunSettingsXml;
+        }
+
+        private void CompatIssueWithVersionCheckAndRunsettings()
+        {
+            var properties = this.testHostManager.GetType().GetRuntimeProperties();
+
+            var versionCheckProperty = properties.FirstOrDefault(p => string.Equals(p.Name, versionCheckPropertyName, StringComparison.OrdinalIgnoreCase));
+            if (versionCheckProperty != null)
+            {
+                this.versionCheckRequired = (bool)versionCheckProperty.GetValue(this.testHostManager);
+            }
+
+            var makeRunsettingsCompatibleProperty = properties.FirstOrDefault(p => string.Equals(p.Name, makeRunsettingsCompatiblePropertyName, StringComparison.OrdinalIgnoreCase));
+            if (makeRunsettingsCompatibleProperty != null)
+            {
+                this.makeRunsettingsCompatible = (bool)makeRunsettingsCompatibleProperty.GetValue(this.testHostManager);
+                this.makeRunsettingsCompatibleSet = true;
+            }
         }
 
         private void TestHostManagerHostLaunched(object sender, HostProviderEventArgs e)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/ExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/ExecutionManager.cs
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
             }
             catch(Exception e)
             {
-                this.testRunEventsHandler.HandleLogMessage(ObjectModel.Logging.TestMessageLevel.Error, e.Message);
+                this.testRunEventsHandler.HandleLogMessage(ObjectModel.Logging.TestMessageLevel.Error, e.ToString());
                 this.Abort();
             }
             finally
@@ -128,7 +128,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
             }
             catch(Exception e)
             {
-                this.testRunEventsHandler.HandleLogMessage(ObjectModel.Logging.TestMessageLevel.Error, e.Message);
+                this.testRunEventsHandler.HandleLogMessage(ObjectModel.Logging.TestMessageLevel.Error, e.ToString());
                 this.Abort();
             }
             finally

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/ExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/ExecutionManager.cs
@@ -87,6 +87,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
 
                 this.activeTestRun.RunTests();
             }
+            catch(Exception e)
+            {
+                this.testRunEventsHandler.HandleLogMessage(ObjectModel.Logging.TestMessageLevel.Error, e.Message);
+                this.Abort();
+            }
             finally
             {
                 this.activeTestRun = null;
@@ -120,6 +125,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
                                          runEventsHandler);
 
                 this.activeTestRun.RunTests();
+            }
+            catch(Exception e)
+            {
+                this.testRunEventsHandler.HandleLogMessage(ObjectModel.Logging.TestMessageLevel.Error, e.Message);
+                this.Abort();
             }
             finally
             {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources {
                 return ResourceManager.GetString("FailedToLaunchTestHost", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Could not find file {0}..
         /// </summary>
@@ -202,6 +202,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources {
         internal static string NoValidSourceFoundForDiscovery {
             get {
                 return ResourceManager.GetString("NoValidSourceFoundForDiscovery", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0..
+        /// </summary>
+        internal static string OldTestHostIsGettingUsed {
+            get {
+                return ResourceManager.GetString("OldTestHostIsGettingUsed", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
@@ -183,4 +183,7 @@
   <data name="FailedToLaunchTestHost" xml:space="preserve">
     <value>Failed to launch testhost with error: {0}</value>
   </data>
+  <data name="OldTestHostIsGettingUsed" xml:space="preserve">
+    <value>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</value>
+  </data>
 </root>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.cs.xlf
@@ -181,6 +181,11 @@
         <target state="new">Failed to launch testhost with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="OldTestHostIsGettingUsed">
+        <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
+        <target state="new">You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.de.xlf
@@ -181,6 +181,11 @@
         <target state="new">Failed to launch testhost with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="OldTestHostIsGettingUsed">
+        <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
+        <target state="new">You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.es.xlf
@@ -181,6 +181,11 @@
         <target state="new">Failed to launch testhost with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="OldTestHostIsGettingUsed">
+        <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
+        <target state="new">You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.fr.xlf
@@ -181,6 +181,11 @@
         <target state="new">Failed to launch testhost with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="OldTestHostIsGettingUsed">
+        <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
+        <target state="new">You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.it.xlf
@@ -181,6 +181,11 @@
         <target state="new">Failed to launch testhost with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="OldTestHostIsGettingUsed">
+        <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
+        <target state="new">You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ja.xlf
@@ -181,6 +181,11 @@
         <target state="new">Failed to launch testhost with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="OldTestHostIsGettingUsed">
+        <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
+        <target state="new">You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ko.xlf
@@ -181,6 +181,11 @@
         <target state="new">Failed to launch testhost with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="OldTestHostIsGettingUsed">
+        <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
+        <target state="new">You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pl.xlf
@@ -181,6 +181,11 @@
         <target state="new">Failed to launch testhost with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="OldTestHostIsGettingUsed">
+        <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
+        <target state="new">You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pt-BR.xlf
@@ -181,6 +181,11 @@
         <target state="new">Failed to launch testhost with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="OldTestHostIsGettingUsed">
+        <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
+        <target state="new">You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ru.xlf
@@ -181,6 +181,11 @@
         <target state="new">Failed to launch testhost with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="OldTestHostIsGettingUsed">
+        <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
+        <target state="new">You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.tr.xlf
@@ -181,6 +181,11 @@
         <target state="new">Failed to launch testhost with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="OldTestHostIsGettingUsed">
+        <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
+        <target state="new">You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf
@@ -92,6 +92,11 @@
         <target state="new">Failed to launch testhost with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="OldTestHostIsGettingUsed">
+        <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
+        <target state="new">You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hans.xlf
@@ -181,6 +181,11 @@
         <target state="new">Failed to launch testhost with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="OldTestHostIsGettingUsed">
+        <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
+        <target state="new">You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hant.xlf
@@ -181,6 +181,11 @@
         <target state="new">Failed to launch testhost with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="OldTestHostIsGettingUsed">
+        <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
+        <target state="new">You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
         /// <summary>
         /// Gets a value indicating whether the test host supports protocol version check
         /// </summary>
-        internal virtual bool TestHostCannotHandleNewRunSettingsNode => this.hostPackageVersion.StartsWith("15.0.0-preview");
+        internal bool TestHostCannotHandleNewRunSettingsNode => this.hostPackageVersion.StartsWith("15.0.0-preview");
 
         /// <summary>
         /// Gets or sets the error length for runtime error stream.

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
         /// <summary>
         /// Gets a value indicating whether the test host supports protocol version check
         /// </summary>
-        internal bool TestHostCannotHandleNewRunSettingsNode => this.hostPackageVersion.StartsWith("15.0.0-preview");
+        internal bool MakeRunsettingsCompatible => this.hostPackageVersion.StartsWith("15.0.0-preview");
 
         /// <summary>
         /// Gets or sets the error length for runtime error stream.

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -108,6 +108,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
         internal virtual bool IsVersionCheckRequired => !this.hostPackageVersion.StartsWith("15.0.0");
 
         /// <summary>
+        /// Gets a value indicating whether the test host supports protocol version check
+        /// </summary>
+        internal virtual bool TestHostCannotHandleNewRunSettingsNode => this.hostPackageVersion.StartsWith("15.0.0-preview");
+
+        /// <summary>
         /// Gets or sets the error length for runtime error stream.
         /// </summary>
         protected int ErrorLength { get; set; } = 4096;

--- a/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
@@ -25,6 +25,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         private const string ResultsDirectoryNodeName = "ResultsDirectory";
         private const string TargetPlatformNodeName = "TargetPlatform";
         private const string TargetFrameworkNodeName = "TargetFrameworkVersion";
+        private const string TestSessionTimeoutNodeName = "TestSessionTimeout";
 
         private const string DesignModeNodePath = @"/RunSettings/RunConfiguration/DesignMode";
         private const string CollectSourceInformationNodePath = @"/RunSettings/RunConfiguration/CollectSourceInformation";
@@ -32,6 +33,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         private const string TargetPlatformNodePath = @"/RunSettings/RunConfiguration/TargetPlatform";
         private const string TargetFrameworkNodePath = @"/RunSettings/RunConfiguration/TargetFrameworkVersion";
         private const string ResultsDirectoryNodePath = @"/RunSettings/RunConfiguration/ResultsDirectory";
+        private const string TestSessionTimeoutNodePath = @"/RunSettings/RunConfiguration/TestSessionTimeout";
 
         /// <summary>
         /// Updates the run settings XML with the specified values.
@@ -100,6 +102,45 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         public static void UpdateCollectSourceInformation(XPathNavigator runSettingsNavigator, bool collectSourceInformationValue)
         {
             AddNodeIfNotPresent<bool>(runSettingsNavigator, CollectSourceInformationNodePath, CollectSourceInformationNodeName, collectSourceInformationValue);
+        }
+
+        /// <summary>
+        /// Remove the <c>RunConfiguration.DesignMode</c> value for a run settings.
+        /// </summary>
+        public static void RemoveDesignMode(XPathNavigator runSettingsNavigator)
+        {
+            RemoveNodeFromRunConfiguration(runSettingsNavigator, DesignModeNodePath, DesignModeNodeName);
+        }
+
+
+        /// <summary>
+        /// Remove the <c>RunConfiguration.CollectSourceInformation</c> value for a run settings.
+        /// </summary>
+        public static void RemoveCollectSourceInformation(XPathNavigator runSettingsNavigator)
+        {
+            RemoveNodeFromRunConfiguration(runSettingsNavigator, CollectSourceInformationNodePath, CollectSourceInformationNodeName);
+        }
+
+        /// <summary>
+        /// Remove the <c>RunConfiguration.CollectSourceInformation</c> value for a run settings.
+        /// </summary>
+        public static void RemoveTestSessionTimeout(XPathNavigator runSettingsNavigator)
+        {
+            RemoveNodeFromRunConfiguration(runSettingsNavigator, TestSessionTimeoutNodePath, TestSessionTimeoutNodeName);
+        }
+
+        private static void RemoveNodeFromRunConfiguration(XPathNavigator runSettingsNavigator, string nodePath, string nodeName)
+        {
+            // Navigator should be at Root of runsettings xml, attempt to move to /RunSettings/RunConfiguration
+            if (!runSettingsNavigator.MoveToChild(RunSettingsNodeName, string.Empty) ||
+                !runSettingsNavigator.MoveToChild(RunConfigurationNodeName, string.Empty))
+            {
+                EqtTrace.Error("InferRunSettingsHelper.RemoveNodeIfPresent: Unable to navigate to RunConfiguration. Current node: " + runSettingsNavigator.LocalName);
+                return;
+            }
+
+            XmlUtilities.RemoveChildNode(runSettingsNavigator, nodePath, nodeName);
+            runSettingsNavigator.MoveToRoot();
         }
 
         /// <summary>

--- a/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
@@ -27,7 +27,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         private const string ResultsDirectoryNodeName = "ResultsDirectory";
         private const string TargetPlatformNodeName = "TargetPlatform";
         private const string TargetFrameworkNodeName = "TargetFrameworkVersion";
-        private const string TestSessionTimeoutNodeName = "TestSessionTimeout";
 
         private const string DesignModeNodePath = @"/RunSettings/RunConfiguration/DesignMode";
         private const string CollectSourceInformationNodePath = @"/RunSettings/RunConfiguration/CollectSourceInformation";
@@ -35,7 +34,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         private const string TargetPlatformNodePath = @"/RunSettings/RunConfiguration/TargetPlatform";
         private const string TargetFrameworkNodePath = @"/RunSettings/RunConfiguration/TargetFrameworkVersion";
         private const string ResultsDirectoryNodePath = @"/RunSettings/RunConfiguration/ResultsDirectory";
-        private const string TestSessionTimeoutNodePath = @"/RunSettings/RunConfiguration/TestSessionTimeout";
 
 
         /// <summary>

--- a/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
 
                         } while (runSettingsNavigator.MoveToNext());
 
-                        // Delele all invalid RunConfiguration Settings
+                        // Delete all invalid RunConfiguration Settings
                         if (listOfInValidRunConfigurationSettings.Count > 0)
                         {
                             if(EqtTrace.IsWarningEnabled)

--- a/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
                         var listOfInValidRunConfigurationSettings = new List<string>();
 
                         // These are the list of valid RunConfiguration setting name which old testhost understand.
-                        var listOfValidRunConfigurationSettings = new List<string>
+                        var listOfValidRunConfigurationSettings = new HashSet<string>
                         {
                             "TargetPlatform",
                             "TargetFrameworkVersion",
@@ -90,7 +90,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
 
                         } while (runSettingsNavigator.MoveToNext());
 
-
                         // Delele all invalid RunConfiguration Settings
                         if (listOfInValidRunConfigurationSettings.Count > 0)
                         {
@@ -99,7 +98,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
                                 string settingsName = string.Join(", ", listOfInValidRunConfigurationSettings);
                                 EqtTrace.Warning(string.Format("InferRunSettingsHelper.MakeRunsettingsCompatible: Removing the following settings: {0} from RunSettings file. To use those settings please move to latest version of Microsoft.NET.Test.Sdk", settingsName));
                             }
-
 
                             // move navigator to RunConfiguration node
                             runSettingsNavigator.MoveToParent();

--- a/src/Microsoft.TestPlatform.Utilities/XmlUtilities.cs
+++ b/src/Microsoft.TestPlatform.Utilities/XmlUtilities.cs
@@ -101,5 +101,15 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
                 }
             }
         }
+
+        internal static void RemoveChildNode(XPathNavigator parentNavigator, string nodeXPath, string childName)
+        {
+            var childNodeNavigator = parentNavigator.SelectSingleNode(nodeXPath);
+            if (childNodeNavigator != null)
+            {
+                parentNavigator.MoveToChild(childName, string.Empty);
+                parentNavigator.DeleteSelf();
+            }
+        }
     }
 }

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -280,9 +280,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
 
                     var navigator = document.CreateNavigator();
 
-                    // If user is already setting DesignMode via runsettings or CLI args; we skip. We also skip if the target framework
-                    // is not known or current run is targeted to netcoreapp (since it is a breaking change; user may be running older
-                    // NET.Test.Sdk; we will remove this constraint in 15.1).
+                    // If user is already setting DesignMode via runsettings or CLI args; we skip.
                     var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(runsettingsXml);
 
                     if (!runConfiguration.DesignModeSet)

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -285,9 +285,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
                     // NET.Test.Sdk; we will remove this constraint in 15.1).
                     var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(runsettingsXml);
 
-                    if (!runConfiguration.DesignModeSet && runConfiguration.TargetFrameworkSet &&
-                        runConfiguration.TargetFrameworkVersion.Name.IndexOf("netstandard", StringComparison.OrdinalIgnoreCase) < 0 &&
-                        runConfiguration.TargetFrameworkVersion.Name.IndexOf("netcoreapp", StringComparison.OrdinalIgnoreCase) < 0)
+                    if (!runConfiguration.DesignModeSet)
                     {
                         InferRunSettingsHelper.UpdateDesignMode(navigator, this.commandLineOptions.IsDesignMode);
                         settingsUpdated = true;

--- a/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
@@ -96,6 +96,20 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         }
 
         [CustomDataTestMethod]
+        [NETCORETargetFramework]
+        public void TestPlatformShouldBeCompatibleWithOldTestHost(string runnerFramework, string targetFramework, string targetRuntime)
+        {
+            AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerFramework, targetFramework, targetRuntime);
+
+            var assemblyPaths = this.BuildMultipleAssemblyPath("SampleProjectWithOldTestHost.dll").Trim('\"');
+            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue);
+
+            this.InvokeVsTest(arguments);
+
+            this.ValidateSummaryStatus(1, 0, 0);
+        }
+
+        [CustomDataTestMethod]
         [NETFullTargetFramework]
         [NETCORETargetFramework]
         public void WorkingDirectoryIsSourceDirectory(string runnerFramework, string targetFramework, string targetRuntime)

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/ExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/ExecutionManagerTests.cs
@@ -19,6 +19,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine.ClientProtocol;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     using Moq;
@@ -186,6 +187,54 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
 
             // Also verify that run stats are passed through.
             mockTestRunEventsHandler.Verify(treh => treh.HandleTestRunStatsChange(It.IsAny<TestRunChangedEventArgs>()), Times.Once);
+        }
+
+        [TestMethod]
+        public void StartTestRunShouldAbortTheRunIfAnyExceptionComesForTheProvidedTests()
+        {
+            var testExecutionContext = new TestExecutionContext(
+                                           frequencyOfRunStatsChangeEvent: 1,
+                                           runStatsChangeEventTimeout: TimeSpan.MaxValue,
+                                           inIsolation: false,
+                                           keepAlive: false,
+                                           isDataCollectionEnabled: false,
+                                           areTestCaseLevelEventsRequired: false,
+                                           hasTestRun: false,
+                                           isDebug: false,
+                                           testCaseFilter: null);
+
+            var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+
+            // Call StartTestRun with faulty runsettings so that it will throw exception
+            this.executionManager.StartTestRun(new Dictionary<string, IEnumerable<string>>(), @"<RunSettings><RunConfiguration><TestSessionTimeout>0</TestSessionTimeout></RunConfiguration></RunSettings>", testExecutionContext, null, mockTestRunEventsHandler.Object);
+
+            // Verify that TestRunComplete get called and error message are getting logged
+            mockTestRunEventsHandler.Verify(treh => treh.HandleTestRunComplete(It.IsAny<TestRunCompleteEventArgs>(), null, null, null), Times.Once);
+            mockTestRunEventsHandler.Verify(treh => treh.HandleLogMessage(TestMessageLevel.Error, It.IsAny<string>()), Times.Once);
+        }
+
+        [TestMethod]
+        public void StartTestRunShouldAbortTheRunIfAnyExceptionComesForTheProvidedSources()
+        {
+            var testExecutionContext = new TestExecutionContext(
+                                           frequencyOfRunStatsChangeEvent: 1,
+                                           runStatsChangeEventTimeout: TimeSpan.MaxValue,
+                                           inIsolation: false,
+                                           keepAlive: false,
+                                           isDataCollectionEnabled: false,
+                                           areTestCaseLevelEventsRequired: false,
+                                           hasTestRun: false,
+                                           isDebug: false,
+                                           testCaseFilter: null);
+
+            var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+
+            // Call StartTestRun with faulty runsettings so that it will throw exception
+            this.executionManager.StartTestRun(new Dictionary<string, IEnumerable<string>>(), @"<RunSettings><RunConfiguration><TestSessionTimeout>0</TestSessionTimeout></RunConfiguration></RunSettings>", testExecutionContext, null, mockTestRunEventsHandler.Object);
+
+            // Verify that TestRunComplete get called and error message are getting logged
+            mockTestRunEventsHandler.Verify(treh => treh.HandleTestRunComplete(It.IsAny<TestRunCompleteEventArgs>(), null, null, null), Times.Once);
+            mockTestRunEventsHandler.Verify(treh => treh.HandleLogMessage(TestMessageLevel.Error, It.IsAny<string>()), Times.Once);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/ExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/ExecutionManagerTests.cs
@@ -32,6 +32,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
     public class ExecutionManagerTests
     {
         private ExecutionManager executionManager;
+        private TestExecutionContext testExecutionContext;
 
         [TestInitialize]
         public void TestInit()
@@ -39,6 +40,17 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
             this.executionManager = new ExecutionManager();
 
             TestPluginCache.Instance = null;
+
+            testExecutionContext = new TestExecutionContext(
+                                           frequencyOfRunStatsChangeEvent: 1,
+                                           runStatsChangeEventTimeout: TimeSpan.MaxValue,
+                                           inIsolation: false,
+                                           keepAlive: false,
+                                           isDataCollectionEnabled: false,
+                                           areTestCaseLevelEventsRequired: false,
+                                           hasTestRun: false,
+                                           isDebug: false,
+                                           testCaseFilter: null);
         }
 
         [TestCleanup]
@@ -99,17 +111,6 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
             var adapterSourceMap = new Dictionary<string, IEnumerable<string>>();
             adapterSourceMap.Add(assemblyLocation, new List<string> { assemblyLocation });
 
-            var testExecutionContext = new TestExecutionContext(
-                                           frequencyOfRunStatsChangeEvent: 1,
-                                           runStatsChangeEventTimeout: TimeSpan.MaxValue,
-                                           inIsolation: false,
-                                           keepAlive: false,
-                                           isDataCollectionEnabled: false,
-                                           areTestCaseLevelEventsRequired: false,
-                                           hasTestRun: false,
-                                           isDebug: false,
-                                           testCaseFilter: null);
-
             var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
 
             var isExecutorCalled = false;
@@ -148,17 +149,6 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
                 new TestCase("A.C.M1", new Uri(RunTestsWithSourcesTestsExecutorUri), assemblyLocation)
             };
 
-            var testExecutionContext = new TestExecutionContext(
-                                           frequencyOfRunStatsChangeEvent: 1,
-                                           runStatsChangeEventTimeout: TimeSpan.MaxValue,
-                                           inIsolation: false,
-                                           keepAlive: false,
-                                           isDataCollectionEnabled: false,
-                                           areTestCaseLevelEventsRequired: false,
-                                           hasTestRun: false,
-                                           isDebug: false,
-                                           testCaseFilter: null);
-
             var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
 
             var isExecutorCalled = false;
@@ -192,17 +182,6 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
         [TestMethod]
         public void StartTestRunShouldAbortTheRunIfAnyExceptionComesForTheProvidedTests()
         {
-            var testExecutionContext = new TestExecutionContext(
-                                           frequencyOfRunStatsChangeEvent: 1,
-                                           runStatsChangeEventTimeout: TimeSpan.MaxValue,
-                                           inIsolation: false,
-                                           keepAlive: false,
-                                           isDataCollectionEnabled: false,
-                                           areTestCaseLevelEventsRequired: false,
-                                           hasTestRun: false,
-                                           isDebug: false,
-                                           testCaseFilter: null);
-
             var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
 
             // Call StartTestRun with faulty runsettings so that it will throw exception
@@ -216,17 +195,6 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
         [TestMethod]
         public void StartTestRunShouldAbortTheRunIfAnyExceptionComesForTheProvidedSources()
         {
-            var testExecutionContext = new TestExecutionContext(
-                                           frequencyOfRunStatsChangeEvent: 1,
-                                           runStatsChangeEventTimeout: TimeSpan.MaxValue,
-                                           inIsolation: false,
-                                           keepAlive: false,
-                                           isDataCollectionEnabled: false,
-                                           areTestCaseLevelEventsRequired: false,
-                                           hasTestRun: false,
-                                           isDebug: false,
-                                           testCaseFilter: null);
-
             var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
 
             // Call StartTestRun with faulty runsettings so that it will throw exception

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/ExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/ExecutionManagerTests.cs
@@ -206,7 +206,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
             var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
 
             // Call StartTestRun with faulty runsettings so that it will throw exception
-            this.executionManager.StartTestRun(new Dictionary<string, IEnumerable<string>>(), @"<RunSettings><RunConfiguration><TestSessionTimeout>0</TestSessionTimeout></RunConfiguration></RunSettings>", testExecutionContext, null, mockTestRunEventsHandler.Object);
+            this.executionManager.StartTestRun(new List<TestCase>(), @"<RunSettings><RunConfiguration><TestSessionTimeout>0</TestSessionTimeout></RunConfiguration></RunSettings>", testExecutionContext, null, mockTestRunEventsHandler.Object);
 
             // Verify that TestRunComplete get called and error message are getting logged
             mockTestRunEventsHandler.Verify(treh => treh.HandleTestRunComplete(It.IsAny<TestRunCompleteEventArgs>(), null, null, null), Times.Once);

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/InferRunSettingsHelperTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/InferRunSettingsHelperTests.cs
@@ -264,7 +264,75 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
 
             Assert.AreEqual(val.ToString(), this.GetValueOf(navigator, "/RunSettings/RunConfiguration/DesignMode"));
             Assert.AreEqual(val.ToString(), this.GetValueOf(navigator, "/RunSettings/RunConfiguration/CollectSourceInformation"));
-        }   
+        }
+
+        [DataTestMethod]
+        [DataRow("DesignMode")]
+        [DataRow("CollectSourceInformation")]
+        [DataRow("TestSessionTimeout")]
+        public void RemoveNodeFromRunConfigurationShouldNotModifyXmlIfNavigatorIsNotAtRootNode(string settingName)
+        {
+            var settings = @"<RunSettings>
+                                <RunConfiguration>
+                                    <DesignMode>False</DesignMode>
+                                    <CollectSourceInformation>False</CollectSourceInformation>
+                                    <TestSessionTimeout>1000</TestSessionTimeout>
+                                </RunConfiguration>
+                            </RunSettings>";
+            var navigator = this.GetNavigator(settings);
+            navigator.MoveToFirstChild();
+
+            switch (settingName.ToUpperInvariant())
+            {
+                case "DESIGNMODE":
+                    InferRunSettingsHelper.RemoveDesignMode(navigator);
+                    break;
+
+                case "COLLECTSOURCEINFORMATION":
+                    InferRunSettingsHelper.RemoveCollectSourceInformation(navigator);
+                    break;
+
+                case "TESTSESSIONTIMEOUT":
+                    InferRunSettingsHelper.RemoveTestSessionTimeout(navigator);
+                    break;
+            };
+
+            navigator.MoveToRoot();
+            Assert.IsTrue(navigator.InnerXml.IndexOf(settingName, StringComparison.OrdinalIgnoreCase) > 0);
+        }
+
+        [TestMethod]
+        public void RemoveDesignModeShouldRemoveDesignModeNode()
+        {
+            var settings = @"<RunSettings><RunConfiguration><DesignMode>False</DesignMode></RunConfiguration></RunSettings>";
+            var navigator = this.GetNavigator(settings);
+
+            InferRunSettingsHelper.RemoveDesignMode(navigator);
+
+            Assert.IsTrue(navigator.InnerXml.IndexOf("DesignMode", StringComparison.OrdinalIgnoreCase) < 0);
+        }
+
+        [TestMethod]
+        public void RemoveCollectSourceInformationShouldRemoveCollectSourceInformationNode()
+        {
+            var settings = @"<RunSettings><RunConfiguration><CollectSourceInformation>False</CollectSourceInformation></RunConfiguration></RunSettings>";
+            var navigator = this.GetNavigator(settings);
+
+            InferRunSettingsHelper.RemoveCollectSourceInformation(navigator);
+
+            Assert.IsTrue(navigator.InnerXml.IndexOf("CollectSourceInformation", StringComparison.OrdinalIgnoreCase) < 0);
+        }
+
+        [TestMethod]
+        public void RemoveTestSessionTimeoutShouldRemoveTestSessionTimeoutNode()
+        {
+            var settings = @"<RunSettings><RunConfiguration><TestSessionTimeout>1000</TestSessionTimeout></RunConfiguration></RunSettings>";
+            var navigator = this.GetNavigator(settings);
+
+            InferRunSettingsHelper.RemoveTestSessionTimeout(navigator);
+
+            Assert.IsTrue(navigator.InnerXml.IndexOf("TestSessionTimeout", StringComparison.OrdinalIgnoreCase) < 0);
+        }
 
         #region private methods
 

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/InferRunSettingsHelperTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/InferRunSettingsHelperTests.cs
@@ -266,72 +266,44 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
             Assert.AreEqual(val.ToString(), this.GetValueOf(navigator, "/RunSettings/RunConfiguration/CollectSourceInformation"));
         }
 
-        [DataTestMethod]
-        [DataRow("DesignMode")]
-        [DataRow("CollectSourceInformation")]
-        [DataRow("TestSessionTimeout")]
-        public void RemoveNodeFromRunConfigurationShouldNotModifyXmlIfNavigatorIsNotAtRootNode(string settingName)
+        [TestMethod]
+        public void MakeRunsettingsCompatibleShouldDeleteNewlyAddedRunConfigurationNode()
+        {
+            var settings = @"<RunSettings><RunConfiguration><DesignMode>False</DesignMode><CollectSourceInformation>False</CollectSourceInformation></RunConfiguration></RunSettings>";
+
+            var result = InferRunSettingsHelper.MakeRunsettingsCompatible(settings);
+
+            Assert.IsTrue(result.IndexOf("DesignMode", StringComparison.OrdinalIgnoreCase) < 0);
+        }
+
+        [TestMethod]
+        public void MakeRunsettingsCompatibleShouldNotDeleteOldRunConfigurationNode()
         {
             var settings = @"<RunSettings>
                                 <RunConfiguration>
                                     <DesignMode>False</DesignMode>
                                     <CollectSourceInformation>False</CollectSourceInformation>
-                                    <TestSessionTimeout>1000</TestSessionTimeout>
+                                    <TargetPlatform>x86</TargetPlatform>
+                                    <TargetFrameworkVersion>net46</TargetFrameworkVersion>
+                                    <TestAdaptersPaths>dummypath</TestAdaptersPaths>
+                                    <ResultsDirectory>dummypath</ResultsDirectory>
+                                    <SolutionDirectory>dummypath</SolutionDirectory>
+                                    <MaxCpuCount>2</MaxCpuCount>
+                                    <DisableParallelization>False</DisableParallelization>
+                                    <DisableAppDomain>False</DisableAppDomain>
                                 </RunConfiguration>
                             </RunSettings>";
-            var navigator = this.GetNavigator(settings);
-            navigator.MoveToFirstChild();
 
-            switch (settingName.ToUpperInvariant())
-            {
-                case "DESIGNMODE":
-                    InferRunSettingsHelper.RemoveDesignMode(navigator);
-                    break;
+            var result = InferRunSettingsHelper.MakeRunsettingsCompatible(settings);
 
-                case "COLLECTSOURCEINFORMATION":
-                    InferRunSettingsHelper.RemoveCollectSourceInformation(navigator);
-                    break;
-
-                case "TESTSESSIONTIMEOUT":
-                    InferRunSettingsHelper.RemoveTestSessionTimeout(navigator);
-                    break;
-            };
-
-            navigator.MoveToRoot();
-            Assert.IsTrue(navigator.InnerXml.IndexOf(settingName, StringComparison.OrdinalIgnoreCase) > 0);
-        }
-
-        [TestMethod]
-        public void RemoveDesignModeShouldRemoveDesignModeNode()
-        {
-            var settings = @"<RunSettings><RunConfiguration><DesignMode>False</DesignMode></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
-
-            InferRunSettingsHelper.RemoveDesignMode(navigator);
-
-            Assert.IsTrue(navigator.InnerXml.IndexOf("DesignMode", StringComparison.OrdinalIgnoreCase) < 0);
-        }
-
-        [TestMethod]
-        public void RemoveCollectSourceInformationShouldRemoveCollectSourceInformationNode()
-        {
-            var settings = @"<RunSettings><RunConfiguration><CollectSourceInformation>False</CollectSourceInformation></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
-
-            InferRunSettingsHelper.RemoveCollectSourceInformation(navigator);
-
-            Assert.IsTrue(navigator.InnerXml.IndexOf("CollectSourceInformation", StringComparison.OrdinalIgnoreCase) < 0);
-        }
-
-        [TestMethod]
-        public void RemoveTestSessionTimeoutShouldRemoveTestSessionTimeoutNode()
-        {
-            var settings = @"<RunSettings><RunConfiguration><TestSessionTimeout>1000</TestSessionTimeout></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
-
-            InferRunSettingsHelper.RemoveTestSessionTimeout(navigator);
-
-            Assert.IsTrue(navigator.InnerXml.IndexOf("TestSessionTimeout", StringComparison.OrdinalIgnoreCase) < 0);
+            Assert.IsTrue(result.IndexOf("TargetPlatform", StringComparison.OrdinalIgnoreCase) > 0);
+            Assert.IsTrue(result.IndexOf("TargetFrameworkVersion", StringComparison.OrdinalIgnoreCase) > 0);
+            Assert.IsTrue(result.IndexOf("TestAdaptersPaths", StringComparison.OrdinalIgnoreCase) > 0);
+            Assert.IsTrue(result.IndexOf("ResultsDirectory", StringComparison.OrdinalIgnoreCase) > 0);
+            Assert.IsTrue(result.IndexOf("SolutionDirectory", StringComparison.OrdinalIgnoreCase) > 0);
+            Assert.IsTrue(result.IndexOf("MaxCpuCount", StringComparison.OrdinalIgnoreCase) > 0);
+            Assert.IsTrue(result.IndexOf("DisableParallelization", StringComparison.OrdinalIgnoreCase) > 0);
+            Assert.IsTrue(result.IndexOf("DisableAppDomain", StringComparison.OrdinalIgnoreCase) > 0);
         }
 
         #region private methods

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/XmlUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/XmlUtilitiesTests.cs
@@ -162,6 +162,36 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
 
         #endregion
 
+        #region AppendOrModifyChild tests
+
+        [TestMethod]
+        public void RemoveChildNodeShouldNotModifyExistingXmlIfNodeDoesnotExist()
+        {
+            var settingsXml = @"<RunSettings></RunSettings>";
+            var navigator = this.GetNavigator(settingsXml);
+
+            navigator.MoveToChild("RunSettings", string.Empty);
+
+            XmlUtilities.RemoveChildNode(navigator, @"/RunSettings/RC", "RC");
+
+            Assert.AreEqual(settingsXml, navigator.OuterXml);
+        }
+
+        [TestMethod]
+        public void RemoveChildNodeShouldRemoveXmlIfExist()
+        {
+            var settingsXml = @"<RunSettings><RC>abc</RC></RunSettings>";
+            var navigator = this.GetNavigator(settingsXml);
+
+            navigator.MoveToChild("RunSettings", string.Empty);
+
+            XmlUtilities.RemoveChildNode(navigator, @"/RunSettings/RC", "RC");
+
+            Assert.AreEqual(@"<RunSettings></RunSettings>", navigator.OuterXml);
+        }
+
+        #endregion
+
         #region private methods
 
         private XPathNavigator GetNavigator(string settingsXml)

--- a/test/TestAssets/SampleProjectWithOldTestHost/SampleProjectWithOldTestHost.csproj
+++ b/test/TestAssets/SampleProjectWithOldTestHost/SampleProjectWithOldTestHost.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Imports Common TestAssets props. -->
+  <Import Project="..\..\..\scripts\build\TestAssets.props" />
+  <!-- Package dependency versions -->
+  <Import Project="..\..\..\scripts\build\TestPlatform.Dependencies.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+	<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20161024-02" />
+    <PackageReference Include="MSTest.TestFramework">
+      <Version>$(MSTestFrameworkVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="MSTest.TestAdapter">
+      <Version>$(MSTestAdapterVersion)</Version>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/test/TestAssets/SampleProjectWithOldTestHost/UnitTest1.cs
+++ b/test/TestAssets/SampleProjectWithOldTestHost/UnitTest1.cs
@@ -1,0 +1,13 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SampleProjectWithOldTestHost
+{
+    [TestClass]
+    public class UnitTest1
+    {
+        [TestMethod]
+        public void TestMethod1()
+        {
+        }
+    }
+}

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -565,32 +565,6 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
                 tp => tp.CreateDiscoveryRequest(It.Is<DiscoveryCriteria>(dc => dc.RunSettings.Contains(designmode)), It.IsAny<ProtocolConfig>()));
         }
 
-        [TestMethod]
-        public void DiscoverTestsShouldNotUpdateDesignModeIfTargetFrameworkIsNotSetInRunSettings()
-        {
-            var runsettings = "<RunSettings><RunConfiguration></RunConfiguration></RunSettings>";
-            var discoveryPayload = CreateDiscoveryPayload(runsettings);
-
-            this.testRequestManager.DiscoverTests(discoveryPayload, new Mock<ITestDiscoveryEventsRegistrar>().Object, It.IsAny<ProtocolConfig>());
-
-            var designmode = "DesignMode";
-            this.mockTestPlatform.Verify(
-                tp => tp.CreateDiscoveryRequest(It.Is<DiscoveryCriteria>(dc => !dc.RunSettings.Contains(designmode)), It.IsAny<ProtocolConfig>()));
-        }
-
-        [TestMethod]
-        public void DiscoverTestsShouldNotUpdateDesignModeIfTargetFrameworkIsSetToNetCoreInRunSettings()
-        {
-            var runsettings = "<RunSettings><RunConfiguration><TargetFrameworkVersion>.NETCoreApp,Version=v1.0</TargetFrameworkVersion></RunConfiguration></RunSettings>";
-            var discoveryPayload = CreateDiscoveryPayload(runsettings);
-
-            this.testRequestManager.DiscoverTests(discoveryPayload, new Mock<ITestDiscoveryEventsRegistrar>().Object, It.IsAny<ProtocolConfig>());
-
-            var designmode = "DesignMode";
-            this.mockTestPlatform.Verify(
-                tp => tp.CreateDiscoveryRequest(It.Is<DiscoveryCriteria>(dc => !dc.RunSettings.Contains(designmode)), It.IsAny<ProtocolConfig>()));
-        }
-
         [DataTestMethod]
         [DataRow(true)]
         [DataRow(false)]


### PR DESCRIPTION
### Issue
**Issue1: ** TestHost of version 15.0.0-preview throw exception if any unknown runsettings node (for example TestSessionTimeout is present in runsettings and it got stuck forever.

**issue2: ** If testhost throw exception before starting test run, it doesn't send any testruncomplete event or it doesn't abort process. As a result of it vstest.console keep waiting forever for testhost to send testruncomplete.

https://github.com/Microsoft/vstest/issues/970 
### Fix
Don't send these newly added runsettings (which are unknown to old testhosts ) to old test hosts.