### PR TITLE
[Port] Fix socket exception on datacollection in parallel

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/LengthPrefixCommunicationChannel.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/LengthPrefixCommunicationChannel.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             }
             catch (Exception ex)
             {
-                EqtTrace.Verbose("LengthPrefixCommunicationChannel: Error sending data: {0}.", ex);
+                EqtTrace.Error("LengthPrefixCommunicationChannel.Send: Error sending data: {0}.", ex);
                 throw new CommunicationException("Unable to send data over channel.", ex);
             }
 
@@ -78,6 +78,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         /// <inheritdoc />
         public void Dispose()
         {
+            EqtTrace.Verbose("LengthPrefixCommunicationChannel.Dispose: Dispose reader and writer.");
             this.reader.Dispose();
             this.writer.Dispose();
         }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketClient.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketClient.cs
@@ -24,6 +24,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         private readonly Func<Stream, ICommunicationChannel> channelFactory;
         private ICommunicationChannel channel;
         private bool stopped;
+        private string endPoint;
 
         public SocketClient()
             : this(stream => new LengthPrefixCommunicationChannel(stream))
@@ -49,12 +50,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         /// <inheritdoc />
         public string Start(string endPoint)
         {
+            this.endPoint = endPoint;
             var ipEndPoint = endPoint.GetIPEndPoint();
 
-            if (EqtTrace.IsVerboseEnabled)
-            {
-                EqtTrace.Verbose("Waiting for connecting to server");
-            }
+            EqtTrace.Info("SocketClient.Start: connecting to server endpoint: {0}", endPoint);
 
             // Don't start if the endPoint port is zero
             this.tcpClient.ConnectAsync(ipEndPoint.Address, ipEndPoint.Port).ContinueWith(this.OnServerConnected);
@@ -64,6 +63,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         /// <inheritdoc />
         public void Stop()
         {
+            EqtTrace.Info("SocketClient.Stop: Stop communication from server endpoint: {0}", this.endPoint);
+
             if (!this.stopped)
             {
                 EqtTrace.Info("SocketClient: Stop: Cancellation requested. Stopping message loop.");
@@ -73,6 +74,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         private void OnServerConnected(Task connectAsyncTask)
         {
+            EqtTrace.Info("SocketClient.OnServerConnected: connected to server endpoint: {0}", this.endPoint);
+
             if (this.Connected != null)
             {
                 if (connectAsyncTask.IsFaulted)
@@ -105,6 +108,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         private void Stop(Exception error)
         {
+            EqtTrace.Info("SocketClient.PrivateStop: Stop communication from server endpoint: {0}, error:{1}", this.endPoint, error);
+
             if (!this.stopped)
             {
                 // Do not allow stop to be called multiple times.

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
             this.tcpListener.Start();
 
-            this.endPoint = ((IPEndPoint)this.tcpListener.LocalEndpoint).ToString();
+            this.endPoint = this.tcpListener.LocalEndpoint.ToString();
             EqtTrace.Info("SocketServer.Start: Listening on endpoint : {0}", this.endPoint);
 
             // Serves a single client at the moment. An error in connection, or message loop just

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -596,6 +596,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 EqtTrace.Verbose("TestRequestSender.SetOperationComplete: Setting operation complete.");
             }
 
+            this.communicationEndpoint.Stop();
             Interlocked.CompareExchange(ref this.operationCompleted, 1, 0);
         }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
@@ -46,6 +46,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
         private string settingsXml;
         private int connectionTimeout;
         private IRequestData requestData;
+        private int dataCollectionPort;
+        private int dataCollectionProcessId;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProxyDataCollectionManager"/> class.
@@ -127,6 +129,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
             this.InvokeDataCollectionServiceAction(
            () =>
            {
+               EqtTrace.Info("ProxyDataCollectionManager.AfterTestRunEnd: Get attachment set for datacollector processId: {0} port: {1}", dataCollectionProcessId, dataCollectionPort);
                attachmentSet = this.dataCollectionRequestSender.SendAfterTestRunStartAndGetResult(runEventsHandler, isCanceled);
            },
                 runEventsHandler);
@@ -160,9 +163,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
             this.InvokeDataCollectionServiceAction(
             () =>
             {
+                EqtTrace.Info("ProxyDataCollectionManager.BeforeTestRunStart: Get env variable and port for datacollector processId: {0} port: {1}", this.dataCollectionProcessId, this.dataCollectionPort);
                 var result = this.dataCollectionRequestSender.SendBeforeTestRunStartAndGetResult(this.settingsXml, runEventsHandler);
                 environmentVariables = result.EnvironmentVariables;
                 dataCollectionEventsPort = result.DataCollectionEventsPort;
+
+                EqtTrace.Info(
+                    "ProxyDataCollectionManager.BeforeTestRunStart: SendBeforeTestRunStartAndGetResult successful, env variable from datacollector: {0}  and testhost port: {1}",
+                    string.Join(";", environmentVariables),
+                    dataCollectionEventsPort);
             },
                 runEventsHandler);
             return new DataCollectionParameters(
@@ -185,21 +194,27 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
         /// </summary>
         public void Dispose()
         {
+            EqtTrace.Info("ProxyDataCollectionManager.Dispose: calling dospose for datacollector processId: {0} port: {1}", this.dataCollectionProcessId, this.dataCollectionPort);
             this.dataCollectionRequestSender.Close();
         }
 
         /// <inheritdoc />
         public void Initialize()
         {
-            var port = this.dataCollectionRequestSender.InitializeCommunication();
+            this.dataCollectionPort = this.dataCollectionRequestSender.InitializeCommunication();
 
             // Warn the user that execution will wait for debugger attach.
-            var processId = this.dataCollectionLauncher.LaunchDataCollector(null, this.GetCommandLineArguments(port));
+            this.dataCollectionProcessId = this.dataCollectionLauncher.LaunchDataCollector(null, this.GetCommandLineArguments(this.dataCollectionPort));
+            EqtTrace.Info("ProxyDataCollectionManager.Initialize: Launched datacollector processId: {0} port: {1}", this.dataCollectionProcessId, this.dataCollectionPort);
 
-            ChangeConnectionTimeoutIfRequired(processId);
+            ChangeConnectionTimeoutIfRequired(dataCollectionProcessId);
+
+            EqtTrace.Info("ProxyDataCollectionManager.Initialize: waiting for connection with timeout: {0}", this.connectionTimeout);
+
             var connected = this.dataCollectionRequestSender.WaitForRequestHandlerConnection(this.connectionTimeout);
             if (connected == false)
             {
+                EqtTrace.Error("ProxyDataCollectionManager.Initialize: failed to connect to datacollector process, processId: {0} port: {1}", this.dataCollectionProcessId, this.dataCollectionPort);
                 throw new TestPlatformException(string.Format(CultureInfo.CurrentUICulture, CrossPlatEngineResources.FailedToConnectDataCollector));
             }
         }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
@@ -10,7 +10,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.EventHandlers;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
-    using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.EventHandlers;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
@@ -20,7 +19,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
     using Microsoft.VisualStudio.TestPlatform.Utilities;
     using CrossPlatResources = Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources.Resources;
-    using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine;
 
     public class TestRequestHandler : IDisposable, ITestRequestHandler
     {
@@ -131,14 +129,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         public void SendTestCases(IEnumerable<TestCase> discoveredTestCases)
         {
             var data = this.dataSerializer.SerializePayload(MessageType.TestCasesFound, discoveredTestCases, this.protocolVersion);
-            this.channel.Send(data);
+            this.SendData(data);
         }
 
         /// <inheritdoc />
         public void SendTestRunStatistics(TestRunChangedEventArgs testRunChangedArgs)
         {
             var data = this.dataSerializer.SerializePayload(MessageType.TestRunStatsChange, testRunChangedArgs, this.protocolVersion);
-            this.channel.Send(data);
+            this.SendData(data);
         }
 
         /// <inheritdoc />
@@ -148,7 +146,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                     MessageType.TestMessage,
                     new TestMessagePayload { MessageLevel = messageLevel, Message = message },
                     this.protocolVersion);
-            this.channel.Send(data);
+            this.SendData(data);
         }
 
         /// <inheritdoc />
@@ -168,7 +166,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                         ExecutorUris = executorUris
                     },
                     this.protocolVersion);
-            this.channel.Send(data);
+            this.SendData(data);
         }
 
         /// <inheritdoc />
@@ -184,7 +182,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                         Metrics = discoveryCompleteEventArgs.Metrics
                     },
                     this.protocolVersion);
