### PR TITLE
Fix return code for framework and platform warnings.

### DIFF
--- a/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs
+++ b/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
 
             if (EqtTrace.IsInfoEnabled)
             {
-                EqtTrace.Info("GetArchitecture: determined atchitecture:{0} info for assembly: {1}", archType,
+                EqtTrace.Info("GetArchitecture: determined architecture:{0} info for assembly: {1}", archType,
                     assemblyPath);
             }
 

--- a/src/vstest.console/Processors/Utilities/LoggerUtilities.cs
+++ b/src/vstest.console/Processors/Utilities/LoggerUtilities.cs
@@ -16,10 +16,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
         internal static void RaiseTestRunError(TestLoggerManager loggerManager, TestRunResultAggregator testRunResultAggregator, Exception exception)
         {
             // testRunResultAggregator can be null, if error is being raised in discovery context.
-            if (null != testRunResultAggregator)
-            {
-                testRunResultAggregator.MarkTestRunFailed();
-            }
+            testRunResultAggregator?.MarkTestRunFailed();
 
             TestRunMessageEventArgs errorMessage = new TestRunMessageEventArgs(TestMessageLevel.Error, exception.Message);
             loggerManager.SendTestRunMessage(errorMessage);
@@ -34,12 +31,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
 
         internal static void RaiseTestRunWarning(TestLoggerManager loggerManager, TestRunResultAggregator testRunResultAggregator, string warningMessage)
         {
-            // testRunResultAggregator can be null, if error is being raised in discovery context.
-            if (null != testRunResultAggregator)
-            {
-                testRunResultAggregator.MarkTestRunFailed();
-            }
-
             TestRunMessageEventArgs testRunMessage = new TestRunMessageEventArgs(TestMessageLevel.Warning, warningMessage);
             loggerManager.SendTestRunMessage(testRunMessage);
         }
@@ -49,7 +40,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
         /// </summary>
         /// <param name="argument">Logger argument</param>
         /// <param name="loggerIdentifier">Receives logger Uri or friendly name.</param>
-        /// <param name="paramters">Receives parse name value pairs.</param>
+        /// <param name="parameters">Receives parse name value pairs.</param>
         /// <returns>True is successful, false otherwise.</returns>
         public static bool TryParseLoggerArgument(string argument, out string loggerIdentifier, out Dictionary<string, string> parameters)
         {

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -422,19 +422,17 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
                         settingsUpdated = true;
                     }
 
-                    string incompatiableSettingWarning = string.Empty;
+                    var compatibleSources = InferRunSettingsHelper.FilterCompatibleSources(chosenPlatform, chosenFramework, sourcePlatforms, sourceFrameworks, out var incompatibleSettingWarning);
 
-                    var compatibleSources = InferRunSettingsHelper.FilterCompatibleSources(chosenPlatform, chosenFramework, sourcePlatforms, sourceFrameworks, out incompatiableSettingWarning);
-
-                    if (!string.IsNullOrEmpty(incompatiableSettingWarning))
+                    if (!string.IsNullOrEmpty(incompatibleSettingWarning))
                     {
-                        EqtTrace.Info(incompatiableSettingWarning);
-                        LoggerUtilities.RaiseTestRunWarning(this.testLoggerManager, this.testRunResultAggregator, incompatiableSettingWarning);
+                        EqtTrace.Info(incompatibleSettingWarning);
+                        LoggerUtilities.RaiseTestRunWarning(this.testLoggerManager, this.testRunResultAggregator, incompatibleSettingWarning);
                     }
 
                     if (EqtTrace.IsInfoEnabled)
                     {
-                        EqtTrace.Info("Compatiable sources list : ");
+                        EqtTrace.Info("Compatible sources list : ");
                         EqtTrace.Info(string.Join("\n", compatibleSources.ToArray()));
                     }
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DiscoveryTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DiscoveryTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
     [TestClass]
     public class DiscoveryTests : AcceptanceTestBase
     {
-        private string dummyFilePath = Path.Combine(Path.GetTempPath(), $"{System.Guid.NewGuid()}.txt");
+        private readonly string dummyFilePath = Path.Combine(Path.GetTempPath(), $"{System.Guid.NewGuid()}.txt");
 
         [CustomDataTestMethod]
         [NETFullTargetFramework(inIsolation: true, inProcess: true)]
@@ -19,8 +19,10 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
 
             this.InvokeVsTestForDiscovery(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue);
-            var listOfTests = new string[] { "SampleUnitTestProject.UnitTest1.PassingTest", "SampleUnitTestProject.UnitTest1.FailingTest", "SampleUnitTestProject.UnitTest1.SkippingTest" };
+
+            var listOfTests = new[] { "SampleUnitTestProject.UnitTest1.PassingTest", "SampleUnitTestProject.UnitTest1.FailingTest", "SampleUnitTestProject.UnitTest1.SkippingTest" };
             this.ValidateDiscoveredTests(listOfTests);
+            this.ExitCodeEquals(0);
         }
 
         [CustomDataTestMethod]
@@ -29,11 +31,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void MultipleSourcesDiscoverAllTests(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
-
-            var assemblyPaths =
-                this.BuildMultipleAssemblyPath("SimpleTestProject.dll", "SimpleTestProject2.dll").Trim('\"');
-            this.InvokeVsTestForDiscovery(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue);
-            var listOfTests = new string[] {
+            var assemblyPaths = this.BuildMultipleAssemblyPath("SimpleTestProject.dll", "SimpleTestProject2.dll").Trim('\"');
+            var listOfTests = new[] {
                 "SampleUnitTestProject.UnitTest1.PassingTest",
                 "SampleUnitTestProject.UnitTest1.FailingTest",
                 "SampleUnitTestProject.UnitTest1.SkippingTest",
@@ -41,20 +40,26 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 "SampleUnitTestProject.UnitTest1.FailingTest2",
                 "SampleUnitTestProject.UnitTest1.SkippingTest2"
             };
+
+            this.InvokeVsTestForDiscovery(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue);
+
             this.ValidateDiscoveredTests(listOfTests);
+            this.ExitCodeEquals(0);
         }
 
         [CustomDataTestMethod]
         [NETFullTargetFramework(inIsolation: true, inProcess: true)]
-        [NETCORETargetFramework]
         public void DiscoverFullyQualifiedTests(RunnerInfo runnerInfo)
         {
             try
             {
                 AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+                var listOfTests = new[] { "SampleUnitTestProject.UnitTest1.PassingTest", "SampleUnitTestProject.UnitTest1.FailingTest", "SampleUnitTestProject.UnitTest1.SkippingTest" };
+
                 this.InvokeVsTestForFullyQualifiedDiscovery(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), this.dummyFilePath, string.Empty);
-                var listOfTests = new string[] { "SampleUnitTestProject.UnitTest1.PassingTest", "SampleUnitTestProject.UnitTest1.FailingTest", "SampleUnitTestProject.UnitTest1.SkippingTest" };
+
                 this.ValidateFullyQualifiedDiscoveredTests(this.dummyFilePath, listOfTests);
+                this.ExitCodeEquals(0);
             }
             finally
             {

--- a/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
@@ -21,10 +21,12 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
 
-            var assemblyPaths =
-                this.BuildMultipleAssemblyPath("SimpleTestProject.dll", "SimpleTestProject2.dll").Trim('\"');
+            var assemblyPaths = this.BuildMultipleAssemblyPath("SimpleTestProject.dll", "SimpleTestProject2.dll").Trim('\"');
+
             this.InvokeVsTestForExecution(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue);
+
             this.ValidateSummaryStatus(2, 2, 2);
+            this.ExitCodeEquals(1); // failing tests
         }
 
         [CustomDataTestMethod]
@@ -41,7 +43,9 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
             assemblyPaths = string.Concat(assemblyPaths, "\" \"", xunitAssemblyPath);
             this.InvokeVsTestForExecution(assemblyPaths, string.Empty, string.Empty, this.FrameworkArgValue);
+
             this.ValidateSummaryStatus(2, 2, 1);
+            this.ExitCodeEquals(1); // failing tests
         }
 
         [CustomDataTestMethod]
@@ -83,13 +87,14 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 testhostProcessName);
 
             this.InvokeVsTest(arguments);
-            cts.Cancel();
 
+            cts.Cancel();
             Assert.AreEqual(
                 expectedNumOfProcessCreated,
                 numOfProcessCreatedTask.Result,
                 $"Number of {testhostProcessName} process created, expected: {expectedNumOfProcessCreated} actual: {numOfProcessCreatedTask.Result}");
             this.ValidateSummaryStatus(2, 2, 2);
+            this.ExitCodeEquals(1); // failing tests
         }
 
         [CustomDataTestMethod]
