### PR TITLE
Remove testhost directory from vsix.

### DIFF
--- a/src/package/VSIXProject/TestPlatform.csproj
+++ b/src/package/VSIXProject/TestPlatform.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <TestPlatformRoot>..\..\..\</TestPlatformRoot>
@@ -101,12 +101,12 @@
     <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\CppUnitFramework\*.*" Exclude="$(VsixInputFileLocation)\Extensions\CppUnitFramework\*.pdb">
       <VSIXSubPath>Extensions\CppUnitFramework</VSIXSubPath>
     </VsixSourceItem>
-
-    <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\TestImpact\x64\*.*">
-      <VSIXSubPath>Extensions\TestImpact\x64</VSIXSubPath>
+    
+    <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\TestImpact\ComComponents\x64\*.*">
+      <VSIXSubPath>Extensions\TestImpact\ComComponents\x64</VSIXSubPath>
     </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\TestImpact\x86\*.*">
-      <VSIXSubPath>Extensions\TestImpact\x86</VSIXSubPath>
+    <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\TestImpact\ComComponents\x86\*.*">
+      <VSIXSubPath>Extensions\TestImpact\ComComponents\x86</VSIXSubPath>
     </VsixSourceItem>
 
     <!-- Test host dependencies -->

--- a/src/package/VSIXProject/TestPlatform.csproj
+++ b/src/package/VSIXProject/TestPlatform.csproj
@@ -102,66 +102,11 @@
       <VSIXSubPath>Extensions\CppUnitFramework</VSIXSubPath>
     </VsixSourceItem>
 
-    <VsixSourceItem Include="$(VsixInputFileLocation)\TestHost\ComComponents\x64\*.*">
-      <VSIXSubPath>TestHost\ComComponents\x64</VSIXSubPath>
-    </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\TestHost\ComComponents\x86\*.*">
-      <VSIXSubPath>TestHost\ComComponents\x86</VSIXSubPath>
-    </VsixSourceItem>
     <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\TestImpact\ComComponents\x64\*.*">
       <VSIXSubPath>Extensions\TestImpact\ComComponents\x64</VSIXSubPath>
     </VsixSourceItem>
     <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\TestImpact\ComComponents\x86\*.*">
       <VSIXSubPath>Extensions\TestImpact\ComComponents\x86</VSIXSubPath>
-    </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\TestHost\*.*" Exclude="$(VsixInputFileLocation)\TestHost\*.pdb" >
-      <VSIXSubPath>TestHost</VSIXSubPath>
-    </VsixSourceItem>
-    <!-- Testhost localized resources -->
-    <VsixSourceItem Include="$(VsixInputFileLocation)\TestHost\cs\*.dll">
-      <VSIXSubPath>TestHost\cs</VSIXSubPath>
-    </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\TestHost\de\*.dll">
-      <VSIXSubPath>TestHost\de</VSIXSubPath>
-    </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\TestHost\es\*.dll">
-      <VSIXSubPath>TestHost\es</VSIXSubPath>
-    </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\TestHost\fr\*.dll">
-      <VSIXSubPath>TestHost\fr</VSIXSubPath>
-    </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\TestHost\it\*.dll">
-      <VSIXSubPath>TestHost\it</VSIXSubPath>
-    </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\TestHost\ja\*.dll">
-      <VSIXSubPath>TestHost\ja</VSIXSubPath>
-    </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\TestHost\ko\*.dll">
-      <VSIXSubPath>TestHost\ko</VSIXSubPath>
-    </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\TestHost\pl\*.dll">
-      <VSIXSubPath>TestHost\pl</VSIXSubPath>
-    </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\TestHost\pt-BR\*.dll">
-      <VSIXSubPath>TestHost\pt-BR</VSIXSubPath>
-    </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\TestHost\ru\*.dll">
-      <VSIXSubPath>TestHost\ru</VSIXSubPath>
-    </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\TestHost\tr\*.dll">
-      <VSIXSubPath>TestHost\tr</VSIXSubPath>
-    </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\TestHost\zh-Hans\*.dll">
-      <VSIXSubPath>TestHost\zh-Hans</VSIXSubPath>
-    </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\TestHost\zh-Hant\*.dll">
-      <VSIXSubPath>TestHost\zh-Hant</VSIXSubPath>
-    </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\TestHost\x86\*.dll">
-      <VSIXSubPath>TestHost\x86</VSIXSubPath>
-    </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\TestHost\x64\*.dll">
-      <VSIXSubPath>TestHost\x64</VSIXSubPath>
     </VsixSourceItem>
 
     <VsixSourceItem Include="$(VsixInputFileLocation)\*.*" Exclude="$(VsixInputFileLocation)\*.pdb" />

--- a/src/package/VSIXProject/TestPlatform.csproj
+++ b/src/package/VSIXProject/TestPlatform.csproj
@@ -102,11 +102,19 @@
       <VSIXSubPath>Extensions\CppUnitFramework</VSIXSubPath>
     </VsixSourceItem>
 
-    <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\TestImpact\ComComponents\x64\*.*">
-      <VSIXSubPath>Extensions\TestImpact\ComComponents\x64</VSIXSubPath>
+    <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\TestImpact\x64\*.*">
+      <VSIXSubPath>Extensions\TestImpact\x64</VSIXSubPath>
     </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\TestImpact\ComComponents\x86\*.*">
-      <VSIXSubPath>Extensions\TestImpact\ComComponents\x86</VSIXSubPath>
+    <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\TestImpact\x86\*.*">
+      <VSIXSubPath>Extensions\TestImpact\x86</VSIXSubPath>
+    </VsixSourceItem>
+
+    <!-- Test host dependencies -->
+    <VsixSourceItem Include="$(VsixInputFileLocation)\x64\*.*">
+      <VSIXSubPath>x64</VSIXSubPath>
+    </VsixSourceItem>
+    <VsixSourceItem Include="$(VsixInputFileLocation)\x86\*.*">
+      <VSIXSubPath>x86</VSIXSubPath>
     </VsixSourceItem>
 
     <VsixSourceItem Include="$(VsixInputFileLocation)\*.*" Exclude="$(VsixInputFileLocation)\*.pdb" />


### PR DESCRIPTION
This is a follow up to the flattening of test host. Nuget flattening has
been completed earlier.