### PR TITLE
Don't lose the stack when rethrowing exceptions from TestHost

### DIFF
--- a/src/testhost.x86/Program.cs
+++ b/src/testhost.x86/Program.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
                 EqtTrace.Error("TestHost: Error occured during initialization of TestHost : {0}", ex);
 
                 // Throw exception so that vstest.console get the exception message.
-                throw ex;
+                throw;
             }
             finally
             {


### PR DESCRIPTION
I'm seeing the following when trying to run vstest:

```
Microsoft (R) Test Execution Command Line Tool Version 15.5.0-dev
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
Testhost process exited with error: Unhandled Exception: System.IO.FileLoadException: Could not load file or assembly 'System.Threading.Thread, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)
   at Microsoft.VisualStudio.TestPlatform.TestHost.Program.Main(String[] args)
```

The strack trace for the exception is lost since it's not re-thrown properly.