### PR TITLE
Increase timeouts for datacollector to connect to Testhost

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
     {
         // On Slower Machines(hosted agents) with Profiling enabled 15secs is not enough for testhost to get started(weird right!!),
         // hence increasing this timeout
-        private const int DATACOLLECTIONCONNTIMEOUT = 60 * 1000;
+        private const int DataCollectionCommTimeOut = 60 * 1000;
 
         private static readonly object SyncObject = new object();
 
@@ -200,7 +200,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
                                         {
                                             if (
                                                 this.dataCollectionTestCaseEventHandler.WaitForRequestHandlerConnection(
-                                                    DATACOLLECTIONCONNTIMEOUT))
+                                                    DataCollectionCommTimeOut))
                                             {
                                                 this.dataCollectionTestCaseEventHandler.ProcessRequests();
                                             }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
@@ -29,7 +29,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
     /// </summary>
     internal class DataCollectionRequestHandler : IDataCollectionRequestHandler, IDisposable
     {
-        private const int DATACOLLECTIONCONNTIMEOUT = 15 * 1000;
+        // On Slower Machines(hosted agents) with Profiling enabled 15secs is not enough for testhost to get started(weird right!!),
+        // hence increasing this timeout
+        private const int DATACOLLECTIONCONNTIMEOUT = 60 * 1000;
 
         private static readonly object SyncObject = new object();
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
@@ -265,7 +265,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
                 case MessageType.ExecutionInitialize:
                     {
-                        EqtTrace.Info("Discovery Session Initialize.");
+                        EqtTrace.Info("Execution Session Initialize.");
                         this.testHostManagerFactoryReady.Wait();
                         var pathToAdditionalExtensions = message.Payload.ToObject<IEnumerable<string>>();
                         jobQueue.QueueJob(

--- a/src/testhost.x86/DefaultEngineInvoker.cs
+++ b/src/testhost.x86/DefaultEngineInvoker.cs
@@ -32,6 +32,8 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
         /// </summary>
         private const int ClientListenTimeOut = Timeout.Infinite;
 
+        private const int DataConnectionClientListenTimeOut = 60 * 1000;
+
         private const string EndpointArgument = "--endpoint";
 
         private const string RoleArgument = "--role";
@@ -107,7 +109,13 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
                 {
                     var dataCollectionTestCaseEventSender = DataCollectionTestCaseEventSender.Create();
                     dataCollectionTestCaseEventSender.InitializeCommunication(dcPort);
-                    dataCollectionTestCaseEventSender.WaitForRequestSenderConnection(ClientListenTimeOut);
+
+                    // It's possible that connection to vstest.console happens, but to datacollector fails, why?
+                    // DataCollector keeps the server alive for testhost only for 15secs(increased to 60 now), 
+                    // if somehow(on slower machines, with Profiler Enabled) testhost can take considerable time to launch,
+                    // in such scenario dc.exe would have killed the server, but testhost will wait infinitely to connect to it,
+                    // hence do not wait to connect to datacollector process infinitely, as it will cause process hang.
+                    dataCollectionTestCaseEventSender.WaitForRequestSenderConnection(DataConnectionClientListenTimeOut);
                 }
 
                 // Checks for Telemetry Opted in or not from Command line Arguments.

--- a/src/testhost.x86/DefaultEngineInvoker.cs
+++ b/src/testhost.x86/DefaultEngineInvoker.cs
@@ -115,7 +115,10 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
                     // if somehow(on slower machines, with Profiler Enabled) testhost can take considerable time to launch,
                     // in such scenario dc.exe would have killed the server, but testhost will wait infinitely to connect to it,
                     // hence do not wait to connect to datacollector process infinitely, as it will cause process hang.
-                    dataCollectionTestCaseEventSender.WaitForRequestSenderConnection(DataConnectionClientListenTimeOut);
+                    if(!dataCollectionTestCaseEventSender.WaitForRequestSenderConnection(DataConnectionClientListenTimeOut))
+                    {
+                        EqtTrace.Info("DefaultEngineInvoker: Connection to DataCollector failed: '{0}', DataCollection will not happen in this session", dcPort);
+                    }
                 }
 
                 // Checks for Telemetry Opted in or not from Command line Arguments.

--- a/src/testhost.x86/DefaultEngineInvoker.cs
+++ b/src/testhost.x86/DefaultEngineInvoker.cs
@@ -163,6 +163,13 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
                 () =>
                     {
                         // Wait for the connection to the sender and start processing requests from sender
+                        // Note that we are waiting here infinitely to connect to vstest.console, but at the same time vstest.console doesn't wait infinitely.
+                        // It has a default timeout of 60secs(which is configurable), & then it kills testhost.exe
+                        // The reason to wait infinitely, was remote debugging scenarios of UWP app,
+                        // in such cases after the app gets launched, VS debugger takes control of it, & causes a lot of delay, which frequently causes timeout with vstest.console.
+                        // One fix would be just double this timeout, but there is no telling how much time it can actually take.
+                        // Hence we are waiting here indefinelty, to avoid such guessed timeouts, & letting user kill the debugging if they feel it is taking too much time.
+                        // In other cases if vstest.console's timeout exceeds it will definitelty such down the app.
                 if (requestHandler.WaitForRequestSenderConnection(ClientListenTimeOut))
                 {
                     requestHandler.ProcessRequests(managerFactory);

--- a/test/vstest.console.PlatformTests/AssemblyMetadataProviderTests.cs
+++ b/test/vstest.console.PlatformTests/AssemblyMetadataProviderTests.cs
@@ -75,9 +75,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.PlatformTests
             var arch = this.assemblyMetadataProvider.GetArchitecture(assemblyPath);
             stopWatch.Stop();
 
-            Assert.AreEqual(Enum.Parse(typeof(Architecture), platform, ignoreCase: true), arch);
             Console.WriteLine("Platform:{0}, {1}", platform, string.Format(PerfAssertMessageFormat, expectedElapsedTime, stopWatch.ElapsedMilliseconds));
-            Assert.IsTrue(stopWatch.ElapsedMilliseconds < expectedElapsedTime, string.Format(PerfAssertMessageFormat, expectedElapsedTime, stopWatch.ElapsedMilliseconds));
+            Assert.AreEqual(Enum.Parse(typeof(Architecture), platform, ignoreCase: true), arch);
+
+            // We should not assert on time elapsed, it will vary depending on machine, & their state, commenting below assert
+            // Assert.IsTrue(stopWatch.ElapsedMilliseconds < expectedElapsedTime, string.Format(PerfAssertMessageFormat, expectedElapsedTime, stopWatch.ElapsedMilliseconds));
         }
 
         [TestMethod]
@@ -109,7 +111,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.PlatformTests
             }
 
             Console.WriteLine("Framework:{0}, {1}", framework, string.Format(PerfAssertMessageFormat, expectedElapsedTime, stopWatch.ElapsedMilliseconds));
-            Assert.IsTrue(stopWatch.ElapsedMilliseconds < expectedElapsedTime, string.Format(PerfAssertMessageFormat, expectedElapsedTime, stopWatch.ElapsedMilliseconds));
+
+            // We should not assert on time elapsed, it will vary depending on machine, & their state.
+            // Assert.IsTrue(stopWatch.ElapsedMilliseconds < expectedElapsedTime, string.Format(PerfAssertMessageFormat, expectedElapsedTime, stopWatch.ElapsedMilliseconds));
         }
 
         [TestMethod]
@@ -121,10 +125,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.PlatformTests
             var stopWatch = Stopwatch.StartNew();
             var fx = this.assemblyMetadataProvider.GetFrameWork(assemblyPath);
             stopWatch.Stop();
-            Assert.AreEqual(Framework.DefaultFramework.Name, fx.FullName);
 
             Console.WriteLine(PerfAssertMessageFormat, expectedElapsedTime, stopWatch.ElapsedMilliseconds);
-            Assert.IsTrue(stopWatch.ElapsedMilliseconds < expectedElapsedTime, string.Format(PerfAssertMessageFormat, expectedElapsedTime, stopWatch.ElapsedMilliseconds));
+            Assert.AreEqual(Framework.DefaultFramework.Name, fx.FullName);
+
+            // We should not assert on time elapsed, it will vary depending on machine, & their state.
+            // Assert.IsTrue(stopWatch.ElapsedMilliseconds < expectedElapsedTime, string.Format(PerfAssertMessageFormat, expectedElapsedTime, stopWatch.ElapsedMilliseconds));
         }
 
         private void TestDotnetAssemblyArch(string projectName, string framework, Architecture expectedArch, long expectedElapsedTime)
