### PR TITLE
Port DataCollection timeout issue to 15.5

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
@@ -29,7 +29,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
     /// </summary>
     internal class DataCollectionRequestHandler : IDataCollectionRequestHandler, IDisposable
     {
-        private const int DATACOLLECTIONCONNTIMEOUT = 15 * 1000;
+        // On Slower Machines(hosted agents) with Profiling enabled 15secs is not enough for testhost to get started(weird right!!),
+        // hence increasing this timeout
+        private const int DataCollectionCommTimeOut = 15 * 1000;
 
         private static readonly object SyncObject = new object();
 
@@ -193,7 +195,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
                                         {
                                             if (
                                                 this.dataCollectionTestCaseEventHandler.WaitForRequestHandlerConnection(
-                                                    DATACOLLECTIONCONNTIMEOUT))
+                                                    DataCollectionCommTimeOut))
                                             {
                                                 this.dataCollectionTestCaseEventHandler.ProcessRequests();
                                             }

--- a/src/testhost.x86/DefaultEngineInvoker.cs
+++ b/src/testhost.x86/DefaultEngineInvoker.cs
@@ -32,6 +32,8 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
         /// </summary>
         private const int ClientListenTimeOut = Timeout.Infinite;
 
+        private const int DataConnectionClientListenTimeOut = 60 * 1000;
+
         private const string EndpointArgument = "--endpoint";
 
         private const string RoleArgument = "--role";
@@ -107,7 +109,16 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
                 {
                     var dataCollectionTestCaseEventSender = DataCollectionTestCaseEventSender.Create();
                     dataCollectionTestCaseEventSender.InitializeCommunication(dcPort);
-                    dataCollectionTestCaseEventSender.WaitForRequestSenderConnection(ClientListenTimeOut);
+
+                    // It's possible that connection to vstest.console happens, but to datacollector fails, why?
+                    // DataCollector keeps the server alive for testhost only for 15secs(increased to 60 now), 
+                    // if somehow(on slower machines, with Profiler Enabled) testhost can take considerable time to launch,
+                    // in such scenario dc.exe would have killed the server, but testhost will wait infinitely to connect to it,
+                    // hence do not wait to connect to datacollector process infinitely, as it will cause process hang.
+                    if (!dataCollectionTestCaseEventSender.WaitForRequestSenderConnection(DataConnectionClientListenTimeOut))
+                    {
+                        EqtTrace.Info("DefaultEngineInvoker: Connection to DataCollector failed: '{0}', DataCollection will not happen in this session", dcPort);
+                    }
                 }
 
                 // Checks for Telemetry Opted in or not from Command line Arguments.
@@ -152,7 +163,14 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
                 () =>
                     {
                         // Wait for the connection to the sender and start processing requests from sender
-                if (requestHandler.WaitForRequestSenderConnection(ClientListenTimeOut))
+                        // Note that we are waiting here infinitely to connect to vstest.console, but at the same time vstest.console doesn't wait infinitely.
+                        // It has a default timeout of 60secs(which is configurable), & then it kills testhost.exe
+                        // The reason to wait infinitely, was remote debugging scenarios of UWP app,
+                        // in such cases after the app gets launched, VS debugger takes control of it, & causes a lot of delay, which frequently causes timeout with vstest.console.
+                        // One fix would be just double this timeout, but there is no telling how much time it can actually take.
+                        // Hence we are waiting here indefinelty, to avoid such guessed timeouts, & letting user kill the debugging if they feel it is taking too much time.
+                        // In other cases if vstest.console's timeout exceeds it will definitelty such down the app.
+                        if (requestHandler.WaitForRequestSenderConnection(ClientListenTimeOut))
                 {
                     requestHandler.ProcessRequests(managerFactory);
                 }


### PR DESCRIPTION
## Description
On Slower Machines(hosted agents) with Profiling enabled 15secs is not enough for testhost to get started,
hence with data collection enabled, the connection b/w testhost, & dc.exe fails.

TestHost process currently waits infinitely to connect to dc.exe, if the above connection does not happen, it causes a hang in th.exe

Fixes #1410 
