### PR TITLE
Add NgenApplication so that default (vsn.exe.config) is not used...

### DIFF
--- a/src/package/VSIXProject/TestPlatform.csproj
+++ b/src/package/VSIXProject/TestPlatform.csproj
@@ -235,8 +235,8 @@
 
     <VsixSourceItem Include="$(VsixInputFileLocation)\*.*" Exclude="$(VsixInputFileLocation)\*.pdb" />
 
-    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.exe" Ngen="true" NgenArchitecture="X64" NgenPriority="1" /> 
-    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="1" />
+    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.exe" Ngen="true" NgenArchitecture="X64" NgenPriority="1" NgenApplication="$(VsixInputFileLocation)\testhost.exe" /> 
+    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="1" NgenApplication="$(VsixInputFileLocation)\testhost.x86.exe" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="License.rtf">


### PR DESCRIPTION
## Description
...when attempting to ngen testhost(.x86).exe.  Some dependent
assemblies not normally loaded in VS will fail to load during ngen
install when vsn.exe.config is used.

## Related issue
https://devdiv.visualstudio.com/DevDiv/_workitems?id=571813&_a=edit
