### PR TITLE
Increase datacollector initial communication timeout

### DIFF
--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestForwardingApp.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestForwardingApp.cs
@@ -58,7 +58,7 @@ namespace Microsoft.TestPlatform.Build.Tasks
             }
             catch(ArgumentException ex)
             {
-                Tracing.Trace(string.Format("VSTest: Killing process throws ArgumentException with the following message {0}. It may be that process is not running", ex.Message));
+                Tracing.Trace(string.Format("VSTest: Killing process throws ArgumentException with the following message {0}. It may be that process is not running", ex));
             }
         }
     }

--- a/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
+++ b/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
@@ -136,7 +136,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.DesignMode
                 {
                     var message = this.communicationManager.ReceiveMessage();
 
-                    EqtTrace.Info("DesignModeClient: Processing Message of message type: {0}", message.MessageType);
+                    if (EqtTrace.IsInfoEnabled)
+                    {
+                        EqtTrace.Info("DesignModeClient.ProcessRequests: Processing Message: {0}", message);
+                    }
+
                     switch (message.MessageType)
                     {
                         case MessageType.VersionCheck:

--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionAttachmentManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionAttachmentManager.cs
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
             }
             catch (Exception ex)
             {
-                EqtTrace.Error(ex.Message);
+                EqtTrace.Error("DataCollectionAttachmentManager.GetAttachments: Fail to get attachments: {0} ", ex);
             }
 
             List<AttachmentSet> attachments = new List<AttachmentSet>();
@@ -295,7 +295,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
                     catch (Exception ex)
                     {
                         this.LogError(
-                           ex.Message,
+                           ex.ToString(),
                            uri,
                            friendlyName,
                            Guid.Parse(testCaseId));

--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
@@ -450,7 +450,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
                 }
 
                 // Log error.
-                dataCollectorInfo.Logger.LogError(this.dataCollectionEnvironmentContext.SessionDataCollectionContext, string.Format(CultureInfo.CurrentCulture, Resources.Resources.DataCollectorInitializationError, dataCollectorConfig.FriendlyName, ex.Message));
+                dataCollectorInfo.Logger.LogError(this.dataCollectionEnvironmentContext.SessionDataCollectionContext, string.Format(CultureInfo.CurrentCulture, Resources.Resources.DataCollectorInitializationError, dataCollectorConfig.FriendlyName, ex.ToString()));
 
                 // Dispose datacollector.
                 dataCollectorInfo.DisposeDataCollector();

--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
@@ -450,7 +450,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
                 }
 
                 // Log error.
-                dataCollectorInfo.Logger.LogError(this.dataCollectionEnvironmentContext.SessionDataCollectionContext, string.Format(CultureInfo.CurrentCulture, Resources.Resources.DataCollectorInitializationError, dataCollectorConfig.FriendlyName, ex.ToString()));
+                dataCollectorInfo.Logger.LogError(this.dataCollectionEnvironmentContext.SessionDataCollectionContext, string.Format(CultureInfo.CurrentCulture, Resources.Resources.DataCollectorInitializationError, dataCollectorConfig.FriendlyName, ex));
 
                 // Dispose datacollector.
                 dataCollectorInfo.DisposeDataCollector();

--- a/src/Microsoft.TestPlatform.Common/DataCollection/TestPlatformDataCollectionLogger.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/TestPlatformDataCollectionLogger.cs
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
                 CultureInfo.CurrentCulture,
                 Resources.Resources.ReportDataCollectorException,
                 exception.GetType(),
-                exception,
+                exception.Message,
                 text);
             this.SendTextMessage(context, message, TestMessageLevel.Error);
         }

--- a/src/Microsoft.TestPlatform.Common/DataCollection/TestPlatformDataCollectionLogger.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/TestPlatformDataCollectionLogger.cs
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
                 CultureInfo.CurrentCulture,
                 Resources.Resources.ReportDataCollectorException,
                 exception.GetType(),
-                exception.Message,
+                exception.ToString(),
                 text);
             this.SendTextMessage(context, message, TestMessageLevel.Error);
         }

--- a/src/Microsoft.TestPlatform.Common/DataCollection/TestPlatformDataCollectionLogger.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/TestPlatformDataCollectionLogger.cs
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
                 CultureInfo.CurrentCulture,
                 Resources.Resources.ReportDataCollectorException,
                 exception.GetType(),
