### PR TITLE
Adding assembly resolver to team foundation folder

### DIFF
--- a/src/Microsoft.TestPlatform.Common/Utilities/InstallationContext.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/InstallationContext.cs
@@ -50,6 +50,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
                 Path.Combine(visualStudioDirectory, PrivateAssembliesDirName),
                 Path.Combine(visualStudioDirectory, PublicAssembliesDirName),
                 Path.Combine(visualStudioDirectory, "CommonExtensions", "Microsoft", "TestWindow"),
+                Path.Combine(visualStudioDirectory, "CommonExtensions", "Microsoft", "TeamFoundation", "Team Explorer"),
                 visualStudioDirectory
             };
         }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Utilities/InstallationContextTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Utilities/InstallationContextTests.cs
@@ -57,6 +57,7 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Utilities
                 @"C:\temp\PrivateAssemblies",
                 @"C:\temp\PublicAssemblies",
                 @"C:\temp\CommonExtensions\Microsoft\TestWindow",
+                @"C:\temp\CommonExtensions\Microsoft\TeamFoundation\Team Explorer",
                 @"C:\temp"
             };
             var commonLocations = this.installationContext.GetVisualStudioCommonLocations(@"C:\temp");


### PR DESCRIPTION
- Data driven tests contacting TFS needs the team foundation DLLs