### PR TITLE
Port fixes

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -61,8 +61,8 @@ $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
 # Dotnet build doesn't support --packages yet. See https://github.com/dotnet/cli/issues/2712
 $env:NUGET_PACKAGES = $env:TP_PACKAGES_DIR
 $env:NUGET_EXE_Version = "3.4.3"
-$env:DOTNET_CLI_VERSION = "LATEST"
-$env:DOTNET_RUNTIME_VERSION = "LATEST"
+$env:DOTNET_CLI_VERSION = "2.1.0-preview1-007372"
+# $env:DOTNET_RUNTIME_VERSION = "LATEST"
 $env:VSWHERE_VERSION = "2.0.2"
 $env:MSBUILD_VERSION = "15.0"
 

--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
@@ -537,9 +537,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
             var dataCollectorEnvironmentVariable = new Dictionary<string, DataCollectionEnvironmentVariable>(StringComparer.OrdinalIgnoreCase);
             foreach (var dataCollectorInfo in this.RunDataCollectors.Values)
             {
-                dataCollectorInfo.SetTestExecutionEnvironmentVariables();
                 try
                 {
+                    dataCollectorInfo.SetTestExecutionEnvironmentVariables();
                     this.AddCollectorEnvironmentVariables(dataCollectorInfo, dataCollectorEnvironmentVariable);
                 }
                 catch (Exception ex)

--- a/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
@@ -109,10 +109,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
                 var document = new XmlDocument();
                 document.Load(reader);
 
-                var navigator = document.CreateNavigator();
-
-                InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(navigator, architecture, framework, defaultResultsDirectory);
-                return navigator.OuterXml;
+                InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(document, architecture, framework, defaultResultsDirectory);
+                return document.OuterXml;
             }
         }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManagerWithDataCollection.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManagerWithDataCollection.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="ProxyExecutionManagerWithDataCollection"/> class. 
         /// </summary>
-        /// <param name="testRequestSender">
+        /// <param name="requestSender">
         /// Test request sender instance.
         /// </param>
         /// <param name="testHostManager">
@@ -44,6 +44,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             this.ProxyDataCollectionManager = proxyDataCollectionManager;
             this.DataCollectionRunEventsHandler = new DataCollectionRunEventsHandler();
             this.requestData = requestData;
