### PR TITLE
Fix test run for x64 c++ tests.

### DIFF
--- a/src/package/VSIXProject/TestPlatform.csproj
+++ b/src/package/VSIXProject/TestPlatform.csproj
@@ -143,8 +143,8 @@
     <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\Cpp\*.*" Exclude="$(VsixInputFileLocation)\Extensions\Cpp\*.pdb">
       <VSIXSubPath>Extensions\Cpp</VSIXSubPath>
     </VsixSourceItem>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\CppUnitFramework\x64\*.*" Exclude="$(VsixInputFileLocation)\Extensions\CppUnitFramework\x64\*.pdb">
-      <VSIXSubPath>Extensions\CppUnitFramework\x64</VSIXSubPath>
+    <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\Cpp\x64\*.*" Exclude="$(VsixInputFileLocation)\Extensions\Cpp\x64\*.pdb">
+      <VSIXSubPath>Extensions\Cpp\x64</VSIXSubPath>
     </VsixSourceItem>
     
     <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\TestImpact\ComComponents\x64\*.*">

--- a/src/package/VSIXProject/TestPlatform.csproj
+++ b/src/package/VSIXProject/TestPlatform.csproj
@@ -143,6 +143,9 @@
     <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\Cpp\*.*" Exclude="$(VsixInputFileLocation)\Extensions\Cpp\*.pdb">
       <VSIXSubPath>Extensions\Cpp</VSIXSubPath>
     </VsixSourceItem>
+    <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\CppUnitFramework\x64\*.*" Exclude="$(VsixInputFileLocation)\Extensions\CppUnitFramework\x64\*.pdb">
+      <VSIXSubPath>Extensions\CppUnitFramework\x64</VSIXSubPath>
+    </VsixSourceItem>
     
     <VsixSourceItem Include="$(VsixInputFileLocation)\Extensions\TestImpact\ComComponents\x64\*.*">
       <VSIXSubPath>Extensions\TestImpact\ComComponents\x64</VSIXSubPath>


### PR DESCRIPTION
Add x64/dbghelp to the vsix package.

An existing integration already exists, we couldn't catch it since it is always running in xcopy mode.