### PR TITLE
Fixing a hang in clients on request init issues in vstest.console

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
@@ -109,12 +109,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             catch (Exception exception)
             {
                 EqtTrace.Error("ProxyDiscoveryManager.DiscoverTests: Failed to discover tests: {0}", exception);
-
-                // Log to vs ide test output
-                var testMessagePayload = new TestMessagePayload { MessageLevel = TestMessageLevel.Error, Message = exception.ToString() };
-                var rawMessage = this.dataSerializer.SerializePayload(MessageType.TestMessage, testMessagePayload);
-                this.HandleRawMessage(rawMessage);
-
+                
                 // Log to vstest.console
                 // Send a discovery complete to caller. Similar logic is also used in ParallelProxyDiscoveryManager.DiscoverTestsOnConcurrentManager
                 // Aborted is `true`: in case of parallel discovery (or non shared host), an aborted message ensures another discovery manager
@@ -125,6 +120,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                 var discoveryCompleteEventsArgs = new DiscoveryCompleteEventArgs(-1, true);
 
                 this.HandleDiscoveryComplete(discoveryCompleteEventsArgs, new List<ObjectModel.TestCase>());
+
+                // Ensure that this exception along with a discovery complete flows through to the clients.
+                // The logic to send out a discovery completion in case of failures here sits in DesignModeClient.
+                throw;
             }
         }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -160,6 +160,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                 // and the test host is lost as well.
                 var completeArgs = new TestRunCompleteEventArgs(null, false, true, exception, new Collection<AttachmentSet>(), TimeSpan.Zero);
                 this.HandleTestRunComplete(completeArgs, null, null, null);
+
+                // Ensure that this exception along with a test run complete flows through to the clients.
+                // The logic to send out a test run completion in case of failures here sits in DesignModeClient.
+                throw;
             }
 
             return 0;


### PR DESCRIPTION
Fixing  a hang in the design mode clients when the start up code fails. We were not actually sending a test run complete in the line above. That was just notifying loggers that test run is complete.

However we are blanket handling this scenario in the DesignModeClient API. So I just went ahead and made sure that the exception flows through.