### PR TITLE
Changes For UWP

### DIFF
--- a/src/Microsoft.TestPlatform.Client/TestPlatform.cs
+++ b/src/Microsoft.TestPlatform.Client/TestPlatform.cs
@@ -94,9 +94,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Client
             var testHostManager = this.testHostProviderManager.GetTestHostManagerByRunConfiguration(discoveryCriteria.RunSettings);
             testHostManager.Initialize(TestSessionMessageLogger.Instance, discoveryCriteria.RunSettings);
 
-            // Allow TestRuntimeProvider to update source map, this is required for remote scenarios.
-            UpdateTestSources(discoveryCriteria.Sources, discoveryCriteria.AdapterSourceMap, testHostManager);
-
             var discoveryManager = this.TestEngine.GetDiscoveryManager(testHostManager, discoveryCriteria, protocolConfig);
             discoveryManager.Initialize();
 
@@ -133,13 +130,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Client
             var testHostManager = this.testHostProviderManager.GetTestHostManagerByRunConfiguration(testRunCriteria.TestRunSettings);
             testHostManager.Initialize(TestSessionMessageLogger.Instance, testRunCriteria.TestRunSettings);
 
-            // Allow TestRuntimeProvider to update source map, this is required for remote scenarios.
-            // If we run for specific tests, then we expect the test case object to contain correct source path for remote scenario as well
-            if (!testRunCriteria.HasSpecificTests)
-            {
-                UpdateTestSources(testRunCriteria.Sources, testRunCriteria.AdapterSourceMap, testHostManager);
-            }
-
             if (testRunCriteria.TestHostLauncher != null)
             {
                 testHostManager.SetCustomLauncher(testRunCriteria.TestHostLauncher);
@@ -168,19 +158,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Client
         {
             this.TestEngine.GetExtensionManager()
                    .UseAdditionalExtensions(pathToAdditionalExtensions, loadOnlyWellKnownExtensions);
-        }
-
-        /// <summary>
-        /// Update the AdapterSourceMap
-        /// </summary>
-        /// <param name="sources">test sources</param>
-        /// <param name="adapterSourceMap">Adapter Source Map</param>
-        /// <param name="testRuntimeProvider">testhostmanager which updates the sources</param>
-        private void UpdateTestSources(IEnumerable<string> sources, Dictionary<string, IEnumerable<string>> adapterSourceMap, ITestRuntimeProvider testRuntimeProvider)
-        {
-            var updatedTestSources = testRuntimeProvider.GetTestSources(sources);
-            adapterSourceMap.Clear();
-            adapterSourceMap.Add(ObjectModel.Constants.UnspecifiedAdapterPath, updatedTestSources);
         }
 
         /// <summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
@@ -94,6 +94,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                 if (this.isCommunicationEstablished)
                 {
                     this.InitializeExtensions(discoveryCriteria.Sources);
+
+                    // Allow TestRuntimeProvider to update source map, this is required for remote scenarios.
+                    // If we run for specific tests, then we expect the test case object to contain correct source path for remote scenario as well
+                    this.UpdateTestSources(discoveryCriteria.Sources, discoveryCriteria.AdapterSourceMap);
                     this.RequestSender.DiscoverTests(discoveryCriteria, eventHandler);
                 }
             }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -123,6 +123,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                     var runsettings = this.RemoveNodesFromRunsettingsIfRequired(testRunCriteria.TestRunSettings, (testMessageLevel, message) => { this.LogMessage(testMessageLevel, message, eventHandler); });
                     if (testRunCriteria.HasSpecificSources)
                     {
+                        // Allow TestRuntimeProvider to update source map, this is required for remote scenarios.
+                        // If we run for specific tests, then we expect the test case object to contain correct source path for remote scenario as well
+                        this.UpdateTestSources(testRunCriteria.Sources, testRunCriteria.AdapterSourceMap);
                         var runRequest = new TestRunCriteriaWithSources(
                             testRunCriteria.AdapterSourceMap,
                             runsettings,

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -175,6 +175,19 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         }
 
         /// <summary>
+        /// Update the AdapterSourceMap
+        /// </summary>
+        /// <param name="sources">test sources</param>
+        /// <param name="adapterSourceMap">Adapter Source Map</param>
+        /// <param name="testRuntimeProvider">testhostmanager which updates the sources</param>
+        public virtual void UpdateTestSources(IEnumerable<string> sources, Dictionary<string, IEnumerable<string>> adapterSourceMap)
+        {
+            var updatedTestSources = this.testHostManager.GetTestSources(sources);
+            adapterSourceMap.Clear();
+            adapterSourceMap.Add(Constants.UnspecifiedAdapterPath, updatedTestSources);
+        }
+
+        /// <summary>
         /// Closes the channel, terminate test host process.
         /// </summary>
         public virtual void Close()

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -193,13 +193,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
             var framework = config.TargetFrameworkVersion;
 
             // This is expected to be called once every run so returning a new instance every time.
-            if (framework.Name.IndexOf("netstandard", StringComparison.OrdinalIgnoreCase) >= 0
-                || framework.Name.IndexOf("netcoreapp", StringComparison.OrdinalIgnoreCase) >= 0)
+            if (framework.Name.IndexOf("NETFramework", StringComparison.OrdinalIgnoreCase) >= 0)
             {
-                return false;
+                return true;
             }
 
-            return true;
+            return false;
         }
 
         /// <inheritdoc/>

