### PR TITLE
Updating QualityTools Nuget package for Generic Test fix

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -360,7 +360,7 @@ function Create-VsixPackage
     Copy-Item -Recurse $legacyDir\* $packageDir -Force
 
     # Copy QtAgent Related depedencies
-    $legacyDir = Join-Path $env:TP_PACKAGES_DIR "Microsoft.VisualStudio.QualityTools\15.5.0-preview-1006826\contentFiles\any\any"
+    $legacyDir = Join-Path $env:TP_PACKAGES_DIR "Microsoft.VisualStudio.QualityTools\15.5.0-preview-1019337\contentFiles\any\any"
     Copy-Item -Recurse $legacyDir\* $packageDir -Force
 
     # Copy Legacy data collectors Related depedencies

--- a/src/package/external/external.csproj
+++ b/src/package/external/external.csproj
@@ -50,7 +50,7 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.QualityTools">
-      <Version>15.5.0-preview-1006826</Version>
+      <Version>15.5.0-preview-1019337</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.QualityTools.DataCollectors">


### PR DESCRIPTION
Validated that locally built VSIX and Nuget Package has SummaryResult.xsd file.