### PR TITLE
Fix for coded UI test debug broken

### DIFF
--- a/samples/Microsoft.TestPlatform.E2ETest/Microsoft.TestPlatform.E2ETest.csproj
+++ b/samples/Microsoft.TestPlatform.E2ETest/Microsoft.TestPlatform.E2ETest.csproj
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+      <TestPlatformRoot Condition="$(TestPlatformRoot) == ''">../../</TestPlatformRoot>
+  </PropertyGroup>
+  <Import Project="$(TestPlatformRoot)scripts/build/TestPlatform.Dependencies.props" />
+  <PropertyGroup>
     <VersionPrefix>15.0.0</VersionPrefix>
     <TargetFramework>net451</TargetFramework>
     <AssemblyName>Microsoft.TestPlatform.E2ETest</AssemblyName>
@@ -22,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Internal.TestPlatform.Extensions">
-      <Version>15.6.0-preview-1202328</Version>
+      <Version>$(TestPlatformExternalsVersion)</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.Client\Microsoft.TestPlatform.Client.csproj" />

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -433,7 +433,8 @@ function Create-VsixPackage
     $testImpactComComponentsDir = Join-Path $extensionsPackageDir "TestImpact"
     $legacyTestImpactComComponentsDir = Join-Path $extensionsPackageDir "V1\TestImpact"
 
-    $testPlatformExternalsVersion = "15.6.0-preview-1251113"
+    $testPlatformExternalsVersion = ([xml](Get-Content $env:TP_ROOT_DIR\scripts\build\TestPlatform.Dependencies.props)).Project.PropertyGroup.TestPlatformExternalsVersion
+
     # Copy legacy dependencies
     $legacyDir = Join-Path $env:TP_PACKAGES_DIR "Microsoft.Internal.TestPlatform.Extensions\$testPlatformExternalsVersion\contentFiles\any\any"
     Copy-Item -Recurse $legacyDir\* $packageDir -Force

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -24,7 +24,7 @@ Param(
 
     [Parameter(Mandatory=$false)]
     [Alias("bn")]
-    [System.String] $BuildNumber = "49999999-99",
+    [System.String] $BuildNumber = "20991231-99",
 
     [Parameter(Mandatory=$false)]
     [Alias("ff")]
@@ -433,16 +433,17 @@ function Create-VsixPackage
     $testImpactComComponentsDir = Join-Path $extensionsPackageDir "TestImpact"
     $legacyTestImpactComComponentsDir = Join-Path $extensionsPackageDir "V1\TestImpact"
 
+    $testPlatformExternalsVersion = "15.6.0-preview-1251113"
     # Copy legacy dependencies
-    $legacyDir = Join-Path $env:TP_PACKAGES_DIR "Microsoft.Internal.TestPlatform.Extensions\15.6.0-preview-1202328\contentFiles\any\any"
+    $legacyDir = Join-Path $env:TP_PACKAGES_DIR "Microsoft.Internal.TestPlatform.Extensions\$testPlatformExternalsVersion\contentFiles\any\any"
     Copy-Item -Recurse $legacyDir\* $packageDir -Force
 
     # Copy QtAgent Related depedencies
-    $legacyDir = Join-Path $env:TP_PACKAGES_DIR "Microsoft.VisualStudio.QualityTools\15.6.0-preview-1202328\contentFiles\any\any"
+    $legacyDir = Join-Path $env:TP_PACKAGES_DIR "Microsoft.VisualStudio.QualityTools\$testPlatformExternalsVersion\contentFiles\any\any"
     Copy-Item -Recurse $legacyDir\* $packageDir -Force
 
     # Copy Legacy data collectors Related depedencies
-    $legacyDir = Join-Path $env:TP_PACKAGES_DIR "Microsoft.VisualStudio.QualityTools.DataCollectors\15.6.0-preview-1202328\contentFiles\any\any"
+    $legacyDir = Join-Path $env:TP_PACKAGES_DIR "Microsoft.VisualStudio.QualityTools.DataCollectors\$testPlatformExternalsVersion\contentFiles\any\any"
     Copy-Item -Recurse $legacyDir\* $packageDir -Force
 
     # Copy COM Components and their manifests over

--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -4,7 +4,7 @@
     <VSSdkBuildToolsVersion>15.0.26201</VSSdkBuildToolsVersion>
 
     <!-- Name of the elements must be in sync with test\Microsoft.TestPlatform.TestUtilities\IntegrationTestBase.cs -->
-    <NETTestSdkPreviousVersion>15.3.0-preview-20170628-02</NETTestSdkPreviousVersion>
+    <NETTestSdkPreviousVersion>15.5.0</NETTestSdkPreviousVersion>
 
     <MSTestFrameworkVersion>1.2.0</MSTestFrameworkVersion>
     <MSTestAdapterVersion>1.2.0</MSTestAdapterVersion>
@@ -25,5 +25,6 @@
 
     <JsonNetVersion>9.0.1</JsonNetVersion>
     <MoqVersion>4.7.63</MoqVersion>
+    <TestPlatformExternalsVersion>15.6.0-preview-1251113</TestPlatformExternalsVersion>
   </PropertyGroup>
 </Project>

--- a/src/package/external/external.csproj
+++ b/src/package/external/external.csproj
@@ -53,15 +53,15 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Internal.TestPlatform.Extensions">
-      <Version>15.6.0-preview-1202328</Version>
+      <Version>$(TestPlatformExternalsVersion)</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.QualityTools">
-      <Version>15.6.0-preview-1202328</Version>
+      <Version>$(TestPlatformExternalsVersion)</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.QualityTools.DataCollectors">
-      <Version>15.6.0-preview-1202328</Version>
+      <Version>$(TestPlatformExternalsVersion)</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Internal.Intellitrace">


### PR DESCRIPTION
- Porting to master. 
- TMIHelper from d15.6stg.
- Keep the default VSIX version in Int32 range.
#### Related issue
[Can't debug coded UI test in latest VS2017](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/534824)
