### PR TITLE
Removed unnecessary Error Message in DC Eqt Trace.

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
@@ -247,7 +247,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
 
                         try
                         {
-                            this.testCaseEventMonitorTask.Wait(this.cancellationTokenSource.Token);
+                            this.testCaseEventMonitorTask?.Wait(this.cancellationTokenSource.Token);
                             this.dataCollectionTestCaseEventHandler.Close();
                         }
                         catch (Exception ex)


### PR DESCRIPTION
Fixed unnecessary Error Message in DC Eqt Trace.

>TpTrace Error: 0 : 28044, 7, 2017/10/13, 20:01:27.663, 629089322622, datacollector.exe, DataCollectionRequestHandler.ProcessRequests : Object reference not set to an instance of an object.