### PR TITLE
Exposing filter support on test discovery

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Adapter/RunContext.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Adapter/RunContext.cs
@@ -3,17 +3,8 @@
 
 namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Adapter
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Globalization;
-    using System.Linq;
-
-    using Microsoft.VisualStudio.TestPlatform.Common.Filtering;
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Discovery;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-
-    using CrossPlatEngineResources = Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources.Resources;
 
     /// <summary>
     /// Provides user specified runSettings and framework provided context of the run. 
@@ -49,39 +40,5 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Adapter
         /// Gets the directory for Solution.
         /// </summary>
         public string SolutionDirectory { get; internal set; }
-
-        /// <summary>
-        /// Returns TestCaseFilterExpression validated for supportedProperties.
-        /// If there is a parsing error or filter expression has unsupported properties, TestPlatformFormatException() is thrown.
-        /// </summary>
-        /// <param name="supportedProperties"> The supported Properties. </param>
-        /// <param name="propertyProvider"> The property Provider. </param>
-        /// <returns> The <see cref="ITestCaseFilterExpression"/>. </returns>
-        public ITestCaseFilterExpression GetTestCaseFilter(IEnumerable<string> supportedProperties, Func<string, TestProperty> propertyProvider)
-        {
-            TestCaseFilterExpression adapterSpecificTestCaseFilter = null;
-            if (this.FilterExpressionWrapper != null)
-            {
-                if (!string.IsNullOrEmpty(this.FilterExpressionWrapper.ParseError))
-                {
-                    throw new TestPlatformFormatException(this.FilterExpressionWrapper.ParseError, this.FilterExpressionWrapper.FilterString);
-                }
-
-                adapterSpecificTestCaseFilter = new TestCaseFilterExpression(this.FilterExpressionWrapper);
-                var invalidProperties = adapterSpecificTestCaseFilter.ValidForProperties(supportedProperties, propertyProvider);
-
-                if (invalidProperties != null)
-                {
-                    var invalidPropertiesString = string.Join(CrossPlatEngineResources.StringSeperator, invalidProperties);
-                    var validPropertiesSttring = supportedProperties == null ? string.Empty : string.Join(CrossPlatEngineResources.StringSeperator, supportedProperties.ToArray());
-                    var errorMessage = string.Format(CultureInfo.CurrentCulture, CrossPlatEngineResources.UnsupportedPropertiesInTestCaseFilter, invalidPropertiesString, validPropertiesSttring);
-
-                    // For unsupported property don’t throw exception, just log the message. Later it is going to handle properly with TestCaseFilterExpression.MatchTestCase().
-                    EqtTrace.Info(errorMessage);
-                }
-            }
-
-            return adapterSpecificTestCaseFilter;
-        }
     }
 }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Adapter/RunContext.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Adapter/RunContext.cs
@@ -51,15 +51,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Adapter
         public string SolutionDirectory { get; internal set; }
 
         /// <summary>
-        /// Gets or sets the FilterExpressionWrapper instance as created from filter string.
-        /// </summary>
-        internal FilterExpressionWrapper FilterExpressionWrapper
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
         /// Returns TestCaseFilterExpression validated for supportedProperties.
         /// If there is a parsing error or filter expression has unsupported properties, TestPlatformFormatException() is thrown.
         /// </summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyDiscoveryManager.cs
@@ -242,6 +242,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel
 
                 // Kick off another discovery task for the next source
                 var discoveryCriteria = new DiscoveryCriteria(new[] { nextSource }, this.actualDiscoveryCriteria.FrequencyOfDiscoveredTestsEvent, this.actualDiscoveryCriteria.DiscoveredTestEventTimeout, this.actualDiscoveryCriteria.RunSettings);
