### PR TITLE
Increase expected elapsed time for GetArchitecture tests

### DIFF
--- a/test/vstest.console.PlatformTests/AssemblyMetadataProviderTests.cs
+++ b/test/vstest.console.PlatformTests/AssemblyMetadataProviderTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.PlatformTests
     [TestClass]
     public class AssemblyMetadataProviderTests : IntegrationTestBase
     {
-        private const int ExpectedTimeForFindingArchForDotNetAssembly = 10; // In milliseconds.
+        private const int ExpectedTimeForFindingArchForDotNetAssembly = 15; // In milliseconds.
         private const string PerfAssertMessageFormat = "Expected Elapsed Time: {0} ms, Actual Elapsed Time: {1} ms";
 
         private IAssemblyMetadataProvider assemblyMetadataProvider;


### PR DESCRIPTION
## Description
> Total tests: 62. Passed: 57. Failed: 1. Skipped: 4.
05:03:11 Test Run Failed.
05:03:11 Test execution time: 16.0186 Seconds
05:03:11 Results File: D:\j\workspace\Windows_NT_Re---eafdf36b\TestResults\Parallel_net451_TrxLogResults.trx
05:03:11 ... .. . Failed tests:
05:03:11 ... .. .. . 1. Microsoft.VisualStudio.TestPlatform.CommandLine.PlatformTests.AssemblyMetadataProviderTests.GetArchitectureShouldReturnCorrentArchForx64Assembly (net451)
05:03:11 ... .. .. .. .ErrorMessage: 
05:03:11 Assert.IsTrue failed. Expected Elapsed Time: 10 ms, Actual Elapsed Time: 10 ms
05:03:11 ... .. .. .. .StackTrace: 
05:03:11    at Microsoft.VisualStudio.TestPlatform.CommandLine.PlatformTests.AssemblyMetadataProviderTests.TestDotnetAssemblyArch(String projectName, String framework, Architecture expectedArch, Int64 expectedElapsedTime)
05:03:11    at Microsoft.VisualStudio.TestPlatform.CommandLine.PlatformTests.AssemblyMetadataProviderTests.GetArchitectureShouldReturnCorrentArchForx64Assembly(String framework)

[here](https://ci.dot.net/job/Microsoft_vstest/job/master/job/Windows_NT_Release_prtest/1612/console). and few other times. These tests are failing intermittently, Increasing timeout by 5 ms.