### PR TITLE
Load C++, & Old Mstest adapter for UWP

### DIFF
--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs
@@ -95,17 +95,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
 
         private void AddKnownExtensions(ref IEnumerable<string> extensionPaths)
         {
-            // For C++ UWP adatper
-            if(this.fileHelper.Exists("Microsoft.VisualStudio.TestTools.CppUnitTestFramework.CppUnitTestExtension.dll"))
-            {
-                extensionPaths = extensionPaths.Concat(new[] { "Microsoft.VisualStudio.TestTools.CppUnitTestFramework.CppUnitTestExtension.dll" });
-            }
-
-            // For OLD C# UWP(MSTest V1) adatper
-            if (this.fileHelper.Exists("Microsoft.VisualStudio.TestPlatform.Extensions.MSAppContainerAdapter.dll"))
-            {
-                extensionPaths = extensionPaths.Concat(new[]{ "Microsoft.VisualStudio.TestPlatform.Extensions.MSAppContainerAdapter.dll" });
-            }
+            // For C++ UWP adatper, & OLD C# UWP(MSTest V1) adatper
+            // In UWP .Net Native Compilation mode managed dll's are packaged differently, & File.Exists() fails.
+            // Include these two dll's if so far no adapters(extensions) were found, & let Assembly.Load() fail if they are not present.
+            extensionPaths = extensionPaths.Concat(new[] { "Microsoft.VisualStudio.TestTools.CppUnitTestFramework.CppUnitTestExtension.dll", "Microsoft.VisualStudio.TestPlatform.Extensions.MSAppContainerAdapter.dll" });
         }
 
         /// <summary>

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginDiscovererTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginDiscovererTests.cs
@@ -144,36 +144,6 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             Assert.That.DoesNotThrow(() =>this.testPluginDiscoverer.GetTestExtensionsInformation<FaultyTestExecutorPluginInformation, ITestExecutor>(pathToExtensions));
         }
 
-        [TestMethod]
-        public void GetTestExtensionsInformationShouldAddUWPCppAdatersIfTheyExists()
-        {
-            var pathToExtensions = new List<string>();
-
-            Mock<IFileHelper> mockFileHelper = new Mock<IFileHelper>();
-            mockFileHelper.Setup(fh => fh.Exists("Microsoft.VisualStudio.TestTools.CppUnitTestFramework.CppUnitTestExtension.dll")).Returns(true);
-
-            this.testPluginDiscoverer = new TestPluginDiscoverer(mockFileHelper.Object);
-
-            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<FaultyTestExecutorPluginInformation, ITestExecutor>(pathToExtensions);
-
-            mockFileHelper.Verify(fh => fh.Exists("Microsoft.VisualStudio.TestTools.CppUnitTestFramework.CppUnitTestExtension.dll"), Times.Once);
-        }
-
-        [TestMethod]
-        public void GetTestExtensionsInformationShouldAddMSTestV1UWPAdaptersIfTheyExists()
-        {
-            var pathToExtensions = new List<string>();
-
-            Mock<IFileHelper> mockFileHelper = new Mock<IFileHelper>();
-            mockFileHelper.Setup(fh => fh.Exists("Microsoft.VisualStudio.TestPlatform.Extensions.MSAppContainerAdapter.dll")).Returns(true);
-
-            this.testPluginDiscoverer = new TestPluginDiscoverer(mockFileHelper.Object);
-
-            var testExtensions = this.testPluginDiscoverer.GetTestExtensionsInformation<FaultyTestExecutorPluginInformation, ITestExecutor>(pathToExtensions);
-
-            mockFileHelper.Verify(fh => fh.Exists("Microsoft.VisualStudio.TestPlatform.Extensions.MSAppContainerAdapter.dll"), Times.Once);
-        }
-
         #region implementations
 
         #region Discoverers


### PR DESCRIPTION
## Description
In UWP .Net Native Compilation mode managed dll's are packaged differently, & File.Exists() fails.
Include these two dll's if so far no adapters(extensions) were found, & let Assembly.Load() fail if they are not present.

## Related issue
Bug 520306: C++ UWP Unit tests are not discovered in release mode if targeting Tpv2
https://devdiv.visualstudio.com/DevDiv/VS.in%20Agile%20Testing%20IDE/_workitems?id=520306&_a=edit&triage=true

Removing tests for loading c++/c# UWP adapter.
One way to fix the test would be to add platform abstraction for Assembly Load
