### PR TITLE
Remove System.Collections.Immutable binding redirects for testhost

### DIFF
--- a/samples/Microsoft.TestPlatform.E2ETest/testhost.exe.config
+++ b/samples/Microsoft.TestPlatform.E2ETest/testhost.exe.config
@@ -40,10 +40,6 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="6.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="1.1.37.0" newVersion="1.2.0.0" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.diagnostics>

--- a/samples/Microsoft.TestPlatform.TranslationLayer.E2ETest/testhost.exe.config
+++ b/samples/Microsoft.TestPlatform.TranslationLayer.E2ETest/testhost.exe.config
@@ -40,10 +40,6 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="6.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="1.1.37.0" newVersion="1.2.0.0" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.diagnostics>

--- a/src/testhost/app.config
+++ b/src/testhost/app.config
@@ -36,10 +36,6 @@
         <assemblyIdentity name="Microsoft.VisualStudio.QualityTools.Common" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="10.0.0.0-14.0.0.0" newVersion="15.0.0.0" />
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="1.1.37.0" newVersion="1.2.0.0" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.diagnostics>


### PR DESCRIPTION
- Tests are failing which have dependent on System.Collections.Immutable 1.1.37.0 due to binding redirects.
- Testhost not dependent on any type from System.Collections.Immutable 
- Binding redirects exist for only x64 app config, reason is unknow. Tpv1 don't have this redirects.