### PR TITLE
Fix socket exception on datacollection in parallel

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/LengthPrefixCommunicationChannel.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/LengthPrefixCommunicationChannel.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             }
             catch (Exception ex)
             {
-                EqtTrace.Verbose("LengthPrefixCommunicationChannel.Send: Error sending data: {0}.", ex);
+                EqtTrace.Error("LengthPrefixCommunicationChannel.Send: Error sending data: {0}.", ex);
                 throw new CommunicationException("Unable to send data over channel.", ex);
             }
 
@@ -68,9 +68,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             // connection is closed.
             if (this.MessageReceived != null)
             {
-                EqtTrace.Verbose("LengthPrefixCommunicationChannel.NotifyDataAvailable: Start reading data. ");
                 var data = this.reader.ReadString();
-                EqtTrace.Verbose("LengthPrefixCommunicationChannel.NotifyDataAvailable: received data: {0}", data);
                 this.MessageReceived.SafeInvoke(this, new MessageReceivedEventArgs { Data = data }, "LengthPrefixCommunicationChannel: MessageReceived");
             }
 

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/LengthPrefixCommunicationChannel.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/LengthPrefixCommunicationChannel.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             }
             catch (Exception ex)
             {
-                EqtTrace.Verbose("LengthPrefixCommunicationChannel: Error sending data: {0}.", ex);
+                EqtTrace.Verbose("LengthPrefixCommunicationChannel.Send: Error sending data: {0}.", ex);
                 throw new CommunicationException("Unable to send data over channel.", ex);
             }
 
@@ -69,6 +69,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             if (this.MessageReceived != null)
             {
                 var data = this.reader.ReadString();
+                EqtTrace.Verbose("LengthPrefixCommunicationChannel.NotifyDataAvailable: received data: {0}", data);
                 this.MessageReceived.SafeInvoke(this, new MessageReceivedEventArgs { Data = data }, "LengthPrefixCommunicationChannel: MessageReceived");
             }
 
@@ -78,6 +79,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         /// <inheritdoc />
         public void Dispose()
         {
+            EqtTrace.Verbose("LengthPrefixCommunicationChannel.Dispose: Dispose reader and writer.");
             this.reader.Dispose();
             this.writer.Dispose();
         }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/LengthPrefixCommunicationChannel.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/LengthPrefixCommunicationChannel.cs