-                exception.ToString(),
+                exception,
                 text);
             this.SendTextMessage(context, message, TestMessageLevel.Error);
         }

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/VSExtensionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/VSExtensionManager.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
             }
             catch (Exception ex)
             {
-                string message = string.Format(CultureInfo.CurrentCulture, Resources.FailedToFindInstalledUnitTestExtensions, ex.Message);
+                string message = string.Format(CultureInfo.CurrentCulture, Resources.FailedToFindInstalledUnitTestExtensions, ex.ToString());
                 throw new TestPlatformException(message, ex);
             }
         }

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/VSExtensionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/VSExtensionManager.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
             }
             catch (Exception ex)
             {
-                string message = string.Format(CultureInfo.CurrentCulture, Resources.FailedToFindInstalledUnitTestExtensions, ex.ToString());
+                string message = string.Format(CultureInfo.CurrentCulture, Resources.FailedToFindInstalledUnitTestExtensions, ex);
                 throw new TestPlatformException(message, ex);
             }
         }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
@@ -164,6 +164,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
             do
             {
                 var message = this.communicationManager.ReceiveMessage();
+
+                if (EqtTrace.IsVerboseEnabled)
+                {
+                    EqtTrace.Verbose("DataCollectionRequestHandler.ProcessRequests : Datacollector received message: {0}", message);
+                }
+
                 switch (message.MessageType)
                 {
                     case MessageType.BeforeTestRunStart:
@@ -214,7 +220,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
                                             {
                                                 EqtTrace.Error(
                                                     "DataCollectionRequestHandler.ProcessRequests : Error occured during initialization of TestHost : {0}",
-                                                    e.Message);
+                                                    e);
                                             }
                                         }
                                     },