@@ -108,6 +113,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             arguments = string.Concat(arguments, " -- RunConfiguration.TestSessionTimeout=7000");
             this.InvokeVsTest(arguments);
 
+            this.ExitCodeEquals(1);
             this.StdErrorContains("Test Run Aborted.");
             this.StdErrorContains("Aborting test run: test run timeout of 7000 milliseconds exceeded.");
             this.StdOutputDoesNotContains("Total tests: 6");
@@ -125,6 +131,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             this.InvokeVsTest(arguments);
 
             this.ValidateSummaryStatus(1, 0, 0);
+            this.ExitCodeEquals(0);
         }
 
         [CustomDataTestMethod]
@@ -134,12 +141,14 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
 
-            var assemblyPaths =
-                this.BuildMultipleAssemblyPath("SimpleTestProject3.dll").Trim('\"');
+            var assemblyPaths = this.BuildMultipleAssemblyPath("SimpleTestProject3.dll").Trim('\"');
             var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, runnerInfo.InIsolationValue);
             arguments = string.Concat(arguments, " /tests:WorkingDirectoryTest");
+
             this.InvokeVsTest(arguments);
+
             this.ValidateSummaryStatus(1, 0, 0);
+            this.ExitCodeEquals(0);
         }
 
         [CustomDataTestMethod]
