### PR TITLE
Add exit call back to custom test host process

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -313,8 +313,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             this.clientExitErrorMessage = stdError;
             this.clientExited.Set();
 
-            // Note that we're not explicitly disconnecting the communication channel; wait for the
-            // channel to determine the disconnection on its own.
+            // Break communication loop.
+            this.communicationEndpoint.Stop();
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -313,7 +313,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             this.clientExitErrorMessage = stdError;
             this.clientExited.Set();
 
-            // Break communication loop.
+            // Break communication loop. In somecases(E.g: When tests creates child processes to testhost) communication channel won't break if testhost exits.
             this.communicationEndpoint.Stop();
         }
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/IProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/IProcessHelper.cs
@@ -97,5 +97,7 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces
         /// </summary>
         /// <param name="process">Reference of process to terminate.</param>
         void TerminateProcess(object process);
+
+        void SetExitCallback(int processId, Action<object> exitCallBack);
     }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/IProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/IProcessHelper.cs
@@ -90,14 +90,12 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces
         /// <param name="callbackAction">
         /// Callback on process exit.
         /// </param>
-        void SetExitCallback(int processId, Action callbackAction);
+        void SetExitCallback(int processId, Action<object> callbackAction);
 
         /// <summary>
         /// Terminates a process.
         /// </summary>
         /// <param name="process">Reference of process to terminate.</param>
         void TerminateProcess(object process);
-
-        void SetExitCallback(int processId, Action<object> exitCallBack);
     }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -51,10 +51,10 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
                     process.Exited += (sender, args) =>
                     {
                         // Call WaitForExit without again to ensure all streams are flushed,
-                        // Add timeout to avoid indefinite waiting on child process exist.
                         var p = sender as Process;
                         try
                         {
+                            // Add timeout to avoid indefinite waiting on child process exit.
                             p.WaitForExit(500);
                         }
                         catch (InvalidOperationException)
@@ -137,11 +137,13 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
             {
                 var process = Process.GetProcessById(processId);
                 process.EnableRaisingEvents = true;
-                process.Exited += (sender, args) => callbackAction.Invoke(process);
+                process.Exited += (sender, args) => callbackAction?.Invoke(sender);
             }
             catch (ArgumentException)
             {
-                // Ignore the exception if process is not running.
+                // Process.GetProcessById() throws ArgumentException if process is not running(identifier might be expired).
+                // Invoke callback immediately.
+                callbackAction?.Invoke(null);
             }
         }
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -131,27 +131,18 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
 
         /// <inheritdoc/>
