### PR TITLE
Insertion 20171031

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -61,8 +61,8 @@ $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
 # Dotnet build doesn't support --packages yet. See https://github.com/dotnet/cli/issues/2712
 $env:NUGET_PACKAGES = $env:TP_PACKAGES_DIR
 $env:NUGET_EXE_Version = "3.4.3"
-$env:DOTNET_CLI_VERSION = "LATEST"
-$env:DOTNET_RUNTIME_VERSION = "LATEST"
+$env:DOTNET_CLI_VERSION = "2.1.0-preview1-007372"
+# $env:DOTNET_RUNTIME_VERSION = "LATEST"
 $env:VSWHERE_VERSION = "2.0.2"
 $env:MSBUILD_VERSION = "15.0"
 

--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
@@ -537,9 +537,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
             var dataCollectorEnvironmentVariable = new Dictionary<string, DataCollectionEnvironmentVariable>(StringComparer.OrdinalIgnoreCase);
             foreach (var dataCollectorInfo in this.RunDataCollectors.Values)
             {
-                dataCollectorInfo.SetTestExecutionEnvironmentVariables();
                 try
                 {
+                    dataCollectorInfo.SetTestExecutionEnvironmentVariables();
                     this.AddCollectorEnvironmentVariables(dataCollectorInfo, dataCollectorEnvironmentVariable);
                 }
                 catch (Exception ex)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManagerWithDataCollection.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManagerWithDataCollection.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="ProxyExecutionManagerWithDataCollection"/> class. 
         /// </summary>
-        /// <param name="testRequestSender">
+        /// <param name="requestSender">
         /// Test request sender instance.
         /// </param>
         /// <param name="testHostManager">
@@ -44,6 +44,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             this.ProxyDataCollectionManager = proxyDataCollectionManager;
             this.DataCollectionRunEventsHandler = new DataCollectionRunEventsHandler();
             this.requestData = requestData;
+            this.dataCollectionEnvironmentVariables = new Dictionary<string, string>();
         }
 
         /// <summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
             ITestMessageEventHandler runEventsHandler)
         {
             var areTestCaseLevelEventsRequired = false;
-            IDictionary<string, string> environmentVariables = null;
+            IDictionary<string, string> environmentVariables = new Dictionary<string, string>();
 
             var dataCollectionEventsPort = 0;
             this.InvokeDataCollectionServiceAction(

--- a/src/Microsoft.TestPlatform.ObjectModel/Navigation/NativeMethods.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Navigation/NativeMethods.cs
@@ -556,19 +556,11 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Navigation
 
         public static IDiaDataSource GetDiaSourceObject()
         {
-            var currentDirectory = new ProcessHelper().GetCurrentProcessLocation();
+            var nativeDllDirectory = new ProcessHelper().GetNativeDllDirectory();
 
-            IntPtr modHandle = IntPtr.Zero;
-            if (IntPtr.Size == 8)
-            {
-                modHandle = LoadLibraryEx(Path.Combine(currentDirectory, "x64\\msdia140.dll"), IntPtr.Zero, 0);
-            }
-            else
-            {
-                modHandle = LoadLibraryEx(Path.Combine(currentDirectory, "x86\\msdia140.dll"), IntPtr.Zero, 0);
-            }
+            IntPtr modHandle = LoadLibraryEx(Path.Combine(nativeDllDirectory, "msdia140.dll"), IntPtr.Zero, 0);
 
-            if(modHandle == IntPtr.Zero)
+            if (modHandle == IntPtr.Zero)
             {
                 throw new COMException(string.Format(Resources.Resources.FailedToLoadMsDia));
             }

--- a/src/Microsoft.TestPlatform.ObjectModel/TestCase.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TestCase.cs
@@ -18,13 +18,12 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
     [DataContract]
     public sealed class TestCase : TestObject
     {
-#if TODO
         /// <summary>
         /// LocalExtensionData which can be used by Adapter developers for local transfer of extended properties. 
         /// Note that this data is available only for in-Proc execution, and may not be available for OutProc executors
         /// </summary>
-        private Object m_localExtensionData;
-#endif
+        private Object localExtensionData;
+
         private Guid defaultId = Guid.Empty;
         private Guid id;
         private string displayName;
@@ -70,17 +69,15 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 
         #region Properties
 
-#if TODO
         /// <summary>
         /// LocalExtensionData which can be used by Adapter developers for local transfer of extended properties. 
         /// Note that this data is available only for in-Proc execution, and may not be available for OutProc executors
         /// </summary>
         public Object LocalExtensionData
         {
-            get { return m_localExtensionData; }
-            set { m_localExtensionData = value; }
+            get { return localExtensionData; }
+            set { localExtensionData = value; }
         }
-#endif
 
         /// <summary>
         /// Gets or sets the id of the test case.

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/IProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/IProcessHelper.cs
@@ -42,6 +42,18 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces
         string GetTestEngineDirectory();
 
         /// <summary>
+        /// Gets the location of native dll's, depending on current process architecture..
+        /// </summary>
+        /// <returns>Location of native dll's</returns>
+        string GetNativeDllDirectory();
+
+        /// <summary>
+        /// Gets current process architecture
+        /// </summary>
+        /// <returns>Process Architecture</returns>
+        PlatformArchitecture GetCurrentProcessArchitecture();
+
+        /// <summary>
         /// Gets the process id of test engine.
         /// </summary>
         /// <returns>process id of test engine.</returns>

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -16,6 +16,8 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
     /// </summary>
     public partial class ProcessHelper : IProcessHelper
     {
+        private static readonly string ARM = "arm";
+
         /// <inheritdoc/>
         public object LaunchProcess(string processPath, string arguments, string workingDirectory, IDictionary<string, string> envVariables, Action<object, string> errorCallback, Action<object> exitCallBack)
         {
@@ -161,6 +163,24 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         {
             var proc = process as Process;
             return proc?.Id ?? -1;
+        }
+
+        /// <inheritdoc/>
+        public PlatformArchitecture GetCurrentProcessArchitecture()
+        {
+            if (IntPtr.Size == 8)
+            {
+                return PlatformArchitecture.X64;
+            }
+
+            return PlatformArchitecture.X86;
+        }
+
+        /// <inheritdoc/>
+        public string GetNativeDllDirectory()
+        {
+            var isArm = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE").Contains("ARM");
+            return Path.Combine(this.GetCurrentProcessLocation(), this.GetCurrentProcessArchitecture().ToString(), isArm ? ARM : string.Empty);
         }
     }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -179,8 +179,13 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         /// <inheritdoc/>
         public string GetNativeDllDirectory()
         {
-            var isArm = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE").Contains("ARM");
-            return Path.Combine(this.GetCurrentProcessLocation(), this.GetCurrentProcessArchitecture().ToString(), isArm ? ARM : string.Empty);
+            var osArchitecture = new PlatformEnvironment().Architecture;
+            if (osArchitecture == PlatformArchitecture.ARM || osArchitecture == PlatformArchitecture.ARM64)
+            {
+                return Path.Combine(this.GetCurrentProcessLocation(), this.GetCurrentProcessArchitecture().ToString().ToLower(), ARM);
+            }
+
+            return Path.Combine(this.GetCurrentProcessLocation(), this.GetCurrentProcessArchitecture().ToString().ToLower());
         }
     }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard1.0/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard1.0/System/ProcessHelper.cs
@@ -78,5 +78,17 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         {
             throw new NotImplementedException();
         }
+
+        /// <inheritdoc/>
+        public string GetNativeDllDirectory()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public PlatformArchitecture GetCurrentProcessArchitecture()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/ProcessHelper.cs
@@ -77,5 +77,23 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         {
             return -1;
         }
+
+        /// <inheritdoc/>
+        public PlatformArchitecture GetCurrentProcessArchitecture()
+        {
+            if (IntPtr.Size == 8)
+            {
+                return PlatformArchitecture.X64;
+            }
+
+            return PlatformArchitecture.X86;
+        }
+
+        /// <inheritdoc/>
+        public string GetNativeDllDirectory()
+        {
+            // For UWP the native dll's are to be kept in same directory
+            return this.GetCurrentProcessLocation();
+        }
     }
 }

--- a/src/package/VSIXProject/testplatform.config
+++ b/src/package/VSIXProject/testplatform.config
@@ -3,7 +3,7 @@
 <configuration>
   <appSettings>
     <!-- Setting feature.net35 to "true" will execute full clr tests targeting framework <=v3.5 through TPV2. -->
-    <add key="feature.net35" value="false" />
+    <add key="feature.net35" value="true" />
     <!-- Setting feature.net40 to "true" will execute full clr tests targeting framework >=4.0 through TPV2. -->
     <add key="feature.net40" value="true" />
     <!-- Setting feature.datacollector to "true"" will execute data collection (code coverage, etc.) through TPV2. -->

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
@@ -136,9 +136,9 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
             var result = this.proxyDataCollectionManager.BeforeTestRunStart(true, true, mockRunEventsHandler.Object);
 
             mockRunEventsHandler.Verify(eh => eh.HandleLogMessage(TestMessageLevel.Error, "Exception of type 'System.Exception' was thrown."), Times.Once);
-            Assert.AreEqual(result.EnvironmentVariables, null);
-            Assert.AreEqual(result.AreTestCaseLevelEventsRequired, false);
-            Assert.AreEqual(result.DataCollectionEventsPort, 0);
+            Assert.AreEqual(0, result.EnvironmentVariables.Count);
+            Assert.AreEqual(false, result.AreTestCaseLevelEventsRequired);
+            Assert.AreEqual(0, result.DataCollectionEventsPort);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/TestCaseTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/TestCaseTests.cs
@@ -53,6 +53,14 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests
             Assert.AreEqual(testGuid, testCase.Id);
         }
 
+        [TestMethod]
+        public void TestCaseLocalExtensionDataIsPubliclySettableGettableProperty()
+        {
+            var dummyData = "foo";
+            this.testCase.LocalExtensionData = dummyData;
+            Assert.AreEqual("foo", this.testCase.LocalExtensionData);
+        }
+
         #region GetSetPropertyValue Tests
 
         [TestMethod]

--- a/test/datacollector.UnitTests/DataCollectionManagerTests.cs
+++ b/test/datacollector.UnitTests/DataCollectionManagerTests.cs
@@ -158,6 +158,17 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
         }
 
         [TestMethod]
