### PR TITLE
[Port] Fix datacollectors temporary files cleanup.

### DIFF
--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <TestPlatformRoot Condition="$(TestPlatformRoot) == ''">$(MSBuildThisFileDirectory)../../</TestPlatformRoot>
-    <TPVersionPrefix>15.6.1</TPVersionPrefix>
+    <TPVersionPrefix>15.6.2</TPVersionPrefix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Versioning is defined from the build script. Use a default dev build if it's not defined.

--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
@@ -327,10 +327,30 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
             {
                 if (disposing)
                 {
+                    CleanupPlugins();
                 }
 
                 this.disposed = true;
             }
+        }
+
+        private void CleanupPlugins()
+        {
+            EqtTrace.Info("DataCollectionManager.CleanupPlugins: CleanupPlugins called");
+
+            if (!this.isDataCollectionEnabled)
+            {
+                return;
+            }
+
+            if (EqtTrace.IsVerboseEnabled)
+            {
+                EqtTrace.Verbose("DataCollectionManager.CleanupPlugins: Cleaning up {0} plugins", this.RunDataCollectors.Count);
+            }
+
+            RemoveDataCollectors(new List<DataCollectorInformation>(this.RunDataCollectors.Values));
+
+            EqtTrace.Info("DataCollectionManager.CleanupPlugins: CleanupPlugins finished");
         }
 
         #region Load and Initialize DataCollectors

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DataCollectionTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DataCollectionTests.cs
@@ -120,6 +120,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             this.StdOutputContains("Data collector 'SampleDataCollector' message: SessionEnded");
             this.StdOutputContains("Data collector 'SampleDataCollector' message: my warning");
             this.StdErrorContains("Data collector 'SampleDataCollector' message: Data collector caught an exception of type 'System.Exception': 'my exception'. More details:");
+            this.StdOutputContains("Data collector 'SampleDataCollector' message: Dispose called.");
 
             // Verify attachments
             var isTestRunLevelAttachmentFound = false;

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/DataCollectionRequestHandlerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/DataCollectionRequestHandlerTests.cs
@@ -181,6 +181,16 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
         }
 
         [TestMethod]
+        public void ProcessRequestsShouldDisposeDataCollectorsOnAfterTestRunEnd()
+        {
+            this.mockCommunicationManager.SetupSequence(x => x.ReceiveMessage()).Returns(new Message() { MessageType = MessageType.AfterTestRunEnd, Payload = "false" });
+
+            this.requestHandler.ProcessRequests();
+
+            this.mockDataCollectionManager.Verify(x => x.Dispose());
+        }
+
+        [TestMethod]
         public void ProcessRequestsShouldThrowExceptionIfThrownByCommunicationManager()
         {
             this.mockCommunicationManager.Setup(x => x.ReceiveMessage()).Throws<Exception>();

--- a/test/TestAssets/OutOfProcDataCollector/SampleDataCollector.cs
+++ b/test/TestAssets/OutOfProcDataCollector/SampleDataCollector.cs
@@ -70,5 +70,10 @@ namespace OutOfProcDataCollector
         {
             return new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("key", "value") };
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            this.logger.LogWarning(this.context.SessionDataCollectionContext, "Dispose called.");
+        }
     }
 }


### PR DESCRIPTION
Porting https://github.com/Microsoft/vstest/pull/1483 for 15.6
## Description
- Call Datacollectors dispose before sending attachments to vstest.console.
- Otherwise datacollector temporary files consuming disk space.  

## Related issue
https://github.com/Microsoft/vsts-tasks/issues/6694
https://github.com/Microsoft/testfx/issues/354#issuecomment-363157680
