### PR TITLE
Data collectors present in runsettings not working when collect args are present

### DIFF
--- a/src/vstest.console/Processors/CollectArgumentProcessor.cs
+++ b/src/vstest.console/Processors/CollectArgumentProcessor.cs
@@ -144,21 +144,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             }
         }
 
-        private static void DisableUnConfiguredDataCollectors(DataCollectionRunSettings dataCollectionRunSettings)
-        {
-            foreach (var dataCollectorSetting in dataCollectionRunSettings.DataCollectorSettingsList)
-            {
-                if (EnabledDataCollectors.Contains(dataCollectorSetting.FriendlyName.ToLower()))
-                {
-                    dataCollectorSetting.IsEnabled = true;
-                }
-                else
-                {
-                    dataCollectorSetting.IsEnabled = false;
-                }
-            }
-        }
-
         private static bool DoesDataCollectorSettingsExist(string friendlyName,
             DataCollectionRunSettings dataCollectionRunSettings,
             out DataCollectorSettings dataCollectorSettings)
@@ -191,12 +176,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             if (dataCollectionRunSettings == null)
             {
                 dataCollectionRunSettings = new DataCollectionRunSettings();
-            }
-            else
-            {
-                // By default, all data collectors present in run settings are enabled, if enabled attribute is not specified.
-                // So explicitely disable those data collectors and enable those which are specified. 
-                DisableUnConfiguredDataCollectors(dataCollectionRunSettings);
             }
 
             // Add data collectors if not already present, enable if already present.

--- a/test/vstest.console.UnitTests/Processors/CollectArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CollectArgumentProcessorTests.cs
@@ -136,9 +136,23 @@ namespace vstest.console.UnitTests.Processors
         }
 
         [TestMethod]
-        public void InitializeShouldDisableOtherDataCollectors()
+        public void InitializeShouldNotDisableOtherDataCollectorsIfEnabled()
         {
             var runsettingsString = string.Format(DefaultRunSettings, "<DataCollector friendlyName=\"MyDataCollector\" enabled=\"False\" /><DataCollector friendlyName=\"MyDataCollector1\" enabled=\"True\" />");
+            var runsettings = new RunSettings();
+            runsettings.LoadSettingsXml(runsettingsString);
+            this.settingsProvider.SetActiveRunSettings(runsettings);
+
+            this.executor.Initialize("MyDataCollector");
+            this.executor.Initialize("MyDataCollector2");
+
+            Assert.AreEqual("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors>\r\n      <DataCollector friendlyName=\"MyDataCollector\" enabled=\"True\" />\r\n      <DataCollector friendlyName=\"MyDataCollector1\" enabled=\"True\" />\r\n      <DataCollector friendlyName=\"MyDataCollector2\" enabled=\"True\" />\r\n    </DataCollectors>\r\n  </DataCollectionRunSettings>\r\n</RunSettings>", this.settingsProvider.ActiveRunSettings.SettingsXml);
+        }
+
+        [TestMethod]
+        public void InitializeShouldNotEnableOtherDataCollectorsIfDisabled()
+        {
+            var runsettingsString = string.Format(DefaultRunSettings, "<DataCollector friendlyName=\"MyDataCollector\" enabled=\"False\" /><DataCollector friendlyName=\"MyDataCollector1\" enabled=\"False\" />");
             var runsettings = new RunSettings();
             runsettings.LoadSettingsXml(runsettingsString);
             this.settingsProvider.SetActiveRunSettings(runsettings);


### PR DESCRIPTION
## Description
When few data collectors are present in runsettings and few as collect argument, then runsettings data collectors are disabled.

**Example**: Code coverage data collector coming form runsettings and blame data collector coming as /blame argument. Code coverage gets falsely disabled in this combination and this code coverage file is not generated.

## Related issue
https://github.com/Microsoft/vstest/issues/1473
