### PR TITLE
Fix test run for x64 c++ tests.

### DIFF
--- a/src/package/VSIXProject/TestPlatform.csproj
+++ b/src/package/VSIXProject/TestPlatform.csproj
@@ -143,6 +143,9 @@
     <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\CppUnitFramework\*.*" Exclude="$(VsixInputFileLocation)\Extensions\CppUnitFramework\*.pdb">
       <VSIXSubPath>Extensions\CppUnitFramework</VSIXSubPath>
     </VsixSourceItem>
+    <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\CppUnitFramework\x64\*.*" Exclude="$(VsixInputFileLocation)\Extensions\CppUnitFramework\x64\*.pdb">
+      <VSIXSubPath>Extensions\CppUnitFramework\x64</VSIXSubPath>
+    </VsixSourceItem>
     
     <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\TestImpact\ComComponents\x64\*.*">
       <VSIXSubPath>Extensions\TestImpact\ComComponents\x64</VSIXSubPath>


### PR DESCRIPTION
Add x64/dbghelp to the vsix package.
