### PR TITLE
Fix for workaround to add Microsoft.CodeCoverage nuget package.

### DIFF
--- a/src/package/nuspec/Microsoft.NET.Test.Sdk.nuspec
+++ b/src/package/nuspec/Microsoft.NET.Test.Sdk.nuspec
@@ -14,6 +14,7 @@
     <projectUrl>https://github.com/microsoft/vstest/</projectUrl>
     <dependencies>
       <dependency id="Microsoft.TestPlatform.TestHost" version="$Version$" />
+      <dependency id="Microsoft.CodeCoverage" version="1.0.3" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Fix for workaround to add Microsoft.CodeCoverage nuget package.
Fixes https://github.com/Microsoft/vstest/issues/852