@@ -165,17 +174,14 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             arguments = string.Concat(arguments, $" /diag:{diagLogFilePath}");
 
             this.InvokeVsTest(arguments);
-            var errorMessage = string.Empty;
 
+            var errorMessage = "Process is terminated due to StackOverflowException.";
             if (runnerInfo.TargetFramework.StartsWith("netcoreapp2."))
             {
                 errorMessage = "Process is terminating due to StackOverflowException.";
             }
-            else
-            {
-                errorMessage = "Process is terminated due to StackOverflowException.";
-            }
 
+            this.ExitCodeEquals(1);
             FileAssert.Contains(diagLogFilePath, errorMessage);
             this.StdErrorContains(errorMessage);
             File.Delete(diagLogFilePath);
@@ -198,6 +204,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             arguments = string.Concat(arguments, $" /diag:{diagLogFilePath}");
 
             this.InvokeVsTest(arguments);
+
             var errorFirstLine = "Test host standard error line: Unhandled Exception: System.InvalidOperationException: Operation is not valid due to the current state of the object.";
             FileAssert.Contains(diagLogFilePath, errorFirstLine);
             File.Delete(diagLogFilePath);
@@ -205,7 +212,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
         [CustomDataTestMethod]
         [NETFullTargetFramework]
-        public void IncompatiableSourcesWarningShouldBeDisplayedInTheConsole(RunnerInfo runnerInfo)
+        public void IncompatibleSourcesWarningShouldBeDisplayedInTheConsole(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
             var expectedWarningContains = @"Following DLL(s) do not match framework/platform settings.SimpleTestProject3.dll is built for Framework 4.5.1 and Platform X64";
@@ -216,6 +223,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             this.InvokeVsTest(arguments);
 
             this.ValidateSummaryStatus(1, 1, 1);
+            this.ExitCodeEquals(1); // there are failing tests
 
             // When both x64 & x86 DLL is passed x64 dll will be ignored.
             this.StdOutputContains(expectedWarningContains);

--- a/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
@@ -219,11 +219,12 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             var assemblyPaths =
                 this.BuildMultipleAssemblyPath("SimpleTestProject3.dll", "SimpleTestProject2.dll").Trim('\"');
             var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, runnerInfo.InIsolationValue);
