### PR TITLE
fixes test to use Newline instead of \r\n

### DIFF
--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -254,7 +254,7 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
             // Verify
             List<string> expectedList = new List<string> { @"C:\Source2\ext1.TestAdapter.dll", @"C:\Source1\ext2.TestAdapter.dll" };
             CollectionAssert.AreEqual(expectedList, resultExtensions);
-            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Warning, "Multiple versions of same extension found. Selecting the highest version." + Environment.NewLine + "  ext1.TestAdapter : 2.2" + Environment.NewLine + "  ext2.TestAdapter : 5.5"), Times.Once);
+            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Warning, "Multiple versions of same extension found. Selecting the highest version." + Environment.NewLine + "  ext1.TestAdapter : 2.2\n  ext2.TestAdapter : 5.5"), Times.Once);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -254,7 +254,7 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
             // Verify
             List<string> expectedList = new List<string> { @"C:\Source2\ext1.TestAdapter.dll", @"C:\Source1\ext2.TestAdapter.dll" };
             CollectionAssert.AreEqual(expectedList, resultExtensions);
-            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Warning, "Multiple versions of same extension found. Selecting the highest version.\n  ext1.TestAdapter : 2.2\n  ext2.TestAdapter : 5.5"), Times.Once);
+            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Warning, "Multiple versions of same extension found. Selecting the highest version." + Environment.NewLine + "  ext1.TestAdapter : 2.2" + Environment.NewLine + "  ext2.TestAdapter : 5.5"), Times.Once);
         }
 
         [TestMethod]
@@ -279,7 +279,7 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
 
             // Verify
             CollectionAssert.AreEqual(extensionsList2, resultExtensions);
-            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Warning, "Multiple versions of same extension found. Selecting the highest version.\n  ext1.TestAdapter : 2.2"), Times.Once);
+            this.mockMessageLogger.Verify(ml => ml.SendMessage(TestMessageLevel.Warning, "Multiple versions of same extension found. Selecting the highest version." + Environment.NewLine + "  ext1.TestAdapter : 2.2"), Times.Once);
         }
 
         [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
@@ -61,7 +61,7 @@ namespace vstest.console.UnitTests.Processors
             var capabilities = new CLIRunSettingsArgumentProcessorCapabilities();
 
             Assert.AreEqual("--", capabilities.CommandName);
-            Assert.AreEqual("RunSettings arguments:\n      Arguments to pass runsettings configurations through commandline. Arguments may be specified as name-value pair of the form [name]=[value] after \"-- \". Note the space after --. \n      Use a space to separate multiple [name]=[value].\n      More info on RunSettings arguments support: https://aka.ms/vstest-runsettings-arguments", capabilities.HelpContentResourceName);
+            Assert.AreEqual("RunSettings arguments:" + Environment.NewLine + "      Arguments to pass runsettings configurations through commandline. Arguments may be specified as name-value pair of the form [name]=[value] after \"-- \". Note the space after --. " + Environment.NewLine + "      Use a space to separate multiple [name]=[value]." + Environment.NewLine + "      More info on RunSettings arguments support: https://aka.ms/vstest-runsettings-arguments", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.CLIRunSettingsArgumentProcessorHelpPriority, capabilities.HelpPriority);
             Assert.AreEqual(false, capabilities.IsAction);

--- a/test/vstest.console.UnitTests/Processors/CollectArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CollectArgumentProcessorTests.cs
@@ -47,7 +47,7 @@ namespace vstest.console.UnitTests.Processors
             var capabilities = new CollectArgumentProcessorCapabilities();
 
             Assert.AreEqual("/Collect", capabilities.CommandName);
-            Assert.AreEqual("--Collect|/Collect:<DataCollector FriendlyName>\n      Enables data collector for the test run. More info here : https://aka.ms/vstest-collect", capabilities.HelpContentResourceName);
+            Assert.AreEqual("--Collect|/Collect:<DataCollector FriendlyName>" + Environment.NewLine + "      Enables data collector for the test run. More info here : https://aka.ms/vstest-collect", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.CollectArgumentProcessorHelpPriority, capabilities.HelpPriority);
             Assert.AreEqual(false, capabilities.IsAction);

--- a/test/vstest.console.UnitTests/Processors/HelpArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/HelpArgumentProcessorTests.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
 {
+    using System;
     using System.Collections.Generic;
 
     using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
@@ -71,7 +72,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.IsTrue(output.Lines.Contains("Arguments:"));
             Assert.IsTrue(output.Lines.Contains("Options:"));
             Assert.IsTrue(output.Lines.Contains("Description: Runs tests from the specified files."));
-            Assert.IsTrue(output.Lines.Contains("  To run tests:\n    >vstest.console.exe tests.dll \n  To run tests with additional settings such as  data collectors:\n    >vstest.console.exe  tests.dll /Settings:Local.RunSettings"));
+            Assert.IsTrue(output.Lines.Contains("  To run tests:" + Environment.NewLine + "    >vstest.console.exe tests.dll " + Environment.NewLine + "  To run tests with additional settings such as  data collectors:" + Environment.NewLine + "    >vstest.console.exe  tests.dll /Settings:Local.RunSettings"));
         }
     }
 

