### PR TITLE
Skip filtering for VSIX extensions

### DIFF
--- a/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
+++ b/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
@@ -149,8 +149,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.DesignMode
 
                         case MessageType.ExtensionsInitialize:
                             {
+                                // Do not filter the Editor/IDE provided extensions by name
                                 var extensionPaths = this.communicationManager.DeserializePayload<IEnumerable<string>>(message);
-                                testRequestManager.InitializeExtensions(extensionPaths, skipFiltering: false);
+                                testRequestManager.InitializeExtensions(extensionPaths, skipExtensionFilters: true);
                                 break;
                             }
 

--- a/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
+++ b/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
@@ -150,7 +150,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.DesignMode
                         case MessageType.ExtensionsInitialize:
                             {
                                 var extensionPaths = this.communicationManager.DeserializePayload<IEnumerable<string>>(message);
-                                testRequestManager.InitializeExtensions(extensionPaths);
+                                testRequestManager.InitializeExtensions(extensionPaths, skipFiltering: false);
                                 break;
                             }
 

--- a/src/Microsoft.TestPlatform.Client/RequestHelper/ITestRequestManager.cs
+++ b/src/Microsoft.TestPlatform.Client/RequestHelper/ITestRequestManager.cs
@@ -19,7 +19,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.RequestHelper
         /// Initializes the extensions while probing additional paths
         /// </summary>
         /// <param name="pathToAdditionalExtensions">Paths to Additional extensions</param>
-        void InitializeExtensions(IEnumerable<string> pathToAdditionalExtensions);
+        /// <param name="skipExtensionFilters">Skip extension filtering by name (if true)</param>
+        void InitializeExtensions(IEnumerable<string> pathToAdditionalExtensions, bool skipExtensionFilters);
 
         /// <summary>
         /// Resets Vstest.console.exe Options

--- a/src/Microsoft.TestPlatform.Client/TestPlatform.cs
+++ b/src/Microsoft.TestPlatform.Client/TestPlatform.cs
@@ -163,11 +163,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Client
         /// The update extensions.
         /// </summary>
         /// <param name="pathToAdditionalExtensions"> The path to additional extensions. </param>
-        /// <param name="loadOnlyWellKnownExtensions"> The load only well known extensions. </param>
-        public void UpdateExtensions(IEnumerable<string> pathToAdditionalExtensions, bool loadOnlyWellKnownExtensions)
+        /// <param name="skipExtensionFilters">Skips filtering by name (if true).</param>
+        public void UpdateExtensions(IEnumerable<string> pathToAdditionalExtensions, bool skipExtensionFilters)
         {
             this.TestEngine.GetExtensionManager()
-                   .UseAdditionalExtensions(pathToAdditionalExtensions, loadOnlyWellKnownExtensions);
+                   .UseAdditionalExtensions(pathToAdditionalExtensions, skipExtensionFilters);
         }
 
         /// <summary>

--- a/src/Microsoft.TestPlatform.Client/TestPlatform.cs
+++ b/src/Microsoft.TestPlatform.Client/TestPlatform.cs
@@ -45,7 +45,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="TestPlatform"/> class.
         /// </summary>
-        /// <param name="isInIsolation">inIsolation command line arg value</param>
         public TestPlatform() : this(new TestEngine(), new FileHelper(), TestRuntimeProviderManager.Instance)
         {
         }
@@ -206,7 +205,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client
                     var extensionAssemblies = new List<string>(this.fileHelper.EnumerateFiles(adapterPath, SearchOption.AllDirectories, TestPlatformConstants.TestAdapterEndsWithPattern, TestPlatformConstants.TestLoggerEndsWithPattern, TestPlatformConstants.RunTimeEndsWithPattern, TestPlatformConstants.SettingsProviderEndsWithPattern));
                     if (extensionAssemblies.Count > 0)
                     {
-                        this.UpdateExtensions(extensionAssemblies, true);
+                        this.UpdateExtensions(extensionAssemblies, skipExtensionFilters: false);
                     }
                 }
             }
