### PR TITLE
This will make vstest.console run as 32bit process on all machines

### DIFF
--- a/src/vstest.console/vstest.console.csproj
+++ b/src/vstest.console/vstest.console.csproj
@@ -10,6 +10,7 @@
     <WarningsAsErrors>true</WarningsAsErrors>
     <OutputType>Exe</OutputType>
     <PlatformTarget Condition="'$(TargetFramework)' == 'net451'">AnyCPU</PlatformTarget>
+    <Prefer32Bit Condition="'$(TargetFramework)' == 'net451'">true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp2.0'">
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>


### PR DESCRIPTION
while if loaded inside a 64 bit process, it will load normally.