+            this.dataCollectionEnvironmentVariables = new Dictionary<string, string>();
         }
 
         /// <summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
             ITestMessageEventHandler runEventsHandler)
         {
             var areTestCaseLevelEventsRequired = false;
-            IDictionary<string, string> environmentVariables = null;
+            IDictionary<string, string> environmentVariables = new Dictionary<string, string>();
 
             var dataCollectionEventsPort = 0;
             this.InvokeDataCollectionServiceAction(

--- a/src/Microsoft.TestPlatform.ObjectModel/Navigation/NativeMethods.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Navigation/NativeMethods.cs
@@ -556,19 +556,11 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Navigation
 
         public static IDiaDataSource GetDiaSourceObject()
         {
-            var currentDirectory = new ProcessHelper().GetCurrentProcessLocation();
+            var nativeDllDirectory = new ProcessHelper().GetNativeDllDirectory();
 
-            IntPtr modHandle = IntPtr.Zero;
-            if (IntPtr.Size == 8)
-            {
-                modHandle = LoadLibraryEx(Path.Combine(currentDirectory, "x64\\msdia140.dll"), IntPtr.Zero, 0);
-            }
-            else
-            {
-                modHandle = LoadLibraryEx(Path.Combine(currentDirectory, "x86\\msdia140.dll"), IntPtr.Zero, 0);
-            }
+            IntPtr modHandle = LoadLibraryEx(Path.Combine(nativeDllDirectory, "msdia140.dll"), IntPtr.Zero, 0);
 
-            if(modHandle == IntPtr.Zero)
+            if (modHandle == IntPtr.Zero)
             {
                 throw new COMException(string.Format(Resources.Resources.FailedToLoadMsDia));
             }

--- a/src/Microsoft.TestPlatform.ObjectModel/TestCase.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TestCase.cs
@@ -18,13 +18,12 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
     [DataContract]
     public sealed class TestCase : TestObject
     {
-#if TODO
         /// <summary>
         /// LocalExtensionData which can be used by Adapter developers for local transfer of extended properties. 
         /// Note that this data is available only for in-Proc execution, and may not be available for OutProc executors
         /// </summary>
-        private Object m_localExtensionData;
-#endif
+        private Object localExtensionData;
+
         private Guid defaultId = Guid.Empty;
         private Guid id;
         private string displayName;
@@ -70,17 +69,15 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 
         #region Properties
 
-#if TODO
         /// <summary>
         /// LocalExtensionData which can be used by Adapter developers for local transfer of extended properties. 
         /// Note that this data is available only for in-Proc execution, and may not be available for OutProc executors
         /// </summary>
         public Object LocalExtensionData
         {
-            get { return m_localExtensionData; }
-            set { m_localExtensionData = value; }
+            get { return localExtensionData; }
+            set { localExtensionData = value; }
         }
-#endif
 
         /// <summary>
         /// Gets or sets the id of the test case.

--- a/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
@@ -212,7 +212,14 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
 #if NET451
             return doc;
 #else
-            return doc.ToXPathNavigable();
+            // Xmldocument doesn't inherit from XmlDocument for netcoreapp2.0
+            var ret = doc as IXPathNavigable;
+            if (ret == null)
+            {
+                return doc.ToXPathNavigable();
+            }
+
+            return ret;
 #endif
         }
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/IProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/IProcessHelper.cs
@@ -42,6 +42,18 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces
         string GetTestEngineDirectory();
 
         /// <summary>
+        /// Gets the location of native dll's, depending on current process architecture..
+        /// </summary>
+        /// <returns>Location of native dll's</returns>
+        string GetNativeDllDirectory();
+
+        /// <summary>
+        /// Gets current process architecture
+        /// </summary>
+        /// <returns>Process Architecture</returns>
+        PlatformArchitecture GetCurrentProcessArchitecture();
+
+        /// <summary>
         /// Gets the process id of test engine.
         /// </summary>
         /// <returns>process id of test engine.</returns>

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -16,6 +16,8 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
     /// </summary>
     public partial class ProcessHelper : IProcessHelper
     {
+        private static readonly string ARM = "arm";
+
         /// <inheritdoc/>
         public object LaunchProcess(string processPath, string arguments, string workingDirectory, IDictionary<string, string> envVariables, Action<object, string> errorCallback, Action<object> exitCallBack)
         {
@@ -161,6 +163,24 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         {
             var proc = process as Process;
             return proc?.Id ?? -1;
+        }
+
+        /// <inheritdoc/>
+        public PlatformArchitecture GetCurrentProcessArchitecture()
+        {
+            if (IntPtr.Size == 8)
+            {
+                return PlatformArchitecture.X64;
+            }
+
+            return PlatformArchitecture.X86;
+        }
+
+        /// <inheritdoc/>
+        public string GetNativeDllDirectory()
+        {
+            var isArm = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE").Contains("ARM");
+            return Path.Combine(this.GetCurrentProcessLocation(), this.GetCurrentProcessArchitecture().ToString(), isArm ? ARM : string.Empty);
         }
     }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -179,8 +179,13 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         /// <inheritdoc/>
         public string GetNativeDllDirectory()
         {
-            var isArm = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE").Contains("ARM");
-            return Path.Combine(this.GetCurrentProcessLocation(), this.GetCurrentProcessArchitecture().ToString(), isArm ? ARM : string.Empty);
+            var osArchitecture = new PlatformEnvironment().Architecture;
+            if (osArchitecture == PlatformArchitecture.ARM || osArchitecture == PlatformArchitecture.ARM64)
+            {
+                return Path.Combine(this.GetCurrentProcessLocation(), this.GetCurrentProcessArchitecture().ToString().ToLower(), ARM);
+            }
+
+            return Path.Combine(this.GetCurrentProcessLocation(), this.GetCurrentProcessArchitecture().ToString().ToLower());
         }
     }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard1.0/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard1.0/System/ProcessHelper.cs
@@ -78,5 +78,17 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         {
             throw new NotImplementedException();
         }
+
+        /// <inheritdoc/>
+        public string GetNativeDllDirectory()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public PlatformArchitecture GetCurrentProcessArchitecture()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/ProcessHelper.cs
@@ -77,5 +77,23 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         {
             return -1;
         }
+
+        /// <inheritdoc/>
+        public PlatformArchitecture GetCurrentProcessArchitecture()
+        {
+            if (IntPtr.Size == 8)
+            {
+                return PlatformArchitecture.X64;
+            }
+
+            return PlatformArchitecture.X86;
+        }
+
+        /// <inheritdoc/>
+        public string GetNativeDllDirectory()
+        {
+            // For UWP the native dll's are to be kept in same directory
+            return this.GetCurrentProcessLocation();
+        }
     }
 }

--- a/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
@@ -375,10 +375,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
             Framework effectiveFramework,
             string resultsDirectory)
         {
-            var resultsDirectoryNavigator = xmlDocument.SelectSingleNode(ResultsDirectoryNodePath);
-            if (null != resultsDirectoryNavigator)
+            var childNode = xmlDocument.SelectSingleNode(ResultsDirectoryNodePath);
+            if (null != childNode)
             {
-                resultsDirectory = resultsDirectoryNavigator.InnerXml;
+                resultsDirectory = childNode.InnerXml;
             }
 
             XmlUtilities.AppendOrModifyChild(xmlDocument, RunConfigurationNodePath, RunConfigurationNodeName, null);

--- a/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
                     {
                         EqtTrace.Error("InferRunSettingsHelper.MakeRunsettingsCompatible: Unable to navigate to RunConfiguration. Current node: " + runSettingsNavigator.LocalName);
                     }
-                    else if(runSettingsNavigator.HasChildren)
+                    else if (runSettingsNavigator.HasChildren)
                     {
                         var listOfInValidRunConfigurationSettings = new List<string>();
 
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
                         runSettingsNavigator.MoveToFirstChild();
                         do
                         {
-                            if(!listOfValidRunConfigurationSettings.Contains(runSettingsNavigator.LocalName))
+                            if (!listOfValidRunConfigurationSettings.Contains(runSettingsNavigator.LocalName))
                             {
                                 listOfInValidRunConfigurationSettings.Add(runSettingsNavigator.LocalName);
                             }
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
                         // Delete all invalid RunConfiguration Settings
                         if (listOfInValidRunConfigurationSettings.Count > 0)
                         {
-                            if(EqtTrace.IsWarningEnabled)
+                            if (EqtTrace.IsWarningEnabled)
                             {
                                 string settingsName = string.Join(", ", listOfInValidRunConfigurationSettings);
                                 EqtTrace.Warning(string.Format("InferRunSettingsHelper.MakeRunsettingsCompatible: Removing the following settings: {0} from RunSettings file. To use those settings please move to latest version of Microsoft.NET.Test.Sdk", settingsName));
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
                             // move navigator to RunConfiguration node
                             runSettingsNavigator.MoveToParent();
 
-                            foreach(var s in listOfInValidRunConfigurationSettings)
+                            foreach (var s in listOfInValidRunConfigurationSettings)
                             {
                                 var nodePath = RunConfigurationNodePath + "/" + s;
                                 XmlUtilities.RemoveChildNode(runSettingsNavigator, nodePath, s);
@@ -129,12 +129,14 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         /// <summary>
         /// Updates the run settings XML with the specified values.
         /// </summary>
-        /// <param name="runSettingsNavigator"> The navigator of the XML. </param>
+        /// <param name="runSettingsDocument"> The XmlDocument of the XML. </param>
         /// <param name="architecture"> The architecture. </param>
         /// <param name="framework"> The framework. </param>
         /// <param name="resultsDirectory"> The results directory. </param>
-        public static void UpdateRunSettingsWithUserProvidedSwitches(XPathNavigator runSettingsNavigator, Architecture architecture, Framework framework, string resultsDirectory)
+        public static void UpdateRunSettingsWithUserProvidedSwitches(XmlDocument runSettingsDocument, Architecture architecture, Framework framework, string resultsDirectory)
         {
+            var runSettingsNavigator = runSettingsDocument.CreateNavigator();
+
             ValidateRunConfiguration(runSettingsNavigator);
 
             // when runsettings specifies platform, that takes precedence over the user specified platform via command line arguments.
@@ -164,67 +166,65 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
             VerifyCompatibilityWithOSArchitecture(architecture);
 
             // Check if inputRunSettings has results directory configured.
-            var hasResultsDirectory = runSettingsNavigator.SelectSingleNode(ResultsDirectoryNodePath) != null;
+            var hasResultsDirectory = runSettingsDocument.SelectSingleNode(ResultsDirectoryNodePath) != null;
 
             // Regenerate the effective settings.
             if (shouldUpdatePlatform || shouldUpdateFramework || !hasResultsDirectory)
             {
-                UpdateRunConfiguration(runSettingsNavigator, architecture, framework, resultsDirectory);
+                UpdateRunConfiguration(runSettingsDocument, architecture, framework, resultsDirectory);
             }
-
-            runSettingsNavigator.MoveToRoot();
         }
 
         /// <summary>
         /// Updates the <c>RunConfiguration.DesignMode</c> value for a run settings. Doesn't do anything if the value is already set.
         /// </summary>
-        /// <param name="runSettingsNavigator">Navigator for runsettings xml</param>
+        /// <param name="runSettingsDocument">Document for runsettings xml</param>
         /// <param name="designModeValue">Value to set</param>
-        public static void UpdateDesignMode(XPathNavigator runSettingsNavigator, bool designModeValue)
+        public static void UpdateDesignMode(XmlDocument runSettingsDocument, bool designModeValue)
         {
-            AddNodeIfNotPresent<bool>(runSettingsNavigator, DesignModeNodePath, DesignModeNodeName, designModeValue);
+            AddNodeIfNotPresent<bool>(runSettingsDocument, DesignModeNodePath, DesignModeNodeName, designModeValue);
         }
 
         /// <summary>
         /// Updates the <c>RunConfiguration.CollectSourceInformation</c> value for a run settings. Doesn't do anything if the value is already set.
         /// </summary>
-        /// <param name="runSettingsNavigator">Navigator for runsettings xml</param>
+        /// <param name="runSettingsDocument">Navigator for runsettings xml</param>
         /// <param name="collectSourceInformationValue">Value to set</param>
-        public static void UpdateCollectSourceInformation(XPathNavigator runSettingsNavigator, bool collectSourceInformationValue)
+        public static void UpdateCollectSourceInformation(XmlDocument runSettingsDocument, bool collectSourceInformationValue)
         {
-            AddNodeIfNotPresent<bool>(runSettingsNavigator, CollectSourceInformationNodePath, CollectSourceInformationNodeName, collectSourceInformationValue);
+            AddNodeIfNotPresent<bool>(runSettingsDocument, CollectSourceInformationNodePath, CollectSourceInformationNodeName, collectSourceInformationValue);
         }
 
         /// <summary>
         /// Updates the <c>RunConfiguration.TargetDevice</c> value for a run settings. Doesn't do anything if the value is already set.
         /// </summary>
-        /// <param name="runSettingsNavigator">Navigator for runsettings xml</param>
+        /// <param name="runSettingsDocument">XmlDocument for runsettings xml</param>
         /// <param name="targetDevice">Value to set</param>
-        public static void UpdateTargetDevice(XPathNavigator runSettingsNavigator, string targetDevice)
+        public static void UpdateTargetDevice(XmlDocument runSettingsDocument, string targetDevice)
         {
-            AddNodeIfNotPresent<string>(runSettingsNavigator, TargetDeviceNodePath, TargetDevice, targetDevice);
+            AddNodeIfNotPresent<string>(runSettingsDocument, TargetDeviceNodePath, TargetDevice, targetDevice);
         }
 
         /// <summary>
         /// Updates the <c>RunConfiguration.TargetFrameworkVersion</c> value for a run settings. if the value is already set, behavior depends on overwrite.
         /// </summary>
-        /// <param name="runSettingsNavigator">Navigator for runsettings xml</param>
+        /// <param name="runSettingsDocument">XmlDocument for runsettings xml</param>
         /// <param name="framework">Value to set</param>
         /// <param name="overwrite">Overwrite option.</param>
-        public static void UpdateTargetFramework(XPathNavigator runSettingsNavigator, string framework, bool overwrite=false)
+        public static void UpdateTargetFramework(XmlDocument runSettingsDocument, string framework, bool overwrite = false)
         {
-            AddNodeIfNotPresent<string>(runSettingsNavigator, TargetFrameworkNodePath, TargetFrameworkNodeName, framework, overwrite);
+            AddNodeIfNotPresent<string>(runSettingsDocument, TargetFrameworkNodePath, TargetFrameworkNodeName, framework, overwrite);
         }
 
         /// <summary>
         /// Updates the <c>RunConfiguration.TargetPlatform</c> value for a run settings. if the value is already set, behavior depends on overwrite.
         /// </summary>
-        /// <param name="runSettingsNavigator">Navigator for runsettings xml</param>
+        /// <param name="runSettingsDocument">Navigator for runsettings xml</param>
         /// <param name="platform">Value to set</param>
         /// <param name="overwrite">Overwrite option.</param>
-        public static void UpdateTargetPlatform(XPathNavigator runSettingsNavigator, string platform, bool overwrite = false)
+        public static void UpdateTargetPlatform(XmlDocument runSettingsDocument, string platform, bool overwrite = false)
         {
-            AddNodeIfNotPresent<string>(runSettingsNavigator, TargetPlatformNodePath, TargetPlatformNodeName, platform, overwrite);
+            AddNodeIfNotPresent<string>(runSettingsDocument, TargetPlatformNodePath, TargetPlatformNodeName, platform, overwrite);
         }
 
         public static bool TryGetDeviceXml(XPathNavigator runSettingsNavigator, out String deviceXml)
@@ -267,7 +267,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
                     }
 
                     var node = runSettingsNavigator.SelectSingleNode(@"/RunSettings/MSTest/SettingsFile");
-                    if(node != null && !string.IsNullOrEmpty(node.InnerXml))
+                    if (node != null && !string.IsNullOrEmpty(node.InnerXml))
                     {
                         return true;
                     }
@@ -280,21 +280,21 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         /// <summary>
         /// Adds node under RunConfiguration setting. Noop if node is already present.
         /// </summary>
-        private static void AddNodeIfNotPresent<T>(XPathNavigator runSettingsNavigator, string nodePath, string nodeName, T nodeValue, bool overwrite = false)
+        private static void AddNodeIfNotPresent<T>(XmlDocument xmlDocument, string nodePath, string nodeName, T nodeValue, bool overwrite = false)
         {
             // Navigator should be at Root of runsettings xml, attempt to move to /RunSettings/RunConfiguration
-            if (!runSettingsNavigator.MoveToChild(RunSettingsNodeName, string.Empty) ||
-                !runSettingsNavigator.MoveToChild(RunConfigurationNodeName, string.Empty))
+            var root = xmlDocument.DocumentElement;
+
+            if (root.SelectSingleNode(RunConfigurationNodePath) == null)
             {
-                EqtTrace.Error("InferRunSettingsHelper.UpdateNodeIfNotPresent: Unable to navigate to RunConfiguration. Current node: " + runSettingsNavigator.LocalName);
+                EqtTrace.Error("InferRunSettingsHelper.UpdateNodeIfNotPresent: Unable to navigate to RunConfiguration. Current node: " + xmlDocument.LocalName);
                 return;
             }
 
-            var node = runSettingsNavigator.SelectSingleNode(nodePath);
+            var node = xmlDocument.SelectSingleNode(nodePath);
             if (node == null || overwrite)
             {
-                XmlUtilities.AppendOrModifyChild(runSettingsNavigator, nodePath, nodeName, nodeValue.ToString());
-                runSettingsNavigator.MoveToRoot();
+                XmlUtilities.AppendOrModifyChild(xmlDocument, nodePath, nodeName, nodeValue.ToString());
             }
         }
 
@@ -370,26 +370,22 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         /// Regenerates the RunConfiguration node with new values under runsettings.
         /// </summary>
         private static void UpdateRunConfiguration(
-            XPathNavigator navigator,
+            XmlDocument xmlDocument,
             Architecture effectivePlatform,
             Framework effectiveFramework,
             string resultsDirectory)
         {
-            var resultsDirectoryNavigator = navigator.SelectSingleNode(ResultsDirectoryNodePath);
+            var resultsDirectoryNavigator = xmlDocument.SelectSingleNode(ResultsDirectoryNodePath);
             if (null != resultsDirectoryNavigator)
             {
                 resultsDirectory = resultsDirectoryNavigator.InnerXml;
             }
 
-            XmlUtilities.AppendOrModifyChild(navigator, RunConfigurationNodePath, RunConfigurationNodeName, null);
-            navigator.MoveToChild(RunConfigurationNodeName, string.Empty);
+            XmlUtilities.AppendOrModifyChild(xmlDocument, RunConfigurationNodePath, RunConfigurationNodeName, null);
+            XmlUtilities.AppendOrModifyChild(xmlDocument, ResultsDirectoryNodePath, ResultsDirectoryNodeName, resultsDirectory);
 
-            XmlUtilities.AppendOrModifyChild(navigator, ResultsDirectoryNodePath, ResultsDirectoryNodeName, resultsDirectory);
-
-            XmlUtilities.AppendOrModifyChild(navigator, TargetPlatformNodePath, TargetPlatformNodeName, effectivePlatform.ToString());
-            XmlUtilities.AppendOrModifyChild(navigator, TargetFrameworkNodePath, TargetFrameworkNodeName, effectiveFramework.ToString());
-
-            navigator.MoveToRoot();
+            XmlUtilities.AppendOrModifyChild(xmlDocument, TargetPlatformNodePath, TargetPlatformNodeName, effectivePlatform.ToString());
+            XmlUtilities.AppendOrModifyChild(xmlDocument, TargetFrameworkNodePath, TargetFrameworkNodeName, effectiveFramework.ToString());
         }
 
         public static bool TryGetPlatformXml(XPathNavigator runSettingsNavigator, out string platformXml)

--- a/src/Microsoft.TestPlatform.Utilities/XmlUtilities.cs
+++ b/src/Microsoft.TestPlatform.Utilities/XmlUtilities.cs
@@ -51,12 +51,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         [SuppressMessage("Microsoft.Security.Xml", "CA3053:UseXmlSecureResolver",
             Justification = "XmlDocument.XmlResolver is not available in core. Suppress until fxcop issue is fixed.")]
         internal static void AppendOrModifyChild(
-            XPathNavigator parentNavigator,
+            XmlDocument xmlDocument,
             string nodeXPath,
             string nodeName,
             string innerXml)
         {
-            var childNodeNavigator = parentNavigator.SelectSingleNode(nodeXPath);
+            var childNodeNavigator = xmlDocument.SelectSingleNode(nodeXPath);
 
             // Todo: There isn't an equivalent API to SecurityElement.Escape in Core yet. 
             // So trusting that the XML is always valid for now.
@@ -67,35 +67,19 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
 #endif
             if (childNodeNavigator == null)
             {
-                var doc = new XmlDocument();
-                var childElement = doc.CreateElement(nodeName);
+                var childElement = xmlDocument.CreateElement(nodeName);
 
                 if (!string.IsNullOrEmpty(innerXml))
                 {
                     childElement.InnerXml = secureInnerXml;
                 }
 
-                childNodeNavigator = childElement.CreateNavigator();
-                parentNavigator.AppendChild(childNodeNavigator);
+                var parentNode = xmlDocument.SelectSingleNode(nodeXPath.Substring(0, nodeXPath.LastIndexOf('/')));
+                parentNode.AppendChild(childElement);
             }
             else if (!string.IsNullOrEmpty(innerXml))
             {
-#if NET451
                 childNodeNavigator.InnerXml = secureInnerXml;
-#else
-                // .Net Core has a bug where calling childNodeNavigator.InnerXml throws an XmlException with "Data at the root level is invalid".
-                // So doing the below instead.
-                var doc = new XmlDocument();
-
-                var childElement = doc.CreateElement(nodeName);
-
-                if (!string.IsNullOrEmpty(innerXml))
-                {
-                    childElement.InnerXml = secureInnerXml;
-                }
-
-                childNodeNavigator.ReplaceSelf(childElement.CreateNavigator().OuterXml);
-#endif
             }
         }
 

--- a/src/Microsoft.TestPlatform.Utilities/XmlUtilities.cs
+++ b/src/Microsoft.TestPlatform.Utilities/XmlUtilities.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
             string nodeName,
             string innerXml)
         {
-            var childNodeNavigator = xmlDocument.SelectSingleNode(nodeXPath);
+            var childNode = xmlDocument.SelectSingleNode(nodeXPath);
 
             // Todo: There isn't an equivalent API to SecurityElement.Escape in Core yet. 
             // So trusting that the XML is always valid for now.
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
 #else
             var secureInnerXml = innerXml;
 #endif
-            if (childNodeNavigator == null)
+            if (childNode == null)
             {
                 var childElement = xmlDocument.CreateElement(nodeName);
 
@@ -75,11 +75,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
                 }
 
                 var parentNode = xmlDocument.SelectSingleNode(nodeXPath.Substring(0, nodeXPath.LastIndexOf('/')));
-                parentNode.AppendChild(childElement);
+                parentNode?.AppendChild(childElement);
             }
             else if (!string.IsNullOrEmpty(innerXml))
             {
-                childNodeNavigator.InnerXml = secureInnerXml;
+                childNode.InnerXml = secureInnerXml;
             }
         }
 

--- a/src/package/VSIXProject/testplatform.config
+++ b/src/package/VSIXProject/testplatform.config
@@ -3,7 +3,7 @@
 <configuration>
   <appSettings>
     <!-- Setting feature.net35 to "true" will execute full clr tests targeting framework <=v3.5 through TPV2. -->
-    <add key="feature.net35" value="false" />
+    <add key="feature.net35" value="true" />
     <!-- Setting feature.net40 to "true" will execute full clr tests targeting framework >=4.0 through TPV2. -->
     <add key="feature.net40" value="true" />
     <!-- Setting feature.datacollector to "true"" will execute data collection (code coverage, etc.) through TPV2. -->

--- a/src/vstest.console/Processors/EnableCodeCoverageArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnableCodeCoverageArgumentProcessor.cs
@@ -160,7 +160,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             {
                 var document = new XmlDocument();
                 document.Load(reader);
+
+#if !NETCOREAPP1_0
                 runSettingsDocument = document;
+#else
+                runSettingsDocument = document.ToXPathNavigable();
+#endif 
             }
 
             var runSettingsNavigator = runSettingsDocument.CreateNavigator();

--- a/src/vstest.console/Processors/EnableCodeCoverageArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnableCodeCoverageArgumentProcessor.cs
@@ -160,11 +160,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             {
                 var document = new XmlDocument();
                 document.Load(reader);
-#if NET451
                 runSettingsDocument = document;
-#else
-                runSettingsDocument = document.ToXPathNavigable();
-#endif
             }
 
             var runSettingsNavigator = runSettingsDocument.CreateNavigator();

--- a/src/vstest.console/Processors/RunSettingsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunSettingsArgumentProcessor.cs
@@ -182,7 +182,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
                     var settingsDocument = new XmlDocument();
                     settingsDocument.Load(reader);
                     ClientUtilities.FixRelativePathsInRunSettings(settingsDocument, runSettingsFile);
+
+#if !NETCOREAPP1_0
                     runSettingsDocument = settingsDocument;
+#else
+                    runSettingsDocument = settingsDocument.ToXPathNavigable();
+#endif                    
                 }
             }
             else

--- a/src/vstest.console/Processors/RunSettingsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunSettingsArgumentProcessor.cs
@@ -182,11 +182,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
                     var settingsDocument = new XmlDocument();
                     settingsDocument.Load(reader);
                     ClientUtilities.FixRelativePathsInRunSettings(settingsDocument, runSettingsFile);
-#if NET451
                     runSettingsDocument = settingsDocument;
-#else
-                    runSettingsDocument = settingsDocument.ToXPathNavigable();
-#endif
                 }
             }
             else

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -410,14 +410,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
 
                     if (updateFramework)
                     {
-                        InferRunSettingsHelper.UpdateTargetFramework(navigator, inferedFramework?.ToString(), overwrite: true);
+                        InferRunSettingsHelper.UpdateTargetFramework(document, inferedFramework?.ToString(), overwrite: true);
                         chosenFramework = inferedFramework;
                         settingsUpdated = true;
                     }
 
                     if (updatePlatform)
                     {
-                        InferRunSettingsHelper.UpdateTargetPlatform(navigator, inferedPlatform.ToString(), overwrite: true);
+                        InferRunSettingsHelper.UpdateTargetPlatform(document, inferedPlatform.ToString(), overwrite: true);
                         chosenPlatform = inferedPlatform;
                         settingsUpdated = true;
                     }