@@ -250,7 +249,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client
 
             if (loggersToUpdate.Count > 0)
             {
-                this.UpdateExtensions(loggersToUpdate, true);
+                this.UpdateExtensions(loggersToUpdate, skipExtensionFilters: false);
             }
         }
 

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginCache.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginCache.cs
@@ -223,14 +223,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
         {
             lock (this.lockForExtensionsUpdate)
             {
-                if (EqtTrace.IsVerboseEnabled)
-                {
-                    EqtTrace.Verbose(
-                        "TestPluginCache: Updating loadOnlyWellKnownExtensions from {0} to {1}.",
-                        this.loadOnlyWellKnownExtensions,
-                        shouldLoadOnlyWellKnownExtensions);
-                }
-
                 var extensions = additionalExtensionsPath?.ToList();
                 if (extensions == null || extensions.Count == 0)
                 {
@@ -314,29 +306,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
         }
 
         /// <summary>
-        ///  Checks if a directory exists
-        /// </summary>
-        /// <param name="path"></param>
-        /// <returns></returns>
-        /// <remarks>Added to mock out FileSystem interaction for unit testing.</remarks>
-        internal virtual bool DoesDirectoryExist(string path)
-        {
-            return this.fileHelper.DirectoryExists(path);
-        }
-
-        /// <summary>
-        /// Gets files in a directory.
-        /// </summary>
-        /// <param name="path"></param>
-        /// <param name="endsWithPattern"></param>
-        /// <returns></returns>
-        /// <remarks>Added to mock out FileSystem interaction for unit testing.</remarks>
-        internal virtual string[] GetFilesInDirectory(string path, string endsWithPattern)
-        {
-            return this.fileHelper.EnumerateFiles(path, SearchOption.TopDirectoryOnly, endsWithPattern).ToArray();
-        }
-
-        /// <summary>
         /// Get the files which match the regex pattern
         /// </summary>
         /// <param name="extensions">
@@ -368,7 +337,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
         /// <returns>
         /// The <see cref="Dictionary"/>.
         /// </returns>
-        internal virtual Dictionary<string, TPluginInfo> GetTestExtensions<TPluginInfo, TExtension>(string extensionAssembly) where TPluginInfo : TestPluginInformation
+        internal Dictionary<string, TPluginInfo> GetTestExtensions<TPluginInfo, TExtension>(string extensionAssembly) where TPluginInfo : TestPluginInformation
         {
             // Check if extensions from this assembly have already been discovered.
             var extensions = this.TestExtensions?.GetExtensionsDiscoveredFromAssembly<TPluginInfo>(this.TestExtensions.GetTestExtensionCache<TPluginInfo>(), extensionAssembly);
@@ -469,7 +438,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
 
             var discoverer = new TestPluginDiscoverer();
 
-            return discoverer.GetTestExtensionsInformation<TPluginInfo, TExtension>(extensionPaths, this.loadOnlyWellKnownExtensions);
+            return discoverer.GetTestExtensionsInformation<TPluginInfo, TExtension>(extensionPaths);
         }
 
         private void SetupAssemblyResolver(string extensionAssembly)

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs
@@ -67,17 +67,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
         /// Gets information about each of the test extensions available.
         /// </summary>
         /// <param name="extensionPaths">
-        /// The path to the extensions.
-        /// </param>
-        /// <param name="loadOnlyWellKnownExtensions">
-        /// Should load only well known extensions or all.
+        ///     The path to the extensions.
         /// </param>
         /// <returns>
-        /// The <see cref="Dictionary"/>` of assembly qualified name and testplugin information.
+        /// A dictionary of assembly qualified name and testplugin information.
         /// </returns>
-        public Dictionary<string, TPluginInfo> GetTestExtensionsInformation<TPluginInfo, TExtension>(
-            IEnumerable<string> extensionPaths,
-            bool loadOnlyWellKnownExtensions) where TPluginInfo : TestPluginInformation
+        public Dictionary<string, TPluginInfo> GetTestExtensionsInformation<TPluginInfo, TExtension>(IEnumerable<string> extensionPaths) where TPluginInfo : TestPluginInformation
         {
             Debug.Assert(extensionPaths != null);
 
@@ -89,7 +84,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
                 this.AddKnownExtensions(ref extensionPaths);
             }
 
-            this.GetTestExtensionsFromFiles<TPluginInfo, TExtension>(extensionPaths.ToArray(), loadOnlyWellKnownExtensions, pluginInfos);
+            this.GetTestExtensionsFromFiles<TPluginInfo, TExtension>(extensionPaths.ToArray(), pluginInfos);
 
             return pluginInfos;
         }
@@ -125,9 +120,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
         /// <param name="files">
         /// List of dll's to check for test extension availability
         /// </param>
-        /// <param name="loadOnlyWellKnownExtensions">
-        /// Should load only well known extensions or all.
-        /// </param>
         /// <param name="pluginInfos">
         /// Test plugins collection to add to.
         /// </param>
@@ -135,18 +127,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "We would like to continue discovering all plugins even if some dll in Extensions folder is not able to be load properly")]
         private void GetTestExtensionsFromFiles<TPluginInfo, TExtension>(
             string[] files,
-            bool loadOnlyWellKnownExtensions,
             Dictionary<string, TPluginInfo> pluginInfos) where TPluginInfo : TestPluginInformation
         {
             Debug.Assert(files != null, "null files");
             Debug.Assert(pluginInfos != null, "null pluginInfos");
-
-            // TODO: Do not see why loadOnlyWellKnowExtensions is still needed.
-            // AssemblyName executingAssemblyName = null;
-            // if (loadOnlyWellKnownExtensions)
-            // {
-            //    executingAssemblyName = new AssemblyName(typeof(TestPluginDiscoverer).GetTypeInfo().Assembly.FullName);
-            // }
 
             // Scan each of the files for data extensions.
             foreach (var file in files)
@@ -160,17 +144,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
                     {
                         this.GetTestExtensionsFromAssembly<TPluginInfo, TExtension>(assembly, pluginInfos);
                     }
-
-                    // Check whether this assembly is known or not.
-                    // if (loadOnlyWellKnownExtensions && assembly != null)
-                    // {
-                    //    var extensionAssemblyName = new AssemblyName(assembly.FullName);
-                    //    if (!AssemblyUtilities.PublicKeyTokenMatches(extensionAssemblyName, executingAssemblyName))
-                    //    {
-                    //        EqtTrace.Warning("TestPluginDiscoverer: Ignoring extensions in assembly {0} as it is not a known assembly.", assembly.FullName);
-                    //        continue;
-                    //    }
-                    // }
                 }
                 catch (Exception e)
                 {

--- a/src/Microsoft.TestPlatform.Common/Interfaces/Engine/ClientProtocol/ITestExtensionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/Interfaces/Engine/ClientProtocol/ITestExtensionManager.cs
@@ -5,8 +5,6 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine
 {
     using System.Collections.Generic;
 
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
-
     /// <summary>
     /// Orchestrates extensions for this engine.
     /// </summary>
@@ -15,7 +13,9 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine
         /// <summary>
         /// Update the extensions data
         /// </summary>
-        void UseAdditionalExtensions(IEnumerable<string> pathToAdditionalExtensions, bool loadOnlyWellKnownExtensions);
+        /// <param name="pathToAdditionalExtensions">List of extension paths</param>
+        /// <param name="skipExtensionFilters">Skips filtering of extensions (if true)</param>
+        void UseAdditionalExtensions(IEnumerable<string> pathToAdditionalExtensions, bool skipExtensionFilters);
 
         /// <summary>
         /// Clear the extensions data

--- a/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
 
         private IAssemblyLoadContext platformAssemblyLoadContext;
 
-        private static readonly string[] SupportedFileExtensions = new string[] { ".dll", ".exe" };
+        private static readonly string[] SupportedFileExtensions = { ".dll", ".exe" };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AssemblyResolver"/> class.
@@ -104,11 +104,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
             // args.Name is like: "Microsoft.VisualStudio.TestTools.Common, Version=[VersionMajor].0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a".
             lock (this.resolvedAssemblies)
             {
-                Assembly assembly;
-                if (this.resolvedAssemblies.TryGetValue(args.Name, out assembly))
+                if (this.resolvedAssemblies.TryGetValue(args.Name, out var assembly))
                 {
                     EqtTrace.Info("AssemblyResolver: {0}: Resolved from cache.", args.Name);
-                    return (assembly);
+                    return assembly;
                 }
 
                 AssemblyName requestedName = null;

--- a/src/Microsoft.TestPlatform.Common/Utilities/InstallationContext.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/InstallationContext.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
+{
+    using System.IO;
+    using System.Reflection;
+    using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
+    using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
+
+    public class InstallationContext
+    {
+        private const string DevenvExe = "devenv.exe";
+        private const string PrivateAssembliesDirName = "PrivateAssemblies";
+        private const string PublicAssembliesDirName = "PublicAssemblies";
+
+        private readonly IFileHelper fileHelper;
+
+        public InstallationContext(IFileHelper fileHelper)
+        {
+            this.fileHelper = fileHelper;
+        }
+
+        public bool TryGetVisualStudioDirectory(out string visualStudioDirectory)
+        {
+            var vsInstallPath = new DirectoryInfo(typeof(InstallationContext).GetTypeInfo().Assembly.GetAssemblyLocation()).Parent?.Parent?.Parent?.FullName;
+            if (!string.IsNullOrEmpty(vsInstallPath))
+            {
+                var pathToDevenv = Path.Combine(vsInstallPath, DevenvExe);
+                if (!string.IsNullOrEmpty(pathToDevenv) && this.fileHelper.Exists(pathToDevenv))
+                {
+                    visualStudioDirectory = vsInstallPath;
+                    return true;
+                }
+            }
+
+            visualStudioDirectory = string.Empty;
+            return false;
+        }
+
+        public string GetVisualStudioPath(string visualStudioDirectory)
+        {
+            return Path.Combine(visualStudioDirectory, DevenvExe);
+        }
+
+        public string[] GetVisualStudioCommonLocations(string visualStudioDirectory)
+        {
+            return new[]
+            {
+                Path.Combine(visualStudioDirectory, PrivateAssembliesDirName),
+                Path.Combine(visualStudioDirectory, PublicAssembliesDirName),
+                visualStudioDirectory
+            };
+        }
+    }
+}

--- a/src/Microsoft.TestPlatform.Common/Utilities/InstallationContext.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/InstallationContext.cs
@@ -49,6 +49,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
             {
                 Path.Combine(visualStudioDirectory, PrivateAssembliesDirName),
                 Path.Combine(visualStudioDirectory, PublicAssembliesDirName),
+                Path.Combine(visualStudioDirectory, "CommonExtensions", "Microsoft", "TestWindow"),
                 visualStudioDirectory
             };
         }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
@@ -351,7 +351,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
 
                     if (extensionAssemblies.Count > 0)
                     {
-                        TestPluginCache.Instance.UpdateExtensions(extensionAssemblies, true);
+                        TestPluginCache.Instance.UpdateExtensions(extensionAssemblies, skipExtensionFilters: false);
                     }
                 }
             }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/ITestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/ITestRequestSender.cs
@@ -41,15 +41,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces
         /// Initializes the Discovery
         /// </summary>
         /// <param name="pathToAdditionalExtensions">Paths to check for additional extensions</param>
-        /// <param name="loadOnlyWellKnownExtensions">Load only well only extensions</param>
-        void InitializeDiscovery(IEnumerable<string> pathToAdditionalExtensions, bool loadOnlyWellKnownExtensions);
+        void InitializeDiscovery(IEnumerable<string> pathToAdditionalExtensions);
 
         /// <summary>
         /// Initializes the Execution
         /// </summary>
         /// <param name="pathToAdditionalExtensions">Paths to check for additional extensions</param>
-        /// <param name="loadOnlyWellKnownExtensions">Load only well only extensions</param>
-        void InitializeExecution(IEnumerable<string> pathToAdditionalExtensions, bool loadOnlyWellKnownExtensions);
+        void InitializeExecution(IEnumerable<string> pathToAdditionalExtensions);
 
         /// <summary>
         /// Discovers the tests

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -125,13 +125,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         }
 
         /// <inheritdoc/>
-        public void InitializeDiscovery(IEnumerable<string> pathToAdditionalExtensions, bool loadOnlyWellKnownExtensions)
+        public void InitializeDiscovery(IEnumerable<string> pathToAdditionalExtensions)
         {
             this.communicationManager.SendMessage(MessageType.DiscoveryInitialize, pathToAdditionalExtensions, version: this.protocolVersion);
         }
 
         /// <inheritdoc/>
-        public void InitializeExecution(IEnumerable<string> pathToAdditionalExtensions, bool loadOnlyWellKnownExtensions)
+        public void InitializeExecution(IEnumerable<string> pathToAdditionalExtensions)
         {
             this.communicationManager.SendMessage(MessageType.ExecutionInitialize, pathToAdditionalExtensions, version: this.protocolVersion);
         }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender2.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender2.cs
@@ -165,7 +165,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         #region Discovery Protocol
 
         /// <inheritdoc />