+                discoveryCriteria.TestCaseFilter = this.actualDiscoveryCriteria.TestCaseFilter;
                 Task.Run(() =>
                     {
                         if (EqtTrace.IsVerboseEnabled)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscoveryContext.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscoveryContext.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Discovery
 {
+    using Microsoft.VisualStudio.TestPlatform.Common.Filtering;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
     /// <summary>
@@ -14,5 +15,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Discovery
         /// Gets the run settings specified for this request.
         /// </summary>
         public IRunSettings RunSettings { get; internal set; }
+
+        /// <summary>
+        /// Gets or sets the FilterExpressionWrapper instance as created from filter string.
+        /// </summary>
+        internal FilterExpressionWrapper FilterExpressionWrapper {get; set; }
     }
 }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscoveryContext.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscoveryContext.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Discovery
         /// <param name="supportedProperties"> The supported Properties. </param>
         /// <param name="propertyProvider"> The property Provider. </param>
         /// <returns> The <see cref="ITestCaseFilterExpression"/>. </returns>
-        public virtual ITestCaseFilterExpression GetTestCaseFilter(IEnumerable<string> supportedProperties, Func<string, TestProperty> propertyProvider)
+        public ITestCaseFilterExpression GetTestCaseFilter(IEnumerable<string> supportedProperties, Func<string, TestProperty> propertyProvider)
         {
             TestCaseFilterExpression adapterSpecificTestCaseFilter = null;
             if (this.FilterExpressionWrapper != null)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscoveryContext.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscoveryContext.cs
@@ -3,8 +3,16 @@
 
 namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Discovery
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+
     using Microsoft.VisualStudio.TestPlatform.Common.Filtering;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+    using CrossPlatEngineResources = Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources.Resources;
 
     /// <summary>
     /// Specifies the user specified RunSettings and framework provided context of the discovery. 
@@ -15,6 +23,40 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Discovery
         /// Gets the run settings specified for this request.
         /// </summary>
         public IRunSettings RunSettings { get; internal set; }
+
+        /// <summary>
+        /// Returns TestCaseFilterExpression validated for supportedProperties.
+        /// If there is a parsing error in filter expression, TestPlatformFormatException() is thrown.
+        /// </summary>
+        /// <param name="supportedProperties"> The supported Properties. </param>
+        /// <param name="propertyProvider"> The property Provider. </param>
+        /// <returns> The <see cref="ITestCaseFilterExpression"/>. </returns>
+        public virtual ITestCaseFilterExpression GetTestCaseFilter(IEnumerable<string> supportedProperties, Func<string, TestProperty> propertyProvider)
+        {
+            TestCaseFilterExpression adapterSpecificTestCaseFilter = null;
+            if (this.FilterExpressionWrapper != null)
+            {
+                if (!string.IsNullOrEmpty(this.FilterExpressionWrapper.ParseError))
+                {
+                    throw new TestPlatformFormatException(this.FilterExpressionWrapper.ParseError, this.FilterExpressionWrapper.FilterString);
+                }
+
+                adapterSpecificTestCaseFilter = new TestCaseFilterExpression(this.FilterExpressionWrapper);
+                var invalidProperties = adapterSpecificTestCaseFilter.ValidForProperties(supportedProperties, propertyProvider);
+
+                if (invalidProperties != null)
+                {
+                    var invalidPropertiesString = string.Join(CrossPlatEngineResources.StringSeperator, invalidProperties);
+                    var validPropertiesSttring = supportedProperties == null ? string.Empty : string.Join(CrossPlatEngineResources.StringSeperator, supportedProperties.ToArray());
+                    var errorMessage = string.Format(CultureInfo.CurrentCulture, CrossPlatEngineResources.UnsupportedPropertiesInTestCaseFilter, invalidPropertiesString, validPropertiesSttring);
+
+                    // For unsupported property don’t throw exception, just log the message. Later it is going to handle properly with TestCaseFilterExpression.MatchTestCase().
+                    EqtTrace.Info(errorMessage);
+                }
+            }
+
+            return adapterSpecificTestCaseFilter;
+        }
 
         /// <summary>
         /// Gets or sets the FilterExpressionWrapper instance as created from filter string.

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscoveryManager.cs
@@ -108,6 +108,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Discovery
                     new DiscovererEnumerator(discoveryResultCache).LoadTests(
                         verifiedExtensionSourceMap,
                         RunSettingsUtilities.CreateAndInitializeRunSettings(discoveryCriteria.RunSettings),
+                        discoveryCriteria.TestCaseFilter,
                         this.sessionMessageLogger);
                 }
             }

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/DiscoveryCriteria.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/DiscoveryCriteria.cs
@@ -131,5 +131,11 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Client
         /// </summary>
         [DataMember]
         public string RunSettings { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the criteria for filtering test cases.
+        /// </summary>
+        [DataMember]
+        public string TestCaseFilter {get; set;}
     }
 }

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -144,6 +144,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
 
             // create discovery request
             var criteria = new DiscoveryCriteria(discoveryPayload.Sources, batchSize, this.commandLineOptions.TestStatsEventTimeout, runsettings);
