### PR TITLE
Handle disposed TestRunRequest object in Abort.

### DIFF
--- a/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
+++ b/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
@@ -236,7 +236,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.Execution
             {
                 if (this.disposed)
                 {
-                    EqtTrace.Warning("Ignoring TestRunRequest.CancelAsync() as testRunRequest aboject has already been disposed.");
+                    EqtTrace.Warning("Ignoring TestRunRequest.CancelAsync() as testRunRequest object has already been disposed.");
                     return;
                 }
 
@@ -265,7 +265,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.Execution
             {
                 if (this.disposed)
                 {
-                    EqtTrace.Warning("Ignoring TestRunRequest.Abort() as testRunRequest aboject has already been disposed");
+                    EqtTrace.Warning("Ignoring TestRunRequest.Abort() as testRunRequest object has already been disposed");
                     return;
                 }
 

--- a/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
+++ b/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
@@ -237,6 +237,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.Execution
                 if (this.disposed)
                 {
                     EqtTrace.Warning("Ignoring TestRunRequest.CancelAsync() as testRunRequest aboject has already been disposed.");
+                    return;
                 }
 
                 if (this.State != TestRunState.InProgress)
@@ -265,6 +266,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.Execution
                 if (this.disposed)
                 {
                     EqtTrace.Warning("Ignoring TestRunRequest.Abort() as testRunRequest aboject has already been disposed");
+                    return;
                 }
 
                 if (this.State != TestRunState.InProgress)

--- a/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
+++ b/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
@@ -236,7 +236,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.Execution
             {
                 if (this.disposed)
                 {
-                    throw new ObjectDisposedException("testRunRequest");
+                    EqtTrace.Warning("Ignoring TestRunRequest.CancelAsync() as testRunRequest aboject has already been disposed.");
                 }
 
                 if (this.State != TestRunState.InProgress)
@@ -264,7 +264,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.Execution
             {
                 if (this.disposed)
                 {
-                    throw new ObjectDisposedException("testRunRequest");
+                    EqtTrace.Warning("Ignoring TestRunRequest.Abort() as testRunRequest aboject has already been disposed");
                 }
 
                 if (this.State != TestRunState.InProgress)

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -498,6 +498,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
                         this.testRunResultAggregator.UnregisterTestRunEvents(this.currentTestRunRequest);
                         testRunEventsRegistrar?.UnregisterTestRunEvents(this.currentTestRunRequest);
 
+                        this.currentTestRunRequest.Dispose();
                         this.currentTestRunRequest = null;
                     }
 

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -479,29 +479,16 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
                     this.currentTestRunRequest = this.testPlatform.CreateTestRunRequest(requestData, testRunCriteria);
                     this.runRequestCreatedEventHandle.Set();
 
-                    try
-                    {
-                        this.testLoggerManager.RegisterTestRunEvents(this.currentTestRunRequest);
-                        this.testRunResultAggregator.RegisterTestRunEvents(this.currentTestRunRequest);
-                        testRunEventsRegistrar?.RegisterTestRunEvents(this.currentTestRunRequest);
+                    this.testLoggerManager.RegisterTestRunEvents(this.currentTestRunRequest);
+                    this.testRunResultAggregator.RegisterTestRunEvents(this.currentTestRunRequest);
+                    testRunEventsRegistrar?.RegisterTestRunEvents(this.currentTestRunRequest);
 
-                        this.testPlatformEventSource.ExecutionRequestStart();
+                    this.testPlatformEventSource.ExecutionRequestStart();
 
-                        this.currentTestRunRequest.ExecuteAsync();
+                    this.currentTestRunRequest.ExecuteAsync();
 
-                        // Wait for the run completion event
-                        this.currentTestRunRequest.WaitForCompletion();
-                    }
-                    finally
-                    {
-                        this.testLoggerManager.UnregisterTestRunEvents(this.currentTestRunRequest);
-                        this.testRunResultAggregator.UnregisterTestRunEvents(this.currentTestRunRequest);
-                        testRunEventsRegistrar?.UnregisterTestRunEvents(this.currentTestRunRequest);
-
-                        this.currentTestRunRequest.Dispose();
-                        this.currentTestRunRequest = null;
-                    }
-
+                    // Wait for the run completion event
+                    this.currentTestRunRequest.WaitForCompletion();
                 }
                 catch (Exception ex)
                 {
@@ -517,6 +504,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
                     {
                         throw;
                     }
+                }
+                finally
+                {
+                    this.testLoggerManager.UnregisterTestRunEvents(this.currentTestRunRequest);
+                    this.testRunResultAggregator.UnregisterTestRunEvents(this.currentTestRunRequest);
+                    testRunEventsRegistrar?.UnregisterTestRunEvents(this.currentTestRunRequest);
+
+                    this.currentTestRunRequest.Dispose();
+                    this.currentTestRunRequest = null;
                 }
 
                 return success;

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -65,7 +65,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
         private readonly EventWaitHandle runRequestCreatedEventHandle = new AutoResetEvent(false);
 
         private object syncobject = new object();
-        private object syncDispose = new object();
 
         private Task<IMetricsPublisher> metricsPublisher;
 
@@ -343,11 +342,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
         {
             EqtTrace.Info("TestRequestManager.CancelTestRun: Sending cancel request.");
 
-            lock (syncDispose)
-            {
-                this.runRequestCreatedEventHandle.WaitOne(runRequestTimeout);
-                this.currentTestRunRequest?.CancelAsync();
-            }
+            this.runRequestCreatedEventHandle.WaitOne(runRequestTimeout);
+            this.currentTestRunRequest?.CancelAsync();
         }
 
         /// <summary>
@@ -357,11 +353,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
         {
             EqtTrace.Info("TestRequestManager.AbortTestRun: Sending abort request.");
 
-            lock (syncDispose)
-            {
-                this.runRequestCreatedEventHandle.WaitOne(runRequestTimeout);
-                this.currentTestRunRequest?.Abort();
-            }
+            this.runRequestCreatedEventHandle.WaitOne(runRequestTimeout);
+            this.currentTestRunRequest?.Abort();
         }
 
         #endregion
@@ -505,11 +498,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
                         this.testRunResultAggregator.UnregisterTestRunEvents(this.currentTestRunRequest);
                         testRunEventsRegistrar?.UnregisterTestRunEvents(this.currentTestRunRequest);
 
-                        lock(syncDispose)
-                        {
-                            this.currentTestRunRequest.Dispose();
-                            this.currentTestRunRequest = null;
-                        }
+                        this.currentTestRunRequest = null;
                     }
 
                 }