-        public void InitializeDiscovery(IEnumerable<string> pathToAdditionalExtensions, bool loadOnlyWellKnownExtensions)
+        public void InitializeDiscovery(IEnumerable<string> pathToAdditionalExtensions)
         {
             var message = this.dataSerializer.SerializePayload(
                 MessageType.DiscoveryInitialize,
@@ -244,7 +244,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         #region Execution Protocol
 
         /// <inheritdoc />
-        public void InitializeExecution(IEnumerable<string> pathToAdditionalExtensions, bool loadOnlyWellKnownExtensions)
+        public void InitializeExecution(IEnumerable<string> pathToAdditionalExtensions)
         {
             var message = this.dataSerializer.SerializePayload(
                 MessageType.ExecutionInitialize,

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
@@ -168,14 +168,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
 
         private void InitializeExtensions(IEnumerable<string> sources)
         {
-            var extensions = new List<string>();
-
-            if (TestPluginCache.Instance.PathToExtensions != null)
-            {
-                extensions.AddRange(TestPluginCache.Instance.PathToExtensions.Where(ext => ext.EndsWith(TestPlatformConstants.TestAdapterEndsWithPattern, StringComparison.OrdinalIgnoreCase)));
-            }
-
-            extensions.AddRange(TestPluginCache.Instance.DefaultExtensionPaths);
+            var extensions = TestPluginCache.Instance.GetExtensionPaths(TestPlatformConstants.TestAdapterEndsWithPattern);
             var sourceList = sources.ToList();
             var platformExtensions = this.testHostManager.GetTestPlatformExtensions(sourceList, extensions).ToList();
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
@@ -182,7 +182,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             // Only send this if needed.
             if (platformExtensions.Any())
             {
-                this.RequestSender.InitializeDiscovery(platformExtensions, false);
+                this.RequestSender.InitializeDiscovery(platformExtensions);
             }
         }
     }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
@@ -182,7 +182,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             // Only send this if needed.
             if (platformExtensions.Any())
             {
-                this.RequestSender.InitializeDiscovery(platformExtensions, TestPluginCache.Instance.LoadOnlyWellKnownExtensions);
+                this.RequestSender.InitializeDiscovery(platformExtensions, false);
             }
         }
     }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -250,7 +250,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             // Only send this if needed.
             if (platformExtensions.Any())
             {
-                this.RequestSender.InitializeExecution(platformExtensions, TestPluginCache.Instance.LoadOnlyWellKnownExtensions);
+                this.RequestSender.InitializeExecution(platformExtensions, false);
             }
         }
     }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -236,14 +236,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
 
         private void InitializeExtensions(IEnumerable<string> sources)
         {
-            var extensions = new List<string>();
-
-            if (TestPluginCache.Instance.PathToExtensions != null)
-            {
-                extensions.AddRange(TestPluginCache.Instance.PathToExtensions.Where(ext => ext.EndsWith(TestPlatformConstants.TestAdapterEndsWithPattern, StringComparison.OrdinalIgnoreCase)));
-            }
-
-            extensions.AddRange(TestPluginCache.Instance.DefaultExtensionPaths);
+            var extensions = TestPluginCache.Instance.GetExtensionPaths(TestPlatformConstants.TestAdapterEndsWithPattern);
             var sourceList = sources.ToList();
             var platformExtensions = this.testHostManager.GetTestPlatformExtensions(sourceList, extensions).ToList();
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -250,7 +250,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             // Only send this if needed.
             if (platformExtensions.Any())
             {
-                this.RequestSender.InitializeExecution(platformExtensions, false);
+                this.RequestSender.InitializeExecution(platformExtensions);
             }
         }
     }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/TestExtensionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/TestExtensionManager.cs
@@ -13,14 +13,16 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine
     /// </summary>
     public class TestExtensionManager : ITestExtensionManager
     {
+        /// <inheritdoc />
         public void ClearExtensions()
         {
             TestPluginCache.Instance.ClearExtensions();
         }
 
-        public void UseAdditionalExtensions(IEnumerable<string> pathToAdditionalExtensions, bool loadOnlyWellKnownExtensions)
+        /// <inheritdoc />
+        public void UseAdditionalExtensions(IEnumerable<string> pathToAdditionalExtensions, bool skipExtensionFilters)
         {
-            TestPluginCache.Instance.UpdateExtensions(pathToAdditionalExtensions, loadOnlyWellKnownExtensions);
+            TestPluginCache.Instance.UpdateExtensions(pathToAdditionalExtensions, skipExtensionFilters: false);
         }
     }
 }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/TestExtensionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/TestExtensionManager.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine
         /// <inheritdoc />
         public void UseAdditionalExtensions(IEnumerable<string> pathToAdditionalExtensions, bool skipExtensionFilters)
         {
-            TestPluginCache.Instance.UpdateExtensions(pathToAdditionalExtensions, skipExtensionFilters: false);
+            TestPluginCache.Instance.UpdateExtensions(pathToAdditionalExtensions, skipExtensionFilters);
         }
     }
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestPlatform.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestPlatform.cs
@@ -12,11 +12,11 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Client
         /// Update the extensions to be used by the test service
         /// </summary>
         /// <param name="pathToAdditionalExtensions">
-        /// Specifies the path to unit test extensions. 
-        /// If no additional extension is available, then specify null or empty list.
+        ///     Specifies the path to unit test extensions. 
+        ///     If no additional extension is available, then specify null or empty list.
         /// </param>
-        /// <param name="loadOnlyWellKnownExtensions">Specifies whether only well known extensions should be loaded.</param>
-        void UpdateExtensions(IEnumerable<string> pathToAdditionalExtensions, bool loadOnlyWellKnownExtensions);
+        /// <param name="skipExtensionFilters"></param>
+        void UpdateExtensions(IEnumerable<string> pathToAdditionalExtensions, bool skipExtensionFilters);
 
         /// <summary>
         /// Clear the extensions

--- a/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs
+++ b/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
             FrameworkName frameworkName = new FrameworkName(Framework.DefaultFramework.Name);
             try
             {
-                using (var assemblyStream = File.Open(filePath, FileMode.Open))
+                using (var assemblyStream = File.Open(filePath, FileMode.Open, FileAccess.Read))
                 {
                     frameworkName = GetFrameworkNameFromAssemblyMetadata(assemblyStream);
                 }
@@ -79,23 +79,25 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
         private static FrameworkName GetFrameworkNameFromAssemblyMetadata(FileStream assemblyStream)
         {
             FrameworkName frameworkName = new FrameworkName(Framework.DefaultFramework.Name);
-            var peReader = new PEReader(assemblyStream);
-            var metadataReader = peReader.GetMetadataReader();
-
-            foreach (var customAttributeHandle in metadataReader.CustomAttributes)
+            using (var peReader = new PEReader(assemblyStream))
             {
-                var attr = metadataReader.GetCustomAttribute(customAttributeHandle);
-                var result = Encoding.UTF8.GetString(metadataReader.GetBlobBytes(attr.Value));
-                if (result.Contains(".NET") && result.Contains(",Version="))
+                var metadataReader = peReader.GetMetadataReader();
+
+                foreach (var customAttributeHandle in metadataReader.CustomAttributes)
                 {
-                    var fxStartIndex = result.IndexOf(".NET", StringComparison.Ordinal);
-                    var fxEndIndex = result.IndexOf("\u0001", fxStartIndex, StringComparison.Ordinal);
-                    if (fxStartIndex > -1 && fxEndIndex > fxStartIndex)
+                    var attr = metadataReader.GetCustomAttribute(customAttributeHandle);
+                    var result = Encoding.UTF8.GetString(metadataReader.GetBlobBytes(attr.Value));
+                    if (result.Contains(".NET") && result.Contains(",Version="))
                     {
-                        // Using -3 because custom attribute values seperated by unicode characters.
-                        result = result.Substring(fxStartIndex, fxEndIndex - 3);
-                        frameworkName = new FrameworkName(result);
-                        break;
+                        var fxStartIndex = result.IndexOf(".NET", StringComparison.Ordinal);
+                        var fxEndIndex = result.IndexOf("\u0001", fxStartIndex, StringComparison.Ordinal);
+                        if (fxStartIndex > -1 && fxEndIndex > fxStartIndex)
+                        {
+                            // Using -3 because custom attribute values seperated by unicode characters.
+                            result = result.Substring(fxStartIndex, fxEndIndex - 3);
+                            frameworkName = new FrameworkName(result);
+                            break;
+                        }
                     }
                 }
             }
@@ -107,6 +109,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
         {
             Architecture arch = Architecture.AnyCPU;
             // Mapping to Architecture based on https://msdn.microsoft.com/en-us/library/system.reflection.processorarchitecture(v=vs.110).aspx
+
             if (processorArchitecture.Equals(ProcessorArchitecture.Amd64)
                 || processorArchitecture.Equals(ProcessorArchitecture.IA64))
             {
@@ -151,10 +154,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
             {
                 //get the input stream
                 using (Stream fs = new FileStream(imagePath, FileMode.Open, FileAccess.Read))
+                using (var reader = new BinaryReader(fs))
                 {
                     var validImage = true;
 
-                    var reader = new BinaryReader(fs);
                     //PE Header starts @ 0x3C (60). Its a 4 byte header.
                     fs.Position = 0x3C;
                     peHeader = reader.ReadUInt32();

--- a/src/vstest.console/Processors/ListFullyQualifiedTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ListFullyQualifiedTestsArgumentProcessor.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
 
     /// <summary>
     /// Argument Executor for the "--ListFullyQualifiedTests|/ListFullyQualifiedTests" command line argument.
-    /// </summary>  
+    /// </summary>
     internal class ListFullyQualifiedTestsArgumentProcessor : IArgumentProcessor
     {
         #region Constants
@@ -173,7 +173,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             this.testRequestManager = testRequestManager;
 
             this.runSettingsManager = runSettingsProvider;
-            this.testCasefilter = new TestCaseFilter();            
+            this.testCasefilter = new TestCaseFilter();
             this.discoveryEventsRegistrar = new DiscoveryEventsRegistrar(output, this.testCasefilter, discoveredTests, this.commandLineOptions);
         }
 
@@ -213,10 +213,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
                 this.output.Information(false, CommandLineResources.VstestDiagLogOutputPath, EqtTrace.LogFile);
             }
 
-            var runSettings = this.runSettingsManager.ActiveRunSettings.SettingsXml; 
+            var runSettings = this.runSettingsManager.ActiveRunSettings.SettingsXml;
 
             var success = this.testRequestManager.DiscoverTests(
-                new DiscoveryRequestPayload() { Sources = this.commandLineOptions.Sources, RunSettings = runSettings },
+                new DiscoveryRequestPayload { Sources = this.commandLineOptions.Sources, RunSettings = runSettings },
                 this.discoveryEventsRegistrar, Constants.DefaultProtocolConfig);
 
             if (string.IsNullOrEmpty(this.commandLineOptions.ListTestsTargetPath))
@@ -224,7 +224,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
                 // This string does not need to go to Resources. Reason - only internal consumption
                 throw new CommandLineException("Target Path should be specified for listing FQDN tests!");
             }
-            
+
             File.WriteAllLines(this.commandLineOptions.ListTestsTargetPath, this.discoveredTests);
             return success ? ArgumentProcessorResult.Success : ArgumentProcessorResult.Fail;
         }
@@ -262,7 +262,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
                 {
                     throw new TestPlatformException("DiscoveredTestsEventArgs cannot be null.");
                 }
-                
+
                 // Initialising the test case filter here because the filter value is read late.
                 this.testCasefilter.Initialize(this.options.TestCaseFilterValue);
                 var discoveredTests = args.DiscoveredTestCases.ToList();
@@ -453,7 +453,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
                     return propertyValueArray;
                 }
                 return null;
-            }            
+            }
         }