+        public void InitializeDataCollectorsShouldLogExceptionToMessageSinkIfSetEnvironmentVariableFails()
+        {
+            this.mockDataCollector.As<ITestExecutionEnvironmentSpecifier>().Setup(x => x.GetTestExecutionEnvironmentVariables()).Throws<Exception>();
+
+            this.dataCollectionManager.InitializeDataCollectors(this.dataCollectorSettings);
+
+            Assert.AreEqual(0, this.dataCollectionManager.RunDataCollectors.Count);
+            this.mockMessageSink.Verify(x => x.SendMessage(It.IsAny<DataCollectionMessageEventArgs>()), Times.Once);
+        }
+
+        [TestMethod]
         public void InitializeDataCollectorsShouldReturnFirstEnvironmentVariableIfMoreThanOneVariablesWithSameKeyIsSpecified()
         {
             this.envVarList.Add(new KeyValuePair<string, string>("key", "value"));


### PR DESCRIPTION
Ported PRs:
#1231 Add back `LocalExtensionData` API for adapters (fix regression reported by Debugger team)
#1230 Do not crash data collector if extension fails to initialize or set environment variables (allow test runs with coverage in non Enterprise SKU)
#1232 Use TPv2 as default for .NET 3.5 test projects
#1234 Loading native dll's correctly for UWP release mode.
https://github.com/Microsoft/vstest/pull/1238 HardCoded version of CLI to 2.1.0-preview1-007372.