### PR TITLE
Using RTM adapters in Perf scripts.

### DIFF
--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -6,17 +6,17 @@
     <!-- Name of the elements must be in sync with test\Microsoft.TestPlatform.TestUtilities\IntegrationTestBase.cs -->
     <NETTestSdkPreviousVersion>15.3.0-preview-20170628-02</NETTestSdkPreviousVersion>
 
-    <MSTestFrameworkVersion>1.2.0-beta</MSTestFrameworkVersion>
-    <MSTestAdapterVersion>1.2.0-beta</MSTestAdapterVersion>
+    <MSTestFrameworkVersion>1.2.0</MSTestFrameworkVersion>
+    <MSTestAdapterVersion>1.2.0</MSTestAdapterVersion>
     <MSTestAssertExtensionVersion>1.0.3-preview</MSTestAssertExtensionVersion>
     
-    <XUnitFrameworkVersion>2.3.0-beta3-build3705</XUnitFrameworkVersion>
-    <XUnitAdapterVersion>2.3.0-beta3-build3705</XUnitAdapterVersion>
-    <XUnitConsoleRunnerVersion>2.3.0-beta3-build3705</XUnitConsoleRunnerVersion>
+    <XUnitFrameworkVersion>2.3.1</XUnitFrameworkVersion>
+    <XUnitAdapterVersion>2.3.1</XUnitAdapterVersion>
+    <XUnitConsoleRunnerVersion>2.3.1</XUnitConsoleRunnerVersion>
 
-    <NUnit3FrameworkVersion>3.7.1</NUnit3FrameworkVersion>
-    <NUnit3AdapterVersion>3.8.0</NUnit3AdapterVersion>
-    <NUnitConsoleRunnerVersion>3.7.0</NUnitConsoleRunnerVersion>
+    <NUnit3FrameworkVersion>3.9.0-dev-04564</NUnit3FrameworkVersion>
+    <NUnit3AdapterVersion>3.9.0</NUnit3AdapterVersion>
+    <NUnitConsoleRunnerVersion>3.8.0-dev-03796</NUnitConsoleRunnerVersion>
     <NUnitFrameworkVersion>2.6.4</NUnitFrameworkVersion>
     <NUnitAdapterVersion>2.0.0</NUnitAdapterVersion>
 

--- a/scripts/perf/perf.ps1
+++ b/scripts/perf/perf.ps1
@@ -54,7 +54,7 @@ $Script:TPT_TestResultsDir = Join-Path $env:TP_ROOT_DIR "TestResults"
 $Script:TPT_DefaultTrxFileName = "TrxLogResults.trx"
 $Script:TPT_ErrorMsgColor = "Red"
 $Script:TPT_PayLoads=New-Object System.Collections.ArrayList
-$Script:TPT_PerfIterations = 5
+$Script:TPT_PerfIterations = 10
 $Script:TPT_Results = New-Object System.Collections.ArrayList
 $Script:TPT_DependencyProps = [xml] (Get-Content $env:TP_ROOT_DIR\scripts\build\TestPlatform.Dependencies.props)
 
@@ -315,12 +315,13 @@ function Invoke-PerformanceTests
                                             elseif($runner -eq "nunit.consolerunner")
                                             {
                                                 $payload | Add-Member currentRunnerVersion "$($Script:TPT_DependencyProps.Project.PropertyGroup.NUnitConsoleRunnerVersion)" -Force
-                                                Measure-DiscoveryTime {&$runnerPath $testContainer --explore} $payload
-                                                Measure-ExecutionTime {&$runnerPath $testContainer} $payload
+                                                Measure-DiscoveryTime {&$runnerPath $testContainer --explore --inprocess} $payload
+                                                Measure-ExecutionTime {&$runnerPath $testContainer --inprocess} $payload
                                             }
                                             elseif($runner -eq "xunit.runner.console")
                                             {
                                                 $payload | Add-Member currentRunnerVersion "$($Script:TPT_DependencyProps.Project.PropertyGroup.XUnitConsoleRunnerVersion)" -Force
+                                                Measure-DiscoveryTime {&$runnerPath $testContainer -class foo} $payload
                                                 Measure-ExecutionTime {&$runnerPath $testContainer} $payload
                                             }
                                         }

--- a/test/TestAssets/TestAssets.sln/TestAssets.sln
+++ b/test/TestAssets/TestAssets.sln/TestAssets.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26815.3
+VisualStudioVersion = 15.0.27106.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NUnitAdapterPerfTestProject", "..\NUnitAdapterPerfTestProject\NUnitAdapterPerfTestProject.csproj", "{F22A8D65-0581-4CC7-9C1C-9BC9F9E80DA4}"
 EndProject
@@ -12,8 +12,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NUTestProject", "..\NUTestProject\NUTestProject.csproj", "{1ADE5795-2365-4790-8ACB-2EF0C2613D61}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlameUnitTestProject", "..\BlameUnitTestProject\BlameUnitTestProject.csproj", "{29294E06-3998-4FF4-910F-EE93A915C3A1}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XUPerfTestProject", "..\XUPerfTestProject\XUPerfTestProject.csproj", "{530FD85F-0222-4078-9610-4AC1C8A5E294}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XUTestProject", "..\XUTestProject\XUTestProject.csproj", "{C8AB532E-28E9-4C5E-9F2D-06B6690FCB72}"
 EndProject
@@ -61,10 +59,6 @@ Global
 		{29294E06-3998-4FF4-910F-EE93A915C3A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{29294E06-3998-4FF4-910F-EE93A915C3A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{29294E06-3998-4FF4-910F-EE93A915C3A1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{530FD85F-0222-4078-9610-4AC1C8A5E294}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{530FD85F-0222-4078-9610-4AC1C8A5E294}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{530FD85F-0222-4078-9610-4AC1C8A5E294}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{530FD85F-0222-4078-9610-4AC1C8A5E294}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C8AB532E-28E9-4C5E-9F2D-06B6690FCB72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C8AB532E-28E9-4C5E-9F2D-06B6690FCB72}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8AB532E-28E9-4C5E-9F2D-06B6690FCB72}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
- Using RTM Adapters for MsTest, xUnit and nUnit
- Adding --inprocess switch for nUnit
- Adding Discovery for xunit.console.runner.
- Increasing the number of iterations 10 for accuracy