-    }    
+    }
 }

--- a/src/vstest.console/Processors/UseVsixExtensionsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/UseVsixExtensionsArgumentProcessor.cs
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             if (commandLineOptions.UseVsixExtensions)
             {
                 var vsixExtensions = extensionManager.GetUnitTestExtensions();
-                testRequestManager.InitializeExtensions(vsixExtensions);
+                testRequestManager.InitializeExtensions(vsixExtensions, skipExtensionFilters: true);
             }
         }
 

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -122,15 +122,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
 
         #region ITestRequestManager
 
-        /// <summary>
-        /// Initializes the extensions while probing additional paths.
-        /// </summary>
-        /// <param name="pathToAdditionalExtensions">Paths to Additional extensions</param>
-        public void InitializeExtensions(IEnumerable<string> pathToAdditionalExtensions)
+        /// <inheritdoc />
+        public void InitializeExtensions(IEnumerable<string> pathToAdditionalExtensions, bool skipExtensionFilters)
         {
             EqtTrace.Info("TestRequestManager.InitializeExtensions: Initialize extensions started.");
             this.testPlatform.ClearExtensions();
-            this.testPlatform.UpdateExtensions(pathToAdditionalExtensions, false);
+            this.testPlatform.UpdateExtensions(pathToAdditionalExtensions, skipExtensionFilters);
             EqtTrace.Info("TestRequestManager.InitializeExtensions: Initialize extensions completed.");
         }
 

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -124,6 +124,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
         /// <inheritdoc />
         public void InitializeExtensions(IEnumerable<string> pathToAdditionalExtensions, bool skipExtensionFilters)
         {
+            // It is possible for an Editor/IDE to keep running the runner in design mode for long duration.
+            // We clear the extensions cache to ensure the extensions don't get reused across discovery/run
+            // requests.
             EqtTrace.Info("TestRequestManager.InitializeExtensions: Initialize extensions started.");
             this.testPlatform.ClearExtensions();
             this.testPlatform.UpdateExtensions(pathToAdditionalExtensions, skipExtensionFilters);

--- a/test/Microsoft.TestPlatform.Client.UnitTests/TestPlatformTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/TestPlatformTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests
         }
 
         [TestMethod]
-        public void CreateTestRunRequestShouldUpdateLoggerExtensionWhenDesingModeIsFalseForRunAll()
+        public void CreateTestRunRequestShouldUpdateLoggerExtensionWhenDesignModeIsFalseForRunAll()
         {
             var additionalExtensions = new List<string> { "foo.TestLogger.dll", "Joo.TestLogger.dll" };
             this.mockFileHelper.Setup(fh => fh.DirectoryExists(It.IsAny<string>())).Returns(true);
@@ -122,11 +122,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests
             var tp = new TestableTestPlatform(this.testEngine.Object, this.mockFileHelper.Object, this.hostManager.Object);
 
             var testRunRequest = tp.CreateTestRunRequest(this.mockRequestData.Object, testRunCriteria);
-            this.extensionManager.Verify(em => em.UseAdditionalExtensions(additionalExtensions, true));
+            this.extensionManager.Verify(em => em.UseAdditionalExtensions(additionalExtensions, false));
         }
 
         [TestMethod]
-        public void CreateTestRunRequestShouldUpdateLoggerExtensionWhenDesingModeIsFalseForRunSelected()
+        public void CreateTestRunRequestShouldUpdateLoggerExtensionWhenDesignModeIsFalseForRunSelected()
         {
             var additionalExtensions = new List<string> { "foo.TestLogger.dll", "Joo.TestLogger.dll" };
             this.mockFileHelper.Setup(fh => fh.DirectoryExists(It.IsAny<string>())).Returns(true);
@@ -150,7 +150,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests
             var tp = new TestableTestPlatform(this.testEngine.Object, this.mockFileHelper.Object, this.hostManager.Object);
 
             var testRunRequest = tp.CreateTestRunRequest(this.mockRequestData.Object, testRunCriteria);
-            this.extensionManager.Verify(em => em.UseAdditionalExtensions(additionalExtensions, true));
+            this.extensionManager.Verify(em => em.UseAdditionalExtensions(additionalExtensions, false));
         }
 
         [TestMethod]
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests
             var tp = new TestableTestPlatform(this.testEngine.Object, this.mockFileHelper.Object, this.hostManager.Object);
 
             tp.CreateTestRunRequest(this.mockRequestData.Object, testRunCriteria);
-            this.extensionManager.Verify(em => em.UseAdditionalExtensions(additionalExtensions, true));
+            this.extensionManager.Verify(em => em.UseAdditionalExtensions(additionalExtensions, false));
             this.hostManager.Verify(hm => hm.GetTestSources(It.IsAny<IEnumerable<string>>()), Times.Never);
         }
 
@@ -235,7 +235,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests
         /// Logger extensions should be updated when design mode is false.
         /// </summary>
         [TestMethod]
-        public void CreateDiscoveryRequestShouldUpdateLoggerExtensionWhenDesingModeIsFalse()
+        public void CreateDiscoveryRequestShouldUpdateLoggerExtensionWhenDesignModeIsFalse()
         {
             var additionalExtensions = new List<string> { "foo.TestLogger.dll", "Joo.TestLogger.dll" };
             this.mockFileHelper.Setup(fh => fh.DirectoryExists(It.IsAny<string>())).Returns(true);
@@ -263,7 +263,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests
             var discoveryRequest = tp.CreateDiscoveryRequest(this.mockRequestData.Object, discoveryCriteria);
 
             // Verify
-            this.extensionManager.Verify(em => em.UseAdditionalExtensions(additionalExtensions, true));
+            this.extensionManager.Verify(em => em.UseAdditionalExtensions(additionalExtensions, false));
         }
 
         private class TestableTestPlatform : TestPlatform

--- a/test/Microsoft.TestPlatform.Client.UnitTests/TestPlatformTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/TestPlatformTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests
             var tp = new TestableTestPlatform(this.testEngine.Object, this.hostManager.Object);
             var additionalExtensions = new List<string> { "e1.dll", "e2.dll" };
 