@@ -68,6 +68,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             // connection is closed.
             if (this.MessageReceived != null)
             {
+                EqtTrace.Verbose("LengthPrefixCommunicationChannel.NotifyDataAvailable: Start reading data. ");
                 var data = this.reader.ReadString();
                 EqtTrace.Verbose("LengthPrefixCommunicationChannel.NotifyDataAvailable: received data: {0}", data);
                 this.MessageReceived.SafeInvoke(this, new MessageReceivedEventArgs { Data = data }, "LengthPrefixCommunicationChannel: MessageReceived");

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketClient.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketClient.cs
@@ -53,10 +53,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             this.endPoint = endPoint;
             var ipEndPoint = endPoint.GetIPEndPoint();
 
-            if (EqtTrace.IsVerboseEnabled)
-            {
-                EqtTrace.Verbose("SocketClient.Start: connecting to server endpoint: {0}", endPoint);
-            }
+            EqtTrace.Info("SocketClient.Start: connecting to server endpoint: {0}", endPoint);
 
             // Don't start if the endPoint port is zero
             this.tcpClient.ConnectAsync(ipEndPoint.Address, ipEndPoint.Port).ContinueWith(this.OnServerConnected);
@@ -66,7 +63,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         /// <inheritdoc />
         public void Stop()
         {
-            EqtTrace.Verbose("SocketClient.Stop: connecting to server endpoint: {0}", this.endPoint);
+            EqtTrace.Info("SocketClient.Stop: Stop communication from server endpoint: {0}", this.endPoint);
 
             if (!this.stopped)
             {
@@ -77,7 +74,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         private void OnServerConnected(Task connectAsyncTask)
         {
-            EqtTrace.Verbose("SocketClient.OnServerConnected: connected to server endpoint: {0}", this.endPoint);
+            EqtTrace.Info("SocketClient.OnServerConnected: connected to server endpoint: {0}", this.endPoint);
 
             if (this.Connected != null)
             {
@@ -111,7 +108,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         private void Stop(Exception error)
         {
-            EqtTrace.Verbose("SocketClient.Stop: connected to server endpoint: {0}, error:{1}", this.endPoint, error);
+            EqtTrace.Info("SocketClient.PrivateStop: Stop communication from server endpoint: {0}, error:{1}", this.endPoint, error);
 
             if (!this.stopped)
             {

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketClient.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketClient.cs
@@ -24,6 +24,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         private readonly Func<Stream, ICommunicationChannel> channelFactory;
         private ICommunicationChannel channel;
         private bool stopped;
+        private string endPoint;
 
         public SocketClient()
             : this(stream => new LengthPrefixCommunicationChannel(stream))
@@ -49,11 +50,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         /// <inheritdoc />
         public string Start(string endPoint)
         {
+            this.endPoint = endPoint;
             var ipEndPoint = endPoint.GetIPEndPoint();
 
             if (EqtTrace.IsVerboseEnabled)
             {
-                EqtTrace.Verbose("Waiting for connecting to server");
+                EqtTrace.Verbose("SocketClient.Start: connecting to server endpoint: {0}", endPoint);
             }
 
             // Don't start if the endPoint port is zero
@@ -64,6 +66,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         /// <inheritdoc />
         public void Stop()
         {
+            EqtTrace.Verbose("SocketClient.Stop: connecting to server endpoint: {0}", this.endPoint);
+
             if (!this.stopped)
             {
                 EqtTrace.Info("SocketClient: Stop: Cancellation requested. Stopping message loop.");
@@ -73,6 +77,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         private void OnServerConnected(Task connectAsyncTask)
         {
+            EqtTrace.Verbose("SocketClient.OnServerConnected: connected to server endpoint: {0}", this.endPoint);
+
             if (this.Connected != null)
             {
                 if (connectAsyncTask.IsFaulted)
@@ -105,6 +111,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         private void Stop(Exception error)
         {
+            EqtTrace.Verbose("SocketClient.Stop: connected to server endpoint: {0}, error:{1}", this.endPoint, error);
+
             if (!this.stopped)
             {
                 // Do not allow stop to be called multiple times.

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
@@ -31,6 +31,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         private bool stopped;
 
+        private string endPoint;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SocketServer"/> class.
         /// </summary>
@@ -60,12 +62,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         public string Start(string endPoint)
         {
-            this.tcpListener = new TcpListener(endPoint.GetIPEndPoint());
+            this.endPoint = endPoint;
+            this.tcpListener = new TcpListener(this.endPoint.GetIPEndPoint());
 
             this.tcpListener.Start();
 
             var connectionInfo = ((IPEndPoint)this.tcpListener.LocalEndpoint).ToString();
-            EqtTrace.Info("SocketServer: Listening on end point : {0}", connectionInfo);
+            EqtTrace.Info("SocketServer.Start: Listening on endpoint : {0}", connectionInfo);
 
             // Serves a single client at the moment. An error in connection, or message loop just
             // terminates the entire server.
@@ -76,9 +79,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         /// <inheritdoc />
         public void Stop()
         {
+            EqtTrace.Info("SocketServer.Stop: Stopping server endpoint: {0}", this.endPoint);
             if (!this.stopped)
             {
-                EqtTrace.Info("SocketServer: Stop: Cancellation requested. Stopping message loop.");
+                EqtTrace.Info("SocketServer.Stop: Cancellation requested. Stopping message loop.");
                 this.cancellation.Cancel();
             }
         }
@@ -95,7 +99,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
                 if (EqtTrace.IsVerboseEnabled)
                 {
-                    EqtTrace.Verbose("Client connected, and starting MessageLoopAsync");
+                    EqtTrace.Verbose("SocketServer.OnClientConnected: Client connected for endpoint: {0}, starting MessageLoopAsync:", this.endPoint);
                 }
 
                 // Start the message loop
@@ -105,6 +109,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         private void Stop(Exception error)
         {
+            EqtTrace.Info("SocketServer.Stop: Stopping server endpoint: {0} error: {1}", this.endPoint, error);
+
             if (!this.stopped)
             {
                 // Do not allow stop to be called multiple times.

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
@@ -11,7 +11,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
     using System.Threading.Tasks;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-    using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
     using Microsoft.VisualStudio.TestPlatform.Utilities;
 
     /// <summary>
@@ -31,7 +30,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         private bool stopped;
 
-        private string connectionInfo;
+        private string endPoint;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SocketServer"/> class.
@@ -62,24 +61,23 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         public string Start(string endPoint)
         {
-            this.connectionInfo = endPoint;
-            this.tcpListener = new TcpListener(this.connectionInfo.GetIPEndPoint());
+            this.tcpListener = new TcpListener(endPoint.GetIPEndPoint());
 
             this.tcpListener.Start();
 
-            this.connectionInfo = ((IPEndPoint)this.tcpListener.LocalEndpoint).ToString();
-            EqtTrace.Info("SocketServer.Start: Listening on endpoint : {0}", this.connectionInfo);
+            this.endPoint = ((IPEndPoint)this.tcpListener.LocalEndpoint).ToString();
+            EqtTrace.Info("SocketServer.Start: Listening on endpoint : {0}", this.endPoint);
 
             // Serves a single client at the moment. An error in connection, or message loop just
             // terminates the entire server.
             this.tcpListener.AcceptTcpClientAsync().ContinueWith(t => this.OnClientConnected(t.Result));
-            return this.connectionInfo;
+            return this.endPoint;
         }
 
         /// <inheritdoc />
         public void Stop()
         {
-            EqtTrace.Info("SocketServer.Stop: Stopping server connectionInfo: {0}", this.connectionInfo);
+            EqtTrace.Info("SocketServer.Stop: Stop server endPoint: {0}", this.endPoint);
             if (!this.stopped)
             {
                 EqtTrace.Info("SocketServer.Stop: Cancellation requested. Stopping message loop.");
@@ -99,7 +97,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
                 if (EqtTrace.IsVerboseEnabled)
                 {
-                    EqtTrace.Verbose("SocketServer.OnClientConnected: Client connected for connectionInfo: {0}, starting MessageLoopAsync:", this.connectionInfo);
+                    EqtTrace.Verbose("SocketServer.OnClientConnected: Client connected for endPoint: {0}, starting MessageLoopAsync:", this.endPoint);
                 }
 
                 // Start the message loop
@@ -109,7 +107,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         private void Stop(Exception error)
         {
-            EqtTrace.Info("SocketServer.Stop: Stopping server connectionInfo: {0} error: {1}", this.connectionInfo, error);
+            EqtTrace.Info("SocketServer.PrivateStop: Stopp server endPoint: {0} error: {1}", this.endPoint, error);
 
             if (!this.stopped)
             {
@@ -130,7 +128,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 this.channel.Dispose();
                 this.cancellation.Dispose();
 
-                EqtTrace.Info("SocketServer.Stop: Raise disconnected event connectionInfo: {0} error: {1}", this.connectionInfo, error);
+                EqtTrace.Info("SocketServer.Stop: Raise disconnected event endPoint: {0} error: {1}", this.endPoint, error);
                 this.Disconnected?.SafeInvoke(this, new DisconnectedEventArgs { Error = error }, "SocketServer: ClientDisconnected");
             }
         }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         private bool stopped;
 
-        private string endPoint;
+        private string connectionInfo;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SocketServer"/> class.
@@ -62,24 +62,24 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         public string Start(string endPoint)
         {
-            this.endPoint = endPoint;
-            this.tcpListener = new TcpListener(this.endPoint.GetIPEndPoint());
+            this.connectionInfo = endPoint;
+            this.tcpListener = new TcpListener(this.connectionInfo.GetIPEndPoint());
 
             this.tcpListener.Start();
 
-            var connectionInfo = ((IPEndPoint)this.tcpListener.LocalEndpoint).ToString();
-            EqtTrace.Info("SocketServer.Start: Listening on endpoint : {0}", connectionInfo);
+            this.connectionInfo = ((IPEndPoint)this.tcpListener.LocalEndpoint).ToString();
+            EqtTrace.Info("SocketServer.Start: Listening on endpoint : {0}", this.connectionInfo);
 
             // Serves a single client at the moment. An error in connection, or message loop just
             // terminates the entire server.
             this.tcpListener.AcceptTcpClientAsync().ContinueWith(t => this.OnClientConnected(t.Result));
-            return connectionInfo;
+            return this.connectionInfo;
         }
 
         /// <inheritdoc />
         public void Stop()
         {
-            EqtTrace.Info("SocketServer.Stop: Stopping server endpoint: {0}", this.endPoint);
+            EqtTrace.Info("SocketServer.Stop: Stopping server connectionInfo: {0}", this.connectionInfo);
             if (!this.stopped)
             {
                 EqtTrace.Info("SocketServer.Stop: Cancellation requested. Stopping message loop.");
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
                 if (EqtTrace.IsVerboseEnabled)
                 {
-                    EqtTrace.Verbose("SocketServer.OnClientConnected: Client connected for endpoint: {0}, starting MessageLoopAsync:", this.endPoint);
+                    EqtTrace.Verbose("SocketServer.OnClientConnected: Client connected for connectionInfo: {0}, starting MessageLoopAsync:", this.connectionInfo);
                 }
 
                 // Start the message loop
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         private void Stop(Exception error)
         {
-            EqtTrace.Info("SocketServer.Stop: Stopping server endpoint: {0} error: {1}", this.endPoint, error);
+            EqtTrace.Info("SocketServer.Stop: Stopping server connectionInfo: {0} error: {1}", this.connectionInfo, error);
 
             if (!this.stopped)
             {
@@ -130,6 +130,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 this.channel.Dispose();
                 this.cancellation.Dispose();
 
+                EqtTrace.Info("SocketServer.Stop: Raise disconnected event connectionInfo: {0} error: {1}", this.connectionInfo, error);
                 this.Disconnected?.SafeInvoke(this, new DisconnectedEventArgs { Error = error }, "SocketServer: ClientDisconnected");
             }
         }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TcpClientExtensions.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TcpClientExtensions.cs
@@ -67,8 +67,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 catch (Exception exception)
                 {
                     EqtTrace.Error(
-                            "Socket: Message loop: failed to receive message {0}",
-                            exception);
+                            "Socket: Message loop: failed to receive message {0}, remoteendPoint: {1} localEndPoint: {2}",
+                            exception,
+                        remoteEndPoint,
+                        localEndPoint);
                     error = exception;
                     break;
                 }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TcpClientExtensions.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TcpClientExtensions.cs
@@ -25,19 +25,19 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 CancellationToken cancellationToken)
         {
             Exception error = null;
-            var remoteEndPoint = ((IPEndPoint)client.Client.RemoteEndPoint).ToString();
-            var localEndPoint = ((IPEndPoint)client.Client.LocalEndPoint).ToString();
+            var remoteEndPoint = client.Client.RemoteEndPoint.ToString();
+            var localEndPoint = client.Client.LocalEndPoint.ToString();
 
             // Set read timeout to avoid blocking receive raw message
             while (channel != null && !cancellationToken.IsCancellationRequested)
             {
-                EqtTrace.Verbose("TcpClientExtensions.MessageLoopAsync: loop starting: remoteendPoint: {0} localEndPoint: {1}", remoteEndPoint, localEndPoint);
+                EqtTrace.Verbose("TcpClientExtensions.MessageLoopAsync: Polling on remoteEndPoint: {0} localEndPoint: {1}", remoteEndPoint, localEndPoint);
 
                 try
                 {
                     if (client.Client.Poll(STREAMREADTIMEOUT, SelectMode.SelectRead))
                     {
-                        EqtTrace.Verbose("TcpClientExtensions.MessageLoopAsync: NotifyDataAvailable remoteendPoint: {0} localEndPoint: {1}", remoteEndPoint, localEndPoint);
+                        EqtTrace.Verbose("TcpClientExtensions.MessageLoopAsync: NotifyDataAvailable remoteEndPoint: {0} localEndPoint: {1}", remoteEndPoint, localEndPoint);
                         channel.NotifyDataAvailable();
                     }
                 }
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                             && socketException.SocketErrorCode == SocketError.TimedOut)
                     {
                         EqtTrace.Info(
-                                "Socket: Message loop: failed to receive message due to read timeout {0}, remoteendPoint: {1} localEndPoint: {2}",
+                                "Socket: Message loop: failed to receive message due to read timeout {0}, remoteEndPoint: {1} localEndPoint: {2}",
                                 ioException,
                                 remoteEndPoint,
                                 localEndPoint);
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                     else
                     {
                         EqtTrace.Error(
-                                "Socket: Message loop: failed to receive message due to socket error {0}, remoteendPoint: {1} localEndPoint: {2}",
+                                "Socket: Message loop: failed to receive message due to socket error {0}, remoteEndPoint: {1} localEndPoint: {2}",
                                 ioException,
                                 remoteEndPoint,
                                 localEndPoint);
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 catch (Exception exception)
                 {
                     EqtTrace.Error(
-                            "Socket: Message loop: failed to receive message {0}, remoteendPoint: {1} localEndPoint: {2}",
+                            "Socket: Message loop: failed to receive message {0}, remoteEndPoint: {1} localEndPoint: {2}",
                             exception,
                         remoteEndPoint,
                         localEndPoint);
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             // Try clean up and raise client disconnected events
             errorHandler(error);
 
-            EqtTrace.Verbose("TcpClientExtensions.MessageLoopAsync: exiting MessageLoopAsync remoteendPoint: {0} localEndPoint: {1}", remoteEndPoint, localEndPoint);
+            EqtTrace.Verbose("TcpClientExtensions.MessageLoopAsync: exiting MessageLoopAsync remoteEndPoint: {0} localEndPoint: {1}", remoteEndPoint, localEndPoint);
 
             return Task.FromResult(0);
         }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TcpClientExtensions.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TcpClientExtensions.cs
@@ -25,14 +25,19 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 CancellationToken cancellationToken)
         {
             Exception error = null;
+            var remoteEndPoint = ((IPEndPoint)client.Client.RemoteEndPoint).ToString();
+            var localEndPoint = ((IPEndPoint)client.Client.LocalEndPoint).ToString();
 
             // Set read timeout to avoid blocking receive raw message
             while (channel != null && !cancellationToken.IsCancellationRequested)
             {
+                EqtTrace.Verbose("TcpClientExtensions.MessageLoopAsync: loop starting: remoteendPoint: {0} localEndPoint: {1}", remoteEndPoint, localEndPoint);
+
                 try
                 {
                     if (client.Client.Poll(STREAMREADTIMEOUT, SelectMode.SelectRead))
                     {
+                        EqtTrace.Verbose("TcpClientExtensions.MessageLoopAsync: NotifyDataAvailable remoteendPoint: {0} localEndPoint: {1}", remoteEndPoint, localEndPoint);
                         channel.NotifyDataAvailable();
                     }
                 }
@@ -43,14 +48,18 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                             && socketException.SocketErrorCode == SocketError.TimedOut)
                     {
                         EqtTrace.Info(
-                                "Socket: Message loop: failed to receive message due to read timeout {0}",
-                                ioException);
+                                "Socket: Message loop: failed to receive message due to read timeout {0}, remoteendPoint: {1} localEndPoint: {2}",
+                                ioException,
+                                remoteEndPoint,
+                                localEndPoint);
                     }
                     else
                     {
                         EqtTrace.Error(
-                                "Socket: Message loop: failed to receive message due to socket error {0}",
-                                ioException);
+                                "Socket: Message loop: failed to receive message due to socket error {0}, remoteendPoint: {1} localEndPoint: {2}",
+                                ioException,
+                                remoteEndPoint,
+                                localEndPoint);
                         error = ioException;
                         break;
                     }
@@ -67,6 +76,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
             // Try clean up and raise client disconnected events
             errorHandler(error);
+
+            EqtTrace.Verbose("TcpClientExtensions.MessageLoopAsync: exiting MessageLoopAsync remoteendPoint: {0} localEndPoint: {1}", remoteEndPoint, localEndPoint);
 
             return Task.FromResult(0);
         }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -384,14 +384,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             try
             {
                 var rawMessage = messageReceived.Data;
-
-                if (this.IsOperationComplete())
-                {
-                    EqtTrace.Verbose("TestRequestSender: OnExecutionMessageReceived: Operation is already complete. Skip additional messages. message: {0}", rawMessage);
-
-                    // return;
-                }
-
                 if (EqtTrace.IsVerboseEnabled)
                 {
                     EqtTrace.Verbose("TestRequestSender.OnExecutionMessageReceived: Received message: {0}", rawMessage);
@@ -451,13 +443,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             try
             {
                 var rawMessage = args.Data;
-
-                if (this.IsOperationComplete())
-                {
-                    EqtTrace.Verbose("TestRequestSender: OnDiscoveryMessageReceived: Operation is already complete. Skip additional messages. message: {0}", rawMessage);
-
-                    // return;
-                }
 
                 // Currently each of the operations are not separate tasks since they should not each take much time. This is just a notification.
                 if (EqtTrace.IsVerboseEnabled)

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -384,6 +384,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             try
             {
                 var rawMessage = messageReceived.Data;
+
+                if (this.IsOperationComplete())
+                {
+                    EqtTrace.Verbose("TestRequestSender: OnExecutionMessageReceived: Operation is already complete. Skip additional messages. message: {0}", rawMessage);
+                    return;
+                }
+
                 if (EqtTrace.IsVerboseEnabled)
                 {
                     EqtTrace.Verbose("TestRequestSender.OnExecutionMessageReceived: Received message: {0}", rawMessage);
@@ -443,6 +450,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             try
             {
                 var rawMessage = args.Data;
+
+                if (this.IsOperationComplete())
+                {
+                    EqtTrace.Verbose("TestRequestSender: OnDiscoveryMessageReceived: Operation is already complete. Skip additional messages. message: {0}", rawMessage);
+                    return;
+                }
 
                 // Currently each of the operations are not separate tasks since they should not each take much time. This is just a notification.
                 if (EqtTrace.IsVerboseEnabled)

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -611,6 +611,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 EqtTrace.Verbose("TestRequestSender.SetOperationComplete: Setting operation complete.");
             }
 
+            this.communicationEndpoint.Stop();
             Interlocked.CompareExchange(ref this.operationCompleted, 1, 0);
         }
 

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -388,7 +388,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 if (this.IsOperationComplete())
                 {
                     EqtTrace.Verbose("TestRequestSender: OnExecutionMessageReceived: Operation is already complete. Skip additional messages. message: {0}", rawMessage);
-                    return;
+
+                    // return;
                 }
 
                 if (EqtTrace.IsVerboseEnabled)
@@ -454,7 +455,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 if (this.IsOperationComplete())
                 {
                     EqtTrace.Verbose("TestRequestSender: OnDiscoveryMessageReceived: Operation is already complete. Skip additional messages. message: {0}", rawMessage);
-                    return;
+
+                    // return;
                 }
 
                 // Currently each of the operations are not separate tasks since they should not each take much time. This is just a notification.

--- a/src/Microsoft.TestPlatform.CoreUtilities/Utilities/MulticastDelegateUtilities.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Utilities/MulticastDelegateUtilities.cs
@@ -41,6 +41,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
                 {
                     try
                     {
+                        EqtTrace.Verbose("MulticastDelegateUtilities.SafeInvoke: {0}", handler);
                         handler.DynamicInvoke(sender, args);
                     }
                     catch (TargetInvocationException e)

--- a/src/Microsoft.TestPlatform.CoreUtilities/Utilities/MulticastDelegateUtilities.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Utilities/MulticastDelegateUtilities.cs
@@ -41,7 +41,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
                 {
                     try
                     {
-                        EqtTrace.Verbose("MulticastDelegateUtilities.SafeInvoke: {0}", handler);
                         handler.DynamicInvoke(sender, args);
                     }
                     catch (TargetInvocationException e)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
@@ -204,7 +204,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
             var connected = this.dataCollectionRequestSender.WaitForRequestHandlerConnection(this.connectionTimeout);
             if (connected == false)
             {
-                EqtTrace.Error("ProxyDataCollectionManager.Initialize: failed to connect to datacollector process.");
+                EqtTrace.Error("ProxyDataCollectionManager.Initialize: failed to connect to datacollector process, processId: {0} port: {1}", this.dataCollectionProcessId, this.dataCollectionPort);
                 throw new TestPlatformException(string.Format(CultureInfo.CurrentUICulture, CrossPlatEngineResources.FailedToConnectDataCollector));
             }
         }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
@@ -128,7 +128,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
             this.InvokeDataCollectionServiceAction(
            () =>
            {
-               EqtTrace.Verbose("ProxyDataCollectionManager.AfterTestRunEnd: Get attachment set for datacollector processId: {0} port: {1}", dataCollectionProcessId, dataCollectionPort);
+               EqtTrace.Info("ProxyDataCollectionManager.AfterTestRunEnd: Get attachment set for datacollector processId: {0} port: {1}", dataCollectionProcessId, dataCollectionPort);
                attachmentSet = this.dataCollectionRequestSender.SendAfterTestRunStartAndGetResult(runEventsHandler, isCanceled);
            },
                 runEventsHandler);
@@ -162,12 +162,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
             this.InvokeDataCollectionServiceAction(
             () =>
             {
-                EqtTrace.Verbose("ProxyDataCollectionManager.BeforeTestRunStart: Get env variable and port for datacollector processId: {0} port: {1}", this.dataCollectionProcessId, this.dataCollectionPort);
+                EqtTrace.Info("ProxyDataCollectionManager.BeforeTestRunStart: Get env variable and port for datacollector processId: {0} port: {1}", this.dataCollectionProcessId, this.dataCollectionPort);
                 var result = this.dataCollectionRequestSender.SendBeforeTestRunStartAndGetResult(this.settingsXml, runEventsHandler);
                 environmentVariables = result.EnvironmentVariables;
                 dataCollectionEventsPort = result.DataCollectionEventsPort;
 
-                EqtTrace.Verbose(
+                EqtTrace.Info(
                     "ProxyDataCollectionManager.BeforeTestRunStart: SendBeforeTestRunStartAndGetResult successful, env variable from datacollector: {0}  and testhost port: {1}",
                     string.Join(";", environmentVariables),
                     dataCollectionEventsPort);
@@ -184,7 +184,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
         /// </summary>
         public void Dispose()
         {
-            EqtTrace.Verbose("ProxyDataCollectionManager.Dispose: calling dospose for datacollector processId: {0} port: {1}", this.dataCollectionProcessId, this.dataCollectionPort);
+            EqtTrace.Info("ProxyDataCollectionManager.Dispose: calling dospose for datacollector processId: {0} port: {1}", this.dataCollectionProcessId, this.dataCollectionPort);
             this.dataCollectionRequestSender.Close();
         }
 
@@ -195,11 +195,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
 
             // Warn the user that execution will wait for debugger attach.
             this.dataCollectionProcessId = this.dataCollectionLauncher.LaunchDataCollector(null, this.GetCommandLineArguments(this.dataCollectionPort));
-            EqtTrace.Verbose("ProxyDataCollectionManager.Initialize: Launched datacollector processId: {0} port: {1}", this.dataCollectionProcessId, this.dataCollectionPort);
+            EqtTrace.Info("ProxyDataCollectionManager.Initialize: Launched datacollector processId: {0} port: {1}", this.dataCollectionProcessId, this.dataCollectionPort);
 
             ChangeConnectionTimeoutIfRequired(dataCollectionProcessId);
 
-            EqtTrace.Verbose("ProxyDataCollectionManager.Initialize: waiting for connection with timeout: {0}", this.connectionTimeout);
+            EqtTrace.Info("ProxyDataCollectionManager.Initialize: waiting for connection with timeout: {0}", this.connectionTimeout);
 
             var connected = this.dataCollectionRequestSender.WaitForRequestHandlerConnection(this.connectionTimeout);
             if (connected == false)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
@@ -389,11 +389,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         private void SendData(string data)
         {
-            if (EqtTrace.IsVerboseEnabled)
-            {
-                EqtTrace.Verbose("TestRequestHandler.SendData:  sending data from testhost: {0}", data);
-            }
-
+            EqtTrace.Verbose("TestRequestHandler.SendData:  sending data from testhost: {0}", data);
             this.channel.Send(data);
         }
     }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
@@ -10,7 +10,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.EventHandlers;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
-    using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.EventHandlers;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
@@ -20,7 +19,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
     using Microsoft.VisualStudio.TestPlatform.Utilities;
     using CrossPlatResources = Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources.Resources;
-    using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine;
 
     public class TestRequestHandler : IDisposable, ITestRequestHandler
     {
@@ -131,14 +129,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         public void SendTestCases(IEnumerable<TestCase> discoveredTestCases)
         {
             var data = this.dataSerializer.SerializePayload(MessageType.TestCasesFound, discoveredTestCases, this.protocolVersion);
-            this.channel.Send(data);
+            this.SendData(data);
         }
 
         /// <inheritdoc />
         public void SendTestRunStatistics(TestRunChangedEventArgs testRunChangedArgs)
         {
             var data = this.dataSerializer.SerializePayload(MessageType.TestRunStatsChange, testRunChangedArgs, this.protocolVersion);
-            this.channel.Send(data);
+            this.SendData(data);
         }
 
         /// <inheritdoc />
@@ -148,7 +146,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                     MessageType.TestMessage,
                     new TestMessagePayload { MessageLevel = messageLevel, Message = message },
                     this.protocolVersion);
-            this.channel.Send(data);
+            this.SendData(data);
         }
 
         /// <inheritdoc />
@@ -168,7 +166,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                         ExecutorUris = executorUris
                     },
                     this.protocolVersion);
-            this.channel.Send(data);
+            this.SendData(data);
         }
 
         /// <inheritdoc />
@@ -184,7 +182,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                         Metrics = discoveryCompleteEventArgs.Metrics
                     },
                     this.protocolVersion);
-            this.channel.Send(data);
+            this.SendData(data);
         }
 
         /// <inheritdoc />
@@ -201,7 +199,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             var data = dataSerializer.SerializePayload(MessageType.LaunchAdapterProcessWithDebuggerAttached,
                 testProcessStartInfo, protocolVersion);
 
-            this.channel.Send(data);
+            this.SendData(data);
 
             EqtTrace.Verbose("Waiting for LaunchAdapterProcessWithDebuggerAttached ack");
             waitHandle.Wait();
@@ -389,5 +387,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             }
         }
 
+        private void SendData(string data)
+        {
+            if (EqtTrace.IsVerboseEnabled)
+            {
+                EqtTrace.Verbose("TestRequestHandler.SendData:  sending data from testhost: {0}", data);
+            }
+
+            this.channel.Send(data);
+        }
     }
 }

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
@@ -290,6 +290,20 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
         }
 
         [TestMethod]
+        public void DiscoverTestsShouldStopServerOnCompleteMessageReceived()
+        {
+            var completePayload = new DiscoveryCompletePayload { TotalTests = 10, IsAborted = false };
+            this.SetupDeserializeMessage(MessageType.DiscoveryComplete, completePayload);
+            this.SetupFakeCommunicationChannel();
+
+            this.testRequestSender.DiscoverTests(new DiscoveryCriteria(), this.mockDiscoveryEventsHandler.Object);
+
+            this.RaiseMessageReceivedEvent();
+
+            this.mockServer.Verify(ms => ms.Stop());
+        }
+
+        [TestMethod]
         public void DiscoverTestShouldNotifyLogMessageOnTestMessageReceived()
         {
             var message = new TestMessagePayload { MessageLevel = TestMessageLevel.Error, Message = "Message1" };
@@ -503,6 +517,25 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
                     testRunCompletePayload.RunAttachments,
                     It.IsAny<ICollection<string>>()),
                 Times.Once);
+        }
+
+        [TestMethod]
+        public void StartTestRunShouldStopServerOnRunCompleteMessageReceived()
+        {
+            var testRunCompletePayload = new TestRunCompletePayload
+            {
+                TestRunCompleteArgs = new TestRunCompleteEventArgs(null, false, false, null, null, TimeSpan.MaxValue),
+                LastRunTests = new TestRunChangedEventArgs(null, null, null),
+                RunAttachments = new List<AttachmentSet>()
+            };
+            this.SetupDeserializeMessage(MessageType.ExecutionComplete, testRunCompletePayload);
+            this.SetupFakeCommunicationChannel();
+
+            this.testRequestSender.StartTestRun(this.testRunCriteriaWithSources, this.mockExecutionEventsHandler.Object);
+
+            this.RaiseMessageReceivedEvent();
+
+            this.mockServer.Verify(ms => ms.Stop());
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description
**Fix**
- Stop the Server/Client on TestExecution.Completed/TestDiscovery.Completed received.
- Make EqtTrace logging friendly to parallel scenario.

## Related issue
https://github.com/Microsoft/vstest/issues/1472
