### PR TITLE
Cancellation timing issue fix.

### DIFF
--- a/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
+++ b/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
@@ -247,7 +247,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.Execution
                 else
                 {
                     // Inform the service about run cancellation
-                    this.ExecutionManager.Cancel();
+                    this.ExecutionManager.Cancel(this);
                 }
             }
 
@@ -275,7 +275,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.Execution
                 }
                 else
                 {
-                    this.ExecutionManager.Abort();
+                    this.ExecutionManager.Abort(this);
                 }
             }
 

--- a/src/Microsoft.TestPlatform.Common/Interfaces/Engine/ClientProtocol/IProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/Interfaces/Engine/ClientProtocol/IProxyExecutionManager.cs
@@ -31,12 +31,12 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine
         /// <summary>
         /// Cancels the test run. On the test host, this will send a message to adapters.
         /// </summary>
-        void Cancel();
+        void Cancel(ITestRunEventsHandler eventHandler);
 
         /// <summary>
         /// Aborts the test operation. This will forcefully terminate the test host.
         /// </summary>
-        void Abort();
+        void Abort(ITestRunEventsHandler eventHandler);
 
         /// <summary>
         /// Closes the current test operation by sending a end session message.

--- a/src/Microsoft.TestPlatform.Common/Interfaces/Engine/ClientProtocol/IProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/Interfaces/Engine/ClientProtocol/IProxyExecutionManager.cs
@@ -31,11 +31,13 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine
         /// <summary>
         /// Cancels the test run. On the test host, this will send a message to adapters.
         /// </summary>
+        // <param name="eventHandler"> EventHandler for handling execution events from Engine. </param> 
         void Cancel(ITestRunEventsHandler eventHandler);
 
         /// <summary>
         /// Aborts the test operation. This will forcefully terminate the test host.
         /// </summary>
+        // <param name="eventHandler"> EventHandler for handling execution events from Engine. </param> 
         void Abort(ITestRunEventsHandler eventHandler);
 
         /// <summary>

--- a/src/Microsoft.TestPlatform.Common/Interfaces/Engine/TesthostProtocol/IExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/Interfaces/Engine/TesthostProtocol/IExecutionManager.cs
@@ -49,11 +49,13 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine.TesthostProtoco
         /// <summary>
         /// Cancel the test execution.
         /// </summary>
-        void Cancel();
+        /// <param name="eventHandler"> EventHandler for handling execution events from Engine. </param>
+        void Cancel(ITestRunEventsHandler testRunEventsHandler);
 
         /// <summary>
         /// Aborts the test execution.
         /// </summary>
-        void Abort();
+        /// <param name="eventHandler"> EventHandler for handling execution events from Engine. </param>
+        void Abort(ITestRunEventsHandler testRunEventsHandler);
     }
 }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/InProcessProxyexecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/InProcessProxyexecutionManager.cs
@@ -109,17 +109,19 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         /// <summary>
         /// Aborts the test operation.
         /// </summary>
-        public void Abort()
+        /// <param name="eventHandler"> EventHandler for handling execution events from Engine. </param>
+        public void Abort(ITestRunEventsHandler eventHandler)
         {
-            Task.Run(() => this.testHostManagerFactory.GetExecutionManager().Abort());
+            Task.Run(() => this.testHostManagerFactory.GetExecutionManager().Abort(eventHandler));
         }
 
         /// <summary>
         /// Cancels the test run.
         /// </summary>
-        public void Cancel()
+        /// <param name="eventHandler"> EventHandler for handling execution events from Engine. </param>
+        public void Cancel(ITestRunEventsHandler eventHandler)
         {
-            Task.Run(() => this.testHostManagerFactory.GetExecutionManager().Cancel());
+            Task.Run(() => this.testHostManagerFactory.GetExecutionManager().Cancel(eventHandler));
         }
 
         /// <summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyExecutionManager.cs
@@ -120,16 +120,16 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel
             return this.StartTestRunPrivate(eventHandler);
         }
 
-        public void Abort()
+        public void Abort(ITestRunEventsHandler runEventsHandler)
         {
             // Test platform initiated abort.
             abortRequested = true;
-            this.DoActionOnAllManagers((proxyManager) => proxyManager.Abort(), doActionsInParallel: true);
+            this.DoActionOnAllManagers((proxyManager) => proxyManager.Abort(runEventsHandler), doActionsInParallel: true);
         }
 
