### PR TITLE
Make default target framework version as net40

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/Framework.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Framework.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
     public class Framework
     {
 #if NET451
-        private static readonly Framework Default = Framework.FromString(".NETFramework,Version=v4.5.1");
+        private static readonly Framework Default = Framework.FromString(".NETFramework,Version=v4.0");
 #else
         private static readonly Framework Default = Framework.FromString(".NETCoreApp,Version=v1.0");
 #endif

--- a/src/Microsoft.TestPlatform.ObjectModel/Utilities/AssemblyHelper.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Utilities/AssemblyHelper.cs
@@ -315,7 +315,6 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
         /// <summary>
         /// When test run is targeted for .Net4.0, set target framework of test appdomain to be v4.0.
         /// With this done tests would be executed in 4.0 compatiblity mode even when  .Net4.5 is installed.
-        /// This needs to be done using reflection, as this dll is compiled for .Net3.5.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Failure to set this property should be ignored.")]
         internal static void SetNETFrameworkCompatiblityMode(AppDomainSetup setup, IRunContext runContext)
@@ -323,24 +322,14 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
             try
             {
                 RunConfiguration runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(runContext.RunSettings.SettingsXml);
-                if (null != runConfiguration && Enum.Equals(runConfiguration.TargetFrameworkVersion, FrameworkVersion.Framework40))
+                if (null != runConfiguration && (Enum.Equals(runConfiguration.TargetFrameworkVersion, FrameworkVersion.Framework40) ||
+                    string.Equals(runConfiguration.TargetFrameworkVersion.ToString(), Constants.DotNetFramework40, StringComparison.OrdinalIgnoreCase)))
                 {
-                    PropertyInfo pInfo = typeof(AppDomainSetup).GetProperty(Constants.TargetFrameworkName);
-                    if (null != pInfo)
+                    if (EqtTrace.IsVerboseEnabled)
                     {
-                        if (EqtTrace.IsVerboseEnabled)
-                        {
-                            EqtTrace.Verbose("AssemblyHelper.SetNETFrameworkCompatiblityMode: setting .NetFramework,Version=v4.0 compatiblity mode.");
-                        }
-                        pInfo.SetValue(setup, Constants.DotNetFramework40, null);
+                        EqtTrace.Verbose("AssemblyHelper.SetNETFrameworkCompatiblityMode: setting .NetFramework,Version=v4.0 compatiblity mode.");
                     }
-                    else
-                    {
-                        if (EqtTrace.IsWarningEnabled)
-                        {
-                            EqtTrace.Warning("AssemblyHelper:SetNETFrameworkCompatiblityMode: Binary compatiblity mode needed, but AppDomainSetup.TargetFrameworkName property not found. Ignoring compatiblity mode.");
-                        }
-                    }
+                    setup.TargetFrameworkName = Constants.DotNetFramework40;
                 }
             }
             catch (Exception e)

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/FrameworkTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/FrameworkTests.cs
@@ -21,10 +21,10 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests
         }
 
         [TestMethod]
-        public void DefaultFrameworkShouldBeNet451OnDesktop()
+        public void DefaultFrameworkShouldBeNet40OnDesktop()
         {
 #if NET451
-            Assert.AreEqual(".NETFramework,Version=v4.5.1", Framework.DefaultFramework.Name);
+            Assert.AreEqual(".NETFramework,Version=v4.0", Framework.DefaultFramework.Name);
 #endif
         }
 

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Utilities/AssemblyHelperTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Utilities/AssemblyHelperTests.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NET451
+
+namespace Microsoft.TestPlatform.ObjectModel.UnitTests.Utilities
+{
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using System;
+
+    [TestClass]
+    public class AssemblyHelperTests
+    {
+        private Mock<IRunContext> runContext;
+        private Mock<IRunSettings> runSettings;
+
+        public AssemblyHelperTests()
+        {
+            this.runContext = new Mock<IRunContext>();
+            this.runSettings = new Mock<IRunSettings>();
+        }
+
+        [TestMethod]
+        public void SetNETFrameworkCompatiblityModeShouldSetAppDomainTargetFrameWorkWhenFramework40()
+        {
+            this.runSettings.Setup(rs => rs.SettingsXml).Returns(@"<RunSettings> <RunConfiguration> <TargetFrameworkVersion>Framework40</TargetFrameworkVersion> </RunConfiguration> </RunSettings>");
+            this.runContext.Setup(rc => rc.RunSettings).Returns(runSettings.Object);
+            AppDomainSetup appDomainSetup = new AppDomainSetup();
+
+            AssemblyHelper.SetNETFrameworkCompatiblityMode(appDomainSetup, runContext.Object);
+
+            Assert.AreEqual(".NETFramework,Version=v4.0", appDomainSetup.TargetFrameworkName);
+        }
+
+        [TestMethod]
+        public void SetNETFrameworkCompatiblityModeShouldSetAppDomainTargetFrameWorkWhenNETFrameworkVersionv40()
+        {
+            this.runSettings.Setup(rs => rs.SettingsXml).Returns(@"<RunSettings> <RunConfiguration> <TargetFrameworkVersion>.NETFramework,Version=v4.0</TargetFrameworkVersion> </RunConfiguration> </RunSettings>");
+            this.runContext.Setup(rc => rc.RunSettings).Returns(runSettings.Object);
+            AppDomainSetup appDomainSetup = new AppDomainSetup();
+
+            AssemblyHelper.SetNETFrameworkCompatiblityMode(appDomainSetup, runContext.Object);
+
+            Assert.AreEqual(".NETFramework,Version=v4.0", appDomainSetup.TargetFrameworkName);
+        }
+
+        [TestMethod]
+        public void SetNETFrameworkCompatiblityModeShouldNotSetAppDomainTargetFrameWorkWhenFramework45()
+        {
+            this.runSettings.Setup(rs => rs.SettingsXml).Returns(@"<RunSettings> <RunConfiguration> <TargetFrameworkVersion>Framework45</TargetFrameworkVersion> </RunConfiguration> </RunSettings>");
+            this.runContext.Setup(rc => rc.RunSettings).Returns(runSettings.Object);
+            AppDomainSetup appDomainSetup = new AppDomainSetup();
+
+            AssemblyHelper.SetNETFrameworkCompatiblityMode(appDomainSetup, runContext.Object);
+
+            Assert.AreEqual(null, appDomainSetup.TargetFrameworkName);
+        }
+
+        [TestMethod]
+        public void SetNETFrameworkCompatiblityModeShouldNotSetAppDomainTargetFrameWorkWhenNETFrameworkVersionv45()
+        {
+            Mock<IRunContext> runContext = new Mock<IRunContext>();
+            Mock<IRunSettings> runSettings = new Mock<IRunSettings>();
+            runSettings.Setup(rs => rs.SettingsXml).Returns(@"<RunSettings> <RunConfiguration> <TargetFrameworkVersion>.NETFramework,Version=v4.5</TargetFrameworkVersion> </RunConfiguration> </RunSettings>");
+            runContext.Setup(rc => rc.RunSettings).Returns(runSettings.Object);
+            AppDomainSetup appDomainSetup = new AppDomainSetup();
+
+            AssemblyHelper.SetNETFrameworkCompatiblityMode(appDomainSetup, runContext.Object);
+
+            Assert.AreEqual(null, appDomainSetup.TargetFrameworkName);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
- In Tpv1 the default target framework is net40.
- MSTest v1 adapter creates app domain with net40 target framework when target framework is net40 in runsettings.
- For compact: Making default target framework is net40.