-            tp.UpdateExtensions(additionalExtensions, loadOnlyWellKnownExtensions: true);
+            tp.UpdateExtensions(additionalExtensions, skipExtensionFilters: true);
 
             this.extensionManager.Verify(em => em.UseAdditionalExtensions(additionalExtensions, true));
         }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestExtensionManagerTests.cs
@@ -23,9 +23,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
         private IEnumerable<LazyExtension<ITestLogger, ITestLoggerCapabilities>> filteredTestExtensions;
         private IEnumerable<LazyExtension<ITestLogger, Dictionary<string, object>>> unfilteredTestExtensions;
 
-
-        [TestInitialize]
-        public void Initialize()
+        public TestExtensionManagerTests()
         {
             TestPluginCacheTests.SetupMockExtensions();
             messageLogger = TestSessionMessageLogger.Instance;

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginCacheTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginCacheTests.cs
@@ -58,22 +58,9 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             Assert.IsNull(TestPluginCache.Instance.PathToExtensions);
         }
 
-        [TestMethod]
-        public void LoadOnlyWellKnownExtensionsShouldBeFalseByDefault()
-        {
-            Assert.IsFalse(TestPluginCache.Instance.LoadOnlyWellKnownExtensions);
-        }
-
         #endregion
 
         #region UpdateAdditionalExtensions tests
-
-        [TestMethod]
-        public void UpdateAdditionalExtensionsShouldUpdateLoadOnlyWellKnownExtensions()
-        {
-            TestPluginCache.Instance.UpdateExtensions(null, true);
-            Assert.IsTrue(TestPluginCache.Instance.LoadOnlyWellKnownExtensions);
-        }
 
         [TestMethod]
         public void UpdateAdditionalExtensionsShouldNotThrowIfExtenionPathIsNull()
@@ -93,7 +80,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
         public void UpdateAdditionalExtensionsShouldUpdateAdditionalExtensions()
         {
             var additionalExtensions = new List<string> { typeof(TestPluginCacheTests).GetTypeInfo().Assembly.Location };
-            TestPluginCache.Instance.UpdateExtensions(additionalExtensions, true);
+            TestPluginCache.Instance.UpdateExtensions(additionalExtensions, false);
             var updatedExtensions = TestPluginCache.Instance.PathToExtensions;
 
             Assert.IsNotNull(updatedExtensions);
@@ -108,7 +95,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
                                                typeof(TestPluginCacheTests).GetTypeInfo().Assembly.Location,
                                                typeof(TestPluginCacheTests).GetTypeInfo().Assembly.Location
                                            };
-            TestPluginCache.Instance.UpdateExtensions(additionalExtensions, true);
+            TestPluginCache.Instance.UpdateExtensions(additionalExtensions, false);
             var updatedExtensions = TestPluginCache.Instance.PathToExtensions.ToList();
 
             Assert.IsNotNull(updatedExtensions);
@@ -120,8 +107,19 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
         public void UpdateAdditionalExtensionsShouldUpdatePathsThatDoNotExist()
         {
             var additionalExtensions = new List<string> { "foo.dll" };
-            TestPluginCache.Instance.UpdateExtensions(additionalExtensions, true);
+            TestPluginCache.Instance.UpdateExtensions(additionalExtensions, false);
             var updatedExtensions = TestPluginCache.Instance.PathToExtensions;
+
+            Assert.IsNotNull(updatedExtensions);
+            Assert.AreEqual(1, updatedExtensions.Count());
+        }
+
+        [TestMethod]
+        public void UpdateAdditionalExtensionsShouldUpdateDefaultExtensionsWhenSkipFilteringIsTrue()
+        {
+            var additionalExtensions = new List<string> { "foo.dll" };
+            TestPluginCache.Instance.UpdateExtensions(additionalExtensions, true);
+            var updatedExtensions = TestPluginCache.Instance.DefaultExtensionPaths;
 
             Assert.IsNotNull(updatedExtensions);
             Assert.AreEqual(1, updatedExtensions.Count());
@@ -384,7 +382,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             TestDiscoveryExtensionManager.Destroy();
             TestExecutorExtensionManager.Destroy();
             SettingsProviderExtensionManager.Destroy();
-            this.UpdateExtensions(extensionsPath, true);
+            this.UpdateExtensions(extensionsPath, skipExtensionFilters: false);
         }
 
         public TestableTestPluginCache(IFileHelper fileHelper) : this(fileHelper, new List<string>())

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginCacheTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginCacheTests.cs
@@ -103,7 +103,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             var updatedExtensions = TestPluginCache.Instance.GetExtensionPaths(string.Empty);
 
             Assert.IsNotNull(updatedExtensions);
-            Assert.AreEqual(1, updatedExtensions.Count());
+            Assert.AreEqual(1, updatedExtensions.Count);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginDiscovererTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginDiscovererTests.cs
@@ -39,7 +39,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             var pathToExtensions = new List<string> { "foo.dll" };
 
             // The below should not throw an exception.
-            Assert.IsNotNull(this.testPluginDiscoverer.GetTestExtensionsInformation<TestLoggerPluginInformation, ITestLogger>(pathToExtensions, loadOnlyWellKnownExtensions: true));
+            Assert.IsNotNull(this.testPluginDiscoverer.GetTestExtensionsInformation<TestLoggerPluginInformation, ITestLogger>(pathToExtensions));
         }
 
         [TestMethod]
@@ -48,7 +48,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             var pathToExtensions = new List<string> { typeof(TestPluginDiscovererTests).GetTypeInfo().Assembly.Location };
 
             // The below should not throw an exception.
-            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<TestDiscovererPluginInformation, ITestDiscoverer>(pathToExtensions, loadOnlyWellKnownExtensions: true);
+            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<TestDiscovererPluginInformation, ITestDiscoverer>(pathToExtensions);
             var discovererPluginInformation = new TestDiscovererPluginInformation(typeof(AbstractTestDiscoverer));
             Assert.IsFalse(testExtensions.ContainsKey(discovererPluginInformation.IdentifierData));
         }
@@ -59,7 +59,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             var pathToExtensions = new List<string> { typeof(TestPluginDiscovererTests).GetTypeInfo().Assembly.Location };
 
             // The below should not throw an exception.
-            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<TestDiscovererPluginInformation, ITestDiscoverer>(pathToExtensions, loadOnlyWellKnownExtensions: true);
+            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<TestDiscovererPluginInformation, ITestDiscoverer>(pathToExtensions);
 
             var discovererPluginInformation = new TestDiscovererPluginInformation(typeof(ValidDiscoverer));
             var discovererPluginInformation2 = new TestDiscovererPluginInformation(typeof(ValidDiscoverer2));
@@ -74,7 +74,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             var pathToExtensions = new List<string> { typeof(TestPluginDiscovererTests).GetTypeInfo().Assembly.Location };
 
             // The below should not throw an exception.
-            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<TestExecutorPluginInformation, ITestExecutor>(pathToExtensions, loadOnlyWellKnownExtensions: true);
+            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<TestExecutorPluginInformation, ITestExecutor>(pathToExtensions);
 
             var pluginInformation = new TestExecutorPluginInformation(typeof(ValidExecutor));
             var pluginInformation2 = new TestExecutorPluginInformation(typeof(ValidExecutor2));
@@ -90,7 +90,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             var pathToExtensions = new List<string> { typeof(TestPluginDiscovererTests).GetTypeInfo().Assembly.Location };
 
             // The below should not throw an exception.
-            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<TestLoggerPluginInformation, ITestLogger>(pathToExtensions, loadOnlyWellKnownExtensions: true);
+            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<TestLoggerPluginInformation, ITestLogger>(pathToExtensions);
 
             var pluginInformation = new TestLoggerPluginInformation(typeof(ValidLogger));
             var pluginInformation2 = new TestLoggerPluginInformation(typeof(ValidLogger2));
@@ -106,7 +106,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             var pathToExtensions = new List<string> { typeof(TestPluginDiscovererTests).GetTypeInfo().Assembly.Location };
 
             // The below should not throw an exception.
-            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<DataCollectorConfig, DataCollector>(pathToExtensions, loadOnlyWellKnownExtensions: true);
+            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<DataCollectorConfig, DataCollector>(pathToExtensions);
 
             var pluginInformation = new DataCollectorConfig(typeof(ValidDataCollector));
 
@@ -121,7 +121,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             var pathToExtensions = new List<string> { typeof(TestPluginDiscovererTests).GetTypeInfo().Assembly.Location };
 
             // The below should not throw an exception.
-            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<TestSettingsProviderPluginInformation, ISettingsProvider>(pathToExtensions, loadOnlyWellKnownExtensions: true);
+            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<TestSettingsProviderPluginInformation, ISettingsProvider>(pathToExtensions);
 
             var pluginInformation = new TestSettingsProviderPluginInformation(typeof(ValidSettingsProvider));
             var pluginInformation2 = new TestSettingsProviderPluginInformation(typeof(ValidSettingsProvider2));
