### PR TITLE
Support multiple paths in TestAdapterPath argument (#1319)

### DIFF
--- a/src/vstest.console/Processors/TestAdapterPathArgumentProcessor.cs
+++ b/src/vstest.console/Processors/TestAdapterPathArgumentProcessor.cs
@@ -186,7 +186,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
                 
                 foreach (var testadapterPath in testAdapterPaths)
                 {
-                    var testAdapterFullPath = Path.GetFullPath(testadapterPath);
+                    // TestAdaptersPaths could contain environment variables
+                    var testAdapterFullPath = Path.GetFullPath(Environment.ExpandEnvironmentVariables(testadapterPath));
 
                     if (!this.fileHelper.DirectoryExists(testAdapterFullPath))
                     {

--- a/src/vstest.console/Processors/TestAdapterPathArgumentProcessor.cs
+++ b/src/vstest.console/Processors/TestAdapterPathArgumentProcessor.cs
@@ -119,6 +119,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
         /// For file related operation
         /// </summary>
         private IFileHelper fileHelper;
+        
+        /// <summary>
+        /// Separators for multiple paths in argument.
+        /// </summary>
+        private readonly char[] argumentSeparators = new [] { ';' };
 
         #endregion
 
@@ -161,43 +166,38 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
 
             try
             {
+                var testAdapterPaths = new List<string>();
+                var testAdapterFullPaths = new List<string>();
+                
                 // VSTS task add double quotes around TestAdapterpath. For example if user has given TestAdapter path C:\temp,
                 // Then VSTS task will add TestAdapterPath as "/TestAdapterPath:\"C:\Temp\"".
                 // Remove leading and trailing ' " ' chars...
                 argument = argument.Trim().Trim(new char[] { '\"' });
-                customAdaptersPath = Path.GetFullPath(argument);
-                if (!fileHelper.DirectoryExists(customAdaptersPath))
-                {
-                    throw new DirectoryNotFoundException(CommandLineResources.TestAdapterPathDoesNotExist);
-                }
 
                 // Get testadapter paths from RunSettings.
                 var testAdapterPathsInRunSettings = this.runSettingsManager.QueryRunSettingsNode("RunConfiguration.TestAdaptersPaths");
 
                 if (!string.IsNullOrWhiteSpace(testAdapterPathsInRunSettings))
                 {
-                    var testAdapterFullPaths = new List<string>();
-                    var testAdapterPathsInRunSettingsArray = testAdapterPathsInRunSettings.Split(
-                        new[] { ';' },
-                        StringSplitOptions.RemoveEmptyEntries);
+                    testAdapterPaths.AddRange(SplitPaths(testAdapterPathsInRunSettings));
+                }
+                
+                testAdapterPaths.AddRange(SplitPaths(argument));
+                
+                foreach (var testadapterPath in testAdapterPaths)
+                {
+                    var testAdapterFullPath = Path.GetFullPath(testadapterPath);
 
-                    foreach (var testadapterPath in testAdapterPathsInRunSettingsArray)
+                    if (!this.fileHelper.DirectoryExists(testAdapterFullPath))
                     {
-                        var testAdapterFullPath = Path.GetFullPath(testadapterPath);
-
-                        if (!this.fileHelper.DirectoryExists(testAdapterFullPath))
-                        {
-                            invalidAdapterPathArgument = testadapterPath;
-                            throw new DirectoryNotFoundException(CommandLineResources.TestAdapterPathDoesNotExist);
-                        }
-
-                        testAdapterFullPaths.Add(testAdapterFullPath);
+                        invalidAdapterPathArgument = testadapterPath;
+                        throw new DirectoryNotFoundException(CommandLineResources.TestAdapterPathDoesNotExist);
                     }
 
-                    testAdapterFullPaths.Add(customAdaptersPath);
-                    testAdapterFullPaths = testAdapterFullPaths.Distinct().ToList();
-                    customAdaptersPath = string.Join(";", testAdapterFullPaths.ToArray());
+                    testAdapterFullPaths.Add(testAdapterFullPath);
                 }
+
+                customAdaptersPath = string.Join(";", testAdapterFullPaths.Distinct().ToArray());
 
                 this.runSettingsManager.UpdateRunSettingsNode("RunConfiguration.TestAdaptersPaths", customAdaptersPath);
             }
@@ -208,6 +208,21 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             }
 
             this.commandLineOptions.TestAdapterPath = customAdaptersPath;
+        }
+
+        /// <summary>
+        /// Splits provided paths into array.
+        /// </summary>
+        /// <param name="paths">Source paths joined by semicolons.</param>
+        /// <returns>Paths.</returns>
+        private string[] SplitPaths(string paths)
+        {
+            if (string.IsNullOrWhiteSpace(paths))
+            {
+                return new string[] { };
+            }
+
+            return paths.Split(argumentSeparators, StringSplitOptions.RemoveEmptyEntries);
         }
 
         /// <summary>

--- a/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
@@ -227,6 +227,26 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         }
 
         [TestMethod]
