### PR TITLE
Use TPv2 as default for .NET 3.5.

### DIFF
--- a/src/package/VSIXProject/testplatform.config
+++ b/src/package/VSIXProject/testplatform.config
@@ -3,7 +3,7 @@
 <configuration>
   <appSettings>
     <!-- Setting feature.net35 to "true" will execute full clr tests targeting framework <=v3.5 through TPV2. -->
-    <add key="feature.net35" value="false" />
+    <add key="feature.net35" value="true" />
     <!-- Setting feature.net40 to "true" will execute full clr tests targeting framework >=4.0 through TPV2. -->
     <add key="feature.net40" value="true" />
     <!-- Setting feature.datacollector to "true"" will execute data collection (code coverage, etc.) through TPV2. -->


### PR DESCRIPTION
In VS Test Explorer, TPv1 is still used as default for .NET 3.5 projects. With this change, we will
enable these test projects to run with TPv2.