+            criteria.TestCaseFilter = this.commandLineOptions.TestCaseFilterValue;
 
             using (IDiscoveryRequest discoveryRequest = this.testPlatform.CreateDiscoveryRequest(criteria, protocolConfig))
             {

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelProxyDiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelProxyDiscoveryManagerTests.cs
@@ -73,6 +73,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         [TestMethod]
         public void DiscoverTestsShouldProcessAllSources()
         {
+            // Testcase filter should be passed to all parallel discovery criteria.
+            this.testDiscoveryCriteria.TestCaseFilter = "Name~Test";
             var parallelDiscoveryManager = this.SetupDiscoveryManager(this.proxyManagerFunc, 2, false);
 
             Task.Run(() =>
@@ -169,6 +171,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
                             Task.Delay(100).Wait();
 
+                            Assert.AreEqual(this.testDiscoveryCriteria.TestCaseFilter, criteria.TestCaseFilter);
                             handler.HandleDiscoveryComplete(isAbort ? new DiscoveryCompleteEventArgs(-1, isAbort) : new DiscoveryCompleteEventArgs(10, isAbort) , null);
                         });
             }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Discovery/DiscovererEnumeratorTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Discovery/DiscovererEnumeratorTests.cs
@@ -51,7 +51,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
             var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
             extensionSourceMap.Add("_none_", sources);
 
-            this.discovererEnumerator.LoadTests(extensionSourceMap, new Mock<IRunSettings>().Object, mockLogger.Object);
+            this.discovererEnumerator.LoadTests(extensionSourceMap, new Mock<IRunSettings>().Object, null, mockLogger.Object);
 
             var messageFormat =
                 "No test is available in {0}. Make sure that test discoverer & executors are registered and platform & framework version settings are appropriate and try again.";
@@ -73,7 +73,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
             var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
             extensionSourceMap.Add("_none_", sources);
 
-            this.discovererEnumerator.LoadTests(extensionSourceMap, new Mock<IRunSettings>().Object, new Mock<IMessageLogger>().Object);
+            this.discovererEnumerator.LoadTests(extensionSourceMap, new Mock<IRunSettings>().Object, null, new Mock<IMessageLogger>().Object);
 
             Assert.IsFalse(DllTestDiscoverer.IsDiscoverTestCalled);
         }
@@ -98,8 +98,9 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
 
                 var settings = new Mock<IRunSettings>().Object;
                 var logger = new Mock<IMessageLogger>().Object;
+                string testCaseFilter = "TestFilter";
 
-                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, logger);
+                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, testCaseFilter, logger);
 
                 Assert.IsTrue(DllTestDiscoverer.IsDiscoverTestCalled);
                 Assert.IsFalse(JsonTestDiscoverer.IsDiscoverTestCalled);
@@ -107,6 +108,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
                 // Also validate that the right set of arguments were passed on to the discoverer.
                 CollectionAssert.AreEqual(sources, DllTestDiscoverer.Sources.ToList());
                 Assert.AreEqual(settings, DllTestDiscoverer.DiscoveryContext.RunSettings);
+                Assert.AreEqual(testCaseFilter, (DllTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
                 Assert.AreEqual(logger, DllTestDiscoverer.MessageLogger);
                 Assert.IsNotNull(DllTestDiscoverer.DiscoverySink);
             }
@@ -143,8 +145,9 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
 
                 var settings = new Mock<IRunSettings>().Object;
                 var logger = new Mock<IMessageLogger>().Object;
+                string testCaseFilter = "TestFilter";
 
-                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, logger);
+                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, testCaseFilter, logger);
 
                 Assert.IsTrue(DllTestDiscoverer.IsDiscoverTestCalled);
                 Assert.IsTrue(JsonTestDiscoverer.IsDiscoverTestCalled);
