### PR TITLE
Remove incorrect DebugType setting

### DIFF
--- a/src/package/nuspec/Microsoft.NET.Test.Sdk.targets
+++ b/src/package/nuspec/Microsoft.NET.Test.Sdk.targets
@@ -33,14 +33,6 @@
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <OutputType>Exe</OutputType>
   </PropertyGroup>
-
-  <!--
-     In IDE scenario for full CLR projects default test platform is v1, which expects full pdbs for source information.
-     This can be removed once TPv2 is default for full CLR. Related issue https://github.com/Microsoft/vstest/issues/373.
-   -->
-  <PropertyGroup>
-    <DebugType Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">Full</DebugType>
-  </PropertyGroup>
  
   <!--
      Generate config file for test project targeting .NET Framework. This config file has binding redirect which is needed at time of running tests.


### PR DESCRIPTION
## Description
Remove incorrect DebugType setting.

Currently the targets file sets ```DebugType``` after it has been used by the SDK to determine whether symbols need to be copied to the output directory. If the project sets ```DebugType``` to ```embedded``` the SDK determines that no PDBs need to be copied but then the test SDK overwrites ```DebugType``` value which makes the compiler to produce Windows PDB. This PDB is not copied to the output directory. XUnit will not find it there when displaying stack traces so the stack traces will miss line and file information.

## Related issue
Fixes https://github.com/Microsoft/vstest/issues/373