@@ -139,9 +139,9 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
                 typeof(TestPluginDiscovererTests).GetTypeInfo().Assembly.Location,
             };
 
-            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<FaultyTestExecutorPluginInformation, ITestExecutor>(pathToExtensions, loadOnlyWellKnownExtensions: true);
+            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<FaultyTestExecutorPluginInformation, ITestExecutor>(pathToExtensions);
 
-            Assert.That.DoesNotThrow(() =>this.testPluginDiscoverer.GetTestExtensionsInformation<FaultyTestExecutorPluginInformation, ITestExecutor>(pathToExtensions, loadOnlyWellKnownExtensions: true));
+            Assert.That.DoesNotThrow(() =>this.testPluginDiscoverer.GetTestExtensionsInformation<FaultyTestExecutorPluginInformation, ITestExecutor>(pathToExtensions));
         }
 
         [TestMethod]
@@ -154,7 +154,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
 
             this.testPluginDiscoverer = new TestPluginDiscoverer(mockFileHelper.Object);
 
-            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<FaultyTestExecutorPluginInformation, ITestExecutor>(pathToExtensions, loadOnlyWellKnownExtensions: true);
+            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<FaultyTestExecutorPluginInformation, ITestExecutor>(pathToExtensions);
 
             mockFileHelper.Verify(fh => fh.Exists("Microsoft.VisualStudio.TestTools.CppUnitTestFramework.CppUnitTestExtension.dll"), Times.Once);
         }
@@ -169,7 +169,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
 
             this.testPluginDiscoverer = new TestPluginDiscoverer(mockFileHelper.Object);
 
-            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<FaultyTestExecutorPluginInformation, ITestExecutor>(pathToExtensions, loadOnlyWellKnownExtensions: true);
+            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<FaultyTestExecutorPluginInformation, ITestExecutor>(pathToExtensions);
 
             mockFileHelper.Verify(fh => fh.Exists("Microsoft.VisualStudio.TestPlatform.Extensions.MSAppContainerAdapter.dll"), Times.Once);
         }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginManagerTests.cs
@@ -111,7 +111,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             Assert.IsNotNull(testExtensions);
             Assert.IsTrue(testExtensions.Any());
 
-            Assert.AreEqual(1, discoveryCount);
+            Assert.AreEqual(2, discoveryCount);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginManagerTests.cs
@@ -45,7 +45,6 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             var instance = TestPluginManager.CreateTestExtension<ITestDiscoverer>(typeof(DummyTestDiscoverer));
 
             Assert.IsNotNull(instance);
-            Assert.IsTrue(instance is ITestDiscoverer);
         }
 
         [TestMethod]
@@ -110,7 +109,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
                 out testExtensions);
 
             Assert.IsNotNull(testExtensions);
-            Assert.IsTrue(testExtensions.Count() > 0);
+            Assert.IsTrue(testExtensions.Any());
 
             Assert.AreEqual(1, discoveryCount);
         }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Utilities/InstallationContextTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Utilities/InstallationContextTests.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.TestPlatform.Common.UnitTests.Utilities
+{
+    using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
+    using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class InstallationContextTests
+    {
+        private Mock<IFileHelper> mockFileHelper;
+        private InstallationContext installationContext;
+
+        public InstallationContextTests()
+        {
+            this.mockFileHelper = new Mock<IFileHelper>();
+            this.installationContext = new InstallationContext(this.mockFileHelper.Object);
+        }
+
+        // public void TryGetVisualStudioDirectoryShouldReturnTrueIfVSIsFound
+        // public void TryGetVisualStudioDirectoryShouldReturnFalseIfVSIsNotFound
+        // public void GetVisualStudioPathShouldReturnPathToDevenvExecutable
+        // public void GetVisualStudioCommonLocationShouldReturnWellKnownLocations
+    }
+}

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Utilities/InstallationContextTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Utilities/InstallationContextTests.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.TestPlatform.Common.UnitTests.Utilities
 {
+    using System.IO;
     using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
     using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -20,9 +21,47 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Utilities
             this.installationContext = new InstallationContext(this.mockFileHelper.Object);
         }
 
-        // public void TryGetVisualStudioDirectoryShouldReturnTrueIfVSIsFound
-        // public void TryGetVisualStudioDirectoryShouldReturnFalseIfVSIsNotFound
-        // public void GetVisualStudioPathShouldReturnPathToDevenvExecutable
-        // public void GetVisualStudioCommonLocationShouldReturnWellKnownLocations
+        [TestMethod]
+        public void TryGetVisualStudioDirectoryShouldReturnTrueIfVSIsFound()
+        {
+            this.mockFileHelper.Setup(m => m.Exists(It.IsAny<string>())).Returns(true);
+
+            Assert.IsTrue(this.installationContext.TryGetVisualStudioDirectory(out string visualStudioDirectory), "VS Install Directory returned false");
+
+            Assert.IsTrue(Directory.Exists(visualStudioDirectory), "VS Install Directory doesn't exist");
+        }
+
+        [TestMethod]
+        public void TryGetVisualStudioDirectoryShouldReturnFalseIfVSIsNotFound()
+        {
+            this.mockFileHelper.Setup(m => m.Exists(It.IsAny<string>())).Returns(false);
+
+            Assert.IsFalse(this.installationContext.TryGetVisualStudioDirectory(out string visualStudioDirectory), "VS Install Directory returned true");
+
+            Assert.IsTrue(string.IsNullOrEmpty(visualStudioDirectory), "VS Install Directory is not empty");
+        }
+
+        [TestMethod]
+        public void GetVisualStudioPathShouldReturnPathToDevenvExecutable()
+        {
+            var devenvPath = this.installationContext.GetVisualStudioPath(@"C:\temp");
+
+            Assert.AreEqual(@"C:\temp\devenv.exe", devenvPath);
+        }
+
+        [TestMethod]
+        public void GetVisualStudioCommonLocationShouldReturnWellKnownLocations()
+        {
+            var expectedLocations = new[]
+            {
+                @"C:\temp\PrivateAssemblies",
+                @"C:\temp\PublicAssemblies",
+                @"C:\temp\CommonExtensions\Microsoft\TestWindow",
+                @"C:\temp"
+            };
+            var commonLocations = this.installationContext.GetVisualStudioCommonLocations(@"C:\temp");
+
+            CollectionAssert.AreEquivalent(expectedLocations, commonLocations);
+        }
     }
 }

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
@@ -162,7 +162,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
         {
             var paths = new List<string>() { "Hello", "World" };
             this.CheckAndSetProtocolVersion();
-            this.testRequestSender.InitializeDiscovery(paths, false);
+            this.testRequestSender.InitializeDiscovery(paths);
 
             this.mockCommunicationManager.Verify(mc => mc.SendMessage(MessageType.DiscoveryInitialize, paths, this.protocolConfig.Version), Times.Once);
         }