@@ -152,11 +155,13 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
                 // Also validate that the right set of arguments were passed on to the discoverer.
                 CollectionAssert.AreEqual(dllsources, DllTestDiscoverer.Sources.ToList());
                 Assert.AreEqual(settings, DllTestDiscoverer.DiscoveryContext.RunSettings);
+                Assert.AreEqual(testCaseFilter, (DllTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
                 Assert.AreEqual(logger, DllTestDiscoverer.MessageLogger);
                 Assert.IsNotNull(DllTestDiscoverer.DiscoverySink);
 
                 CollectionAssert.AreEqual(jsonsources, JsonTestDiscoverer.Sources.ToList());
                 Assert.AreEqual(settings, JsonTestDiscoverer.DiscoveryContext.RunSettings);
+                Assert.AreEqual(testCaseFilter, (JsonTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
                 Assert.AreEqual(logger, JsonTestDiscoverer.MessageLogger);
                 Assert.IsNotNull(JsonTestDiscoverer.DiscoverySink);
             }
@@ -186,8 +191,9 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
 
                 var settings = new Mock<IRunSettings>().Object;
                 var logger = new Mock<IMessageLogger>().Object;
+                string testCaseFilter = "TestFilter";
 
-                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, logger);
+                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, testCaseFilter, logger);
 
                 Assert.IsTrue(DllTestDiscoverer.IsDiscoverTestCalled);
                 Assert.IsFalse(SingletonTestDiscoverer.IsDiscoverTestCalled);
@@ -195,6 +201,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
                 // Also validate that the right set of arguments were passed on to the discoverer.
                 CollectionAssert.AreEqual(new List<string> { sources[1] }, DllTestDiscoverer.Sources.ToList());
                 Assert.AreEqual(settings, DllTestDiscoverer.DiscoveryContext.RunSettings);
+                Assert.AreEqual(testCaseFilter, (DllTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
                 Assert.AreEqual(logger, DllTestDiscoverer.MessageLogger);
                 Assert.IsNotNull(DllTestDiscoverer.DiscoverySink);
             }
@@ -224,8 +231,9 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
 
                 var settings = new Mock<IRunSettings>().Object;
                 var mocklogger = new Mock<IMessageLogger>();
+                string testCaseFilter = "TestFilter";
 
-                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, mocklogger.Object);
+                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, testCaseFilter, mocklogger.Object);
 
                 Assert.IsTrue(DllTestDiscoverer.IsDiscoverTestCalled);
                 Assert.IsTrue(NotImplementedTestDiscoverer.IsDiscoverTestCalled);
@@ -233,6 +241,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
                 // Also validate that the right set of arguments were passed on to the discoverer.
                 CollectionAssert.AreEqual(new List<string> { sources[1] }, DllTestDiscoverer.Sources.ToList());
                 Assert.AreEqual(settings, DllTestDiscoverer.DiscoveryContext.RunSettings);
+                Assert.AreEqual(testCaseFilter, (DllTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
                 Assert.AreEqual(mocklogger.Object, DllTestDiscoverer.MessageLogger);
                 Assert.IsNotNull(DllTestDiscoverer.DiscoverySink);
 
@@ -349,8 +358,9 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
 
                 var settings = new Mock<IRunSettings>().Object;
                 var logger = new Mock<IMessageLogger>().Object;
+                string testCaseFilter = "TestFilter";
 
-                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, logger);
+                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, testCaseFilter, logger);
 
                 Assert.IsTrue(DllTestDiscoverer.IsDiscoverTestCalled);
                 Assert.IsTrue(JsonTestDiscoverer.IsDiscoverTestCalled);
@@ -358,11 +368,13 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
                 // Also validate that the right set of arguments were passed on to the discoverer.
                 CollectionAssert.AreEqual(dllsources, DllTestDiscoverer.Sources.ToList());
                 Assert.AreEqual(settings, DllTestDiscoverer.DiscoveryContext.RunSettings);
