### PR TITLE
Fix generate runsettings for fakes scenarios

### DIFF
--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -247,8 +247,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
 
             this.CollectMetrics(requestData, runConfiguration);
 
-            if (!commandLineOptions.IsDesignMode && string.IsNullOrWhiteSpace(runsettings))
+            if (!commandLineOptions.IsDesignMode)
             {
+                // Generate fakes settings only for command line scenarios. In case of
+                // Editors/IDEs, this responsibility is with the caller.
                 GenerateFakesUtilities.GenerateFakesSettings(this.commandLineOptions, this.commandLineOptions.Sources.ToList(), ref runsettings);
             }
 


### PR DESCRIPTION
A check for empty runsettings is not necessary to enables fakes.