### PR TITLE
Do not crash data collector if a extension initialize fails.

### DIFF
--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
@@ -537,9 +537,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
             var dataCollectorEnvironmentVariable = new Dictionary<string, DataCollectionEnvironmentVariable>(StringComparer.OrdinalIgnoreCase);
             foreach (var dataCollectorInfo in this.RunDataCollectors.Values)
             {
-                dataCollectorInfo.SetTestExecutionEnvironmentVariables();
                 try
                 {
+                    dataCollectorInfo.SetTestExecutionEnvironmentVariables();
                     this.AddCollectorEnvironmentVariables(dataCollectorInfo, dataCollectorEnvironmentVariable);
                 }
                 catch (Exception ex)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManagerWithDataCollection.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManagerWithDataCollection.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="ProxyExecutionManagerWithDataCollection"/> class. 
         /// </summary>
-        /// <param name="testRequestSender">
+        /// <param name="requestSender">
         /// Test request sender instance.
         /// </param>
         /// <param name="testHostManager">
@@ -44,6 +44,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             this.ProxyDataCollectionManager = proxyDataCollectionManager;
             this.DataCollectionRunEventsHandler = new DataCollectionRunEventsHandler();
             this.requestData = requestData;
+            this.dataCollectionEnvironmentVariables = new Dictionary<string, string>();
         }
 
         /// <summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
             ITestMessageEventHandler runEventsHandler)
         {
             var areTestCaseLevelEventsRequired = false;
-            IDictionary<string, string> environmentVariables = null;
+            IDictionary<string, string> environmentVariables = new Dictionary<string, string>();
 
             var dataCollectionEventsPort = 0;
             this.InvokeDataCollectionServiceAction(

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
@@ -136,9 +136,9 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
             var result = this.proxyDataCollectionManager.BeforeTestRunStart(true, true, mockRunEventsHandler.Object);
 
             mockRunEventsHandler.Verify(eh => eh.HandleLogMessage(TestMessageLevel.Error, "Exception of type 'System.Exception' was thrown."), Times.Once);
-            Assert.AreEqual(result.EnvironmentVariables, null);
-            Assert.AreEqual(result.AreTestCaseLevelEventsRequired, false);
-            Assert.AreEqual(result.DataCollectionEventsPort, 0);
+            Assert.AreEqual(0, result.EnvironmentVariables.Count);
+            Assert.AreEqual(false, result.AreTestCaseLevelEventsRequired);
+            Assert.AreEqual(0, result.DataCollectionEventsPort);
         }
 
         [TestMethod]

--- a/test/datacollector.UnitTests/DataCollectionManagerTests.cs
+++ b/test/datacollector.UnitTests/DataCollectionManagerTests.cs
@@ -158,6 +158,17 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
         }
 
         [TestMethod]
+        public void InitializeDataCollectorsShouldLogExceptionToMessageSinkIfSetEnvironmentVariableFails()
+        {
+            this.mockDataCollector.As<ITestExecutionEnvironmentSpecifier>().Setup(x => x.GetTestExecutionEnvironmentVariables()).Throws<Exception>();
+
+            this.dataCollectionManager.InitializeDataCollectors(this.dataCollectorSettings);
+
+            Assert.AreEqual(0, this.dataCollectionManager.RunDataCollectors.Count);
+            this.mockMessageSink.Verify(x => x.SendMessage(It.IsAny<DataCollectionMessageEventArgs>()), Times.Once);
+        }
+
+        [TestMethod]
         public void InitializeDataCollectorsShouldReturnFirstEnvironmentVariableIfMoreThanOneVariablesWithSameKeyIsSpecified()
         {
             this.envVarList.Add(new KeyValuePair<string, string>("key", "value"));


### PR DESCRIPTION
In VS Professional SKU, code coverage data collector is not available. Initialize fails and data collector used to crash. This aborts the run with error. With this fix, the error will be logged for user, however test run will continue and results will be displayed.
Issue: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/VS.in%20Agile%20Testing%20IDE/_workitems/edit/513913