@@ -171,7 +171,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
         public void InitializeExecutionShouldSendCommunicationMessageWithCorrectParameters()
         {
             var paths = new List<string>() { "Hello", "World" };
-            this.testRequestSender.InitializeExecution(paths, true);
+            this.testRequestSender.InitializeExecution(paths);
 
             this.mockCommunicationManager.Verify(mc => mc.SendMessage(MessageType.ExecutionInitialize, paths, this.protocolConfig.Version), Times.Once);
         }

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests2.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests2.cs
@@ -199,7 +199,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
         {
             this.SetupFakeCommunicationChannel();
 
-            this.testRequestSender.InitializeDiscovery(this.pathToAdditionalExtensions, false);
+            this.testRequestSender.InitializeDiscovery(this.pathToAdditionalExtensions);
 
             this.mockDataSerializer.Verify(d => d.SerializePayload(MessageType.DiscoveryInitialize, this.pathToAdditionalExtensions, 1), Times.Once);
             this.mockChannel.Verify(mc => mc.Send(It.IsAny<string>()), Times.Once);
@@ -210,7 +210,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
         {
             this.SetupFakeChannelWithVersionNegotiation(DUMMYNEGOTIATEDPROTOCOLVERSION);
 
-            this.testRequestSender.InitializeDiscovery(this.pathToAdditionalExtensions, false);
+            this.testRequestSender.InitializeDiscovery(this.pathToAdditionalExtensions);
 
             this.mockDataSerializer.Verify(d => d.SerializePayload(MessageType.DiscoveryInitialize, this.pathToAdditionalExtensions, DUMMYNEGOTIATEDPROTOCOLVERSION), Times.Once);
         }
@@ -414,7 +414,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
         {
             this.SetupFakeCommunicationChannel();
 
-            this.testRequestSender.InitializeExecution(this.pathToAdditionalExtensions, true);
+            this.testRequestSender.InitializeExecution(this.pathToAdditionalExtensions);
 
             this.mockDataSerializer.Verify(d => d.SerializePayload(MessageType.ExecutionInitialize, this.pathToAdditionalExtensions, 1), Times.Once);
             this.mockChannel.Verify(mc => mc.Send(It.IsAny<string>()), Times.Once);
@@ -425,7 +425,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
         {
             this.SetupFakeChannelWithVersionNegotiation(DUMMYNEGOTIATEDPROTOCOLVERSION);
 
-            this.testRequestSender.InitializeExecution(this.pathToAdditionalExtensions, true);
+            this.testRequestSender.InitializeExecution(this.pathToAdditionalExtensions);
 
             this.mockDataSerializer.Verify(d => d.SerializePayload(MessageType.ExecutionInitialize, this.pathToAdditionalExtensions, DUMMYNEGOTIATEDPROTOCOLVERSION), Times.Once);
         }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/InProcessProxyDiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/InProcessProxyDiscoveryManagerTests.cs
@@ -59,29 +59,21 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         }
 
         [TestMethod]
-        public void DiscoverTestsShouldUpdateTestPlauginCacheWithExtensionsReturnByTestHost()
+        public void DiscoverTestsShouldUpdateTestPluginCacheWithExtensionsReturnByTestHost()
         {
             var manualResetEvent = new ManualResetEvent(false);
-
             this.mockDiscoveryManager.Setup(o => o.Initialize(Enumerable.Empty<string>())).Callback(
                 () => manualResetEvent.Set());
 
             this.mockTestHostManager.Setup(o => o.GetTestPlatformExtensions(It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>())).Returns(new List<string> { "C:\\DiscoveryDummy.dll" });
-
-            List<string> expectedResult = new List<string>();
-            if (TestPluginCache.Instance.PathToExtensions != null)
-            {
-                expectedResult.AddRange(TestPluginCache.Instance.PathToExtensions);
-            }
-
+            var expectedResult = TestPluginCache.Instance.GetExtensionPaths(string.Empty);
             expectedResult.Add("C:\\DiscoveryDummy.dll");
-
             var discoveryCriteria = new DiscoveryCriteria(new[] { "test.dll" }, 1, string.Empty);
+
             this.inProcessProxyDiscoveryManager.DiscoverTests(discoveryCriteria, null);
 
             Assert.IsTrue(manualResetEvent.WaitOne(5000), "DiscoverTests should call Initialize");
-
-            Assert.IsFalse(expectedResult.Except(TestPluginCache.Instance.PathToExtensions).Any());
+            CollectionAssert.AreEquivalent(expectedResult, TestPluginCache.Instance.GetExtensionPaths(string.Empty));
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/InProcessProxyexecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/InProcessProxyexecutionManagerTests.cs
@@ -57,17 +57,13 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         public void StartTestRunShouldUpdateTestPlauginCacheWithExtensionsReturnByTestHost()
         {
             this.mockTestHostManager.Setup(o => o.GetTestPlatformExtensions(It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>())).Returns(new List<string> { "C:\\dummy.dll" });
-            List<string> expectedResult = new List<string>();
-            if (TestPluginCache.Instance.PathToExtensions != null)
-            {
-                expectedResult.AddRange(TestPluginCache.Instance.PathToExtensions);
-            }
+            var expectedResult = TestPluginCache.Instance.GetExtensionPaths(string.Empty);
             expectedResult.Add("C:\\dummy.dll");
 
             var testRunCriteria = new TestRunCriteria(new List<string> { "source.dll" }, 10);
             this.inProcessProxyExecutionManager.StartTestRun(testRunCriteria, null);
 
-            Assert.IsFalse(expectedResult.Except(TestPluginCache.Instance.PathToExtensions).Any());
+            CollectionAssert.AreEquivalent(expectedResult, TestPluginCache.Instance.GetExtensionPaths(string.Empty));
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
@@ -66,7 +66,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
             this.mockDataSerializer.Setup(mds => mds.DeserializeMessage(string.Empty)).Returns(new Message());
 
             this.testDiscoveryManager = new ProxyDiscoveryManager(
-                                            this.mockRequestData.Object, 
+                                            this.mockRequestData.Object,
                                             this.mockRequestSender.Object,
                                             this.mockTestHostManager.Object,
                                             this.mockDataSerializer.Object,
@@ -100,7 +100,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
             this.testDiscoveryManager.DiscoverTests(this.discoveryCriteria, null);
 
-            this.mockRequestSender.Verify(s => s.InitializeDiscovery(It.IsAny<IEnumerable<string>>(), It.IsAny<bool>()), Times.Never);
+            this.mockRequestSender.Verify(s => s.InitializeDiscovery(It.IsAny<IEnumerable<string>>()), Times.Never);
         }
 
         [TestMethod]
@@ -115,7 +115,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
             this.testDiscoveryManager.DiscoverTests(this.discoveryCriteria, mockTestDiscoveryEventHandler.Object);
 
-            this.mockRequestSender.Verify(s => s.InitializeExecution(It.IsAny<IEnumerable<string>>(), It.IsAny<bool>()), Times.Never);
+            this.mockRequestSender.Verify(s => s.InitializeExecution(It.IsAny<IEnumerable<string>>()), Times.Never);
         }
 
         [TestMethod]
@@ -220,7 +220,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
                 this.testDiscoveryManager.DiscoverTests(this.discoveryCriteria, null);
 
                 // Also verify that we have waited for client connection.
-                this.mockRequestSender.Verify(s => s.InitializeDiscovery(extensions, true), Times.Once);
+                this.mockRequestSender.Verify(s => s.InitializeDiscovery(extensions), Times.Once);
             }
             finally
             {
@@ -240,7 +240,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
                 this.testDiscoveryManager.DiscoverTests(this.discoveryCriteria, null);
 
-                this.mockRequestSender.Verify(s => s.InitializeDiscovery(new[] { "he1.dll", "c:\\e1.dll" }, true), Times.Once);
+                this.mockRequestSender.Verify(s => s.InitializeDiscovery(new[] { "he1.dll", "c:\\e1.dll" }), Times.Once);
             }
             finally
             {

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
@@ -257,10 +257,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
             try
             {
                 this.mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(true);
-
-                var expectedResult = new List<string>();
-                expectedResult.AddRange(TestPluginCache.Instance.PathToExtensions);
-                expectedResult.AddRange(TestPluginCache.Instance.DefaultExtensionPaths);
+                var expectedResult = TestPluginCache.Instance.GetExtensionPaths(string.Empty);
 
                 this.testDiscoveryManager.DiscoverTests(this.discoveryCriteria, null);
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
@@ -223,10 +223,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
             try
             {
                 this.mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(true);
-
-                var expectedResult = new List<string>();
-                expectedResult.AddRange(TestPluginCache.Instance.PathToExtensions);
-                expectedResult.AddRange(TestPluginCache.Instance.DefaultExtensionPaths);
+                var expectedResult = TestPluginCache.Instance.GetExtensionPaths(string.Empty);
 
                 this.testExecutionManager.StartTestRun(this.mockTestRunCriteria.Object, null);
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
@@ -93,7 +93,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
             this.testExecutionManager.StartTestRun(this.mockTestRunCriteria.Object, null);
 
-            this.mockRequestSender.Verify(s => s.InitializeExecution(It.IsAny<IEnumerable<string>>(), It.IsAny<bool>()), Times.Never);
+            this.mockRequestSender.Verify(s => s.InitializeExecution(It.IsAny<IEnumerable<string>>()), Times.Never);
         }
 
         [TestMethod]
@@ -168,7 +168,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
             this.testExecutionManager.StartTestRun(this.mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
 
-            this.mockRequestSender.Verify(s => s.InitializeExecution(It.IsAny<IEnumerable<string>>(), It.IsAny<bool>()), Times.Never);
+            this.mockRequestSender.Verify(s => s.InitializeExecution(It.IsAny<IEnumerable<string>>()), Times.Never);
         }
 
         [TestMethod]
@@ -187,7 +187,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
                 this.testExecutionManager.StartTestRun(this.mockTestRunCriteria.Object, null);
 
                 // Also verify that we have waited for client connection.
-                this.mockRequestSender.Verify(s => s.InitializeExecution(extensions, false), Times.Once);
+                this.mockRequestSender.Verify(s => s.InitializeExecution(extensions), Times.Once);
             }
             finally
             {
@@ -206,7 +206,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
                 this.testExecutionManager.StartTestRun(this.mockTestRunCriteria.Object, null);
 
-                this.mockRequestSender.Verify(s => s.InitializeExecution(new[] { "he1.dll", "c:\\e1.dll" }, false), Times.Once);
+                this.mockRequestSender.Verify(s => s.InitializeExecution(new[] { "he1.dll", "c:\\e1.dll" }), Times.Once);
             }
             finally
             {
@@ -282,7 +282,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
             this.testExecutionManager.StartTestRun(this.mockTestRunCriteria.Object, null);
 
-            this.mockRequestSender.Verify(s => s.InitializeExecution(It.IsAny<IEnumerable<string>>(), It.IsAny<bool>()), Times.Once);
+            this.mockRequestSender.Verify(s => s.InitializeExecution(It.IsAny<IEnumerable<string>>()), Times.Once);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Discovery/DiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Discovery/DiscoveryManagerTests.cs
@@ -53,7 +53,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
         {
             var mockFileHelper = new Mock<IFileHelper>();
             mockFileHelper.Setup(fh => fh.DirectoryExists(It.IsAny<string>())).Returns(false);
-            TestPluginCache.Instance = new TestableTestPluginCache(mockFileHelper.Object);
+            TestPluginCache.Instance = new TestableTestPluginCache();
 
             this.discoveryManager.Initialize(
                 new string[] { typeof(TestPluginCacheTests).GetTypeInfo().Assembly.Location });

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestExtensionManagerTests.cs
@@ -42,7 +42,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
         public void ClearExtensionsShouldClearExtensionsInCache()
         {
             var extensions = new List<string> { @"Foo.dll" };
-            this.testExtensionManager.UseAdditionalExtensions(extensions, true);
+            this.testExtensionManager.UseAdditionalExtensions(extensions, false);
 
             this.testExtensionManager.ClearExtensions();
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestExtensionManagerTests.cs
@@ -4,7 +4,6 @@
 namespace TestPlatform.CrossPlatEngine.UnitTests
 {
     using System.Collections.Generic;
-    using System.Linq;
     using System.Reflection;
 
     using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestExtensionManagerTests.cs
@@ -35,7 +35,6 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
 
             this.testExtensionManager.UseAdditionalExtensions(extensions, true);
 
-            Assert.IsTrue(TestPluginCache.Instance.LoadOnlyWellKnownExtensions);
             CollectionAssert.AreEqual(extensions, TestPluginCache.Instance.PathToExtensions.ToList());
         }
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestExtensionManagerTests.cs
@@ -20,10 +20,13 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
         public TestExtensionManagerTests()
         {
             this.testExtensionManager = new TestExtensionManager();
+
+            // Reset the singleton
+            TestPluginCache.Instance = null;
         }
 
         [TestCleanup]
-        public void CleanUp()
+        public void TestCleanup()
         {
             TestPluginCache.Instance = null;
         }
@@ -35,7 +38,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
 
             this.testExtensionManager.UseAdditionalExtensions(extensions, true);
 
-            CollectionAssert.AreEqual(extensions, TestPluginCache.Instance.PathToExtensions.ToList());
+            CollectionAssert.AreEquivalent(extensions, TestPluginCache.Instance.GetExtensionPaths(string.Empty));
         }
 
         [TestMethod]
@@ -46,7 +49,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
 
             this.testExtensionManager.ClearExtensions();
 
-            Assert.AreEqual(0, TestPluginCache.Instance.PathToExtensions.Count());
+            Assert.AreEqual(0, TestPluginCache.Instance.GetExtensionPaths(string.Empty).Count);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -252,7 +252,7 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
             // Verify
             List<string> expectedList = new List<string> { @"C:\Source2\ext1.TestAdapter.dll", @"C:\Source1\ext2.TestAdapter.dll" };
             CollectionAssert.AreEqual(expectedList, resultExtensions);
-            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Warning, "Multiple versions of same extension found. Selecting the highest version.\n  ext1.TestAdapter : 2.2\n  ext2.TestAdapter : 5.5"), Times.Once);
+            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Warning, "Multiple versions of same extension found. Selecting the highest version.\r\n  ext1.TestAdapter : 2.2\n  ext2.TestAdapter : 5.5"), Times.Once);
         }
 
         [TestMethod]