--- a/src/testhost.x86/DefaultEngineInvoker.cs
+++ b/src/testhost.x86/DefaultEngineInvoker.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
 
             ConnectionRole connectionRole = ConnectionRole.Client;
             string role = CommandLineArgumentsHelper.GetStringArgFromDict(argsDictionary, RoleArgument);
-            if (string.IsNullOrWhiteSpace(role) && string.Equals(role, "host", StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrWhiteSpace(role) && string.Equals(role, "host", StringComparison.OrdinalIgnoreCase))
             {
                 connectionRole = ConnectionRole.Host;
             }

--- a/test/Microsoft.TestPlatform.Client.UnitTests/TestPlatformTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/TestPlatformTests.cs
@@ -61,31 +61,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests
         }
 
         [TestMethod]
-        public void CreateDiscoveryRequestShouldAllowRuntimeProviderToUpdateAdapterSource()
-        {
-            var updatedSources = new List<string> { @"x:\dummy2\foo.dll" };
-            var originalSource = new List<string> { @"x:dummy\foo.dll" };
-            this.discoveryManager.Setup(dm => dm.Initialize()).Verifiable();
-
-            var discoveryCriteria = new DiscoveryCriteria(originalSource, 1, null);
-
-            this.hostManager.Setup(hm => hm.GetTestSources(discoveryCriteria.Sources))
-                .Returns(updatedSources);
-
-            this.testEngine.Setup(te => te.GetDiscoveryManager(this.hostManager.Object, It.IsAny<DiscoveryCriteria>(), It.IsAny<ProtocolConfig>())).Returns(this.discoveryManager.Object);
-            this.testEngine.Setup(te => te.GetExtensionManager()).Returns(this.extensionManager.Object);
-            var tp = new TestableTestPlatform(this.testEngine.Object, this.hostManager.Object);
-
-            var discoveryRequest = tp.CreateDiscoveryRequest(discoveryCriteria, It.IsAny<ProtocolConfig>());
-
-            this.hostManager.Verify(hm => hm.Initialize(It.IsAny<TestSessionMessageLogger>(), It.IsAny<string>()), Times.Once);
-            this.discoveryManager.Verify(dm => dm.Initialize(), Times.Once);
-
-            this.hostManager.Verify(hm => hm.GetTestSources(originalSource), Times.Once);
-            Assert.IsTrue(!discoveryCriteria.Sources.Except(updatedSources).Any());
-        }
-
-        [TestMethod]
         public void CreateDiscoveryRequestThrowsIfDiscoveryCriteriaIsNull()
         {
             TestPlatform tp = new TestPlatform();
@@ -132,42 +107,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests
             var tp = new TestableTestPlatform(this.testEngine.Object, this.mockFileHelper.Object, this.hostManager.Object);
 
             var testRunRequest = tp.CreateTestRunRequest(testRunCriteria, It.IsAny<ProtocolConfig>());
-            this.extensionManager.Verify(em => em.UseAdditionalExtensions(additionalExtensions, true));
-        }
-
-        [TestMethod]
-        public void CreateTestRunRequestShouldAllowRuntimeProviderToUpdateAdapterSource()
-        {
-            var updatedSources = new List<string> { @"x:\dummy2\foo.dll" };
-            var originalSource = new List<string> { @"x:dummy\foo.dll" };
-            var additionalExtensions = new List<string> { "foo.TestLogger.dll", "Joo.TestLogger.dll" };
-            this.mockFileHelper.Setup(fh => fh.DirectoryExists(It.IsAny<string>())).Returns(true);
-            this.mockFileHelper.Setup(fh => fh.EnumerateFiles(It.IsAny<string>(), System.IO.SearchOption.TopDirectoryOnly, It.IsAny<string[]>())).Returns(additionalExtensions);
-
-            this.executionManager.Setup(dm => dm.Initialize()).Verifiable();
-
-            string settingsXml =
-                @"<?xml version=""1.0"" encoding=""utf-8""?>
-                <RunSettings>
-                     <RunConfiguration>
-                       <DesignMode>false</DesignMode>
-                     </RunConfiguration>
-                </RunSettings>";
-
-            var testRunCriteria = new TestRunCriteria(originalSource, 10, false, settingsXml, TimeSpan.Zero);
-
-            this.hostManager.Setup(hm => hm.GetTestSources(testRunCriteria.Sources))
-                .Returns(updatedSources);
-
-            this.testEngine.Setup(te => te.GetExecutionManager(this.hostManager.Object, It.IsAny<TestRunCriteria>(), It.IsAny<ProtocolConfig>())).Returns(this.executionManager.Object);
-            this.testEngine.Setup(te => te.GetExtensionManager()).Returns(this.extensionManager.Object);
-
-            var tp = new TestableTestPlatform(this.testEngine.Object, this.mockFileHelper.Object, this.hostManager.Object);
-
-            var testRunRequest = tp.CreateTestRunRequest(testRunCriteria, It.IsAny<ProtocolConfig>());
-
-            this.hostManager.Verify(hm => hm.GetTestSources(originalSource), Times.Once);
-            Assert.IsTrue(!testRunCriteria.Sources.Except(updatedSources).Any());
             this.extensionManager.Verify(em => em.UseAdditionalExtensions(additionalExtensions, true));
         }
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
@@ -89,6 +89,22 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
             this.mockRequestSender.Verify(s => s.InitializeExecution(It.IsAny<IEnumerable<string>>(), It.IsAny<bool>()), Times.Never);
         }
 