@@ -441,19 +441,19 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
 
                     if (!runConfiguration.DesignModeSet)
                     {
-                        InferRunSettingsHelper.UpdateDesignMode(navigator, this.commandLineOptions.IsDesignMode);
+                        InferRunSettingsHelper.UpdateDesignMode(document, this.commandLineOptions.IsDesignMode);
                         settingsUpdated = true;
                     }
 
                     if (!runConfiguration.CollectSourceInformationSet)
                     {
-                        InferRunSettingsHelper.UpdateCollectSourceInformation(navigator, this.commandLineOptions.ShouldCollectSourceInformation);
+                        InferRunSettingsHelper.UpdateCollectSourceInformation(document, this.commandLineOptions.ShouldCollectSourceInformation);
                         settingsUpdated = true;
                     }
 
                     if (InferRunSettingsHelper.TryGetDeviceXml(navigator, out string deviceXml))
                     {
-                        InferRunSettingsHelper.UpdateTargetDevice(navigator, deviceXml);
+                        InferRunSettingsHelper.UpdateTargetDevice(document, deviceXml);
                         settingsUpdated = true;
                     }
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
@@ -136,9 +136,9 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
             var result = this.proxyDataCollectionManager.BeforeTestRunStart(true, true, mockRunEventsHandler.Object);
 
             mockRunEventsHandler.Verify(eh => eh.HandleLogMessage(TestMessageLevel.Error, "Exception of type 'System.Exception' was thrown."), Times.Once);