+            arguments = string.Concat(arguments, " /testcasefilter:PassingTest2");
 
             this.InvokeVsTest(arguments);
 
-            this.ValidateSummaryStatus(1, 1, 1);
-            this.ExitCodeEquals(1); // there are failing tests
+            this.ValidateSummaryStatus(1, 0, 0);
+            this.ExitCodeEquals(0);
 
             // When both x64 & x86 DLL is passed x64 dll will be ignored.
             this.StdOutputContains(expectedWarningContains);

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -27,6 +27,7 @@ namespace Microsoft.TestPlatform.TestUtilities
         private const string TestSummaryStatusMessageFormat = "Total tests: {0}. Passed: {1}. Failed: {2}. Skipped: {3}";
         private string standardTestOutput = string.Empty;
         private string standardTestError = string.Empty;
+        private int runnerExitCode = -1;
 
         private string arguments = string.Empty;
 
@@ -87,7 +88,7 @@ namespace Microsoft.TestPlatform.TestUtilities
         /// <param name="arguments">Arguments provided to <c>vstest.console</c>.exe</param>
         public void InvokeVsTest(string arguments)
         {
-            this.Execute(arguments, out this.standardTestOutput, out this.standardTestError);
+            this.Execute(arguments, out this.standardTestOutput, out this.standardTestError, out this.runnerExitCode);
             this.FormatStandardOutCome();
         }
 
@@ -122,7 +123,7 @@ namespace Microsoft.TestPlatform.TestUtilities
         }
 
         /// <summary>
-        /// Invokes <c>vstest.console</c> to discover tests in a test assembly. "/ListFullyQualifiedTests /ListTestsTarget:'filename'" 
+        /// Invokes <c>vstest.console</c> to discover tests in a test assembly. "/ListFullyQualifiedTests /ListTestsTarget:'filename'"
         /// is appended to the arguments.
         /// </summary>
         /// <param name="testAssembly">A test assembly.</param>
@@ -201,6 +202,11 @@ namespace Microsoft.TestPlatform.TestUtilities
         public void StdOutputDoesNotContains(string substring)
         {
             Assert.IsFalse(this.standardTestOutput.Contains(substring), $"StdOutout:{Environment.NewLine} Not expected substring: {substring}{Environment.NewLine}Acutal string: {this.standardTestOutput}");
+        }
+
+        public void ExitCodeEquals(int exitCode)
+        {
+            Assert.AreEqual(exitCode, this.runnerExitCode, $"ExitCode - [{this.runnerExitCode}] doesn't match expected '{exitCode}'.");
         }
 
         /// <summary>