@@ -253,7 +259,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
                         {
                             if (EqtTrace.IsErrorEnabled)
                             {
-                                EqtTrace.Error("DataCollectionRequestHandler.ProcessRequests : {0}", ex.Message);
+                                EqtTrace.Error("DataCollectionRequestHandler.ProcessRequests : {0}", ex.ToString());
                             }
                         }
 

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestSender.cs
@@ -55,6 +55,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
         /// <returns>Port number</returns>
         public int InitializeCommunication()
         {
+            if (EqtTrace.IsVerboseEnabled)
+            {
+                EqtTrace.Verbose("DataCollectionRequestSender.InitializeCommunication : Initialize communication. ");
+            }
+
             var endpoint = this.communicationManager.HostServer(new IPEndPoint(IPAddress.Loopback, 0));
             this.communicationManager.AcceptClientAsync();
             return endpoint.Port;
@@ -67,6 +72,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
         /// <returns>True, if Handler is connected</returns>
         public bool WaitForRequestHandlerConnection(int clientConnectionTimeout)
         {
+            if (EqtTrace.IsVerboseEnabled)
+            {
+                EqtTrace.Verbose("DataCollectionRequestSender.WaitForRequestHandlerConnection : Waiting for connection with timeout: {0}", clientConnectionTimeout);
+            }
+
             return this.communicationManager.WaitForClientConnection(clientConnectionTimeout);
         }
 
@@ -97,11 +107,21 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
             var isDataCollectionStarted = false;
             BeforeTestRunStartResult result = null;
 
+            if (EqtTrace.IsVerboseEnabled)
+            {
+                EqtTrace.Verbose("DataCollectionRequestSender.SendBeforeTestRunStartAndGetResult : Send BeforeTestRunStart message with settingsXml: {0}", settingsXml);
+            }
+
             this.communicationManager.SendMessage(MessageType.BeforeTestRunStart, settingsXml);
 
             while (!isDataCollectionStarted)
             {
                 var message = this.communicationManager.ReceiveMessage();
+
+                if (EqtTrace.IsVerboseEnabled)
+                {
+                    EqtTrace.Verbose("DataCollectionRequestSender.SendBeforeTestRunStartAndGetResult : Received message: {0}", message);
+                }
 
                 if (message.MessageType == MessageType.DataCollectionMessage)
                 {
@@ -124,6 +144,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
             var isDataCollectionComplete = false;
             Collection<AttachmentSet> attachmentSets = null;
 
+            if (EqtTrace.IsVerboseEnabled)
+            {
+                EqtTrace.Verbose("DataCollectionRequestSender.SendAfterTestRunStartAndGetResult : Send AfterTestRunEnd message with isCancelled: {0}", isCancelled);
+            }
+
             this.communicationManager.SendMessage(MessageType.AfterTestRunEnd, isCancelled);
 
             // Cycle through the messages that the datacollector sends.
@@ -131,6 +156,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
             while (!isDataCollectionComplete)
             {
                 var message = this.communicationManager.ReceiveMessage();
+
+                if (EqtTrace.IsVerboseEnabled)
+                {
+                    EqtTrace.Verbose("DataCollectionRequestSender.SendAfterTestRunStartAndGetResult : Received message: {0}", message);
+                }
 
                 if (message.MessageType == MessageType.DataCollectionMessage)
                 {

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketCommunicationManager.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketCommunicationManager.cs
@@ -196,7 +196,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 }
                 catch (Exception ex)
                 {
-                    EqtTrace.Verbose("Connection Failed with error {0}, retrying", ex.Message);
+                    EqtTrace.Verbose("Connection Failed with error {0}, retrying", ex.ToString());
                 }
             }
             while ((this.tcpClient != null) && !this.tcpClient.Connected && watch.ElapsedMilliseconds < CONNECTIONRETRYTIMEOUT);

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -165,19 +165,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 if (message.MessageType == MessageType.VersionCheck)
                 {
                     this.protocolVersion = this.dataSerializer.DeserializePayload<int>(message);
-
-                    EqtTrace.Info(@"TestRequestSender: VersionCheck Succeeded, NegotiatedVersion = {0}", this.protocolVersion);
                 }
 
                 // TRH can also send TestMessage if tracing is enabled, so log it at runner end
                 else if (message.MessageType == MessageType.TestMessage)
                 {
-                    // Only Deserialize if Tracing is enabled
-                    if (EqtTrace.IsInfoEnabled)
-                    {
-                        var testMessagePayload = this.dataSerializer.DeserializePayload<TestMessagePayload>(message);
-                        EqtTrace.Info("TestRequestSender.CheckVersionWithTestHost: " + testMessagePayload.Message);
-                    }
+                    // Ignore test messages. Currently we don't have handler(which sends messages to client/console.) here.
+                    // Above we are logging it to EqtTrace.
                 }
                 else if (message.MessageType == MessageType.ProtocolError)
                 {

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -6,7 +6,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-    using System.Net;
     using System.Threading;
 
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                 EqtTrace.Error("ProxyDiscoveryManager.DiscoverTests: Failed to discover tests: {0}", exception);
 
                 // Log to vs ide test output
-                var testMessagePayload = new TestMessagePayload { MessageLevel = TestMessageLevel.Error, Message = exception.Message };
+                var testMessagePayload = new TestMessagePayload { MessageLevel = TestMessageLevel.Error, Message = exception.ToString() };
                 var rawMessage = this.dataSerializer.SerializePayload(MessageType.TestMessage, testMessagePayload);
                 this.HandleRawMessage(rawMessage);
 
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                 // Aborted is `true`: in case of parallel discovery (or non shared host), an aborted message ensures another discovery manager
                 // created to replace the current one. This will help if the current discovery manager is aborted due to irreparable error
                 // and the test host is lost as well.
-                this.HandleLogMessage(TestMessageLevel.Error, exception.Message);
+                this.HandleLogMessage(TestMessageLevel.Error, exception.ToString());
 
                 var discoveryCompleteEventsArgs = new DiscoveryCompleteEventArgs(-1, true);
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             catch (Exception exception)
             {
                 EqtTrace.Error("ProxyExecutionManager.StartTestRun: Failed to start test run: {0}", exception);
-                this.LogMessage(TestMessageLevel.Error, exception.Message);
+                this.LogMessage(TestMessageLevel.Error, exception.ToString());
 
                 // Send a run complete to caller. Similar logic is also used in ParallelProxyExecutionManager.StartTestRunOnConcurrentManager
                 // Aborted is `true`: in case of parallel run (or non shared host), an aborted message ensures another execution manager

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
@@ -230,7 +230,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
                 EqtTrace.Error(exception);
             }
 
-            runEventsHandler.HandleLogMessage(ObjectModel.Logging.TestMessageLevel.Error, exception.Message);
+            runEventsHandler.HandleLogMessage(ObjectModel.Logging.TestMessageLevel.Error, exception.ToString());
         }
 
         private IList<string> GetCommandLineArguments(int portNumber)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscovererEnumerator.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscovererEnumerator.cs
@@ -129,7 +129,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Discovery
                         CrossPlatEngineResources.DiscovererInstantiationException,
                         e.Message);
                     logger.SendMessage(TestMessageLevel.Warning, mesage);
-                    EqtTrace.Error(e);
+                    EqtTrace.Error("DiscovererEnumerator.LoadTestsFromAnExtension: {0} ", e);
 
                     continue;
                 }
@@ -182,7 +182,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Discovery
                         e.Message);
 
                     logger.SendMessage(TestMessageLevel.Error, message);
-                    EqtTrace.Error(e);
+                    EqtTrace.Error("DiscovererEnumerator.LoadTestsFromAnExtension: {0} ", e);
                 }
             }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
