### PR TITLE
Set anycpu arch for non dotnet test sources

### DIFF
--- a/src/vstest.console/CommandLine/InferHelper.cs
+++ b/src/vstest.console/CommandLine/InferHelper.cs
@@ -44,8 +44,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLineUtilities
                         }
                         else
                         {
-                            //TODO what to do for js, appx and others? Using default for now.
-                            arch = Constants.DefaultPlatform;
+                            //TODO what to do for js, appx and others? Using AnyCPU for now.
+                            arch = Architecture.AnyCPU;
                         }
                         sourcePlatforms[source]=(Architecture)arch;
 
@@ -78,10 +78,18 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLineUtilities
             {
                 EqtTrace.Error("Failed to determine platform: {0}, using default: {1}", ex, architecture);
             }
+
+            if (EqtTrace.IsInfoEnabled)
+            {
+                EqtTrace.Info("Determined platform for all sources: {0}", architecture);
+            }
+
             return architecture;
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Determines Framework from sources.
+        /// </summary>
         public Framework AutoDetectFramework(List<string> sources, IDictionary<string, Framework> sourceFrameworkVersions)
         {
             Framework framework = Framework.DefaultFramework;
@@ -107,7 +115,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLineUtilities
 
             if (EqtTrace.IsInfoEnabled)
             {
-                EqtTrace.Info("Determined framework: {0}", framework);
+                EqtTrace.Info("Determined framework for all sources: {0}", framework);
             }
 
             return framework;

--- a/src/vstest.console/CommandLine/InferHelper.cs
+++ b/src/vstest.console/CommandLine/InferHelper.cs
@@ -44,7 +44,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLineUtilities
                         }
                         else
                         {
-                            //TODO what to do for js, appx and others? Using AnyCPU for now.
+                            // Set AnyCPU for non dotnet test sources (js, py and other). Otherwise warning will
+                            // show up if there is mismatch with user provided platform.
                             arch = Architecture.AnyCPU;
                         }
                         sourcePlatforms[source]=(Architecture)arch;

--- a/test/vstest.console.UnitTests/CommandLine/InferHelperTests.cs
+++ b/test/vstest.console.UnitTests/CommandLine/InferHelperTests.cs
@@ -75,6 +75,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.CommandLine
         }
 
         [TestMethod]
+        public void AutoDetectArchitectureShouldSetAnyCpuArchForNotDotNetAssembly()
+        {
+            inferHelper.AutoDetectArchitecture(new List<string>() { "NotDotNetAssebly.appx" }, sourceArchitectures);
+            Assert.AreEqual(Architecture.AnyCPU, sourceArchitectures["NotDotNetAssebly.appx"]);
+        }
+
+        [TestMethod]
         public void AutoDetectArchitectureShouldReturnDefaultArchForAllAnyCpuAssemblies()
         {
             this.mockAssemblyHelper.SetupSequence(ah => ah.GetArchitecture(It.IsAny<string>()))


### PR DESCRIPTION
- Settings DefaultPlatform for js, appx or other test source causing warning message showing up if /platform specify not not default platform.