-        public void Cancel()
+        public void Cancel(ITestRunEventsHandler runEventsHandler)
         {
-            this.DoActionOnAllManagers((proxyManager) => proxyManager.Cancel(), doActionsInParallel: true);
+            this.DoActionOnAllManagers((proxyManager) => proxyManager.Cancel(runEventsHandler), doActionsInParallel: true);
         }
 
         public void Close()

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -168,7 +168,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         /// <summary>
         /// Cancels the test run.
         /// </summary>
-        public virtual void Cancel()
+        /// <param name="eventHandler"> EventHandler for handling execution events from Engine. </param>
+        public virtual void Cancel(ITestRunEventsHandler eventHandler)
         {
             // Cancel fast, try to stop testhost deployment/launch
             this.cancellationTokenSource.Cancel();
@@ -187,7 +188,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         /// <summary>
         /// Aborts the test run.
         /// </summary>
-        public void Abort()
+        /// <param name="eventHandler"> EventHandler for handling execution events from Engine. </param>
+        public void Abort(ITestRunEventsHandler eventHandler)
         {
             this.RequestSender.SendTestRunAbort();
         }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -171,6 +171,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         /// <param name="eventHandler"> EventHandler for handling execution events from Engine. </param>
         public virtual void Cancel(ITestRunEventsHandler eventHandler)
         {
+            // Just in case ExecuteAsync isn't called yet, set the eventhandler
+            if(this.baseTestRunEventsHandler == null)
+            {
+                this.baseTestRunEventsHandler = eventHandler;
+            }
+
             // Cancel fast, try to stop testhost deployment/launch
             this.cancellationTokenSource.Cancel();
             if (this.isCommunicationEstablished)
@@ -191,6 +197,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         /// <param name="eventHandler"> EventHandler for handling execution events from Engine. </param>
         public void Abort(ITestRunEventsHandler eventHandler)
         {
+            // Just in case ExecuteAsync isn't called yet, set the eventhandler
+            if(this.baseTestRunEventsHandler == null)
+            {
+                this.baseTestRunEventsHandler = eventHandler;
+            }
+
             this.RequestSender.SendTestRunAbort();
         }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManagerWithDataCollection.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManagerWithDataCollection.cs
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         }
 
         /// <inheritdoc/>
-        public override void Cancel()
+        public override void Cancel(ITestRunEventsHandler eventHandler)
         {
             try
             {
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             }
             finally
             {
-                base.Cancel();
+                base.Cancel(eventHandler);
             }
         }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
@@ -321,7 +321,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 case MessageType.CancelTestRun:
                     jobQueue.Pause();
                     this.testHostManagerFactoryReady.Wait();
-                    testHostManagerFactory.GetExecutionManager().Cancel();
+                    testHostManagerFactory.GetExecutionManager().Cancel(new TestRunEventsHandler(this));
                     break;
 
                 case MessageType.LaunchAdapterProcessWithDebuggerAttachedCallback:
@@ -331,7 +331,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 case MessageType.AbortTestRun:
                     jobQueue.Pause();
                     this.testHostManagerFactoryReady.Wait();
-                    testHostManagerFactory.GetExecutionManager().Abort();
+                    testHostManagerFactory.GetExecutionManager().Abort(new TestRunEventsHandler(this));
                     break;
 
                 case MessageType.SessionEnd:

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/ExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/ExecutionManager.cs
@@ -22,8 +22,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
     /// </summary>
     public class ExecutionManager : IExecutionManager
     {
-        private ITestRunEventsHandler testRunEventsHandler;
-
         private readonly ITestPlatformEventSource testPlatformEventSource;
 
         private BaseRunTests activeTestRun;
@@ -85,7 +83,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
             ITestCaseEventsHandler testCaseEventsHandler,
             ITestRunEventsHandler runEventsHandler)
         {
-            this.testRunEventsHandler = runEventsHandler;
             try
             {
                 this.activeTestRun = new RunTestsWithSources(this.requestData, adapterSourceMap, package, runSettings, testExecutionContext, testCaseEventsHandler, runEventsHandler);
@@ -94,8 +91,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
             }
             catch(Exception e)
             {
-                this.testRunEventsHandler.HandleLogMessage(ObjectModel.Logging.TestMessageLevel.Error, e.ToString());
-                this.Abort();
+                runEventsHandler.HandleLogMessage(ObjectModel.Logging.TestMessageLevel.Error, e.ToString());
+                this.Abort(runEventsHandler);
             }
             finally
             {
@@ -120,8 +117,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
             ITestCaseEventsHandler testCaseEventsHandler,
             ITestRunEventsHandler runEventsHandler)
         {
-            this.testRunEventsHandler = runEventsHandler;
-
             try
             {
                 this.activeTestRun = new RunTestsWithTests(this.requestData, tests, package, runSettings, testExecutionContext, testCaseEventsHandler, runEventsHandler);
@@ -130,8 +125,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
             }
             catch(Exception e)
             {
-                this.testRunEventsHandler.HandleLogMessage(ObjectModel.Logging.TestMessageLevel.Error, e.ToString());
-                this.Abort();
+                runEventsHandler.HandleLogMessage(ObjectModel.Logging.TestMessageLevel.Error, e.ToString());
+                this.Abort(runEventsHandler);
             }
             finally
             {
@@ -142,12 +137,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
         /// <summary>
         /// Cancel the test execution.
         /// </summary>
-        public void Cancel()
+        public void Cancel(ITestRunEventsHandler testRunEventsHandler)
         {
             if (this.activeTestRun == null)
             {
                 var testRunCompleteEventArgs = new TestRunCompleteEventArgs(null, true, false, null, null, TimeSpan.Zero);
-                this.testRunEventsHandler.HandleTestRunComplete(testRunCompleteEventArgs, null, null, null);
+                testRunEventsHandler.HandleTestRunComplete(testRunCompleteEventArgs, null, null, null);
             }
             else
             {
@@ -158,12 +153,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
         /// <summary>
         /// Aborts the test execution.
         /// </summary>
-        public void Abort()
+        public void Abort(ITestRunEventsHandler testRunEventsHandler)
         {
             if (this.activeTestRun == null)
             {
                 var testRunCompleteEventArgs = new TestRunCompleteEventArgs(null, false, true, null, null, TimeSpan.Zero);
-                this.testRunEventsHandler.HandleTestRunComplete(testRunCompleteEventArgs, null, null, null);
+                testRunEventsHandler.HandleTestRunComplete(testRunCompleteEventArgs, null, null, null);
             }
             else
             {

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
         /// </summary>
         private ITestRunRequest currentTestRunRequest;
 
-        private readonly EventWaitHandle runRequestCreatedEventHandle = new AutoResetEvent(false);
+        private readonly EventWaitHandle runRequestStartedEventHandle = new AutoResetEvent(false);
 
         private object syncobject = new object();
 
@@ -322,7 +322,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
         {
             EqtTrace.Info("TestRequestManager.CancelTestRun: Sending cancel request.");
 
-            this.runRequestCreatedEventHandle.WaitOne(runRequestTimeout);
+            this.runRequestStartedEventHandle.WaitOne(runRequestTimeout);
             this.currentTestRunRequest?.CancelAsync();
         }
 
@@ -333,7 +333,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
         {
             EqtTrace.Info("TestRequestManager.AbortTestRun: Sending abort request.");
 
-            this.runRequestCreatedEventHandle.WaitOne(runRequestTimeout);
+            this.runRequestStartedEventHandle.WaitOne(runRequestTimeout);
             this.currentTestRunRequest?.Abort();
         }
 
@@ -457,7 +457,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
                 try
                 {
                     this.currentTestRunRequest = this.testPlatform.CreateTestRunRequest(requestData, testRunCriteria);
-                    this.runRequestCreatedEventHandle.Set();
 
                     this.testLoggerManager.RegisterTestRunEvents(this.currentTestRunRequest);
                     this.testRunResultAggregator.RegisterTestRunEvents(this.currentTestRunRequest);
@@ -466,6 +465,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
                     this.testPlatformEventSource.ExecutionRequestStart();
 
                     this.currentTestRunRequest.ExecuteAsync();
+                    
+                    this.runRequestStartedEventHandle.Set();
 
                     // Wait for the run completion event
                     this.currentTestRunRequest.WaitForCompletion();

--- a/test/Microsoft.TestPlatform.Client.UnitTests/Execution/TestRunRequestTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/Execution/TestRunRequestTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.Execution
         {
             //ExecuteAsync has not been called, so State is not InProgress
             testRunRequest.Abort();
-            executionManager.Verify(dm => dm.Abort(), Times.Never);
+            executionManager.Verify(dm => dm.Abort(It.IsAny<ITestRunEventsHandler>()), Times.Never);
         }
 
         [TestMethod]
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.Execution
             testRunRequest.ExecuteAsync();
 
             testRunRequest.Abort();
-            executionManager.Verify(dm => dm.Abort(), Times.Once);
+            executionManager.Verify(dm => dm.Abort(It.IsAny<ITestRunEventsHandler>()), Times.Once);
         }
 
         [TestMethod]
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.Execution
         public void CancelAsyncIfTestRunStateNotInProgressWillNotCallExecutionManagerCancel()
         {
             testRunRequest.CancelAsync();
-            executionManager.Verify(dm => dm.Cancel(), Times.Never);
+            executionManager.Verify(dm => dm.Cancel(It.IsAny<ITestRunEventsHandler>()), Times.Never);
         }
 
         [TestMethod]
@@ -151,7 +151,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.Execution
         {
             testRunRequest.ExecuteAsync();
             testRunRequest.CancelAsync();
-            executionManager.Verify(dm => dm.Cancel(), Times.Once);
+            executionManager.Verify(dm => dm.Cancel(It.IsAny<ITestRunEventsHandler>()), Times.Once);
         }
 
 
@@ -160,7 +160,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.Execution
         {
             this.testRunRequest.ExecuteAsync();
             this.testRunRequest.OnTestSessionTimeout(null);
-            this.executionManager.Verify(o => o.Abort(), Times.Once);
+            this.executionManager.Verify(o => o.Abort(It.IsAny<ITestRunEventsHandler>()), Times.Once);
         }
 
         [TestMethod]
@@ -202,12 +202,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.Execution
 
             ManualResetEvent onTestSessionTimeoutCalled = new ManualResetEvent(true);
             onTestSessionTimeoutCalled.Reset();
-            executionManager.Setup(o => o.Abort()).Callback(() => onTestSessionTimeoutCalled.Set());
+            executionManager.Setup(o => o.Abort(It.IsAny<ITestRunEventsHandler>())).Callback(() => onTestSessionTimeoutCalled.Set());
 
             testRunRequest.ExecuteAsync();
             onTestSessionTimeoutCalled.WaitOne(20 * 1000);
 
-            executionManager.Verify(o => o.Abort(), Times.Once);
+            executionManager.Verify(o => o.Abort(It.IsAny<ITestRunEventsHandler>()), Times.Once);
         }
 
         /// <summary>
@@ -232,7 +232,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.Execution
 
             testRunRequest.ExecuteAsync();
 
-            executionManager.Verify(o => o.Abort(), Times.Never);
+            executionManager.Verify(o => o.Abort(It.IsAny<ITestRunEventsHandler>()), Times.Never);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/InProcessProxyexecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/InProcessProxyexecutionManagerTests.cs
@@ -179,10 +179,10 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         {
             var manualResetEvent = new ManualResetEvent(true);
 
-            this.mockExecutionManager.Setup(o => o.Abort()).Callback(
+            this.mockExecutionManager.Setup(o => o.Abort(It.IsAny<ITestRunEventsHandler>())).Callback(
                 () => manualResetEvent.Set());
 
-            this.inProcessProxyExecutionManager.Abort();
+            this.inProcessProxyExecutionManager.Abort(It.IsAny<ITestRunEventsHandler>());
 
             Assert.IsTrue(manualResetEvent.WaitOne(5000), "IExecutionManager.Abort should get called");
         }
@@ -192,10 +192,10 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         {
             var manualResetEvent = new ManualResetEvent(true);
 
-            this.mockExecutionManager.Setup(o => o.Cancel()).Callback(
+            this.mockExecutionManager.Setup(o => o.Cancel(It.IsAny<ITestRunEventsHandler>())).Callback(
                 () => manualResetEvent.Set());
 
-            this.inProcessProxyExecutionManager.Cancel();
+            this.inProcessProxyExecutionManager.Cancel(It.IsAny<ITestRunEventsHandler>());
 
             Assert.IsTrue(manualResetEvent.WaitOne(5000), "IExecutionManager.Abort should get called");
         }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelProxyExecutionManagerTests.cs
@@ -89,10 +89,10 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         {
             var parallelExecutionManager = new ParallelProxyExecutionManager(this.mockRequestData.Object, this.proxyManagerFunc, 4);
 
-            parallelExecutionManager.Abort();
+            parallelExecutionManager.Abort(It.IsAny<ITestRunEventsHandler>());
 
             Assert.AreEqual(4, createdMockManagers.Count, "Number of Concurrent Managers created should be 4");
-            createdMockManagers.ForEach(em => em.Verify(m => m.Abort(), Times.Once));
+            createdMockManagers.ForEach(em => em.Verify(m => m.Abort(It.IsAny<ITestRunEventsHandler>()), Times.Once));
         }
 
         [TestMethod]
@@ -100,10 +100,10 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         {
             var parallelExecutionManager = new ParallelProxyExecutionManager(this.mockRequestData.Object, this.proxyManagerFunc, 4);
 
-            parallelExecutionManager.Cancel();
+            parallelExecutionManager.Cancel(It.IsAny<ITestRunEventsHandler>());
 
             Assert.AreEqual(4, createdMockManagers.Count, "Number of Concurrent Managers created should be 4");
-            createdMockManagers.ForEach(em => em.Verify(m => m.Cancel(), Times.Once));
+            createdMockManagers.ForEach(em => em.Verify(m => m.Cancel(It.IsAny<ITestRunEventsHandler>()), Times.Once));
         }
 
         [TestMethod]
@@ -215,7 +215,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
             this.SetupMockManagers(this.processedSources, isCanceled: false, isAborted: false);
             SetupHandleTestRunComplete(this.executionCompleted);
 
-            parallelExecutionManager.Abort();
+            parallelExecutionManager.Abort(It.IsAny<ITestRunEventsHandler>());
             Task.Run(() => { parallelExecutionManager.StartTestRun(this.testRunCriteriaWithSources, this.mockHandler.Object); });
 
             Assert.IsTrue(this.executionCompleted.Wait(taskTimeout), "Test run not completed.");

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
@@ -387,7 +387,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
             this.testExecutionManager.StartTestRun(this.mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
 
-            this.testExecutionManager.Cancel();
+            this.testExecutionManager.Cancel(It.IsAny<ITestRunEventsHandler>());
 
             this.mockRequestSender.Verify(s => s.SendTestRunCancel(), Times.Never);
         }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerWithDataCollectionTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerWithDataCollectionTests.cs
@@ -115,7 +115,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         [TestMethod]
         public void CancelShouldInvokeAfterTestCaseEnd()
         {
-            this.proxyExecutionManager.Cancel();
+            this.proxyExecutionManager.Cancel(It.IsAny<ITestRunEventsHandler>());
 
             this.mockDataCollectionManager.Verify(x => x.AfterTestRunEnd(true, It.IsAny<ITestMessageEventHandler>()), Times.Once);
         }
@@ -127,7 +127,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
             Assert.ThrowsException<Exception>(() =>
             {
-                this.proxyExecutionManager.Cancel();
+                this.proxyExecutionManager.Cancel(It.IsAny<ITestRunEventsHandler>());
             });
         }
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/EventHandlers/TestRequestHandlerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/EventHandlers/TestRequestHandlerTests.cs
@@ -285,7 +285,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             this.ProcessRequestsAsync(this.mockTestHostManagerFactory.Object);
             this.SendMessageOnChannel(message);
 
-            mockExecutionManager.Verify(e => e.Cancel());
+            mockExecutionManager.Verify(e => e.Cancel(It.IsAny<ITestRunEventsHandler>()));
             this.SendSessionEnd();
         }
 
@@ -313,7 +313,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             this.ProcessRequestsAsync(this.mockTestHostManagerFactory.Object);
             this.SendMessageOnChannel(message);
 
-            mockExecutionManager.Verify(e => e.Abort());
+            mockExecutionManager.Verify(e => e.Abort(It.IsAny<ITestRunEventsHandler>()));
             this.SendSessionEnd();
         }
 


### PR DESCRIPTION
Fix for a timing issue where a cancel request before test run request has been started is being ignored.

We have the right plumbing in place but just seem to have missed initializing a var. Put that in place.
All interface changes are internal only.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/559064

From testhost diag logs, this is the stack trace:
TpTrace Error: 0 : 17096, 8, 2018/01/30, 15:50:44.560, 1284210642450, testhost.x86.exe, LengthPrefixCommunicationChannel: MessageReceived: Exception occurred while calling handler of type Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.TestRequestHandler for MessageReceivedEventArgs: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.NullReferenceException: Object reference not set to an instance of an object.
at Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution.ExecutionManager.Cancel()
at Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.TestRequestHandler.OnMessageReceived(Object sender, MessageReceivedEventArgs messageReceivedArgs)
--- End of inner exception stack trace ---
at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
at System.Delegate.DynamicInvokeImpl(Object[] args)
at Microsoft.VisualStudio.TestPlatform.Utilities.MulticastDelegateUtilities.SafeInvoke(Delegate delegates, Object sender, EventArgs args, String traceDisplayName)