@@ -134,6 +134,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to connect datacollector..
+        /// </summary>
+        internal static string FailedToConnectDataCollector {
+            get {
+                return ResourceManager.GetString("FailedToConnectDataCollector", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to launch testhost with error: {0}.
         /// </summary>
         internal static string FailedToLaunchTestHost {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to connect datacollector..
+        ///   Looks up a localized string similar to Failed to connect to datacollector process..
         /// </summary>
         internal static string FailedToConnectDataCollector {
             get {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
@@ -190,6 +190,6 @@
     <value>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</value>
   </data>
   <data name="FailedToConnectDataCollector" xml:space="preserve">
-    <value>Failed to connect datacollector.</value>
+    <value>Failed to connect to datacollector process.</value>
   </data>
 </root>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
@@ -189,4 +189,7 @@
   <data name="OldTestHostIsGettingUsed" xml:space="preserve">
     <value>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</value>
   </data>
+  <data name="FailedToConnectDataCollector" xml:space="preserve">
+    <value>Failed to connect datacollector.</value>
+  </data>
 </root>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.cs.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx" build-num="1496413687">
     <header>
@@ -190,6 +190,11 @@
         <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
         <target state="translated">Používáte starší verzi sady Microsoft.NET.Test.Sdk. Přejděte prosím na verzi 15.3.0 nebo vyšší.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="FailedToConnectDataCollector">
+        <source>Failed to connect datacollector.</source>
+        <target state="new">Failed to connect datacollector.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.cs.xlf
@@ -192,7 +192,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToConnectDataCollector">
-        <source>Failed to connect datacollector.</source>
+        <source>Failed to connect to datacollector process.</source>
         <target state="new">Failed to connect datacollector.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.de.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx" build-num="-1605532954">
     <header>
@@ -190,6 +190,11 @@
         <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
         <target state="translated">Sie verwenden eine ältere Version von Microsoft.NET.Test.Sdk. Wechseln Sie zu Version 15.3.0 oder höher.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="FailedToConnectDataCollector">
+        <source>Failed to connect datacollector.</source>
+        <target state="new">Failed to connect datacollector.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.de.xlf
@@ -192,7 +192,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToConnectDataCollector">
-        <source>Failed to connect datacollector.</source>
+        <source>Failed to connect to datacollector process.</source>
         <target state="new">Failed to connect datacollector.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.es.xlf
@@ -192,7 +192,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToConnectDataCollector">
-        <source>Failed to connect datacollector.</source>
+        <source>Failed to connect to datacollector process.</source>
         <target state="new">Failed to connect datacollector.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.es.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx" build-num="1392533617">
     <header>
@@ -190,6 +190,11 @@
         <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
         <target state="translated">Está utilizando una versión anterior de Microsoft.NET.Test.Sdk. Cámbiese a una versión igual o superior a 15.3.0.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="FailedToConnectDataCollector">
+        <source>Failed to connect datacollector.</source>
+        <target state="new">Failed to connect datacollector.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.fr.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx" build-num="-1747068205">
     <header>
@@ -190,6 +190,11 @@
         <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
         <target state="translated">Vous utilisez une ancienne version de Microsoft.NET.Test.Sdk. Passez à une version égale ou supérieure à la version 15.3.0.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="FailedToConnectDataCollector">
+        <source>Failed to connect datacollector.</source>
+        <target state="new">Failed to connect datacollector.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.fr.xlf
@@ -192,7 +192,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToConnectDataCollector">
-        <source>Failed to connect datacollector.</source>
+        <source>Failed to connect to datacollector process.</source>
         <target state="new">Failed to connect datacollector.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.it.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx" build-num="-2078370022">
     <header>
@@ -190,6 +190,11 @@
         <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
         <target state="translated">La versione di Microsoft.NET.Test.Sdk è obsoleta. Passare alla versione 15.3.0 o a una versione successiva.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="FailedToConnectDataCollector">
+        <source>Failed to connect datacollector.</source>
+        <target state="new">Failed to connect datacollector.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.it.xlf
@@ -192,7 +192,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToConnectDataCollector">
-        <source>Failed to connect datacollector.</source>
+        <source>Failed to connect to datacollector process.</source>
         <target state="new">Failed to connect datacollector.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ja.xlf
@@ -192,7 +192,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToConnectDataCollector">
-        <source>Failed to connect datacollector.</source>
+        <source>Failed to connect to datacollector process.</source>
         <target state="new">Failed to connect datacollector.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ja.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx" build-num="-1298029716">
     <header>
@@ -190,6 +190,11 @@
         <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
         <target state="translated">Microsoft.NET.Test.Sdk の古いバージョンを使用しています。15.3.0 以降のバージョンに移行することをお勧めします。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="FailedToConnectDataCollector">
+        <source>Failed to connect datacollector.</source>
+        <target state="new">Failed to connect datacollector.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ko.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx" build-num="1470250083">
     <header>
@@ -190,6 +190,11 @@
         <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
         <target state="translated">이전 버전의 Microsoft.NET.Test.Sdk를 사용하고 있습니다. 15.3.0 이상 버전으로 이동하세요.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="FailedToConnectDataCollector">
+        <source>Failed to connect datacollector.</source>
+        <target state="new">Failed to connect datacollector.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ko.xlf
@@ -192,7 +192,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToConnectDataCollector">
-        <source>Failed to connect datacollector.</source>
+        <source>Failed to connect to datacollector process.</source>
         <target state="new">Failed to connect datacollector.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pl.xlf
@@ -192,7 +192,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToConnectDataCollector">
-        <source>Failed to connect datacollector.</source>
+        <source>Failed to connect to datacollector process.</source>
         <target state="new">Failed to connect datacollector.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pl.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx" build-num="1548376603">
     <header>
@@ -190,6 +190,11 @@
         <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
         <target state="translated">Używamy starszej wersji zestawu Microsoft.NET.Test.Sdk. Przejdź na wersję 15.3.0 lub nowszą.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="FailedToConnectDataCollector">
+        <source>Failed to connect datacollector.</source>
+        <target state="new">Failed to connect datacollector.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pt-BR.xlf
@@ -192,7 +192,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToConnectDataCollector">
-        <source>Failed to connect datacollector.</source>
+        <source>Failed to connect to datacollector process.</source>
         <target state="new">Failed to connect datacollector.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pt-BR.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx" build-num="1733331294">
     <header>
@@ -190,6 +190,11 @@
         <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
         <target state="translated">Você está usando uma versão mais antiga do Microsoft.NET.Test.Sdk. Mude para uma versão igual ou maior que 15.3.0.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="FailedToConnectDataCollector">
+        <source>Failed to connect datacollector.</source>
+        <target state="new">Failed to connect datacollector.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ru.xlf
@@ -192,7 +192,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToConnectDataCollector">
-        <source>Failed to connect datacollector.</source>
+        <source>Failed to connect to datacollector process.</source>
         <target state="new">Failed to connect datacollector.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ru.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx" build-num="-1103770912">
     <header>
@@ -190,6 +190,11 @@
         <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
         <target state="translated">Вы используете более старую версию Microsoft.NET.Test.Sdk. Перейдите на версию 15.3.0 или более позднюю.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="FailedToConnectDataCollector">
+        <source>Failed to connect datacollector.</source>
+        <target state="new">Failed to connect datacollector.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.tr.xlf
@@ -192,7 +192,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToConnectDataCollector">
-        <source>Failed to connect datacollector.</source>
+        <source>Failed to connect to datacollector process.</source>
         <target state="new">Failed to connect datacollector.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.tr.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx" build-num="1612553793">
     <header>
@@ -190,6 +190,11 @@
         <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
         <target state="translated">Eski bir Microsoft.NET.Test.Sdk sürümü kullanıyorsunuz. Lütfen 15.3.0 veya daha yeni bir sürüme geçin.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="FailedToConnectDataCollector">
+        <source>Failed to connect datacollector.</source>
+        <target state="new">Failed to connect datacollector.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf
@@ -102,6 +102,11 @@
         <target state="new">You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="FailedToConnectDataCollector">
+        <source>Failed to connect datacollector.</source>
+        <target state="new">Failed to connect datacollector.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf
@@ -103,7 +103,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="FailedToConnectDataCollector">
-        <source>Failed to connect datacollector.</source>
+        <source>Failed to connect to datacollector process.</source>
         <target state="new">Failed to connect datacollector.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hans.xlf
@@ -192,7 +192,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToConnectDataCollector">
-        <source>Failed to connect datacollector.</source>
+        <source>Failed to connect to datacollector process.</source>
         <target state="new">Failed to connect datacollector.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hans.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx" build-num="-1038642004">
     <header>
@@ -190,6 +190,11 @@
         <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
         <target state="translated">你使用的是旧版 Microsoft.NET.Test.Sdk。请迁移到 15.3.0 及更高版本。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="FailedToConnectDataCollector">
+        <source>Failed to connect datacollector.</source>
+        <target state="new">Failed to connect datacollector.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hant.xlf
@@ -192,7 +192,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToConnectDataCollector">
-        <source>Failed to connect datacollector.</source>
+        <source>Failed to connect to datacollector process.</source>
         <target state="new">Failed to connect datacollector.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hant.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx" build-num="1380117387">
     <header>
@@ -190,6 +190,11 @@
         <source>You are using an older version of Microsoft.NET.Test.Sdk. Kindly move to a version equal or greater than 15.3.0.</source>
         <target state="translated">您正使用較舊版的 Microsoft.NET.Test.Sdk。請移到等於或大於 15.3.0 的版本。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="FailedToConnectDataCollector">
+        <source>Failed to connect datacollector.</source>
+        <target state="new">Failed to connect datacollector.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/XML/XmlPersistence.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/XML/XmlPersistence.cs
@@ -670,7 +670,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.XML
                 }
                 catch (NotSupportedException nosupportEx)
                 {
-                    EqtTrace.Info("TypeConverter not supported for {0} : NotSupportedException Exception Message {1}", value.ToString(), nosupportEx.Message);
+                    EqtTrace.Info("TypeConverter not supported for {0} : NotSupportedException: {1}", value.ToString(), nosupportEx);
                     valueToSave = value.ToString();
                 }
             }

--- a/src/Microsoft.TestPlatform.ObjectModel/Utilities/AssemblyLoadWorker.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Utilities/AssemblyLoadWorker.cs
@@ -376,7 +376,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
                 //Ignore all exception
                 if (EqtTrace.IsErrorEnabled)
                 {
-                    EqtTrace.Error("AssemblyLoadWorker:GetArchitectureForSource() Returning default:{0}. Unhandled exception: {1}.", "AnyCPU", ex.Message);
+                    EqtTrace.Error("AssemblyLoadWorker:GetArchitectureForSource() Returning default:{0}. Unhandled exception: {1}.", "AnyCPU", ex.ToString());
                 }
             }
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/PlatformEqtTrace.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/PlatformEqtTrace.cs
@@ -352,7 +352,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
                 catch (Exception e)
                 {
                     UnInitializeVerboseTrace();
-                    ErrorOnInitialization = e.Message;
+                    ErrorOnInitialization = e.ToString();
                     return false;
                 }
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -389,7 +389,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
             }
             catch (OperationCanceledException ex)
             {
-                this.messageLogger.SendMessage(TestMessageLevel.Error, ex.Message);
+                EqtTrace.Error("DefaultTestHostManager.LaunchHost: Failed to launch testhost: {0}", ex);
+                this.messageLogger.SendMessage(TestMessageLevel.Error, ex.ToString());
                 return false;
             }
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -344,7 +344,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
             }
             catch (OperationCanceledException ex)
             {
-                this.messageLogger.SendMessage(TestMessageLevel.Error, ex.Message);
+                EqtTrace.Error("DotnetTestHostManager.LaunchHost: Failed to launch testhost: {0}", ex);
+                this.messageLogger.SendMessage(TestMessageLevel.Error, ex.ToString());
                 return false;
             }
 

--- a/src/Microsoft.TestPlatform.Utilities/CodeCoverageDataAttachmentsHandler.cs
+++ b/src/Microsoft.TestPlatform.Utilities/CodeCoverageDataAttachmentsHandler.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
             {
                 if (EqtTrace.IsErrorEnabled)
                 {
-                    EqtTrace.Error("CodeCoverageDataCollectorAttachmentsHandler: Failed to load datacollector of type : {0} from location : {1}. Error : ", CodeCoverageAnalysisAssemblyName, assemblyPath, ex.Message);
+                    EqtTrace.Error("CodeCoverageDataCollectorAttachmentsHandler: Failed to load datacollector of type : {0} from location : {1}. Error : {2}", CodeCoverageAnalysisAssemblyName, assemblyPath, ex.ToString());
                 }
             }
 

--- a/src/datacollector/Program.cs
+++ b/src/datacollector/Program.cs
@@ -65,7 +65,13 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector
         private static void Run(string[] args)
         {
             var argsDictionary = CommandLineArgumentsHelper.GetArgumentsDictionary(args);
-            var requestHandler = DataCollectionRequestHandler.Create(new SocketCommunicationManager(), new MessageSink());
+
+            // Setup logging if enabled
+            string logFile;
+            if (argsDictionary.TryGetValue(LogFileArgument, out logFile))
+            {
+                EqtTrace.InitializeVerboseTrace(logFile);
+            }
 
             // Attach to exit of parent process
             var parentProcessId = CommandLineArgumentsHelper.GetIntArgFromDict(argsDictionary, ParentProcessArgument);
@@ -80,13 +86,6 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector
                         Environment.Exit(1);
                     });
 