--- a/test/vstest.console.UnitTests/Processors/InIsolationArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/InIsolationArgumentProcessorTests.cs
@@ -6,6 +6,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
     using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
     using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
     using vstest.console.UnitTests.Processors;
 
     using ExceptionUtilities = Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.ExceptionUtilities;
@@ -55,7 +56,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual(null, isolationProcessor.Metadata.Value.ShortCommandName);
             Assert.AreEqual(ArgumentProcessorPriority.AutoUpdateRunSettings, isolationProcessor.Metadata.Value.Priority);
             Assert.AreEqual(HelpContentPriority.InIsolationArgumentProcessorHelpPriority, isolationProcessor.Metadata.Value.HelpPriority);
-            Assert.AreEqual("--InIsolation|/InIsolation\n      Runs the tests in an isolated process. This makes vstest.console.exe \n      process less likely to be stopped on an error in the tests, but tests \n      may run slower.", isolationProcessor.Metadata.Value.HelpContentResourceName);
+            Assert.AreEqual("--InIsolation|/InIsolation" + Environment.NewLine + "      Runs the tests in an isolated process. This makes vstest.console.exe " + Environment.NewLine + "      process less likely to be stopped on an error in the tests, but tests " + Environment.NewLine + "      may run slower.", isolationProcessor.Metadata.Value.HelpContentResourceName);
         }
 
         [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             var capabilities = new ListTestsArgumentProcessorCapabilities();
             Assert.AreEqual("/ListTests", capabilities.CommandName);
             Assert.AreEqual("/lt", capabilities.ShortCommandName);
-            Assert.AreEqual("-lt|--ListTests|/lt|/ListTests:<File Name>\n      Lists all discovered tests from the given test container.", capabilities.HelpContentResourceName);
+            Assert.AreEqual("-lt|--ListTests|/lt|/ListTests:<File Name>" + Environment.NewLine + "      Lists all discovered tests from the given test container.", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.ListTestsArgumentProcessorHelpPriority, capabilities.HelpPriority);
             Assert.AreEqual(true, capabilities.IsAction);

--- a/test/vstest.console.UnitTests/Processors/ParallelArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ParallelArgumentProcessorTests.cs
@@ -9,6 +9,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
     using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
 
     using ExceptionUtilities = Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.ExceptionUtilities;
+    using System;
 
     [TestClass]
     public class ParallelArgumentProcessorTests
@@ -49,7 +50,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         {
             var capabilities = new ParallelArgumentProcessorCapabilities();
             Assert.AreEqual("/Parallel", capabilities.CommandName);
-            Assert.AreEqual("--Parallel|/Parallel\n      Specifies that the tests be executed in parallel. By default up\n      to all available cores on the machine may be used.\n      The number of cores to use may be configured using a settings file.", capabilities.HelpContentResourceName);
+            Assert.AreEqual("--Parallel|/Parallel" + Environment.NewLine + "      Specifies that the tests be executed in parallel. By default up" + Environment.NewLine + "      to all available cores on the machine may be used." + Environment.NewLine + "      The number of cores to use may be configured using a settings file.", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.ParallelArgumentProcessorHelpPriority, capabilities.HelpPriority);
             Assert.AreEqual(false, capabilities.IsAction);

--- a/test/vstest.console.UnitTests/Processors/ParentProcessIdArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ParentProcessIdArgumentProcessorTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         {
             var capabilities = new ParentProcessIdArgumentProcessorCapabilities();
             Assert.AreEqual("/ParentProcessId", capabilities.CommandName);
-            Assert.AreEqual("--ParentProcessId|/ParentProcessId:<ParentProcessId>\n      Process Id of the Parent Process responsible for launching current process.", capabilities.HelpContentResourceName);
+            Assert.AreEqual("--ParentProcessId|/ParentProcessId:<ParentProcessId>" + Environment.NewLine + "      Process Id of the Parent Process responsible for launching current process.", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.ParentProcessIdArgumentProcessorHelpPriority, capabilities.HelpPriority);
             Assert.AreEqual(false, capabilities.IsAction);

--- a/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
@@ -8,6 +8,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
     using vstest.console.UnitTests.Processors;
     using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
     using ExceptionUtilities = Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.ExceptionUtilities;
+    using System;
 
     [TestClass]
     public class PlatformArgumentProcessorTests
@@ -49,7 +50,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         {
             var capabilities = new PlatformArgumentProcessorCapabilities();
             Assert.AreEqual("/Platform", capabilities.CommandName);
-            Assert.AreEqual("--Platform|/Platform:<Platform type>\n      Target platform architecture to be used for test execution. \n      Valid values are x86, x64 and ARM.", capabilities.HelpContentResourceName);
+            Assert.AreEqual("--Platform|/Platform:<Platform type>" + Environment.NewLine + "      Target platform architecture to be used for test execution. " + Environment.NewLine + "      Valid values are x86, x64 and ARM.", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.PlatformArgumentProcessorHelpPriority, capabilities.HelpPriority);
             Assert.AreEqual(false, capabilities.IsAction);

--- a/test/vstest.console.UnitTests/Processors/ResultsDirectoryArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ResultsDirectoryArgumentProcessorTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         {
             var capabilities = new ResultsDirectoryArgumentProcessorCapabilities();
             Assert.AreEqual("/ResultsDirectory", capabilities.CommandName);
-            Assert.AreEqual("--ResultsDirectory|/ResultsDirectory\n      Test results directory will be created in specified path if not exists.\n      Example  /ResultsDirectory:<pathToResultsDirectory>", capabilities.HelpContentResourceName);
+            Assert.AreEqual("--ResultsDirectory|/ResultsDirectory" + Environment.NewLine + "      Test results directory will be created in specified path if not exists." + Environment.NewLine + "      Example  /ResultsDirectory:<pathToResultsDirectory>", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.ResultsDirectoryArgumentProcessorHelpPriority, capabilities.HelpPriority);
             Assert.AreEqual(false, capabilities.IsAction);

--- a/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         {
             var capabilities = new RunSettingsArgumentProcessorCapabilities();
             Assert.AreEqual("/Settings", capabilities.CommandName);
-            Assert.AreEqual("--Settings|/Settings:<Settings File>\n      Settings to use when running tests.", capabilities.HelpContentResourceName);
+            Assert.AreEqual("--Settings|/Settings:<Settings File>" + Environment.NewLine + "      Settings to use when running tests.", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.RunSettingsArgumentProcessorHelpPriority, capabilities.HelpPriority);
             Assert.AreEqual(false, capabilities.IsAction);

--- a/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         {
             RunSpecificTestsArgumentProcessorCapabilities capabilities = new RunSpecificTestsArgumentProcessorCapabilities();
             Assert.AreEqual("/Tests", capabilities.CommandName);
-            StringAssert.Contains(capabilities.HelpContentResourceName, "/Tests:<Test Names>\n      Run tests with names that match the provided values.");
+            StringAssert.Contains(capabilities.HelpContentResourceName, "/Tests:<Test Names>" + Environment.NewLine + "      Run tests with names that match the provided values.");
 
             Assert.AreEqual(HelpContentPriority.RunSpecificTestsArgumentProcessorHelpPriority, capabilities.HelpPriority);
             Assert.AreEqual(true, capabilities.IsAction);

--- a/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         {
             RunTestsArgumentProcessorCapabilities capabilities = new RunTestsArgumentProcessorCapabilities();
             Assert.AreEqual("/RunTests", capabilities.CommandName);
-            Assert.AreEqual("[TestFileNames]\n      Run tests from the specified files. Separate multiple test file names\n      by spaces.\n      Examples: mytestproject.dll\n                mytestproject.dll myothertestproject.exe", capabilities.HelpContentResourceName);
+            Assert.AreEqual("[TestFileNames]" + Environment.NewLine + "      Run tests from the specified files. Separate multiple test file names" + Environment.NewLine + "      by spaces." + Environment.NewLine + "      Examples: mytestproject.dll" + Environment.NewLine + "                mytestproject.dll myothertestproject.exe", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.RunTestsArgumentProcessorHelpPriority, capabilities.HelpPriority);
             Assert.AreEqual(true, capabilities.IsAction);

--- a/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         {
             var capabilities = new TestAdapterPathArgumentProcessorCapabilities();
             Assert.AreEqual("/TestAdapterPath", capabilities.CommandName);
-            Assert.AreEqual("--TestAdapterPath|/TestAdapterPath\n      This makes vstest.console.exe process use custom test adapters\n      from a given path (if any) in the test run. \n      Example  /TestAdapterPath:<pathToCustomAdapters>", capabilities.HelpContentResourceName);
+            Assert.AreEqual("--TestAdapterPath|/TestAdapterPath" + Environment.NewLine + "      This makes vstest.console.exe process use custom test adapters" + Environment.NewLine + "      from a given path (if any) in the test run. " + Environment.NewLine + "      Example  /TestAdapterPath:<pathToCustomAdapters>", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.TestAdapterPathArgumentProcessorHelpPriority, capabilities.HelpPriority);
             Assert.AreEqual(false, capabilities.IsAction);


### PR DESCRIPTION
## Description
fixes test to use Newline instead of \r\n
we still don't know why it passes locally in command line and fails in VS. we are trying to unblock realsign build