### PR TITLE
Replace space with underscore in RunDeploymentRootDirectory name

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -486,8 +486,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
         /// </summary>
         private void SetDefaultTrxFilePath()
         {
-            // [RunDeploymentRootDirectory] Replace white space with underscore from trx file name to make it command line friendly
-            var defaultTrxFileName = this.testRun.RunConfiguration.RunDeploymentRootDirectory.Replace(' ', '_') + ".trx";
+            var defaultTrxFileName = this.testRun.RunConfiguration.RunDeploymentRootDirectory + ".trx";
             this.trxFilePath = FileHelper.GetNextIterationFileName(this.testResultsDirPath, defaultTrxFileName, false);
         }
 

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/FileHelper.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/FileHelper.cs
@@ -57,6 +57,10 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.Utility
             AdditionalInvalidFileNameChars.Add('(', null);
             AdditionalInvalidFileNameChars.Add(')', null);
             AdditionalInvalidFileNameChars.Add('^', null);
+
+            // Replace white space with underscore from folder/file name to make it command line friendly
+            // Related issues https://github.com/Microsoft/vstest/issues/244 & https://devdiv.visualstudio.com/DevDiv/_workitems?id=507982&_a=edit
+            AdditionalInvalidFileNameChars.Add(' ', null);
         }
 
         #endregion

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/FileHelper.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/FileHelper.cs
@@ -52,7 +52,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.Utility
 
             // Needed becuase when kicking off qtsetup.bat cmd.exe is used.  '@' is a special character
             // for cmd so must be removed from the path to the bat file
-            AdditionalInvalidFileNameChars = new Dictionary<char, object>(4);
+            AdditionalInvalidFileNameChars = new Dictionary<char, object>(5);
             AdditionalInvalidFileNameChars.Add('@', null);
             AdditionalInvalidFileNameChars.Add('(', null);
             AdditionalInvalidFileNameChars.Add(')', null);

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/Utility/FileHelperTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/Utility/FileHelperTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests.Utility
+{
+    using Microsoft.TestPlatform.Extensions.TrxLogger.Utility;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class FileHelperTests
+    {
+        [TestMethod]
+        public void ReplaceInvalidFileNameCharsShouldReplaceSpace()
+        {
+            Assert.AreEqual("samadala_SAMADALA_2017-10-13_18_33_17",
+                FileHelper.ReplaceInvalidFileNameChars("samadala_SAMADALA 2017-10-13 18_33_17"));
+        }
+    }
+}


### PR DESCRIPTION
Issue: TFS VSTest task depends on trx file name to publish code coverage results. As trx file name was changed here: https://github.com/Microsoft/vstest/pull/261, publishing code coverage results broken. 

Fix: Replace space with underscore in RunDeploymentRootDirectory name which is used by both default trx filename and code coverage attachments directory.

Related Issue: https://devdiv.visualstudio.com/DevDiv/_workitems?id=507982&_a=edit