+        [TestMethod]
+        public void DiscoverTestsShouldAllowRuntimeProviderToUpdateAdapterSource()
+        {
+            // Make sure TestPlugincache is refreshed.
+            TestPluginCache.Instance = null;
+
+            this.mockTestHostManager.Setup(hm => hm.GetTestSources(this.discoveryCriteria.Sources)).Returns(this.discoveryCriteria.Sources);
+            this.mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(true);
+
+            Mock<ITestDiscoveryEventsHandler> mockTestDiscoveryEventHandler = new Mock<ITestDiscoveryEventsHandler>();
+
+            this.testDiscoveryManager.DiscoverTests(this.discoveryCriteria, mockTestDiscoveryEventHandler.Object);
+
+            this.mockTestHostManager.Verify(hm => hm.GetTestSources(this.discoveryCriteria.Sources), Times.Once);
+        }
+
 
         [TestMethod]
         public void DiscoverTestsShouldNotSendDiscoveryRequestIfCommunicationFails()

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
@@ -73,6 +73,22 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         }
 
         [TestMethod]
+        public void StartTestRunShouldAllowRuntimeProviderToUpdateAdapterSource()
+        {
+            // Make sure TestPlugincache is refreshed.
+            TestPluginCache.Instance = null;
+
+            this.mockTestHostManager.Setup(hm => hm.GetTestSources(this.mockTestRunCriteria.Object.Sources)).Returns(this.mockTestRunCriteria.Object.Sources);
+            this.mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(true);
+
+            Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+
+            this.testExecutionManager.StartTestRun(this.mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
+
+            this.mockTestHostManager.Verify(hm => hm.GetTestSources(this.mockTestRunCriteria.Object.Sources), Times.Once);
+        }
+
+        [TestMethod]
         public void StartTestRunShouldNotInitializeExtensionsOnCommunicationFailure()
         {
             // Make sure TestPlugincache is refreshed.


### PR DESCRIPTION
- DesktopTestHost should check for "NETFramework", else it will always be testhost provider for non netcore tests

- Update AdapterSourceMap during Start Test Run/Discovery since in parallel we create new TestCriteria where we lose information we generated during TestPlatform CreateDiscoveryRequest/CreateTestRunRequest