@@ -277,7 +277,7 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
 
             // Verify
             CollectionAssert.AreEqual(extensionsList2, resultExtensions);
-            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Warning, "Multiple versions of same extension found. Selecting the highest version.\n  ext1.TestAdapter : 2.2"), Times.Once);
+            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Warning, "Multiple versions of same extension found. Selecting the highest version.\r\n  ext1.TestAdapter : 2.2"), Times.Once);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -252,7 +252,7 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
             // Verify
             List<string> expectedList = new List<string> { @"C:\Source2\ext1.TestAdapter.dll", @"C:\Source1\ext2.TestAdapter.dll" };
             CollectionAssert.AreEqual(expectedList, resultExtensions);
-            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Warning, "Multiple versions of same extension found. Selecting the highest version.\r\n  ext1.TestAdapter : 2.2\n  ext2.TestAdapter : 5.5"), Times.Once);
+            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Warning, "Multiple versions of same extension found. Selecting the highest version.\n  ext1.TestAdapter : 2.2\n  ext2.TestAdapter : 5.5"), Times.Once);
         }
 
         [TestMethod]
@@ -277,7 +277,7 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
 
             // Verify
             CollectionAssert.AreEqual(extensionsList2, resultExtensions);
-            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Warning, "Multiple versions of same extension found. Selecting the highest version.\r\n  ext1.TestAdapter : 2.2"), Times.Once);
+            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Warning, "Multiple versions of same extension found. Selecting the highest version.\n  ext1.TestAdapter : 2.2"), Times.Once);
         }
 
         [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
@@ -286,7 +286,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
                 .Callback(callback)
                 .Returns(extensions);
 
-            var testableTestPluginCache = new TestableTestPluginCache(mockFileHelper.Object);
+            var testableTestPluginCache = new TestableTestPluginCache();
 
             // Setup the testable instance.
             TestPluginCache.Instance = testableTestPluginCache;
@@ -322,9 +322,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
 
     public class TestableTestPluginCache : TestPluginCache
     {
-        public TestableTestPluginCache(IFileHelper fileHelper) : base(fileHelper)
-        {
-        }
     }
 
     #endregion

--- a/test/vstest.console.UnitTests/Processors/UseVsixExtensionsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/UseVsixExtensionsArgumentProcessorTests.cs
@@ -20,8 +20,8 @@ namespace vstest.console.UnitTests.Processors
         private Mock<ITestRequestManager> testRequestManager;
         private Mock<IVSExtensionManager> extensionManager;
         private Mock<IOutput> output;
-        private UseVsixExtensionsArgumentExecutor executor;                  
-        
+        private UseVsixExtensionsArgumentExecutor executor;
+
         public UseVsixExtensionsArgumentProcessorTests()
         {
             this.testRequestManager = new Mock<ITestRequestManager>();
@@ -65,7 +65,7 @@ namespace vstest.console.UnitTests.Processors
         #endregion
 
         #region UseVsixExtensionsArgumentExecutor tests
-        
+
         [TestMethod]
         public void InitializeShouldThrowExceptionIfArgumentIsNull()
         {
@@ -92,7 +92,7 @@ namespace vstest.console.UnitTests.Processors
 
             this.output.Verify(o => o.WriteLine(DeprecationMessage, OutputLevel.Warning), Times.Once);
             this.extensionManager.Verify(em => em.GetUnitTestExtensions(), Times.Once);
-            this.testRequestManager.Verify(trm => trm.InitializeExtensions(extensions), Times.Once);
+            this.testRequestManager.Verify(trm => trm.InitializeExtensions(extensions, true), Times.Once);
         }
 
         [TestMethod]
@@ -102,7 +102,7 @@ namespace vstest.console.UnitTests.Processors
 
             this.output.Verify(o => o.WriteLine(DeprecationMessage, OutputLevel.Warning), Times.Once);
             this.extensionManager.Verify(em => em.GetUnitTestExtensions(), Times.Never);
-            this.testRequestManager.Verify(trm => trm.InitializeExtensions(It.IsAny<IEnumerable<string>>()), Times.Never);
+            this.testRequestManager.Verify(trm => trm.InitializeExtensions(It.IsAny<IEnumerable<string>>(), true), Times.Never);
         }
 
         #endregion

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -141,7 +141,7 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
         public void InitializeExtensionsShouldCallTestPlatformToClearAndUpdateExtensions()
         {
             var paths = new List<string>() { "a", "b" };
-            this.testRequestManager.InitializeExtensions(paths);
+            this.testRequestManager.InitializeExtensions(paths, false);
 
             this.mockTestPlatform.Verify(mt => mt.ClearExtensions(), Times.Once);
             this.mockTestPlatform.Verify(mt => mt.UpdateExtensions(paths, false), Times.Once);


### PR DESCRIPTION
* Add API to skip filtering of extensions by name.
* For UseVsixExtensions option, the extensions are specified by name in a <Asset Type=UnitTestExtension Path=xyz />. Test platform must use the path directly (even if it doesn't adhere to the test adapter naming guidelines (compat with VS 2017.3 and previous).
* Removed the `loadWellKnownExtensions` API in Test Plugin component. It was not used anywhere.