### PR TITLE
Add timeout for process WaitForExit

### DIFF
--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
                     process.Exited += (sender, args) =>
                     {
                         // Call WaitForExit without again to ensure all streams are flushed,
-                        // Add timeout to avoid indefinate waiting on child process exists.
+                        // Add timeout to avoid indefinite waiting on child process exist.
                         var p = sender as Process;
                         try
                         {

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -48,11 +48,12 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
                 {
                     process.Exited += (sender, args) =>
                     {
-                        // Call WaitForExit again to ensure all streams are flushed
+                        // Call WaitForExit without again to ensure all streams are flushed,
+                        // Add timeout to avoid indefinate waiting on child process exists.
                         var p = sender as Process;
                         try
                         {
-                            p.WaitForExit();
+                            p.WaitForExit(500);
                         }
                         catch (InvalidOperationException)
                         {


### PR DESCRIPTION
- Vstest.console waiting indefinitely if testhost launch a process and won't kill it.