@@ -290,7 +296,7 @@ namespace Microsoft.TestPlatform.TestUtilities
         {
             var fileOutput = File.ReadAllLines(filePath);
             Assert.IsTrue(fileOutput.Length == 3);
-            
+
             foreach (var test in discoveredTestsList)
             {
                 var flag = fileOutput.Contains(test)
@@ -390,7 +396,7 @@ namespace Microsoft.TestPlatform.TestUtilities
             return testMethodName;
         }
 
-        private void Execute(string args, out string stdOut, out string stdError)
+        private void Execute(string args, out string stdOut, out string stdError, out int exitCode)
         {
             if (this.IsNetCoreRunner())
             {
@@ -439,7 +445,8 @@ namespace Microsoft.TestPlatform.TestUtilities
 
                 stdError = stderrBuffer.ToString();
                 stdOut = stdoutBuffer.ToString();
-                Console.WriteLine("IntegrationTestBase.Execute: Stopped vstest.console.exe. Exit code = {0}", vstestconsole.ExitCode);
+                exitCode = vstestconsole.ExitCode;
+                Console.WriteLine("IntegrationTestBase.Execute: Stopped vstest.console.exe. Exit code = {0}", exitCode);
             }
         }
 

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/InferRunSettingsHelperTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/InferRunSettingsHelperTests.cs
@@ -415,7 +415,7 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         }
 
         [TestMethod]
-        public void FilterCompatiableSourcesShouldIdentifyIncomaptiableSourcesAndConstructWarningMessage()
+        public void FilterCompatibleSourcesShouldIdentifyIncomaptiableSourcesAndConstructWarningMessage()
         {
             #region Arrange
             sourceArchitectures["AnyCPU1net46.dll"] = Architecture.AnyCPU;
@@ -438,13 +438,13 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
             string warningMessage = string.Empty;
             var compatibleSources = InferRunSettingsHelper.FilterCompatibleSources(Constants.DefaultPlatform, frameworkNet47, sourceArchitectures, sourceFrameworks, out warningMessage);
 
-            // None of the DLLs passed are compatiable to the chosen settings
+            // None of the DLLs passed are compatible to the chosen settings
             Assert.AreEqual(0, compatibleSources.Count());
             Assert.AreEqual(expected, warningMessage);
         }
 
         [TestMethod]
-        public void FilterCompatiableSourcesShouldIdentifyCompatiableSources()
+        public void FilterCompatibleSourcesShouldIdentifyCompatibleSources()
         {
             sourceArchitectures["x64net45.exe"] = Architecture.X64;
             sourceArchitectures["x86net45.dll"] = Architecture.X86;
@@ -461,13 +461,13 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
             string warningMessage = string.Empty;
             var compatibleSources = InferRunSettingsHelper.FilterCompatibleSources(Constants.DefaultPlatform, frameworkNet45, sourceArchitectures, sourceFrameworks, out warningMessage);
 
-            // only "x86net45.dll" is the compatiable source
+            // only "x86net45.dll" is the compatible source
             Assert.AreEqual(1, compatibleSources.Count());
             Assert.AreEqual(expected, warningMessage);
         }
 
         [TestMethod]
-        public void FilterCompatiableSourcesShouldNotComposeWarningIfSettingsAreCorrect()
+        public void FilterCompatibleSourcesShouldNotComposeWarningIfSettingsAreCorrect()
         {
             sourceArchitectures["x86net45.dll"] = Architecture.X86;
             sourceFrameworks["x86net45.dll"] = frameworkNet45;
@@ -475,13 +475,13 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
             string warningMessage = string.Empty;
             var compatibleSources = InferRunSettingsHelper.FilterCompatibleSources(Constants.DefaultPlatform, frameworkNet45, sourceArchitectures, sourceFrameworks, out warningMessage);
 
-            // only "x86net45.dll" is the compatiable source
+            // only "x86net45.dll" is the compatible source
             Assert.AreEqual(1, compatibleSources.Count());
             Assert.IsTrue(string.IsNullOrEmpty(warningMessage));
         }
 
         [TestMethod]
-        public void FilterCompatiableSourcesShouldRetrunWarningMessageIfNoConflict()
+        public void FilterCompatibleSourcesShouldRetrunWarningMessageIfNoConflict()
         {
             sourceArchitectures["x64net45.exe"] = Architecture.X64;
             sourceFrameworks["x64net45.exe"] = frameworkNet45;


### PR DESCRIPTION
Do not set exit code as non-zero for warnings. Add checks for acceptance tests
for exit code.