--- a/test/Microsoft.TestPlatform.Client.UnitTests/Execution/TestRunRequestTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/Execution/TestRunRequestTests.cs
@@ -95,10 +95,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.Execution
         }
 
         [TestMethod]
-        public void AbortIfTestRunRequestDisposedShouldThrowObjectDisposedException()
+        public void AbortIfTestRunRequestDisposedShouldNotThrowException()
         {
             testRunRequest.Dispose();
-            Assert.ThrowsException<ObjectDisposedException>(() => testRunRequest.Abort());
+            testRunRequest.Abort();
         }
 
         [TestMethod]
@@ -133,10 +133,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.Execution
         }
 
         [TestMethod]
-        public void CancelAsyncIfTestRunRequestDisposedThrowsObjectDisposedException()
+        public void CancelAsyncIfTestRunRequestDisposedShouldNotThrowException()
         {
             testRunRequest.Dispose();
-            Assert.ThrowsException<ObjectDisposedException>(() => testRunRequest.CancelAsync());
+            testRunRequest.CancelAsync();
         }
 
         [TestMethod]

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -840,7 +840,6 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
         }
 
         [TestMethod]
-        [Ignore]
         public void CancelTestRunShouldWaitForCreateTestRunRequest()
         {
             var payload = new TestRunRequestPayload()
@@ -848,8 +847,6 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
                 Sources = new List<string>() { "a", "b" },
                 RunSettings = DefaultRunsettings
             };
-
-            TestRunCriteria observedCriteria = null;
 
             var sw = new Stopwatch();
             sw.Start();
@@ -859,11 +856,10 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
 
             var mockRunRequest = new Mock<ITestRunRequest>();
             this.mockTestPlatform.Setup(mt => mt.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>())).Callback(
-               (TestRunCriteria runCriteria, ProtocolConfig config) =>
+               (IRequestData requestData, TestRunCriteria testRunCriteria) =>
                {
                    Thread.Sleep(1);
                    createRunRequestTime = sw.ElapsedMilliseconds;
-                   observedCriteria = runCriteria;
                }).Returns(mockRunRequest.Object);
 
             mockRunRequest.Setup(mr => mr.CancelAsync()).Callback(() =>
@@ -884,8 +880,7 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
         }
 
         [TestMethod]
-        [Ignore]
-        public void AbortTestRunShouldWaitForCreateTestRunRequest()
+        public void CancelShouldNotThrowExceptionIfTestRunRequestHasBeenDisposed()
         {
             var payload = new TestRunRequestPayload()
             {
@@ -893,7 +888,37 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
                 RunSettings = DefaultRunsettings
             };
 
-            TestRunCriteria observedCriteria = null;
+            var mockRunEventsRegistrar = new Mock<ITestRunEventsRegistrar>();
+            var mockCustomlauncher = new Mock<ITestHostLauncher>();
+
+            this.testRequestManager.RunTests(payload, mockCustomlauncher.Object, mockRunEventsRegistrar.Object, this.protocolConfig);
+            this.testRequestManager.CancelTestRun();
+        }
+
+        [TestMethod]
+        public void AbortShouldNotThrowExceptionIfTestRunRequestHasBeenDisposed()
+        {
+            var payload = new TestRunRequestPayload()
+            {
+                Sources = new List<string>() { "a", "b" },
+                RunSettings = DefaultRunsettings
+            };
+
+            var mockRunEventsRegistrar = new Mock<ITestRunEventsRegistrar>();
+            var mockCustomlauncher = new Mock<ITestHostLauncher>();
+
+            this.testRequestManager.RunTests(payload, mockCustomlauncher.Object, mockRunEventsRegistrar.Object, this.protocolConfig);
+            this.testRequestManager.AbortTestRun();
+        }
+
+        [TestMethod]
+        public void AbortTestRunShouldWaitForCreateTestRunRequest()
+        {
+            var payload = new TestRunRequestPayload()
+            {
+                Sources = new List<string>() { "a", "b" },
+                RunSettings = DefaultRunsettings
+            };
 
             var sw = new Stopwatch();
             sw.Start();
@@ -903,11 +928,10 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
 
             var mockRunRequest = new Mock<ITestRunRequest>();
             this.mockTestPlatform.Setup(mt => mt.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>())).Callback(
-                (TestRunCriteria runCriteria, ProtocolConfig config) =>
+                (IRequestData requestData, TestRunCriteria testRunCriteria) =>
                 {
                     Thread.Sleep(1);
                     createRunRequestTime = sw.ElapsedMilliseconds;
-                    observedCriteria = runCriteria;
                 }).Returns(mockRunRequest.Object);
 
             mockRunRequest.Setup(mr => mr.Abort()).Callback(() =>


### PR DESCRIPTION
Resolves: https://github.com/Microsoft/vstest/issues/1256

## Description
We were calling Abort and Cancel on disposed TestRunRequest Object

## Related issue
https://github.com/Microsoft/vstest/issues/1256