@@ -134,11 +140,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.PlatformTests
             var stopWatch = Stopwatch.StartNew();
             var arch = this.assemblyMetadataProvider.GetArchitecture(assemblyPath);
             stopWatch.Stop();
-            Assert.AreEqual(expectedArch, arch, $"Expected: {expectedArch} Actual: {arch}");
+
             Console.WriteLine("Framework:{0}, {1}", framework, string.Format(PerfAssertMessageFormat, expectedElapsedTime, stopWatch.ElapsedMilliseconds));
-            Assert.IsTrue(
-                stopWatch.ElapsedMilliseconds < expectedElapsedTime,
-                string.Format(PerfAssertMessageFormat, expectedElapsedTime, stopWatch.ElapsedMilliseconds));
+            Assert.AreEqual(expectedArch, arch, $"Expected: {expectedArch} Actual: {arch}");
+
+            // We should not assert on time elapsed, it will vary depending on machine, & their state.
+            // Assert.IsTrue(stopWatch.ElapsedMilliseconds < expectedElapsedTime, string.Format(PerfAssertMessageFormat, expectedElapsedTime, stopWatch.ElapsedMilliseconds));
         }
 
         private void LoadAssemblyIntoMemory(string assemblyPath)


### PR DESCRIPTION
## Description
On Slower Machines(hosted agents) with Profiling enabled 15secs is not enough for testhost to get started,
hence with data collection enabled, the connection b/w testhost, & dc.exe fails.

TestHost process currently waits infinitely to connect to dc.exe, if the above connection does not happen, it causes a hang in th.exe

Fixes #1410 