+        public void InitializeShouldHonorEnvironmentVariablesInTestAdapterPaths()
+        {
+            var runSettingsXml = "<RunSettings><RunConfiguration><TestAdaptersPaths>%temp%\\adapters1</TestAdaptersPaths></RunConfiguration></RunSettings>";
+            var runSettings = new RunSettings();
+            runSettings.LoadSettingsXml(runSettingsXml);
+            RunSettingsManager.Instance.SetActiveRunSettings(runSettings);
+            var mockFileHelper = new Mock<IFileHelper>();
+            var mockOutput = new Mock<IOutput>();
+
+            mockFileHelper.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
+            var executor = new TestAdapterPathArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance, mockOutput.Object, mockFileHelper.Object);
+
+            executor.Initialize("%temp%\\adapters2");
+            var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(RunSettingsManager.Instance.ActiveRunSettings.SettingsXml);
+
+            var tempPath = Path.GetFullPath(Environment.ExpandEnvironmentVariables("%temp%"));
+            Assert.AreEqual(string.Format("{0}\\adapters1;{0}\\adapters2", tempPath), runConfiguration.TestAdaptersPaths);
+        }
+
+        [TestMethod]
         public void InitializeShouldAddRightAdapterPathInErrorMessage()
         {
             var runSettingsXml = "<RunSettings><RunConfiguration><TestAdaptersPaths>d:\\users</TestAdaptersPaths></RunConfiguration></RunSettings>";

--- a/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
@@ -209,6 +209,24 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         }
 
         [TestMethod]
+        public void InitializeShouldMergeMultipleTestAdapterPathsWithPathsInRunSettings()
+        {
+            var runSettingsXml = "<RunSettings><RunConfiguration><TestAdaptersPaths>d:\\users;f:\\users</TestAdaptersPaths></RunConfiguration></RunSettings>";
+            var runSettings = new RunSettings();
+            runSettings.LoadSettingsXml(runSettingsXml);
+            RunSettingsManager.Instance.SetActiveRunSettings(runSettings);
+            var mockFileHelper = new Mock<IFileHelper>();
+            var mockOutput = new Mock<IOutput>();
+
+            mockFileHelper.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
+            var executor = new TestAdapterPathArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance, mockOutput.Object, mockFileHelper.Object);
+
+            executor.Initialize("c:\\users;e:\\users");
+            var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(RunSettingsManager.Instance.ActiveRunSettings.SettingsXml);
+            Assert.AreEqual("d:\\users;f:\\users;c:\\users;e:\\users", runConfiguration.TestAdaptersPaths);
+        }
+
+        [TestMethod]
         public void InitializeShouldAddRightAdapterPathInErrorMessage()
         {
             var runSettingsXml = "<RunSettings><RunConfiguration><TestAdaptersPaths>d:\\users</TestAdaptersPaths></RunConfiguration></RunSettings>";


### PR DESCRIPTION
## Description
Currently when using `VSTestTestAdapterPath` as a command line parameter in `msbuild` or `dotnet test` `VSTestTask` bypasses it in vstest console which throws exception like that:
```
specified in the 'TestAdapterPath' is invalid. Error: The given path's format is not supported.
```
This change handles this case and merges provided paths with paths retrieved from test settings file.

## Related issue
#1319, #141
