### PR TITLE
Removed Security Event Log from default Event Log configuration.

### DIFF
--- a/src/DataCollectors/Microsoft.TestPlatform.Extensions.EventLogCollector/EventLogDataCollector.cs
+++ b/src/DataCollectors/Microsoft.TestPlatform.Extensions.EventLogCollector/EventLogDataCollector.cs
@@ -544,7 +544,6 @@ namespace Microsoft.TestPlatform.Extensions.EventLogCollector
             {
                 // Default to collecting these standard logs
                 this.eventLogNames.Add("System");
-                this.eventLogNames.Add("Security");
                 this.eventLogNames.Add("Application");
             }
 

--- a/test/DataCollectors/Microsoft.TestPlatform.Extensions.EventLogCollector.UnitTests/EventLogDataCollectorTests.cs
+++ b/test/DataCollectors/Microsoft.TestPlatform.Extensions.EventLogCollector.UnitTests/EventLogDataCollectorTests.cs
@@ -98,7 +98,6 @@ namespace Microsoft.TestPlatform.Extensions.EventLogCollector.UnitTests
         {
             List<string> eventLogNames = new List<string>();
             eventLogNames.Add("System");
-            eventLogNames.Add("Security");
             eventLogNames.Add("Application");
 
             this.eventLogDataCollector.Initialize(null, this.mockDataCollectionEvents.Object, this.mockDataCollectionSink, this.mockDataCollectionLogger.Object, this.dataCollectionEnvironmentContext);


### PR DESCRIPTION
Fix for https://github.com/Microsoft/vstest/issues/1257
