### PR TITLE
Runsettings compat fix with testsettings

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
@@ -283,9 +283,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
                     reader.ReadToNextElement();
 
                     // Read till we reach DC element or reach EOF
-                    while (!string.Equals(reader.Name, Constants.DataCollectionRunSettingsName)
-                           &&
-                           !reader.EOF)
+                    while (!string.Equals(reader.Name, Constants.DataCollectionRunSettingsName) && !reader.EOF)
                     {
                         reader.SkipToNextElement();
                     }
@@ -302,9 +300,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
             }
             catch (XmlException ex)
             {
-                throw new SettingsException(
-                    string.Format(CultureInfo.CurrentCulture, "{0} {1}", Resources.CommonResources.MalformedRunSettingsFile, ex.Message),
-                    ex);
+                throw new SettingsException(string.Format(CultureInfo.CurrentCulture, "{0} {1}", Resources.CommonResources.MalformedRunSettingsFile, ex.Message), ex);
             }
         }
 
@@ -320,37 +316,35 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
         public static DataCollectionRunSettings GetInProcDataCollectionRunSettings(string runSettingsXml)
         {
             // use XmlReader to avoid loading of the plugins in client code (mainly from VS).
-            if (!string.IsNullOrWhiteSpace(runSettingsXml))
+            if (string.IsNullOrWhiteSpace(runSettingsXml))
             {
-                runSettingsXml = runSettingsXml.Trim();
-                using (StringReader stringReader1 = new StringReader(runSettingsXml))
-                {
-                    XmlReader reader = XmlReader.Create(stringReader1, ReaderSettings);
-
-                    // read to the fist child
-                    XmlReaderUtilities.ReadToRootNode(reader);
-                    reader.ReadToNextElement();
-
-                    // Read till we reach In Proc IDC element or reach EOF
-                    while (!string.Equals(reader.Name, Constants.InProcDataCollectionRunSettingsName)
-                           &&
-                           !reader.EOF)
-                    {
-                        reader.SkipToNextElement();
-                    }
-
-                    // If reached EOF => IDC element not there
-                    if (reader.EOF)
-                    {
-                        return null;
-                    }
-
-                    // Reached here => In Proc IDC element present.
-                    return DataCollectionRunSettings.FromXml(reader, Constants.InProcDataCollectionRunSettingsName, Constants.InProcDataCollectorsSettingName, Constants.InProcDataCollectorSettingName);
-                }
+                return null;
             }
 
-            return null;
+            runSettingsXml = runSettingsXml.Trim();
+            using (StringReader stringReader1 = new StringReader(runSettingsXml))
+            {
+                XmlReader reader = XmlReader.Create(stringReader1, ReaderSettings);
+
+                // read to the fist child
+                XmlReaderUtilities.ReadToRootNode(reader);
+                reader.ReadToNextElement();
+
+                // Read till we reach In Proc IDC element or reach EOF
+                while (!string.Equals(reader.Name, Constants.InProcDataCollectionRunSettingsName) && !reader.EOF)
+                {
+                    reader.SkipToNextElement();
+                }
+
+                // If reached EOF => IDC element not there
+                if (reader.EOF)
+                {
+                    return null;
+                }
+
+                // Reached here => In Proc IDC element present.
+                return DataCollectionRunSettings.FromXml(reader, Constants.InProcDataCollectionRunSettingsName, Constants.InProcDataCollectorsSettingName, Constants.InProcDataCollectorSettingName);
+            }
         }
 
         /// <summary>

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -676,6 +676,6 @@
     <value>--Collect|/Collect:"{0}" is not supported if test run is configured using testsettings.</value>
   </data>
   <data name="RunsettingsWithDCErrorMessage" xml:space="preserve">
-    <value>Data collectors configured via run settings are not supported with embedded test settings. Please see https://aka.ms/vstest-configure-datacollector for more information. Run settings: {0}.</value>
+    <value>Data collectors other than Code Coverage and Microsoft Fakes configured via run settings are not supported with embedded test settings. Please see https://aka.ms/vstest-configure-datacollector for more information. Run settings: {0}.</value>
   </data>
 </root>

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -11,12 +11,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
     using System.Threading.Tasks;
     using System.Xml;
     using System.Xml.XPath;
-
     using Microsoft.VisualStudio.TestPlatform.Client;
     using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
     using Microsoft.VisualStudio.TestPlatform.CommandLine.Internal;
     using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities;
     using Microsoft.VisualStudio.TestPlatform.CommandLine.Publisher;
+    using Microsoft.VisualStudio.TestPlatform.CommandLine.Resources;
     using Microsoft.VisualStudio.TestPlatform.CommandLineUtilities;
     using Microsoft.VisualStudio.TestPlatform.Common;
     using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
@@ -30,8 +30,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
     using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
     using Microsoft.VisualStudio.TestPlatform.Utilities;
-    using System.Text;
-    using Microsoft.VisualStudio.TestPlatform.CommandLine.Resources;
 
     /// <summary>
     /// Defines the TestRequestManger which can fire off discovery and test run requests
@@ -260,27 +258,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
                 runsettings = updatedRunsettings;
             }
 
-            if (InferRunSettingsHelper.IsTestSettingsEnabled(runsettings))
+            if (InferRunSettingsHelper.AreRunSettingsCollectorsInCompatibleWithTestSettings(runsettings))
             {
-                bool throwException = false;
-                if (this.commandLineOptions.EnableCodeCoverage)
-                {
-                    var dataCollectorsFriendlyNames = XmlRunSettingsUtilities.GetDataCollectorsFriendlyName(runsettings);
-                    if (dataCollectorsFriendlyNames.Count >= 2)
-                    {
-                        throwException = true;
-                    }
-
-                }
-                else if (XmlRunSettingsUtilities.IsDataCollectionEnabled(runsettings))
-                {
-                    throwException = true;
-                }
-
-                if (throwException)
-                {
-                    throw new SettingsException(string.Format(Resources.RunsettingsWithDCErrorMessage, runsettings));
-                }
+                throw new SettingsException(string.Format(Resources.RunsettingsWithDCErrorMessage, runsettings));
             }
 
             var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(runsettings);


### PR DESCRIPTION


## Description
Updated the runsettings validation to permit codecoverage and fakes collectors usage along with an embedded testsetting

## Related issue
Performing code coverage analysis from VS IDE for a project with testsettings fails today.
