### PR TITLE
Put quotes around TestHost path so in case of spaces in name it starts correctly

### DIFF
--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -169,7 +169,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
                 !this.processHelper.GetCurrentProcessFileName().EndsWith(DotnetHostHelper.MONOEXENAME, StringComparison.OrdinalIgnoreCase))
             {
                 launcherPath = this.dotnetHostHelper.GetMonoPath();
-                argumentsString = testhostProcessPath + " " + argumentsString;
+                argumentsString = testhostProcessPath.AddDoubleQuote() + " " + argumentsString;
             }
 
             // For IDEs and other scenario, current directory should be the

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -162,7 +162,7 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
                 default(TestRunnerConnectionInfo));
 
             Assert.AreEqual("/usr/bin/mono", info.FileName);
-            StringAssert.Contains(info.Arguments, "TestHost" + Path.DirectorySeparatorChar + "testhost.exe");
+            StringAssert.Contains(info.Arguments, "TestHost" + Path.DirectorySeparatorChar + "testhost.exe\"");
         }
 
         [TestMethod]


### PR DESCRIPTION
This is issue for Visual Studio for Mac, because application is installed in "/Applications/Visual Studio.app/..." which means it has space in path..