+                Assert.AreEqual(testCaseFilter, (DllTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
                 Assert.AreEqual(logger, DllTestDiscoverer.MessageLogger);
                 Assert.IsNotNull(DllTestDiscoverer.DiscoverySink);
 
                 CollectionAssert.AreEqual(jsonsources, JsonTestDiscoverer.Sources.ToList());
                 Assert.AreEqual(settings, JsonTestDiscoverer.DiscoveryContext.RunSettings);
+                Assert.AreEqual(testCaseFilter, (JsonTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
                 Assert.AreEqual(logger, JsonTestDiscoverer.MessageLogger);
                 Assert.IsNotNull(JsonTestDiscoverer.DiscoverySink);
             }
@@ -396,7 +408,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
             var settings = new Mock<IRunSettings>().Object;
             var logger = new Mock<IMessageLogger>().Object;
 
-            this.discovererEnumerator.LoadTests(extensionSourceMap, settings, logger);
+            this.discovererEnumerator.LoadTests(extensionSourceMap, settings, null, logger);
         }
 
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Discovery/DiscoveryContextTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Discovery/DiscoveryContextTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
+{
+    using System.Collections.Generic;
+
+    using Microsoft.VisualStudio.TestPlatform.Common.Filtering;
+    using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Discovery;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using MSTest.TestFramework.AssertExtensions;
+
+    [TestClass]
+    public class DiscoveryContextTests
+    {
+        private DiscoveryContext discoveryContext;
+
+        [TestInitialize]
+        public void TestInit()
+        {
+            this.discoveryContext = new DiscoveryContext();
+        }
+
+        /// <summary>
+        /// GetTestCaseFilter should return null in case filter expression is null
+        /// </summary>
+        [TestMethod]
+        public void GetTestCaseFilterShouldReturnNullIfFilterExpressionIsNull()
+        {
+            this.discoveryContext.FilterExpressionWrapper = null;
+
+            Assert.IsNull(this.discoveryContext.GetTestCaseFilter(null, (s) => { return null; }));
+        }
+
+        /// <summary>
+        /// If only property value passed, consider property key and operation defaults.
+        /// </summary>
+        [TestMethod]
+        public void GetTestCaseFilterShouldNotThrowIfPropertyValueOnlyPassed()
+        {
+            this.discoveryContext.FilterExpressionWrapper = new FilterExpressionWrapper("Infinity");
+
+            var filter = this.discoveryContext.GetTestCaseFilter(new List<string>{ "FullyQualifiedName" }, (s) => { return null; });
+
+            Assert.IsNotNull(filter);
+        }
+
+        /// <summary>
+        /// Exception should not be thrown in case invalid properties passed in filter expression.
+        /// </summary>
+        [TestMethod]
+        public void GetTestCaseFilterShouldNotThrowOnInvalidProperties()
+        {
+            this.discoveryContext.FilterExpressionWrapper = new FilterExpressionWrapper("highlyunlikelyproperty=unused");
+
+            var filter = this.discoveryContext.GetTestCaseFilter(new List<string> { "TestCategory" }, (s) => { return null; });
+
+            Assert.IsNotNull(filter);
+        }
+
+        /// <summary>
+        /// GetTestCaseFilter should return correct filter as present in filter expression.
+        /// </summary>
+        [TestMethod]
+        public void GetTestCaseFilterShouldReturnTestCaseFilter()
+        {
+            this.discoveryContext.FilterExpressionWrapper = new FilterExpressionWrapper("TestCategory=Important");
+
+            var filter = this.discoveryContext.GetTestCaseFilter(new List<string> { "TestCategory" }, (s) => { return null; });
+
+            Assert.IsNotNull(filter);
+            Assert.AreEqual("TestCategory=Important", filter.TestCaseFilterValue);
+        }
+    }
+}

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Client/DiscoveryCriteriaTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Client/DiscoveryCriteriaTests.cs
@@ -26,12 +26,13 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests.Client
                                          new[] { "sampleTest.dll" },
                                          100,
                                          "<RunConfiguration></RunConfiguration>");
+            this.discoveryCriteria.TestCaseFilter = "TestFilter";
         }
 
         [TestMethod]
         public void DiscoveryCriteriaSerializesToExpectedJson()
         {
-            var expectedJson = "{\"Package\":null,\"AdapterSourceMap\":{\"_none_\":[\"sampleTest.dll\"]},\"FrequencyOfDiscoveredTestsEvent\":100,\"DiscoveredTestEventTimeout\":\"10675199.02:48:05.4775807\",\"RunSettings\":\"<RunConfiguration></RunConfiguration>\"}";
+            var expectedJson = "{\"Package\":null,\"AdapterSourceMap\":{\"_none_\":[\"sampleTest.dll\"]},\"FrequencyOfDiscoveredTestsEvent\":100,\"DiscoveredTestEventTimeout\":\"10675199.02:48:05.4775807\",\"RunSettings\":\"<RunConfiguration></RunConfiguration>\",\"TestCaseFilter\":\"TestFilter\"}";
 
             var json = JsonConvert.SerializeObject(this.discoveryCriteria, Settings);
 
@@ -41,13 +42,14 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests.Client
         [TestMethod]
         public void DiscoveryCriteriaShouldBeDeserializable()
         {
-            var json = "{\"Sources\":[\"sampleTest.dll\"],\"AdapterSourceMap\":{\"_none_\":[\"sampleTest.dll\"]},\"FrequencyOfDiscoveredTestsEvent\":100,\"DiscoveredTestEventTimeout\":\"10675199.02:48:05.4775807\",\"RunSettings\":\"<RunConfiguration></RunConfiguration>\"}";
+            var json = "{\"Sources\":[\"sampleTest.dll\"],\"AdapterSourceMap\":{\"_none_\":[\"sampleTest.dll\"]},\"FrequencyOfDiscoveredTestsEvent\":100,\"DiscoveredTestEventTimeout\":\"10675199.02:48:05.4775807\",\"RunSettings\":\"<RunConfiguration></RunConfiguration>\",\"TestCaseFilter\":\"TestFilter\"}";
 
             var criteria = JsonConvert.DeserializeObject<DiscoveryCriteria>(json, Settings);
 
             Assert.AreEqual(TimeSpan.MaxValue, criteria.DiscoveredTestEventTimeout);
             Assert.AreEqual(100, criteria.FrequencyOfDiscoveredTestsEvent);
             Assert.AreEqual("<RunConfiguration></RunConfiguration>", criteria.RunSettings);
+            Assert.AreEqual("TestFilter", criteria.TestCaseFilter);
             Assert.AreEqual("sampleTest.dll", criteria.AdapterSourceMap["_none_"].Single());
             CollectionAssert.AreEqual(new[] { "sampleTest.dll" }, criteria.Sources.ToArray());
         }

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -157,9 +157,18 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
                 }).Returns(mockDiscoveryRequest.Object);
 
             var mockDiscoveryRegistrar = new Mock<ITestDiscoveryEventsRegistrar>();
