### PR TITLE
Fix flakiness of BlameDataCollectorShouldOutputDumpFile acceptance test

### DIFF
--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionAttachmentManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionAttachmentManager.cs
@@ -24,6 +24,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
     /// </summary>
     internal class DataCollectionAttachmentManager : IDataCollectionAttachmentManager
     {
+        private static object lockObject = new object();
+
         #region Fields
 
         /// <summary>
@@ -312,9 +314,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
                     {
                         if (t.Exception == null)
                         {
-                        // Uri doesn't recognize file paths in unix. See https://github.com/dotnet/corefx/issues/1745
-                        var attachmentUri = new UriBuilder() { Scheme = "file", Host = "", Path = localFilePath }.Uri;
-                            this.AttachmentSets[fileTransferInfo.Context][uri].Attachments.Add(new UriDataAttachment(attachmentUri, fileTransferInfo.Description));
+                            lock (lockObject)
+                            {
+                                // Uri doesn't recognize file paths in unix. See https://github.com/dotnet/corefx/issues/1745
+                                var attachmentUri = new UriBuilder() { Scheme = "file", Host = "", Path = localFilePath }.Uri;
+                                this.AttachmentSets[fileTransferInfo.Context][uri].Attachments.Add(new UriDataAttachment(attachmentUri, fileTransferInfo.Description));
+                            }
                         }
 
                         if (sendFileCompletedCallback != null)

--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionAttachmentManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionAttachmentManager.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
     /// </summary>
     internal class DataCollectionAttachmentManager : IDataCollectionAttachmentManager
     {
-        private static object lockObject = new object();
+        private static object attachmentTaskLock = new object();
 
         #region Fields
 
@@ -314,10 +314,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
                     {
                         if (t.Exception == null)
                         {
-                            lock (lockObject)
+                            // Uri doesn't recognize file paths in unix. See https://github.com/dotnet/corefx/issues/1745
+                            var attachmentUri = new UriBuilder() { Scheme = "file", Host = "", Path = localFilePath }.Uri;
+                            lock (attachmentTaskLock)
                             {
-                                // Uri doesn't recognize file paths in unix. See https://github.com/dotnet/corefx/issues/1745
-                                var attachmentUri = new UriBuilder() { Scheme = "file", Host = "", Path = localFilePath }.Uri;
                                 this.AttachmentSets[fileTransferInfo.Context][uri].Attachments.Add(new UriDataAttachment(attachmentUri, fileTransferInfo.Description));
                             }
                         }

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
@@ -174,7 +174,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                 }
                 catch (FileNotFoundException ex)
                 {
-                    this.logger.LogError(args.Context, ex.Message);
+                    this.logger.LogWarning(args.Context, ex.Message);
                 }
             }
 
@@ -204,7 +204,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                     EqtTrace.Warning("BlameCollector.TestHostLaunched_Handler: Could not start process dump. {0}", e);
                 }
 
-                this.logger.LogError(args.Context, e.Message);
+                this.logger.LogWarning(args.Context, e.Message);
             }
             catch (Exception e)
             {
@@ -213,7 +213,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                     EqtTrace.Warning("BlameCollector.TestHostLaunched_Handler: Could not start process dump. {0}", e);
                 }
 
-                this.logger.LogError(args.Context, e.ToString());
+                this.logger.LogWarning(args.Context, e.ToString());
             }
         }
 

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameCollectorTests.cs
@@ -155,7 +155,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
         /// The trigger session ended handler should log exception if GetDumpfile throws FileNotFound Exception
         /// </summary>
         [TestMethod]
-        public void TriggerSessionEndedHandlerShouldLogErrorIfGetDumpFileThrowsFileNotFound()
+        public void TriggerSessionEndedHandlerShouldLogWarningIfGetDumpFileThrowsFileNotFound()
         {
             // Initializing Blame Data Collector
             this.blameDataCollector.Initialize(
@@ -171,7 +171,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockDataColectionEvents.Raise(x => x.SessionEnd += null, new SessionEndEventArgs(this.dataCollectionContext));
 
             // Verify GetDumpFiles Call
-            this.mockLogger.Verify(x => x.LogError(It.IsAny<DataCollectionContext>(), It.IsAny<string>()), Times.Once);
+            this.mockLogger.Verify(x => x.LogWarning(It.IsAny<DataCollectionContext>(), It.IsAny<string>()), Times.Once);
         }
 
         /// <summary>
@@ -218,7 +218,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockDataColectionEvents.Raise(x => x.TestHostLaunched += null, new TestHostLaunchedEventArgs(this.dataCollectionContext, 1234));
 
             // Verify
-            this.mockLogger.Verify(x => x.LogError(It.IsAny<DataCollectionContext>(), It.Is<string>(str => str == tpex.Message)), Times.Once);
+            this.mockLogger.Verify(x => x.LogWarning(It.IsAny<DataCollectionContext>(), It.Is<string>(str => str == tpex.Message)), Times.Once);
         }
 
         /// <summary>
@@ -244,7 +244,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockDataColectionEvents.Raise(x => x.TestHostLaunched += null, new TestHostLaunchedEventArgs(this.dataCollectionContext, 1234));
 
             // Verify
-            this.mockLogger.Verify(x => x.LogError(It.IsAny<DataCollectionContext>(), It.Is<string>(str => str == ex.ToString())), Times.Once);
+            this.mockLogger.Verify(x => x.LogWarning(It.IsAny<DataCollectionContext>(), It.Is<string>(str => str == ex.ToString())), Times.Once);
         }
 
         [TestCleanup]


### PR DESCRIPTION
This PR fixes the occasional failing of BlameDataCollectorShouldOutputDumpFile acceptance test
This PR also changes BlameCollector's LogErrors to LogWarnings