-            // Setup logging if enabled
-            string logFile;
-            if (argsDictionary.TryGetValue(LogFileArgument, out logFile))
-            {
-                EqtTrace.InitializeVerboseTrace(logFile);
-            }
-
             // Get server port and initialize communication.
             string portValue;
             int port = argsDictionary.TryGetValue(PortArgument, out portValue) ? int.Parse(portValue) : 0;
@@ -96,6 +95,7 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector
                 throw new ArgumentException("Incorrect/No Port number");
             }
 
+            var requestHandler = DataCollectionRequestHandler.Create(new SocketCommunicationManager(), new MessageSink());
             requestHandler.InitializeCommunication(port);
 
             // Can only do this after InitializeCommunication because datacollector cannot "Send Log" unless communications are initialized

--- a/src/datacollector/Program.cs
+++ b/src/datacollector/Program.cs
@@ -55,13 +55,10 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector
                 WaitForDebuggerIfEnabled();
                 Run(args);
             }
-            catch (SocketException ex)
-            {
-                EqtTrace.Error("DataCollector: Socket exception is thrown : {0}", ex);
-            }
             catch (Exception ex)
             {
                 EqtTrace.Error("DataCollector: Error occured during initialization of Datacollector : {0}", ex);
+                throw;
             }
         }
 