+
+            string testCaseFilterValue = "TestFilter";
+            CommandLineOptions.Instance.TestCaseFilterValue = testCaseFilterValue;
+            this.testRequestManager = new TestRequestManager(CommandLineOptions.Instance,
+                this.mockTestPlatform.Object,
+                TestLoggerManager.Instance,
+                TestRunResultAggregator.Instance,
+                this.mockTestPlatformEventSource.Object);
             var success = this.testRequestManager.DiscoverTests(payload, mockDiscoveryRegistrar.Object, It.IsAny<ProtocolConfig>());
 
             Assert.IsTrue(success, "DiscoverTests call must succeed");
+            Assert.AreEqual(testCaseFilterValue, actualDiscoveryCriteria.TestCaseFilter, "TestCaseFilter must be set");
 
             Assert.AreEqual(createDiscoveryRequestCalled, 1, "CreateDiscoveryRequest must be invoked only once.");
             Assert.AreEqual(2, actualDiscoveryCriteria.Sources.Count(), "All Sources must be used for discovery request");


### PR DESCRIPTION
**Contains following changes**:
1. Setting filter expression in discovery context
2. Exposing GetTestCaseFilter from discovery context

**Workaround**:
Instead of exposing GettestcaseFilter from IDiscoveryContext, GetTestCaseFilter is a method of DiscoveryContext. Thus, all adapters need to use reflection to access GetTestCaseFilter. 

Addition of GetTestCaseFilter in IDiscoveryContext can be done when callout to all adapters is made that adapter version having these changes can no longer support old vs versions.