### PR TITLE
Trim Quotes from start, & end of log file

### DIFF
--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Tracing/PlatformEqtTrace.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Tracing/PlatformEqtTrace.cs
@@ -64,7 +64,17 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         /// <inheritdoc/>
         public bool InitializeVerboseTrace(string customLogFile)
         {
-            LogFile = Path.GetTempPath() + Path.GetFileNameWithoutExtension(customLogFile).Replace(" ", "_") + ".TpTrace.log";
+            string logFileName = string.Empty;
+            try
+            {
+                logFileName = Path.GetFileNameWithoutExtension(customLogFile.TrimStart('"').TrimEnd('"')).Replace(" ", "_");
+            }
+            catch
+            {
+                logFileName = Guid.NewGuid().ToString();
+            }
+
+            LogFile = Path.GetTempPath() + logFileName + ".TpTrace.log";
             TraceLevel = PlatformTraceLevel.Verbose;
 
             return this.TraceInitialized();

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Tracing/PlatformEqtTrace.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Tracing/PlatformEqtTrace.cs
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
                 logFileName = Guid.NewGuid().ToString();
             }
 
-            LogFile = Path.GetTempPath() + logFileName + ".TpTrace.log";
+            LogFile = Path.Combine(Path.GetTempPath(), logFileName, ".TpTrace.log");
             TraceLevel = PlatformTraceLevel.Verbose;
 
             return this.TraceInitialized();


### PR DESCRIPTION
Add try catch as Path.GetFileNameWithoutExtension() can throw exception. If exception is thrown application hangs, so avoiding that.