-            this.channel.Send(data);
+            this.SendData(data);
         }
 
         /// <inheritdoc />
@@ -201,7 +199,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             var data = dataSerializer.SerializePayload(MessageType.LaunchAdapterProcessWithDebuggerAttached,
                 testProcessStartInfo, protocolVersion);
 
-            this.channel.Send(data);
+            this.SendData(data);
 
             EqtTrace.Verbose("Waiting for LaunchAdapterProcessWithDebuggerAttached ack");
             waitHandle.Wait();
@@ -389,5 +387,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             }
         }
 
+        private void SendData(string data)
+        {
+            EqtTrace.Verbose("TestRequestHandler.SendData:  sending data from testhost: {0}", data);
+            this.channel.Send(data);
+        }
     }
 }

--- a/src/testhost.x86/Program.cs
+++ b/src/testhost.x86/Program.cs
@@ -44,6 +44,7 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
             finally
             {
                 TestPlatformEventSource.Instance.TestHostStop();
+                EqtTrace.Info("Testhost process exiting.");
             }
         }
 

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
@@ -290,6 +290,20 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
         }
 
         [TestMethod]
+        public void DiscoverTestsShouldStopServerOnCompleteMessageReceived()
+        {
+            var completePayload = new DiscoveryCompletePayload { TotalTests = 10, IsAborted = false };
+            this.SetupDeserializeMessage(MessageType.DiscoveryComplete, completePayload);
+            this.SetupFakeCommunicationChannel();
+
+            this.testRequestSender.DiscoverTests(new DiscoveryCriteria(), this.mockDiscoveryEventsHandler.Object);
+
+            this.RaiseMessageReceivedEvent();
+
+            this.mockServer.Verify(ms => ms.Stop());
+        }
+
+        [TestMethod]
         public void DiscoverTestShouldNotifyLogMessageOnTestMessageReceived()
         {
             var message = new TestMessagePayload { MessageLevel = TestMessageLevel.Error, Message = "Message1" };
@@ -503,6 +517,25 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
                     testRunCompletePayload.RunAttachments,
                     It.IsAny<ICollection<string>>()),
                 Times.Once);
+        }
+
+        [TestMethod]
+        public void StartTestRunShouldStopServerOnRunCompleteMessageReceived()
+        {
+            var testRunCompletePayload = new TestRunCompletePayload
+            {
+                TestRunCompleteArgs = new TestRunCompleteEventArgs(null, false, false, null, null, TimeSpan.MaxValue),
+                LastRunTests = new TestRunChangedEventArgs(null, null, null),
+                RunAttachments = new List<AttachmentSet>()
+            };
+            this.SetupDeserializeMessage(MessageType.ExecutionComplete, testRunCompletePayload);
+            this.SetupFakeCommunicationChannel();
+
+            this.testRequestSender.StartTestRun(this.testRunCriteriaWithSources, this.mockExecutionEventsHandler.Object);
+
+            this.RaiseMessageReceivedEvent();
+
+            this.mockServer.Verify(ms => ms.Stop());
         }
 
         [TestMethod]


### PR DESCRIPTION
Port https://github.com/Microsoft/vstest/pull/1505 for 15.7
## Description
**Fix**
- Stop the Server/Client on TestExecution.Completed/TestDiscovery.Completed received.
- Make EqtTrace logging friendly to parallel scenario.

## Related issue
https://github.com/Microsoft/vstest/issues/1472