-            Assert.AreEqual(result.EnvironmentVariables, null);
-            Assert.AreEqual(result.AreTestCaseLevelEventsRequired, false);
-            Assert.AreEqual(result.DataCollectionEventsPort, 0);
+            Assert.AreEqual(0, result.EnvironmentVariables.Count);
+            Assert.AreEqual(false, result.AreTestCaseLevelEventsRequired);
+            Assert.AreEqual(0, result.DataCollectionEventsPort);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/TestCaseTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/TestCaseTests.cs
@@ -53,6 +53,14 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests
             Assert.AreEqual(testGuid, testCase.Id);
         }
 
+        [TestMethod]
+        public void TestCaseLocalExtensionDataIsPubliclySettableGettableProperty()
+        {
+            var dummyData = "foo";
+            this.testCase.LocalExtensionData = dummyData;
+            Assert.AreEqual("foo", this.testCase.LocalExtensionData);
+        }
+
         #region GetSetPropertyValue Tests
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/InferRunSettingsHelperTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/InferRunSettingsHelperTests.cs
@@ -40,9 +40,9 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         public void UpdateRunSettingsShouldThrowIfRunSettingsNodeDoesNotExist()
         {
             var settings = @"<RandomSettings></RandomSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            Action action = () => InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(navigator, Architecture.X86, Framework.DefaultFramework, "temp");
+            Action action = () => InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(xmlDocument, Architecture.X86, Framework.DefaultFramework, "temp");
 
             Assert.That.Throws<XmlException>(action)
                         .WithMessage(string.Format("An error occurred while loading the settings.  Error: {0}.",
@@ -53,9 +53,9 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         public void UpdateRunSettingsShouldThrowIfPlatformNodeIsInvalid()
         {
             var settings = @"<RunSettings><RunConfiguration><TargetPlatform>foo</TargetPlatform></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            Action action = () => InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(navigator, Architecture.X86, Framework.DefaultFramework, "temp");
+            Action action = () => InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(xmlDocument, Architecture.X86, Framework.DefaultFramework, "temp");
 
             Assert.That.Throws<XmlException>(action)
                         .WithMessage(string.Format("An error occurred while loading the settings.  Error: {0}.",
@@ -69,9 +69,9 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         public void UpdateRunSettingsShouldThrowIfFrameworkNodeIsInvalid()
         {
             var settings = @"<RunSettings><RunConfiguration><TargetFrameworkVersion>foo</TargetFrameworkVersion></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            Action action = () => InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(navigator, Architecture.X86, Framework.DefaultFramework, "temp");
+            Action action = () => InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(xmlDocument, Architecture.X86, Framework.DefaultFramework, "temp");
 
             Assert.That.Throws<XmlException>(action)
                         .WithMessage(string.Format("An error occurred while loading the settings.  Error: {0}.",
@@ -85,11 +85,11 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         public void UpdateRunSettingsShouldUpdateWithPlatformSettings()
         {
             var settings = @"<RunSettings></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(navigator, Architecture.X86, Framework.DefaultFramework, "temp");
+            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(xmlDocument, Architecture.X86, Framework.DefaultFramework, "temp");
 
-            var xml = navigator.OuterXml;
+            var xml = xmlDocument.OuterXml;
 
             StringAssert.Contains(xml, "<TargetPlatform>X86</TargetPlatform>");
         }
@@ -98,11 +98,11 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         public void UpdateRunSettingsShouldUpdateWithFrameworkSettings()
         {
             var settings = @"<RunSettings></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(navigator, Architecture.X86, Framework.DefaultFramework, "temp");
+            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(xmlDocument, Architecture.X86, Framework.DefaultFramework, "temp");
 
-            var xml = navigator.OuterXml;
+            var xml = xmlDocument.OuterXml;
 
             StringAssert.Contains(xml, $"<TargetFrameworkVersion>{Framework.DefaultFramework.Name}</TargetFrameworkVersion>");
         }
@@ -111,11 +111,11 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         public void UpdateRunSettingsShouldUpdateWithResultsDirectorySettings()
         {
             var settings = @"<RunSettings></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(navigator, Architecture.X86, Framework.DefaultFramework, "temp");
+            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(xmlDocument, Architecture.X86, Framework.DefaultFramework, "temp");
 
-            var xml = navigator.OuterXml;
+            var xml = xmlDocument.OuterXml;
 
             StringAssert.Contains(xml, "<ResultsDirectory>temp</ResultsDirectory>");
         }
@@ -124,11 +124,11 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         public void UpdateRunSettingsShouldNotUpdatePlatformIfRunSettingsAlreadyHasIt()
         {
             var settings = @"<RunSettings><RunConfiguration><TargetPlatform>X86</TargetPlatform></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(navigator, Architecture.X64, Framework.DefaultFramework, "temp");
+            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(xmlDocument, Architecture.X64, Framework.DefaultFramework, "temp");
 
-            var xml = navigator.OuterXml;
+            var xml = xmlDocument.OuterXml;
 
             StringAssert.Contains(xml, "<TargetPlatform>X86</TargetPlatform>");
         }
@@ -137,11 +137,11 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         public void UpdateRunSettingsShouldNotUpdateFrameworkIfRunSettingsAlreadyHasIt()
         {
             var settings = @"<RunSettings><RunConfiguration><TargetFrameworkVersion>Framework40</TargetFrameworkVersion></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(navigator, Architecture.X64, Framework.DefaultFramework, "temp");
+            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(xmlDocument, Architecture.X64, Framework.DefaultFramework, "temp");
 
-            var xml = navigator.OuterXml;
+            var xml = xmlDocument.OuterXml;
 
             StringAssert.Contains(xml, "<TargetFrameworkVersion>.NETFramework,Version=v4.0</TargetFrameworkVersion>");
         }
@@ -152,11 +152,11 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         {
 
             var settings = @"<RunSettings><RunConfiguration><TargetFrameworkVersion>.NETFramework,Version=v4.0</TargetFrameworkVersion></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(navigator, Architecture.X64, Framework.DefaultFramework, "temp");
+            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(xmlDocument, Architecture.X64, Framework.DefaultFramework, "temp");
 
-            var xml = navigator.OuterXml;
+            var xml = xmlDocument.OuterXml;
 
             StringAssert.Contains(xml, "<TargetFrameworkVersion>.NETFramework,Version=v4.0</TargetFrameworkVersion>");
         }
@@ -165,11 +165,11 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         public void UpdateRunSettingsShouldNotUpdateResultsDirectoryIfRunSettingsAlreadyHasIt()
         {
             var settings = @"<RunSettings><RunConfiguration><ResultsDirectory>someplace</ResultsDirectory></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(navigator, Architecture.X64, Framework.DefaultFramework, "temp");
+            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(xmlDocument, Architecture.X64, Framework.DefaultFramework, "temp");
 
-            var xml = navigator.OuterXml;
+            var xml = xmlDocument.OuterXml;
 
             StringAssert.Contains(xml, "<ResultsDirectory>someplace</ResultsDirectory>");
         }
@@ -178,11 +178,11 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         public void UpdateRunSettingsShouldNotUpdatePlatformOrFrameworkOrResultsDirectoryIfRunSettingsAlreadyHasIt()
         {
             var settings = @"<RunSettings><RunConfiguration><TargetPlatform>X86</TargetPlatform><TargetFrameworkVersion>Framework40</TargetFrameworkVersion><ResultsDirectory>someplace</ResultsDirectory></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(navigator, Architecture.X64, Framework.DefaultFramework, "temp");
+            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(xmlDocument, Architecture.X64, Framework.DefaultFramework, "temp");
 
-            var xml = navigator.OuterXml;
+            var xml = xmlDocument.OuterXml;
 
             StringAssert.Contains(xml, "<TargetPlatform>X86</TargetPlatform>");
             StringAssert.Contains(xml, "<TargetFrameworkVersion>Framework40</TargetFrameworkVersion>");
@@ -193,11 +193,11 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         public void UpdateRunSettingsWithAnEmptyRunSettingsShouldAddValuesSpecifiedInRunConfiguration()
         {
             var settings = @"<RunSettings></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(navigator, Architecture.X64, Framework.DefaultFramework, "temp");
+            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(xmlDocument, Architecture.X64, Framework.DefaultFramework, "temp");
 
-            var xml = navigator.OuterXml;
+            var xml = xmlDocument.OuterXml;
 
             StringAssert.Contains(xml, "<TargetPlatform>X64</TargetPlatform>");
             StringAssert.Contains(xml, $"<TargetFrameworkVersion>{Framework.DefaultFramework.Name}</TargetFrameworkVersion>");
@@ -208,12 +208,12 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         public void UpdateRunSettingsShouldReturnBackACompleteRunSettings()
         {
             var settings = @"<RunSettings></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(navigator, Architecture.X64, Framework.DefaultFramework, "temp");
+            InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(xmlDocument, Architecture.X64, Framework.DefaultFramework, "temp");
 
-            var xml = navigator.OuterXml;
-            var expectedRunSettings = string.Format("<RunSettings>\r\n  <RunConfiguration>\r\n    <ResultsDirectory>temp</ResultsDirectory>\r\n    <TargetPlatform>X64</TargetPlatform>\r\n    <TargetFrameworkVersion>{0}</TargetFrameworkVersion>\r\n  </RunConfiguration>\r\n</RunSettings>", Framework.DefaultFramework.Name);
+            var xml = xmlDocument.OuterXml;
+            var expectedRunSettings = string.Format("<RunSettings><RunConfiguration><ResultsDirectory>temp</ResultsDirectory><TargetPlatform>X64</TargetPlatform><TargetFrameworkVersion>{0}</TargetFrameworkVersion></RunConfiguration></RunSettings>", Framework.DefaultFramework.Name);
 
             Assert.AreEqual(expectedRunSettings, xml);
         }
@@ -222,9 +222,9 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         public void UpdateRunSettingsShouldThrowIfArchitectureSetIsIncompatibleWithCurrentSystemArchitecture()
         {
             var settings = @"<RunSettings></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            Action action = () => InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(navigator, Architecture.ARM, Framework.DefaultFramework, "temp");
+            Action action = () => InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(xmlDocument, Architecture.ARM, Framework.DefaultFramework, "temp");
 
             Assert.That.Throws<SettingsException>(action)
                 .WithMessage(string.Format(
@@ -233,41 +233,17 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
                         XmlRunSettingsUtilities.OSArchitecture.ToString()));
         }
 
-        [DataTestMethod]
-        [DataRow("DesignMode")]
-        [DataRow("CollectSourceInformation")]
-        public void UpdateRunSettingsShouldNotModifyXmlIfNavigatorIsNotAtRootNode(string settingName)
-        {
-            var settings = @"<RunSettings><RunConfiguration></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
-            navigator.MoveToFirstChild();
-
-            switch (settingName.ToUpperInvariant())
-            {
-                case "DESIGNMODE":
-                    InferRunSettingsHelper.UpdateDesignMode(navigator, true);
-                    break;
-
-                case "COLLECTSOURCEINFORMATION":
-                    InferRunSettingsHelper.UpdateCollectSourceInformation(navigator, true);
-                    break;
-            };
-
-            navigator.MoveToRoot();
-            Assert.IsTrue(navigator.InnerXml.IndexOf(settingName, StringComparison.OrdinalIgnoreCase) < 0);
-        }
-
         [TestMethod]
         public void UpdateDesignModeOrCsiShouldNotModifyXmlIfNodeIsAlreadyPresent()
         {
             var settings = @"<RunSettings><RunConfiguration><DesignMode>False</DesignMode><CollectSourceInformation>False</CollectSourceInformation></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            InferRunSettingsHelper.UpdateDesignMode(navigator, true);
-            InferRunSettingsHelper.UpdateCollectSourceInformation(navigator, true);
+            InferRunSettingsHelper.UpdateDesignMode(xmlDocument, true);
+            InferRunSettingsHelper.UpdateCollectSourceInformation(xmlDocument, true);
 
-            Assert.AreEqual("False", this.GetValueOf(navigator, "/RunSettings/RunConfiguration/DesignMode"));
-            Assert.AreEqual("False", this.GetValueOf(navigator, "/RunSettings/RunConfiguration/CollectSourceInformation"));
+            Assert.AreEqual("False", this.GetValueOf(xmlDocument, "/RunSettings/RunConfiguration/DesignMode"));
+            Assert.AreEqual("False", this.GetValueOf(xmlDocument, "/RunSettings/RunConfiguration/CollectSourceInformation"));
         }
 
         [DataTestMethod]
@@ -276,13 +252,13 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         public void UpdateDesignModeOrCsiShouldModifyXmlToValueProvided(bool val)
         {
             var settings = @"<RunSettings><RunConfiguration></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            InferRunSettingsHelper.UpdateDesignMode(navigator, val);
-            InferRunSettingsHelper.UpdateCollectSourceInformation(navigator, val);
+            InferRunSettingsHelper.UpdateDesignMode(xmlDocument, val);
+            InferRunSettingsHelper.UpdateCollectSourceInformation(xmlDocument, val);
 
-            Assert.AreEqual(val.ToString(), this.GetValueOf(navigator, "/RunSettings/RunConfiguration/DesignMode"));
-            Assert.AreEqual(val.ToString(), this.GetValueOf(navigator, "/RunSettings/RunConfiguration/CollectSourceInformation"));
+            Assert.AreEqual(val.ToString(), this.GetValueOf(xmlDocument, "/RunSettings/RunConfiguration/DesignMode"));
+            Assert.AreEqual(val.ToString(), this.GetValueOf(xmlDocument, "/RunSettings/RunConfiguration/CollectSourceInformation"));
         }
 
         [TestMethod]
@@ -339,79 +315,79 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
                                 </MSPhoneTest>
                             </RunSettings>";
 
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            var result = InferRunSettingsHelper.TryGetDeviceXml(navigator, out string deviceXml);
+            var result = InferRunSettingsHelper.TryGetDeviceXml(xmlDocument.CreateNavigator(), out string deviceXml);
             Assert.IsTrue(result);
 
-            InferRunSettingsHelper.UpdateTargetDevice(navigator, deviceXml);
-            Assert.AreEqual(deviceXml.ToString(), this.GetValueOf(navigator, "/RunSettings/RunConfiguration/TargetDevice"));
+            InferRunSettingsHelper.UpdateTargetDevice(xmlDocument, deviceXml);
+            Assert.AreEqual(deviceXml.ToString(), this.GetValueOf(xmlDocument, "/RunSettings/RunConfiguration/TargetDevice"));
         }
 
         [TestMethod]
         public void UpdateTargetPlatformShouldNotModifyXmlIfNodeIsAlreadyPresentForOverwriteFalse()
         {
             var settings = @"<RunSettings><RunConfiguration><TargetPlatform>x86</TargetPlatform></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            InferRunSettingsHelper.UpdateTargetPlatform(navigator, "X64", overwrite: false);
+            InferRunSettingsHelper.UpdateTargetPlatform(xmlDocument, "X64", overwrite: false);
 
-            Assert.AreEqual("x86", this.GetValueOf(navigator, "/RunSettings/RunConfiguration/TargetPlatform"));
+            Assert.AreEqual("x86", this.GetValueOf(xmlDocument, "/RunSettings/RunConfiguration/TargetPlatform"));
         }
 
         [TestMethod]
         public void UpdateTargetPlatformShouldModifyXmlIfNodeIsAlreadyPresentForOverwriteTrue()
         {
             var settings = @"<RunSettings><RunConfiguration><TargetPlatform>x86</TargetPlatform></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            InferRunSettingsHelper.UpdateTargetPlatform(navigator, "X64", overwrite: true);
+            InferRunSettingsHelper.UpdateTargetPlatform(xmlDocument, "X64", overwrite: true);
 
-            Assert.AreEqual("X64", this.GetValueOf(navigator, "/RunSettings/RunConfiguration/TargetPlatform"));
+            Assert.AreEqual("X64", this.GetValueOf(xmlDocument, "/RunSettings/RunConfiguration/TargetPlatform"));
         }
 
         [TestMethod]
         public void UpdateTargetPlatformShouldAddPlatformXmlNodeIfNotPresent()
         {
             var settings = @"<RunSettings><RunConfiguration></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            InferRunSettingsHelper.UpdateTargetPlatform(navigator, "X64");
+            InferRunSettingsHelper.UpdateTargetPlatform(xmlDocument, "X64");
 
-            Assert.AreEqual("X64", this.GetValueOf(navigator, "/RunSettings/RunConfiguration/TargetPlatform"));
+            Assert.AreEqual("X64", this.GetValueOf(xmlDocument, "/RunSettings/RunConfiguration/TargetPlatform"));
         }
 
         [TestMethod]
         public void UpdateTargetFrameworkShouldNotModifyXmlIfNodeIsAlreadyPresentForOverwriteFalse()
         {
             var settings = @"<RunSettings><RunConfiguration><TargetFrameworkVersion>.NETFramework,Version=v4.5</TargetFrameworkVersion></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            InferRunSettingsHelper.UpdateTargetFramework(navigator, ".NETCoreApp,Version=v1.0", overwrite: false);
+            InferRunSettingsHelper.UpdateTargetFramework(xmlDocument, ".NETCoreApp,Version=v1.0", overwrite: false);
 
-            Assert.AreEqual(".NETFramework,Version=v4.5", this.GetValueOf(navigator, "/RunSettings/RunConfiguration/TargetFrameworkVersion"));
+            Assert.AreEqual(".NETFramework,Version=v4.5", this.GetValueOf(xmlDocument, "/RunSettings/RunConfiguration/TargetFrameworkVersion"));
         }
 
         [TestMethod]
         public void UpdateTargetFrameworkShouldModifyXmlIfNodeIsAlreadyPresentForOverwriteTrue()
         {
             var settings = @"<RunSettings><RunConfiguration><TargetFrameworkVersion>.NETFramework,Version=v4.5</TargetFrameworkVersion></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            InferRunSettingsHelper.UpdateTargetFramework(navigator, ".NETCoreApp,Version=v1.0", overwrite: true);
+            InferRunSettingsHelper.UpdateTargetFramework(xmlDocument, ".NETCoreApp,Version=v1.0", overwrite: true);
 
-            Assert.AreEqual(".NETCoreApp,Version=v1.0", this.GetValueOf(navigator, "/RunSettings/RunConfiguration/TargetFrameworkVersion"));
+            Assert.AreEqual(".NETCoreApp,Version=v1.0", this.GetValueOf(xmlDocument, "/RunSettings/RunConfiguration/TargetFrameworkVersion"));
         }
 
         [TestMethod]
         public void UpdateTargetFrameworkShouldAddFrameworkXmlNodeIfNotPresent()
         {
             var settings = @"<RunSettings><RunConfiguration></RunConfiguration></RunSettings>";
-            var navigator = this.GetNavigator(settings);
+            var xmlDocument = this.GetXmlDocument(settings);
 
-            InferRunSettingsHelper.UpdateTargetFramework(navigator, ".NETCoreApp,Version=v1.0");
+            InferRunSettingsHelper.UpdateTargetFramework(xmlDocument, ".NETCoreApp,Version=v1.0");
 
-            Assert.AreEqual(".NETCoreApp,Version=v1.0", this.GetValueOf(navigator, "/RunSettings/RunConfiguration/TargetFrameworkVersion"));
+            Assert.AreEqual(".NETCoreApp,Version=v1.0", this.GetValueOf(xmlDocument, "/RunSettings/RunConfiguration/TargetFrameworkVersion"));
         }
 
         [TestMethod]
@@ -524,18 +500,17 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
             return string.Format(CultureInfo.CurrentCulture, OMResources.SourceIncompatible, source, sourceFrameworks[source].Version, sourceArchitectures[source]);
         }
 
-        private XPathNavigator GetNavigator(string settingsXml)
+        private XmlDocument GetXmlDocument(string settingsXml)
         {
             var doc = new XmlDocument();
             doc.LoadXml(settingsXml);
 
-            return doc.CreateNavigator();
+            return doc;
         }
 
-        private string GetValueOf(XPathNavigator navigator, string xpath)
+        private string GetValueOf(XmlDocument xmlDocument, string xpath)
         {
-            navigator.MoveToRoot();
-            return navigator.SelectSingleNode(xpath).Value;
+            return xmlDocument.SelectSingleNode(xpath).InnerText;
         }
         #endregion
     }

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/XmlUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/XmlUtilitiesTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         #region GetNodeXml tests
 
         [TestMethod]
-        public void GetNodeXmlShouldThrowIfNavigatorIsNull()
+        public void GetNodeXmlShouldThrowIfxmlDocumentIsNull()
         {
             Assert.ThrowsException<NullReferenceException>(() => XmlUtilities.GetNodeXml(null, @"/RunSettings/RunConfiguration"));
         }
@@ -26,36 +26,36 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         public void GetNodeXmlShouldThrowIfXPathIsNull()
         {
             var settingsXml = @"<RunSettings></RunSettings>";
-            var navigator = this.GetNavigator(settingsXml);
+            var xmlDocument = this.GetXmlDocument(settingsXml);
 
-            Assert.ThrowsException<XPathException>(() => XmlUtilities.GetNodeXml(navigator, null));
+            Assert.ThrowsException<XPathException>(() => XmlUtilities.GetNodeXml(xmlDocument.CreateNavigator(), null));
         }
 
         [TestMethod]
         public void GetNodeXmlShouldThrowIfXPathIsInvalid()
         {
             var settingsXml = @"<RunSettings></RunSettings>";
-            var navigator = this.GetNavigator(settingsXml);
+            var xmlDocument = this.GetXmlDocument(settingsXml);
 
-            Assert.ThrowsException<XPathException>(() => XmlUtilities.GetNodeXml(navigator, @"Rs\r"));
+            Assert.ThrowsException<XPathException>(() => XmlUtilities.GetNodeXml(xmlDocument.CreateNavigator(), @"Rs\r"));
         }
 
         [TestMethod]
         public void GetNodeXmlShouldReturnNullIfNodeDoesNotExist()
         {
             var settingsXml = @"<RunSettings></RunSettings>";
-            var navigator = this.GetNavigator(settingsXml);
+            var xmlDocument = this.GetXmlDocument(settingsXml);
 
-            Assert.IsNull(XmlUtilities.GetNodeXml(navigator, @"/RunSettings/RunConfiguration"));
+            Assert.IsNull(XmlUtilities.GetNodeXml(xmlDocument.CreateNavigator(), @"/RunSettings/RunConfiguration"));
         }
 
         [TestMethod]
         public void GetNodeXmlShouldReturnNodeValue()
         {
             var settingsXml = @"<RunSettings><RC>abc</RC></RunSettings>";
-            var navigator = this.GetNavigator(settingsXml);
+            var xmlDocument = this.GetXmlDocument(settingsXml);
 
-            Assert.AreEqual("abc", XmlUtilities.GetNodeXml(navigator, @"/RunSettings/RC"));
+            Assert.AreEqual("abc", XmlUtilities.GetNodeXml(xmlDocument.CreateNavigator(), @"/RunSettings/RC"));
         }
 
         #endregion
@@ -99,65 +99,57 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         #endregion
 
         #region AppendOrModifyChild tests
-        
+
         [TestMethod]
         public void AppendOrModifyChildShouldModifyExistingNode()
         {
             var settingsXml = @"<RunSettings><RC>abc</RC></RunSettings>";
-            var navigator = this.GetNavigator(settingsXml);
+            var xmlDocument = this.GetXmlDocument(settingsXml);
 
-            navigator.MoveToChild("RunSettings", string.Empty);
+            XmlUtilities.AppendOrModifyChild(xmlDocument, @"/RunSettings/RC", "RC", "ab");
 
-            XmlUtilities.AppendOrModifyChild(navigator, @"/RunSettings/RC", "RC", "ab");
-
-            var rcNavigator = navigator.SelectSingleNode(@"/RunSettings/RC");
-            Assert.IsNotNull(rcNavigator);
-            Assert.AreEqual("ab", rcNavigator.InnerXml);
+            var rcxmlDocument = xmlDocument.SelectSingleNode(@"/RunSettings/RC");
+            Assert.IsNotNull(rcxmlDocument);
+            Assert.AreEqual("ab", rcxmlDocument.InnerXml);
         }
 
         [TestMethod]
         public void AppendOrModifyChildShouldAppendANewNode()
         {
             var settingsXml = @"<RunSettings></RunSettings>";
-            var navigator = this.GetNavigator(settingsXml);
+            var xmlDocument = this.GetXmlDocument(settingsXml);
 
-            navigator.MoveToChild("RunSettings", string.Empty);
+            XmlUtilities.AppendOrModifyChild(xmlDocument, @"/RunSettings/RC", "RC", "abc");
 
-            XmlUtilities.AppendOrModifyChild(navigator, @"/RunSettings/RC", "RC", "abc");
-
-            var rcNavigator = navigator.SelectSingleNode(@"/RunSettings/RC");
-            Assert.IsNotNull(rcNavigator);
-            Assert.AreEqual("abc", rcNavigator.InnerXml);
+            var rcxmlDocument = xmlDocument.SelectSingleNode(@"/RunSettings/RC");
+            Assert.IsNotNull(rcxmlDocument);
+            Assert.AreEqual("abc", rcxmlDocument.InnerXml);
         }
 
         [TestMethod]
         public void AppendOrModifyChildShouldNotModifyExistingXmlIfInnerXmlPassedInIsNull()
         {
             var settingsXml = @"<RunSettings><RC>abc</RC></RunSettings>";
-            var navigator = this.GetNavigator(settingsXml);
+            var xmlDocument = this.GetXmlDocument(settingsXml);
 
-            navigator.MoveToChild("RunSettings", string.Empty);
+            XmlUtilities.AppendOrModifyChild(xmlDocument, @"/RunSettings/RC", "RC", null);
 
-            XmlUtilities.AppendOrModifyChild(navigator, @"/RunSettings/RC", "RC", null);
-
-            var rcNavigator = navigator.SelectSingleNode(@"/RunSettings/RC");
-            Assert.IsNotNull(rcNavigator);
-            Assert.AreEqual("abc", rcNavigator.InnerXml);
+            var rcxmlDocument = xmlDocument.SelectSingleNode(@"/RunSettings/RC");
+            Assert.IsNotNull(rcxmlDocument);
+            Assert.AreEqual("abc", rcxmlDocument.InnerXml);
         }
 
         [TestMethod]
         public void AppendOrModifyChildShouldCreateAnEmptyNewNodeIfInnerXmlPassedInIsNull()
         {
             var settingsXml = @"<RunSettings></RunSettings>";
-            var navigator = this.GetNavigator(settingsXml);
+            var xmlDocument = this.GetXmlDocument(settingsXml);
 
-            navigator.MoveToChild("RunSettings", string.Empty);
+            XmlUtilities.AppendOrModifyChild(xmlDocument, @"/RunSettings/RC", "RC", null);
 
-            XmlUtilities.AppendOrModifyChild(navigator, @"/RunSettings/RC", "RC", null);
-
-            var rcNavigator = navigator.SelectSingleNode(@"/RunSettings/RC");
-            Assert.IsNotNull(rcNavigator);
-            Assert.AreEqual(string.Empty, rcNavigator.InnerXml);
+            var rcxmlDocument = xmlDocument.SelectSingleNode(@"/RunSettings/RC");
+            Assert.IsNotNull(rcxmlDocument);
+            Assert.AreEqual(string.Empty, rcxmlDocument.InnerXml);
         }
 
         #endregion
@@ -168,38 +160,35 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
         public void RemoveChildNodeShouldNotModifyExistingXmlIfNodeDoesnotExist()
         {
             var settingsXml = @"<RunSettings></RunSettings>";
-            var navigator = this.GetNavigator(settingsXml);
+            var xmlDocument = this.GetXmlDocument(settingsXml);
 
-            navigator.MoveToChild("RunSettings", string.Empty);
+            XmlUtilities.RemoveChildNode(xmlDocument.CreateNavigator(), @"/RunSettings/RC", "RC");
 
-            XmlUtilities.RemoveChildNode(navigator, @"/RunSettings/RC", "RC");
-
-            Assert.AreEqual(settingsXml, navigator.OuterXml);
+            Assert.AreEqual(settingsXml, xmlDocument.OuterXml);
         }
 
         [TestMethod]
         public void RemoveChildNodeShouldRemoveXmlIfExist()
         {
             var settingsXml = @"<RunSettings><RC>abc</RC></RunSettings>";
-            var navigator = this.GetNavigator(settingsXml);
-
+            var xmlDocument = this.GetXmlDocument(settingsXml);
+            var navigator = xmlDocument.CreateNavigator();
             navigator.MoveToChild("RunSettings", string.Empty);
-
             XmlUtilities.RemoveChildNode(navigator, @"/RunSettings/RC", "RC");
 
-            Assert.AreEqual(@"<RunSettings></RunSettings>", navigator.OuterXml);
+            Assert.AreEqual(@"<RunSettings></RunSettings>", xmlDocument.OuterXml);
         }
 
         #endregion
 
         #region private methods
 
-        private XPathNavigator GetNavigator(string settingsXml)
+        private XmlDocument GetXmlDocument(string settingsXml)
         {
             var doc = new XmlDocument();
             doc.LoadXml(settingsXml);
 
-            return doc.CreateNavigator();
+            return doc;
         }
 
         #endregion

--- a/test/datacollector.UnitTests/DataCollectionManagerTests.cs
+++ b/test/datacollector.UnitTests/DataCollectionManagerTests.cs
@@ -158,6 +158,17 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
         }
 
         [TestMethod]
+        public void InitializeDataCollectorsShouldLogExceptionToMessageSinkIfSetEnvironmentVariableFails()
+        {
+            this.mockDataCollector.As<ITestExecutionEnvironmentSpecifier>().Setup(x => x.GetTestExecutionEnvironmentVariables()).Throws<Exception>();
+
+            this.dataCollectionManager.InitializeDataCollectors(this.dataCollectorSettings);
+
+            Assert.AreEqual(0, this.dataCollectionManager.RunDataCollectors.Count);
+            this.mockMessageSink.Verify(x => x.SendMessage(It.IsAny<DataCollectionMessageEventArgs>()), Times.Once);
+        }
+
+        [TestMethod]
         public void InitializeDataCollectorsShouldReturnFirstEnvironmentVariableIfMoreThanOneVariablesWithSameKeyIsSpecified()
         {
             this.envVarList.Add(new KeyValuePair<string, string>("key", "value"));

--- a/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
@@ -235,7 +235,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
 
             // Assert.
             Assert.IsNotNull(this.settingsProvider.ActiveRunSettings);
-            StringAssert.Contains(this.settingsProvider.ActiveRunSettings.SettingsXml, $"<RunSettings>\r\n  <RunConfiguration>\r\n    <TargetPlatform>{Constants.DefaultPlatform}</TargetPlatform>\r\n    <TargetFrameworkVersion>{Framework.FromString(FrameworkVersion.Framework45.ToString()).Name}</TargetFrameworkVersion>\r\n    <ResultsDirectory>{Constants.DefaultResultsDirectory}</ResultsDirectory>\r\n  </RunConfiguration>\r\n  <MSTest>\r\n    <SettingsFile>C:\\temp\\r.testsettings</SettingsFile>\r\n    <ForcedLegacyMode>true</ForcedLegacyMode>\r\n  </MSTest>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n</RunSettings>");
+            StringAssert.Contains(this.settingsProvider.ActiveRunSettings.SettingsXml, $"<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <RunConfiguration>\r\n    <TargetPlatform>{Constants.DefaultPlatform}</TargetPlatform>\r\n    <TargetFrameworkVersion>{Framework.FromString(FrameworkVersion.Framework45.ToString()).Name}</TargetFrameworkVersion>\r\n    <ResultsDirectory>{Constants.DefaultResultsDirectory}</ResultsDirectory>\r\n  </RunConfiguration>\r\n  <MSTest>\r\n    <SettingsFile>C:\\temp\\r.testsettings</SettingsFile>\r\n    <ForcedLegacyMode>true</ForcedLegacyMode>\r\n  </MSTest>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n</RunSettings>");
         }
 
 


### PR DESCRIPTION
Port fixes for following issues:
#1231 Add back `LocalExtensionData` API for adapters (fix regression reported by Debugger team)
#1230 Do not crash data collector if extension fails to initialize or set environment variables (allow test runs with coverage in non Enterprise SKU)
#1226 Fix XPathNavigator for netcoreapp2.0 (enable `dotnet test --collect` scenario)
#1232 Use TPv2 as default for .NET 3.5 test projects
#1234 Loading native dll's correctly for UWP release mode.
https://github.com/Microsoft/vstest/pull/1238 HardCoded version of CLI to 2.1.0-preview1-007372.