-        public void SetExitCallback(int processId, Action callbackAction)
-        {
-            var process = Process.GetProcessById(processId);
-
-            process.EnableRaisingEvents = true;
-            process.Exited += (sender, args) =>
-            {
-                callbackAction.Invoke();
-            };
-        }
-
-        /// <inheritdoc/>
         public void SetExitCallback(int processId, Action<object> callbackAction)
         {
-            var process = Process.GetProcessById(processId);
-
-            process.EnableRaisingEvents = true;
-            process.Exited += (sender, args) =>
+            try
             {
-                callbackAction.Invoke(process);
-            };
+                var process = Process.GetProcessById(processId);
+                process.EnableRaisingEvents = true;
+                process.Exited += (sender, args) => callbackAction.Invoke(process);
+            }
+            catch (ArgumentException)
+            {
+                // Ignore the exception if process is not running.
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -143,6 +143,18 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
 
         /// <inheritdoc/>
+        public void SetExitCallback(int processId, Action<object> callbackAction)
+        {
+            var process = Process.GetProcessById(processId);
+
+            process.EnableRaisingEvents = true;
+            process.Exited += (sender, args) =>
+            {
+                callbackAction.Invoke(process);
+            };
+        }
+
+        /// <inheritdoc/>
         public void TerminateProcess(object process)
         {
             var proc = process as Process;

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard1.0/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard1.0/System/ProcessHelper.cs
@@ -68,6 +68,12 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
 
         /// <inheritdoc/>
+        public void SetExitCallback(int parentProcessId, Action<object> callbackAction)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
         public void TerminateProcess(object process)
         {
             throw new NotImplementedException();

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard1.0/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard1.0/System/ProcessHelper.cs
@@ -62,12 +62,6 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
 
         /// <inheritdoc/>
-        public void SetExitCallback(int parentProcessId, Action callbackAction)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <inheritdoc/>
         public void SetExitCallback(int parentProcessId, Action<object> callbackAction)
         {
             throw new NotImplementedException();

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/ProcessHelper.cs
@@ -62,11 +62,6 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
 
         /// <inheritdoc/>
-        public void SetExitCallback(int parentProcessId, Action callbackAction)
-        {
-        }
-
-        /// <inheritdoc/>
         public void SetExitCallback(int parentProcessId, Action<object> callbackAction)
         {
         }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/ProcessHelper.cs
@@ -67,6 +67,11 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
 
         /// <inheritdoc/>
+        public void SetExitCallback(int parentProcessId, Action<object> callbackAction)
+        {
+        }
+
+        /// <inheritdoc/>
         public void TerminateProcess(object process)
         {
             throw new NotImplementedException();

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -385,6 +385,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
                 {
                     int processId = this.customTestHostLauncher.LaunchTestHost(testHostStartInfo);
                     this.testHostProcess = Process.GetProcessById(processId);
+                    this.processHelper.SetExitCallback(processId, this.ExitCallBack);
                 }
             }
             catch (OperationCanceledException ex)

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -340,6 +340,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
                 {
                     var processId = this.testHostLauncher.LaunchTestHost(testHostStartInfo);
                     this.testHostProcess = Process.GetProcessById(processId);
+                    this.processHelper.SetExitCallback(processId, this.ExitCallBack);
                 }
             }
             catch (OperationCanceledException ex)

--- a/src/datacollector/Program.cs
+++ b/src/datacollector/Program.cs
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector
             var processHelper = new ProcessHelper();
             processHelper.SetExitCallback(
                 parentProcessId,
-                () =>
+                (obj) =>
                     {
                         EqtTrace.Info("DataCollector: ParentProcess '{0}' Exited.", parentProcessId);
                         Environment.Exit(1);

--- a/src/testhost.x86/DefaultEngineInvoker.cs
+++ b/src/testhost.x86/DefaultEngineInvoker.cs
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
                     var processHelper = new ProcessHelper();
                     processHelper.SetExitCallback(
                         parentProcessId,
-                        () =>
+                        (obj) =>
                             {
                                 EqtTrace.Info("DefaultEngineInvoker: ParentProcess '{0}' Exited.", parentProcessId);
                                 new PlatformEnvironment().Exit(1);

--- a/src/vstest.console/Processors/PortArgumentProcessor.cs
+++ b/src/vstest.console/Processors/PortArgumentProcessor.cs
@@ -203,7 +203,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
         {
             if (parentProcessId > 0)
             {
-                processHelper.SetExitCallback(parentProcessId, () =>
+                processHelper.SetExitCallback(parentProcessId, (obj) =>
                 {
                     EqtTrace.Info($"PortArgumentProcessor: parent process:{parentProcessId} exited.");
                     DesignModeClient.Instance?.HandleParentProcessExit();

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -381,6 +381,18 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
         }
 
         [TestMethod]
+        public void LaunchTestHostShouldSetExitCallbackInCaseCustomHost()
+        {
+            var mockCustomLauncher = new Mock<ITestHostLauncher>();
+            this.testHostManager.SetCustomLauncher(mockCustomLauncher.Object);
+            var currentProcess = Process.GetCurrentProcess();
+            mockCustomLauncher.Setup(mc => mc.LaunchTestHost(It.IsAny<TestProcessStartInfo>())).Returns(currentProcess.Id);
+            this.testHostManager.LaunchTestHostAsync(this.startInfo, CancellationToken.None).Wait();
+
+            this.mockProcessHelper.Verify(ph => ph.SetExitCallback(currentProcess.Id, It.IsAny<Action<object>>()));
+        }
+
+        [TestMethod]
         public void GetTestSourcesShouldReturnAppropriateSourceIfAppxRecipeIsProvided()
         {
             var sourcePath = Path.Combine(Path.GetDirectoryName(typeof(TestableTestHostManager).GetTypeInfo().Assembly.GetAssemblyLocation()), @"..\..\..\..\TestAssets\UWPTestAssets\UnitTestApp8.build.appxrecipe");

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -370,6 +370,20 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
         }
 
         [TestMethod]
+        public void LaunchTestHostShouldSetExitCallBackInCaseCustomHost()
+        {
+            var expectedProcessId = Process.GetCurrentProcess().Id;
+            this.mockTestHostLauncher.Setup(thl => thl.LaunchTestHost(It.IsAny<TestProcessStartInfo>())).Returns(expectedProcessId);
+            this.mockFileHelper.Setup(ph => ph.Exists("testhost.dll")).Returns(true);
+
+            var startInfo = this.GetDefaultStartInfo();
+            this.dotnetHostManager.SetCustomLauncher(this.mockTestHostLauncher.Object);
+            this.dotnetHostManager.LaunchTestHostAsync(startInfo, CancellationToken.None).Wait();
+
+            this.mockProcessHelper.Verify(ph => ph.SetExitCallback(expectedProcessId, It.IsAny<Action<object>>()));
+        }
+
+        [TestMethod]
         public void GetTestHostProcessStartInfoShouldIncludeTestHostPathFromSourceDirectoryIfDepsFileNotFound()
         {
             // Absolute path to the source directory

--- a/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
@@ -124,7 +124,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
 
             this.executor.Initialize(port.ToString());
 
-            this.mockProcessHelper.Verify(ph => ph.SetExitCallback(processId, It.IsAny<Action>()), Times.Once);
+            this.mockProcessHelper.Verify(ph => ph.SetExitCallback(processId, It.IsAny<Action<object>>()), Times.Once);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description
- `TcpClient.Poll()` not throwing the exception on testhost process exit if testhost process have child process like geckodriver.exe(Which do some socket operations), but normal processes ( notepad.exe, etc..).
- Don't just relay on `TcpClient.Poll()`, Have process exit call back for custom testhost.

## Related issue
- [[Feedback] Cannot Stop/Cancel Debugged Unit Tests when using Selenium WebDriver](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/537068?src=WorkItemMention&src-action=artifact_link&fullScreen=true)
- https://github.com/Microsoft/vstest/issues/1183
- https://developercommunity.visualstudio.com/content/problem/161037/cannot-stopcancel-debugged-unit-tests-when-using-s.html