### PR TITLE
Call abort in place of Cancel if test session timeout reach

### DIFF
--- a/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
+++ b/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
@@ -188,7 +188,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.Execution
 
             this.HandleLogMessage(TestMessageLevel.Error, message);
             this.HandleRawMessage(rawMessage);
-            this.CancelAsync();
+            this.Abort();
         }
 
         /// <summary>

--- a/src/Microsoft.TestPlatform.Client/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.Client/Resources/Resources.Designer.cs
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Canceling test run: test run timeout of {0} milliseconds exceeded..
+        ///   Looks up a localized string similar to Aborting test run: test run timeout of {0} milliseconds exceeded..
         /// </summary>
         internal static string TestSessionTimeoutMessage
         {

--- a/src/Microsoft.TestPlatform.Client/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.Client/Resources/Resources.resx
@@ -121,7 +121,7 @@
     <value>The test run could not be executed because the initial state was invalid.</value>
   </data>
   <data name="TestSessionTimeoutMessage" xml:space="preserve">
-    <value>Canceling test run: test run timeout of {0} milliseconds exceeded.</value>
+    <value>Aborting test run: test run timeout of {0} milliseconds exceeded.</value>
   </data>
   <data name="WaitForCompletionOperationIsNotAllowedWhenNoTestRunIsActive" xml:space="preserve">
     <value>Wait for completion operation is not allowed when there is no active test run. </value>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.cs.xlf
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="TestSessionTimeoutMessage">
-        <source>Canceling test run: test run timeout of {0} milliseconds exceeded.</source>
+        <source>Aborting test run: test run timeout of {0} milliseconds exceeded.</source>
         <target state="new">Canceling test run as it crossed testSessionTimeout: {0} milliseconds.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.de.xlf
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="TestSessionTimeoutMessage">
-        <source>Canceling test run: test run timeout of {0} milliseconds exceeded.</source>
+        <source>Aborting test run: test run timeout of {0} milliseconds exceeded.</source>
         <target state="new">Canceling test run as it crossed testSessionTimeout: {0} milliseconds.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.es.xlf
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="TestSessionTimeoutMessage">
-        <source>Canceling test run: test run timeout of {0} milliseconds exceeded.</source>
+        <source>Aborting test run: test run timeout of {0} milliseconds exceeded.</source>
         <target state="new">Canceling test run as it crossed testSessionTimeout: {0} milliseconds.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.fr.xlf
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="TestSessionTimeoutMessage">
-        <source>Canceling test run: test run timeout of {0} milliseconds exceeded.</source>
+        <source>Aborting test run: test run timeout of {0} milliseconds exceeded.</source>
         <target state="new">Canceling test run as it crossed testSessionTimeout: {0} milliseconds.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.it.xlf
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="TestSessionTimeoutMessage">
-        <source>Canceling test run: test run timeout of {0} milliseconds exceeded.</source>
+        <source>Aborting test run: test run timeout of {0} milliseconds exceeded.</source>
         <target state="new">Canceling test run as it crossed testSessionTimeout: {0} milliseconds.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.ja.xlf
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="TestSessionTimeoutMessage">
-        <source>Canceling test run: test run timeout of {0} milliseconds exceeded.</source>
+        <source>Aborting test run: test run timeout of {0} milliseconds exceeded.</source>
         <target state="new">Canceling test run as it crossed testSessionTimeout: {0} milliseconds.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.ko.xlf
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="TestSessionTimeoutMessage">
-        <source>Canceling test run: test run timeout of {0} milliseconds exceeded.</source>
+        <source>Aborting test run: test run timeout of {0} milliseconds exceeded.</source>
         <target state="new">Canceling test run as it crossed testSessionTimeout: {0} milliseconds.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.pl.xlf
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="TestSessionTimeoutMessage">
-        <source>Canceling test run: test run timeout of {0} milliseconds exceeded.</source>
+        <source>Aborting test run: test run timeout of {0} milliseconds exceeded.</source>
         <target state="new">Canceling test run as it crossed testSessionTimeout: {0} milliseconds.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.pt-BR.xlf
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="TestSessionTimeoutMessage">
-        <source>Canceling test run: test run timeout of {0} milliseconds exceeded.</source>
+        <source>Aborting test run: test run timeout of {0} milliseconds exceeded.</source>
         <target state="new">Canceling test run as it crossed testSessionTimeout: {0} milliseconds.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.ru.xlf
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="TestSessionTimeoutMessage">
-        <source>Canceling test run: test run timeout of {0} milliseconds exceeded.</source>
+        <source>Aborting test run: test run timeout of {0} milliseconds exceeded.</source>
         <target state="new">Canceling test run as it crossed testSessionTimeout: {0} milliseconds.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.tr.xlf
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="TestSessionTimeoutMessage">
-        <source>Canceling test run: test run timeout of {0} milliseconds exceeded.</source>
+        <source>Aborting test run: test run timeout of {0} milliseconds exceeded.</source>
         <target state="new">Canceling test run as it crossed testSessionTimeout: {0} milliseconds.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.xlf
@@ -11,7 +11,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="TestSessionTimeoutMessage">
-        <source>Canceling test run: test run timeout of {0} milliseconds exceeded.</source>
+        <source>Aborting test run: test run timeout of {0} milliseconds exceeded.</source>
         <target state="new">Canceling test run as it crossed testSessionTimeout: {0} milliseconds.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.zh-Hans.xlf
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="TestSessionTimeoutMessage">
-        <source>Canceling test run: test run timeout of {0} milliseconds exceeded.</source>
+        <source>Aborting test run: test run timeout of {0} milliseconds exceeded.</source>
         <target state="new">Canceling test run as it crossed testSessionTimeout: {0} milliseconds.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.zh-Hant.xlf
@@ -39,7 +39,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="14" adjWordcount="11.9" curWordcount="11.9"</note>
       </trans-unit>
       <trans-unit id="TestSessionTimeoutMessage">
-        <source>Canceling test run: test run timeout of {0} milliseconds exceeded.</source>
+        <source>Aborting test run: test run timeout of {0} milliseconds exceeded.</source>
         <target state="new">Canceling test run as it crossed testSessionTimeout: {0} milliseconds.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyExecutionManager.cs
@@ -23,6 +23,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel
     {
         #region TestRunSpecificData
 
+        private bool abortRequested = false;
+
         private int runCompletedClients = 0;
         private int runStartedClients = 0;
         private int availableTestSources = -1;
@@ -121,6 +123,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel
 
         public void Abort()
         {
+            abortRequested = true;
             this.DoActionOnAllManagers((proxyManager) => proxyManager.Abort(), doActionsInParallel: true);
         }
 
@@ -162,7 +165,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel
                 // So, we need to keep track of total runcomplete calls
                 this.runCompletedClients++;
 
-                if (testRunCompleteArgs.IsCanceled)
+                if (testRunCompleteArgs.IsCanceled || abortRequested)
                 {
                     allRunsCompleted = this.runCompletedClients == this.runStartedClients;
                 }
@@ -215,7 +218,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel
 
             // If cancel is triggered for any one run, there is no reason to fetch next source
             // and queue another test run
-            if (!testRunCompleteArgs.IsCanceled)
+            if (!testRunCompleteArgs.IsCanceled && !abortRequested)
             {
                 this.StartTestRunOnConcurrentManager(proxyExecutionManager);
             }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyExecutionManager.cs
@@ -23,6 +23,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel
     {
         #region TestRunSpecificData
 
+        // This variable id to differentiate between implicit (abort requested by testPlatform) and explicit (test host aborted) abort.
         private bool abortRequested = false;
 
         private int runCompletedClients = 0;
@@ -123,6 +124,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel
 
         public void Abort()
         {
+            // Test platform initiated abort.
             abortRequested = true;
             this.DoActionOnAllManagers((proxyManager) => proxyManager.Abort(), doActionsInParallel: true);
         }
@@ -216,7 +218,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel
                 this.AddManager(proxyExecutionManager, parallelEventsHandler);
             }
 
-            // If cancel is triggered for any one run, there is no reason to fetch next source
+            // If cancel is triggered for any one run or abort is requested by test platform, there is no reason to fetch next source
             // and queue another test run
             if (!testRunCompleteArgs.IsCanceled && !abortRequested)
             {

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -428,7 +428,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
             {
                 string testCountDetails;
 
-                if(e.IsAborted || e.IsCanceled)
+                if (e.IsAborted || e.IsCanceled)
                 {
                     testCountDetails = string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryForCanceledOrAbortedRun, testsPassed, testsFailed, testsSkipped);
                 }
@@ -438,24 +438,27 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
                 }
 
                 Output.Information(false, testCountDetails);
+            }
 
-                if (e.IsCanceled)
-                {
-                    Output.Error(false, CommandLineResources.TestRunCanceled);
-                }
-                else if (e.IsAborted)
-                {
-                    Output.Error(false, CommandLineResources.TestRunAborted);
-                }
-                else if (this.testOutcome == TestOutcome.Failed)
-                {
-                    Output.Error(false, CommandLineResources.TestRunFailed);
-                }
-                else
-                {
-                    Output.Information(false, ConsoleColor.Green, CommandLineResources.TestRunSuccessful);
-                }
+            if (e.IsCanceled)
+            {
+                Output.Error(false, CommandLineResources.TestRunCanceled);
+            }
+            else if (e.IsAborted)
+            {
+                Output.Error(false, CommandLineResources.TestRunAborted);
+            }
+            else if (this.testOutcome == TestOutcome.Failed && this.testsTotal > 0)
+            {
+                Output.Error(false, CommandLineResources.TestRunFailed);
+            }
+            else if(this.testsTotal > 0)
+            {
+                Output.Information(false, ConsoleColor.Green, CommandLineResources.TestRunSuccessful);
+            }
 
+            if (this.testsTotal > 0)
+            {
                 if (!e.ElapsedTimeInRunningTests.Equals(TimeSpan.Zero))
                 {
                     PrintTimeSpan(e.ElapsedTimeInRunningTests);

--- a/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
@@ -108,8 +108,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             arguments = string.Concat(arguments, " -- RunConfiguration.TestSessionTimeout=7000");
             this.InvokeVsTest(arguments);
 
-            this.StdErrorContains("Test Run Canceled.");
-            this.StdErrorContains("Canceling test run: test run timeout of 7000 milliseconds exceeded.");
+            this.StdErrorContains("Test Run Aborted.");
+            this.StdErrorContains("Aborting test run: test run timeout of 7000 milliseconds exceeded.");
             this.StdOutputDoesNotContains("Total tests: 6");
         }
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelProxyExecutionManagerTests.cs
@@ -213,6 +213,22 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         }
 
         [TestMethod]
+        public void StartTestRunShouldNotProcessAllSourcesOnExecutionAborted()
+        {
+            var executionManagerMock = new Mock<IProxyExecutionManager>();
+            var parallelExecutionManager = new ParallelProxyExecutionManager(this.mockRequestData.Object, () => executionManagerMock.Object, 1);
+            this.createdMockManagers.Add(executionManagerMock);
+            this.SetupMockManagers(this.processedSources, isCanceled: false, isAborted: false);
+            SetupHandleTestRunComplete(this.executionCompleted);
+
+            parallelExecutionManager.Abort();
+            Task.Run(() => { parallelExecutionManager.StartTestRun(this.testRunCriteriaWithSources, this.mockHandler.Object); });
+
+            Assert.IsTrue(this.executionCompleted.Wait(taskTimeout), "Test run not completed.");
+            Assert.AreEqual(1, this.processedSources.Count, "Abort should stop all sources execution.");
+        }
+
+        [TestMethod]
         public void StartTestRunShouldProcessAllSourcesOnExecutionAbortsForAnySource()
         {
             var executionManagerMock = new Mock<IProxyExecutionManager>();

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -507,7 +507,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
             this.mockOutput.Verify(o => o.WriteLine(CommandLineResources.TestRunAborted, OutputLevel.Error), Times.Once());
         }
 
-
         [TestMethod]
         public void TestRunCompleteHandlerShouldWriteToConsoleIfTestsAborted()
         {

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -472,6 +472,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
         }
 
         [TestMethod]
+        public void TestRunCompleteHandlerShouldWriteToConsoleIfTestsCanceledWithoutRunningAnyTest()
+        {
+            // Raise an event on mock object
+            this.testRunRequest.Raise(m => m.OnRunCompletion += null, new TestRunCompleteEventArgs(null, true, false, null, null, new TimeSpan(1, 0, 0, 0)));
+            this.mockOutput.Verify(o => o.WriteLine(CommandLineResources.TestRunCanceled, OutputLevel.Error), Times.Once());
+        }
+
+        [TestMethod]
         public void TestRunCompleteHandlerShouldNotWriteTolatTestToConsoleIfTestsCanceled()
         {
             // Raise an event on mock object raised to register test case count and mark Outcome as Outcome.Failed
@@ -499,6 +507,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
             this.mockOutput.Verify(o => o.WriteLine(CommandLineResources.TestRunAborted, OutputLevel.Error), Times.Once());
         }
 
+
         [TestMethod]
         public void TestRunCompleteHandlerShouldWriteToConsoleIfTestsAborted()
         {
@@ -510,6 +519,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
             this.testRunRequest.Raise(m => m.OnRunCompletion += null, new TestRunCompleteEventArgs(null, false, true, null, null, new TimeSpan(1, 0, 0, 0)));
 
             this.mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryForCanceledOrAbortedRun, 0, 1, 0), OutputLevel.Information), Times.Once());
+            this.mockOutput.Verify(o => o.WriteLine(CommandLineResources.TestRunAborted, OutputLevel.Error), Times.Once());
+        }
+
+        [TestMethod]
+        public void TestRunCompleteHandlerShouldWriteToConsoleIfTestsAbortedWithoutRunningAnyTest()
+        {
+            // Raise an event on mock object
+            this.testRunRequest.Raise(m => m.OnRunCompletion += null, new TestRunCompleteEventArgs(null, false, true, null, null, new TimeSpan(1, 0, 0, 0)));
             this.mockOutput.Verify(o => o.WriteLine(CommandLineResources.TestRunAborted, OutputLevel.Error), Times.Once());
         }
 


### PR DESCRIPTION
**Issue1:** Suppose there are two test in one project, first one takes 2 second and second one takes 2 minutes and we are using TestSessionTimeout=5000 (5 second). vstest.console.exe runs both test.

Expected: Only first test should run and abort should get called.
Actual: vstest,console is sending cancel request to adapter. Adapter runs second test and then abort run.

**Issue2:**: https://github.com/Microsoft/vstest/issues/1077 