--- a/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs
+++ b/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs
@@ -243,7 +243,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
                 //Ignore all exception
                 EqtTrace.Info(
                     "GetArchitectureForSource: Returning default:{0}. Unhandled exception: {1}.",
-                    archType, ex.Message);
+                    archType, ex);
             }
 
             return archType;

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerWithDataCollectionTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerWithDataCollectionTests.cs
@@ -100,6 +100,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         {
             var mockRequestSender = new Mock<IDataCollectionRequestSender>();
             mockRequestSender.Setup(x => x.SendBeforeTestRunStartAndGetResult(It.IsAny<string>(), It.IsAny<ITestMessageEventHandler>())).Throws(new Exception("MyException"));
+            mockRequestSender.Setup(x => x.WaitForRequestHandlerConnection(ProxyDataCollectionManager.DataCollectorConnectionTimeout)).Returns(true);
 
             var mockDataCollectionLauncher = new Mock<IDataCollectionLauncher>();
             var proxyDataCollectonManager = new ProxyDataCollectionManager(this.mockRequestData.Object, string.Empty, mockRequestSender.Object, this.mockProcessHelper.Object, mockDataCollectionLauncher.Object);

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerWithDataCollectionTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerWithDataCollectionTests.cs
@@ -108,7 +108,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
             proxyExecutionManager.Initialize();
             Assert.IsNotNull(proxyExecutionManager.DataCollectionRunEventsHandler.Messages);
             Assert.AreEqual(TestMessageLevel.Error, proxyExecutionManager.DataCollectionRunEventsHandler.Messages[0].Item1);
-            Assert.AreEqual("MyException", proxyExecutionManager.DataCollectionRunEventsHandler.Messages[0].Item2);
+            StringAssert.Contains(proxyExecutionManager.DataCollectionRunEventsHandler.Messages[0].Item2, "MyException");
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
@@ -135,7 +135,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
 
             var result = this.proxyDataCollectionManager.BeforeTestRunStart(true, true, mockRunEventsHandler.Object);
 
-            mockRunEventsHandler.Verify(eh => eh.HandleLogMessage(TestMessageLevel.Error, "Exception of type 'System.Exception' was thrown."), Times.Once);
+            mockRunEventsHandler.Verify(eh => eh.HandleLogMessage(TestMessageLevel.Error, It.IsRegex("Exception of type 'System.Exception' was thrown..*")), Times.Once);
             Assert.AreEqual(0, result.EnvironmentVariables.Count);
             Assert.AreEqual(false, result.AreTestCaseLevelEventsRequired);
             Assert.AreEqual(0, result.DataCollectionEventsPort);
@@ -171,7 +171,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
 
             var result = this.proxyDataCollectionManager.AfterTestRunEnd(false, mockRunEventsHandler.Object);
 
-            mockRunEventsHandler.Verify(eh => eh.HandleLogMessage(TestMessageLevel.Error, "Exception of type 'System.Exception' was thrown."), Times.Once);
+            mockRunEventsHandler.Verify(eh => eh.HandleLogMessage(TestMessageLevel.Error, It.IsRegex("Exception of type 'System.Exception' was thrown..*")), Times.Once);
         }
 
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
@@ -55,6 +55,37 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
         }
 
         [TestMethod]
