### PR TITLE
Make TPV2 trx and console logger compatible with Tpv1

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
         /// <summary>
         /// Uri used to uniquely identify the TRX logger.
         /// </summary>
-        public const string ExtensionUri = "logger://Microsoft/TestPlatform/TrxLogger/v2";
+        public const string ExtensionUri = "logger://Microsoft/TestPlatform/TrxLogger/v1";
 
         /// <summary>
         /// Alternate user friendly string to uniquely identify the console logger.

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
         /// <summary>
         /// Uri used to uniquely identify the console logger.
         /// </summary>
-        public const string ExtensionUri = "logger://Microsoft/TestPlatform/ConsoleLogger/v2";
+        public const string ExtensionUri = "logger://Microsoft/TestPlatform/ConsoleLogger/v1";
 
         /// <summary>
         /// Alternate user friendly string to uniquely identify the console logger.

--- a/test/Microsoft.TestPlatform.AcceptanceTests/LoggerTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/LoggerTests.cs
@@ -14,8 +14,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
     {
         [CustomDataTestMethod]
         [NETFullTargetFramework(inIsolation: true, inProcess: true)]
-        [NETCORETargetFramework]
-        public void TrxLoggerShouldProperlyOverwriteFile(RunnerInfo runnerInfo)
+        public void TrxLoggerWithFriendlyNameShouldProperlyOverwriteFile(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
 
@@ -30,6 +29,26 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             this.InvokeVsTest(arguments);
 
             var trxLogFilePath = Path.Combine(Directory.GetCurrentDirectory(), "TestResults",  trxFileName);
+            Assert.IsTrue(IsValidXml(trxLogFilePath), "Invalid content in Trx log file");
+        }
+
+        [CustomDataTestMethod]
+        [NETCORETargetFramework]
+        public void TrxLoggerWithExecutorUriShouldProperlyOverwriteFile(RunnerInfo runnerInfo)
+        {
+            AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+
+            var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            var trxFileName = "TestResults.trx";
+            arguments = string.Concat(arguments, $" /logger:\"logger://Microsoft/TestPlatform/TrxLogger/v1;LogFileName{trxFileName}\"");
+            this.InvokeVsTest(arguments);
+
+            arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            arguments = string.Concat(arguments, $" /logger:\"logger://Microsoft/TestPlatform/TrxLogger/v1;LogFileName={trxFileName}\"");
+            arguments = string.Concat(arguments, " /testcasefilter:Name~Pass");
+            this.InvokeVsTest(arguments);
+
+            var trxLogFilePath = Path.Combine(Directory.GetCurrentDirectory(), "TestResults", trxFileName);
             Assert.IsTrue(IsValidXml(trxLogFilePath), "Invalid content in Trx log file");
         }
 

--- a/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             var executor = new EnableLoggerArgumentExecutor(testloggerManager);
 
             executor.Initialize("console;verbosity=minimal");
-            Assert.IsTrue(testloggerManager.GetInitializedLoggers.Contains("logger://Microsoft/TestPlatform/ConsoleLogger/v2"));
+            Assert.IsTrue(testloggerManager.GetInitializedLoggers.Contains("logger://Microsoft/TestPlatform/ConsoleLogger/v1"));
         }
 
         [TestMethod]


### PR DESCRIPTION
Steps to reproduce:

1. Run TPv2 console runner with following command line:
```
G:\vs\2017\Enterprise\vsualm\Common7\IDE\Extensions\TestPlatform\vstest.console.exe  /InIsolation /Tests:Anycpu4xDllWithNoSetting_MSTEST /Settings:C:\Users\armahapa\AppData\Local\Temp\tmpCDDD.tmp /Framework:Framework45 MSTestcsharpAnycpu4x.dll /logger:logger://Microsoft/TestPlatform/ConsoleLogger/v1
   STDOUT : Microsoft (R) Test Execution Command Line Tool Version 15.5.0-preview-20170810-02Copyright (c) Microsoft Corporation.  All rights reserved.The /InIsolation flag is deprecated. The tests are always run in a separate processStarting test discovery, please wait...
   STDERROR
 Could not find a test logger with URI or FriendlyName 'logger://Microsoft/TestPlatform/ConsoleLogger/v1'.
```

Expected
Test runs

Actual
Test does not run, error shows for logger not found.


Fix for issue: https://devdiv.visualstudio.com/DevDiv/VS.in%20Agile%20Testing%20IDE/_workitems/edit/489780