+        public void InitializeShouldThrowExceptionIfConnectionTimeouts()
+        {
+            this.mockDataCollectionRequestSender.Setup( x => x.WaitForRequestHandlerConnection(ProxyDataCollectionManager.DataCollectorConnectionTimeout)).Returns(false);
+
+            Assert.ThrowsException<TestPlatformException>(() => this.proxyDataCollectionManager.Initialize());
+        }
+
+        [TestMethod]
+        public void InitializeShouldSetTimeoutBasedOnTimeoutEnvironmentVarible()
+        {
+            var timeout = 10;
+            Environment.SetEnvironmentVariable(ProxyDataCollectionManager.TimeoutEnvironmentVaribleName, timeout.ToString());
+
+            this.proxyDataCollectionManager.Initialize();
+            Environment.SetEnvironmentVariable(ProxyDataCollectionManager.TimeoutEnvironmentVaribleName, string.Empty);
+
+            this.mockDataCollectionRequestSender.Verify(x => x.WaitForRequestHandlerConnection(timeout * 1000), Times.Once);
+        }
+
+        [TestMethod]
+        public void InitializeShouldSetTimeoutBasedOnDebugEnvironmentVaribleName()
+        {
+            Environment.SetEnvironmentVariable(ProxyDataCollectionManager.DebugEnvironmentVaribleName, "1");
+
+            this.proxyDataCollectionManager.Initialize();
+            Environment.SetEnvironmentVariable(ProxyDataCollectionManager.DebugEnvironmentVaribleName, string.Empty);
+
+            this.mockDataCollectionRequestSender.Verify(x => x.WaitForRequestHandlerConnection(ProxyDataCollectionManager.DataCollectorConnectionTimeout * 5), Times.Once);
+        }
+
+        [TestMethod]
         public void InitializeShouldPassDiagArgumentsIfDiagIsEnabled()
         {
             // Saving the EqtTrace state

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
@@ -48,6 +48,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
         [TestMethod]
         public void InitializeShouldInitializeCommunication()
         {
+            this.mockDataCollectionRequestSender.Setup(x => x.WaitForRequestHandlerConnection(ProxyDataCollectionManager.DataCollectorConnectionTimeout)).Returns(true);
             this.proxyDataCollectionManager.Initialize();
 
             this.mockDataCollectionLauncher.Verify(x => x.LaunchDataCollector(It.IsAny<IDictionary<string, string>>(), It.IsAny<IList<string>>()), Times.Once);
@@ -65,8 +66,10 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
         [TestMethod]
         public void InitializeShouldSetTimeoutBasedOnTimeoutEnvironmentVarible()
         {
+
             var timeout = 10;
             Environment.SetEnvironmentVariable(ProxyDataCollectionManager.TimeoutEnvironmentVaribleName, timeout.ToString());
+            this.mockDataCollectionRequestSender.Setup(x => x.WaitForRequestHandlerConnection(timeout * 1000)).Returns(true);
 
             this.proxyDataCollectionManager.Initialize();
             Environment.SetEnvironmentVariable(ProxyDataCollectionManager.TimeoutEnvironmentVaribleName, string.Empty);
@@ -78,6 +81,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
         public void InitializeShouldSetTimeoutBasedOnDebugEnvironmentVaribleName()
         {
             Environment.SetEnvironmentVariable(ProxyDataCollectionManager.DebugEnvironmentVaribleName, "1");
+            this.mockDataCollectionRequestSender.Setup(x => x.WaitForRequestHandlerConnection(ProxyDataCollectionManager.DataCollectorConnectionTimeout * 5)).Returns(true);
 
             this.proxyDataCollectionManager.Initialize();
             Environment.SetEnvironmentVariable(ProxyDataCollectionManager.DebugEnvironmentVaribleName, string.Empty);
@@ -101,6 +105,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
             try
             {
                 EqtTrace.InitializeVerboseTrace("mylog.txt");
+                this.mockDataCollectionRequestSender.Setup(x => x.WaitForRequestHandlerConnection(ProxyDataCollectionManager.DataCollectorConnectionTimeout)).Returns(true);
 
                 this.proxyDataCollectionManager.Initialize();
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
@@ -51,7 +51,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
             this.proxyDataCollectionManager.Initialize();
 
             this.mockDataCollectionLauncher.Verify(x => x.LaunchDataCollector(It.IsAny<IDictionary<string, string>>(), It.IsAny<IList<string>>()), Times.Once);
-            this.mockDataCollectionRequestSender.Verify(x => x.WaitForRequestHandlerConnection(5000), Times.Once);
+            this.mockDataCollectionRequestSender.Verify(x => x.WaitForRequestHandlerConnection(ProxyDataCollectionManager.DataCollectorConnectionTimeout), Times.Once);
         }
 
         [TestMethod]
@@ -79,7 +79,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
                             It.IsAny<IDictionary<string, string>>(),
                             It.Is<IList<string>>(list => list.Contains("--diag"))),
                     Times.Once);
-                this.mockDataCollectionRequestSender.Verify(x => x.WaitForRequestHandlerConnection(5000), Times.Once);
+                this.mockDataCollectionRequestSender.Verify(x => x.WaitForRequestHandlerConnection(ProxyDataCollectionManager.DataCollectorConnectionTimeout), Times.Once);
             }
             finally
             {


### PR DESCRIPTION
## Description
- Increase datacollector initial communication timeout to 30 sec.
- Provide environment variable to config datacollector initial communication timeout.
- Add more logging(print whole stacktrace, and update messagelevel).

## Related issue
https://github.com/Microsoft/vstest/issues/1354 
