### PR TITLE
Extend FastFilter to support multiple properties...

### DIFF
--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FastFilterTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FastFilterTests.cs
@@ -5,6 +5,7 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Microsoft.VisualStudio.TestPlatform.Common.Filtering;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
@@ -13,15 +14,6 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
     [TestClass]
     public class FastFilterTests
     {
-        [TestMethod]
-        public void MultiplePropertyNamesShouldNotCreateFastFilter()
-        {
-            var filterExpressionWrapper = new FilterExpressionWrapper("FullyQualifiedName=Test1|Category=Core");
-            var fastFilter = filterExpressionWrapper.fastFilter;
-
-            Assert.IsTrue(fastFilter == null);
-        }
-
         [TestMethod]
         public void MultipleOperatorKindsShouldNotCreateFastFilter()
         {
@@ -75,14 +67,14 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
             var filterExpressionWrapper = new FilterExpressionWrapper("FullyQualifiedName=Test1");
             var fastFilter = filterExpressionWrapper.fastFilter;
 
-            var expectedFilterValues = new HashSet<string>() { "test1" };
+            var expectedFilterValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "test1" };
 
             Assert.IsTrue(fastFilter != null);
-            Assert.AreEqual("FullyQualifiedName", fastFilter.FilterPropertyName);
+            Assert.AreEqual("FullyQualifiedName", fastFilter.FilterProperties.Keys.Single());
             Assert.IsFalse(fastFilter.IsFilteredOutWhenMatched);
-            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterPropertyValues));
+            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterProperties.Values.Single()));
 
-            filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null);            
+            Assert.IsNull(filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null));            
 
             Assert.IsTrue(fastFilter.Evaluate((s) => "Test1"));
             Assert.IsFalse(fastFilter.Evaluate((s) => "Test2"));
@@ -94,18 +86,18 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
             var filterExpressionWrapper = new FilterExpressionWrapper("FullyQualifiedName=Test1|FullyQualifiedName=Test2|FullyQualifiedName=Test3");
             var fastFilter = filterExpressionWrapper.fastFilter;
 
-            var expectedFilterValues = new HashSet<string>() { "test1", "test2", "test3" };
+            var expectedFilterValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "test1", "test2", "test3" };
 
             Assert.IsTrue(fastFilter != null);
-            Assert.AreEqual("FullyQualifiedName", fastFilter.FilterPropertyName);
+            Assert.AreEqual("FullyQualifiedName", fastFilter.FilterProperties.Keys.Single());
             Assert.IsFalse(fastFilter.IsFilteredOutWhenMatched);
-            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterPropertyValues));
+            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterProperties.Values.Single()));
 
-            filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null);            
+            Assert.IsNull(filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null));            
 
             Assert.IsTrue(fastFilter.Evaluate((s) => "Test1"));
-            Assert.IsTrue(fastFilter.Evaluate((s) => "Test2"));
-            Assert.IsTrue(fastFilter.Evaluate((s) => "Test3"));
+            Assert.IsTrue(fastFilter.Evaluate((s) => "test2"));
+            Assert.IsTrue(fastFilter.Evaluate((s) => "test3"));
             Assert.IsFalse(fastFilter.Evaluate((s) => "Test4"));
         }
 
@@ -115,14 +107,14 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
             var filterExpressionWrapper = new FilterExpressionWrapper("FullyQualifiedName=Test1|(FullyQualifiedName=Test2|FullyQualifiedName=Test3)");
             var fastFilter = filterExpressionWrapper.fastFilter;
 
-            var expectedFilterValues = new HashSet<string>() { "test1", "test2", "test3" };
+            var expectedFilterValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "test1", "test2", "test3" };
 
             Assert.IsTrue(fastFilter != null);
-            Assert.AreEqual("FullyQualifiedName", fastFilter.FilterPropertyName);
+            Assert.AreEqual("FullyQualifiedName", fastFilter.FilterProperties.Keys.Single());
             Assert.IsFalse(fastFilter.IsFilteredOutWhenMatched);
-            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterPropertyValues));
+            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterProperties.Values.Single()));
 
-            filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null);
+            Assert.IsNull(filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null));
 
             Assert.IsTrue(fastFilter.Evaluate((s) => "Test1"));
             Assert.IsTrue(fastFilter.Evaluate((s) => "Test2"));
@@ -136,14 +128,14 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
             var filterExpressionWrapper = new FilterExpressionWrapper("FullyQualifiedName=Test1|FullyQualifiedName=Test2|FullyQualifiedName=Test3", new FilterOptions() { FilterRegEx = @"^[^\s\(]+" });
             var fastFilter = filterExpressionWrapper.fastFilter;
 
-            var expectedFilterValues = new HashSet<string>() { "test1", "test2", "test3" };
+            var expectedFilterValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "test1", "test2", "test3" };
 
             Assert.IsTrue(fastFilter != null);
-            Assert.AreEqual("FullyQualifiedName", fastFilter.FilterPropertyName);
+            Assert.AreEqual("FullyQualifiedName", fastFilter.FilterProperties.Keys.Single());
             Assert.IsFalse(fastFilter.IsFilteredOutWhenMatched);
-            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterPropertyValues));
+            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterProperties.Values.Single()));
 
-            filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null);
+            Assert.IsNull(filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null));
 
             Assert.IsTrue(fastFilter.Evaluate((s) => "Test1"));
             Assert.IsTrue(fastFilter.Evaluate((s) => "Test2"));
@@ -161,14 +153,14 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
             var filterExpressionWrapper = new FilterExpressionWrapper("Category=UnitTest|Category=PerfTest", null);
             var fastFilter = filterExpressionWrapper.fastFilter;
 
-            var expectedFilterValues = new HashSet<string>() { "unittest", "perftest"};
+            var expectedFilterValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "unittest", "perftest"};
 
             Assert.IsTrue(fastFilter != null);
-            Assert.AreEqual("Category", fastFilter.FilterPropertyName);
+            Assert.AreEqual("Category", fastFilter.FilterProperties.Keys.Single());
             Assert.IsFalse(fastFilter.IsFilteredOutWhenMatched);
-            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterPropertyValues));
+            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterProperties.Values.Single()));
 
-            filterExpressionWrapper.ValidForProperties(new List<string>() { "Category" }, null);
+            Assert.IsNull(filterExpressionWrapper.ValidForProperties(new List<string>() { "Category" }, null));
 
             Assert.IsTrue(fastFilter.Evaluate((s) => new[] { "UnitTest" }));
             Assert.IsTrue(fastFilter.Evaluate((s) => new[] { "PerfTest" }));
@@ -184,14 +176,14 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
             var filterExpressionWrapper = new FilterExpressionWrapper("FullyQualifiedName=TestClass.Test1|FullyQualifiedName=TestClass.Test2|FullyQualifiedName=TestClass.Test3", new FilterOptions() { FilterRegEx = @"\s*\([^\)]*\)", FilterRegExReplacement = "" });
             var fastFilter = filterExpressionWrapper.fastFilter;
 
-            var expectedFilterValues = new HashSet<string>() { "testclass.test1", "testclass.test2", "testclass.test3" };
+            var expectedFilterValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "testclass.test1", "testclass.test2", "testclass.test3" };
 
             Assert.IsTrue(fastFilter != null);
-            Assert.AreEqual("FullyQualifiedName", fastFilter.FilterPropertyName);
+            Assert.AreEqual("FullyQualifiedName", fastFilter.FilterProperties.Keys.Single());
             Assert.IsFalse(fastFilter.IsFilteredOutWhenMatched);
-            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterPropertyValues));
+            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterProperties.Values.Single()));
 
-            filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null);
+            Assert.IsNull(filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null));
 
             Assert.IsTrue(fastFilter.Evaluate((s) => "TestClass(1).Test1"));
             Assert.IsTrue(fastFilter.Evaluate((s) => "TestClass().Test1()"));
@@ -224,14 +216,14 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
             var filterExpressionWrapper = new FilterExpressionWrapper(filterString);
             var fastFilter = filterExpressionWrapper.fastFilter;
 
-            var expectedFilterValues = new HashSet<string>() { "test1" };
+            var expectedFilterValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "test1" };
 
             Assert.IsTrue(fastFilter != null);
-            Assert.AreEqual("FullyQualifiedName", fastFilter.FilterPropertyName);
+            Assert.AreEqual("FullyQualifiedName", fastFilter.FilterProperties.Keys.Single());
             Assert.IsTrue(fastFilter.IsFilteredOutWhenMatched);
-            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterPropertyValues));
+            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterProperties.Values.Single()));
 
-            filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null);
+            Assert.IsNull(filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null));
 
             Assert.IsFalse(fastFilter.Evaluate((s) => "Test1"));
             Assert.IsTrue(fastFilter.Evaluate((s) => "Test2"));
@@ -243,14 +235,14 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
             var filterExpressionWrapper = new FilterExpressionWrapper("FullyQualifiedName!=Test1&FullyQualifiedName!=Test2&FullyQualifiedName!=Test3");
             var fastFilter = filterExpressionWrapper.fastFilter;
 
-            var expectedFilterValues = new HashSet<string>() { "test1", "test2", "test3" };
+            var expectedFilterValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "test1", "test2", "test3" };
 
             Assert.IsTrue(fastFilter != null);
-            Assert.AreEqual("FullyQualifiedName", fastFilter.FilterPropertyName);
+            Assert.AreEqual("FullyQualifiedName", fastFilter.FilterProperties.Keys.Single());
             Assert.IsTrue(fastFilter.IsFilteredOutWhenMatched);
-            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterPropertyValues));
+            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterProperties.Values.Single()));
 
-            filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null);
+            Assert.IsNull(filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null));
 
             Assert.IsFalse(fastFilter.Evaluate((s) => "Test1"));
             Assert.IsFalse(fastFilter.Evaluate((s) => "Test2"));
@@ -264,14 +256,14 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
             var filterExpressionWrapper = new FilterExpressionWrapper("FullyQualifiedName!=Test1&FullyQualifiedName!=Test2&FullyQualifiedName!=Test3", new FilterOptions() { FilterRegEx = @"^[^\s\(]+" });
             var fastFilter = filterExpressionWrapper.fastFilter;
 
-            var expectedFilterValues = new HashSet<string>() { "test1", "test2", "test3" };
+            var expectedFilterValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "test1", "test2", "test3" };
 
             Assert.IsTrue(fastFilter != null);
-            Assert.AreEqual("FullyQualifiedName", fastFilter.FilterPropertyName);
+            Assert.AreEqual("FullyQualifiedName", fastFilter.FilterProperties.Keys.Single());
             Assert.IsTrue(fastFilter.IsFilteredOutWhenMatched);
-            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterPropertyValues));
+            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterProperties.Values.Single()));
 
-            filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null);
+            Assert.IsNull(filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null));
 
             Assert.IsFalse(fastFilter.Evaluate((s) => "Test1"));
             Assert.IsFalse(fastFilter.Evaluate((s) => "Test2"));
@@ -289,14 +281,14 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
             var filterExpressionWrapper = new FilterExpressionWrapper("Category!=UnitTest&Category!=PerfTest", null);
             var fastFilter = filterExpressionWrapper.fastFilter;
 
-            var expectedFilterValues = new HashSet<string>() { "unittest", "perftest" };
+            var expectedFilterValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "unittest", "perftest" };
 
             Assert.IsTrue(fastFilter != null);
-            Assert.AreEqual("Category", fastFilter.FilterPropertyName);
+            Assert.AreEqual("Category", fastFilter.FilterProperties.Keys.Single());
             Assert.IsTrue(fastFilter.IsFilteredOutWhenMatched);
-            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterPropertyValues));
+            Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterProperties.Values.Single()));
 
-            filterExpressionWrapper.ValidForProperties(new List<string>() { "Category" }, null);
+            Assert.IsNull(filterExpressionWrapper.ValidForProperties(new List<string>() { "Category" }, null));
 
             Assert.IsFalse(fastFilter.Evaluate((s) => new[] { "UnitTest" }));
             Assert.IsFalse(fastFilter.Evaluate((s) => new[] { "PerfTest" }));
@@ -321,13 +313,74 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
             ImmutableHashSet<string>.Builder filterHashSetBuilder = ImmutableHashSet.CreateBuilder<string>();
             try
             {
-                var filter = new FastFilter("dummyName", filterHashSetBuilder.ToImmutableHashSet(), Operation.Equal, Operator.And);
+                var filter = new FastFilter(ImmutableDictionary.CreateRange(new[] { new KeyValuePair<string, ISet<string>>("dummyName", filterHashSetBuilder.ToImmutableHashSet()) }), Operation.Equal, Operator.And);
             }
             catch (Exception ex)
             {
                 Assert.IsTrue(ex is ArgumentException);
                 Assert.AreEqual("An error occured while creating Fast filter.", ex.Message);
             }
+        }
+
+        [TestMethod]
+        public void MultiplePropertyNames()
+        {
+            var filterExpressionWrapper = new FilterExpressionWrapper("FullyQualifiedName=Test1|Category=IntegrationTest");
+            var fastFilter = filterExpressionWrapper.fastFilter;
+
+            var expectedFilterKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Category", "FullyQualifiedName" };
+
+            Assert.IsNotNull(fastFilter);
+            Assert.IsTrue(expectedFilterKeys.SetEquals(fastFilter.FilterProperties.Keys));
+            Assert.IsFalse(fastFilter.IsFilteredOutWhenMatched);
+            Assert.IsTrue(fastFilter.FilterProperties["FullyQualifiedName"].SequenceEqual(new[] { "Test1" }));
+            Assert.IsTrue(fastFilter.FilterProperties["Category"].SequenceEqual(new[] { "IntegrationTest" }));
+
+            Assert.IsNull(filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName", "Category" }, null));
+            Assert.AreEqual("FullyQualifiedName", filterExpressionWrapper.ValidForProperties(new List<string>() { "Category" }, null).Single());
+
+            Assert.IsFalse(fastFilter.Evaluate((s) => s == "Category" ? new[] { "UnitTest" } : null));
+            Assert.IsFalse(fastFilter.Evaluate((s) => s == "Category" ? new[] { "PerfTest" } : null));
+            Assert.IsFalse(fastFilter.Evaluate((s) => s == "Category" ? new[] { "UnitTest", "PerfTest" } : null));
+            Assert.IsTrue(fastFilter.Evaluate((s) => s == "Category" ? new[] { "UnitTest", "IntegrationTest" } : null));
+            Assert.IsTrue(fastFilter.Evaluate((s) => s == "Category" ? new[] { "IntegrationTest" } : null));
+            Assert.IsTrue(fastFilter.Evaluate((s) =>
+            {
+                switch (s)
+                {
+                    case "Category":
+                        return new[] { "UnitTest" };
+                    case "FullyQualifiedName":
+                        return new[] { "Test1" };
+                    default:
+                        return null;
+                }
+            }));
+            Assert.IsFalse(fastFilter.Evaluate((s) =>
+            {
+                switch (s)
+                {
+                    case "Category":
+                        return "UnitTest";
+                    case "FullyQualifiedName":
+                        return "Test2";
+                    default:
+                        return null;
+                }
+            }));
+            Assert.IsTrue(fastFilter.Evaluate((s) =>
+            {
+                switch (s)
+                {
+                    case "Category":
+                        return new[] { "IntegrationTest" };
+                    case "FullyQualifiedName":
+                        return new[] { "Test2" };
+                    default:
+                        return null;
+                }
+            }));
+            Assert.IsFalse(fastFilter.Evaluate((s) => null));
         }
     }
 }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FastFilterTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FastFilterTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
             Assert.IsFalse(fastFilter.IsFilteredOutWhenMatched);
             Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterProperties.Values.Single()));
 
-            Assert.IsNull(filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null));            
+            Assert.IsNull(filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null));
 
             Assert.IsTrue(fastFilter.Evaluate((s) => "Test1"));
             Assert.IsFalse(fastFilter.Evaluate((s) => "Test2"));
@@ -93,7 +93,7 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
             Assert.IsFalse(fastFilter.IsFilteredOutWhenMatched);
             Assert.IsTrue(expectedFilterValues.SetEquals(fastFilter.FilterProperties.Values.Single()));
 
-            Assert.IsNull(filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null));            
+            Assert.IsNull(filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null));
 
             Assert.IsTrue(fastFilter.Evaluate((s) => "Test1"));
             Assert.IsTrue(fastFilter.Evaluate((s) => "test2"));
@@ -153,7 +153,7 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
             var filterExpressionWrapper = new FilterExpressionWrapper("Category=UnitTest|Category=PerfTest", null);
             var fastFilter = filterExpressionWrapper.fastFilter;
 
-            var expectedFilterValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "unittest", "perftest"};
+            var expectedFilterValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "unittest", "perftest" };
 
             Assert.IsTrue(fastFilter != null);
             Assert.AreEqual("Category", fastFilter.FilterProperties.Keys.Single());
@@ -323,7 +323,7 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
         }
 
         [TestMethod]
-        public void MultiplePropertyNames()
+        public void MultiplePropertyNamesEqualOr()
         {
             var filterExpressionWrapper = new FilterExpressionWrapper("FullyQualifiedName=Test1|Category=IntegrationTest");
             var fastFilter = filterExpressionWrapper.fastFilter;
@@ -381,6 +381,64 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
                 }
             }));
             Assert.IsFalse(fastFilter.Evaluate((s) => null));
+        }
+
+        [TestMethod]
+        public void MultiplePropertyNamesNotEqualAnd()
+        {
+            var filterExpressionWrapper = new FilterExpressionWrapper("FullyQualifiedName!=Test1&Category!=IntegrationTest");
+            var fastFilter = filterExpressionWrapper.fastFilter;
+
+            var expectedFilterKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Category", "FullyQualifiedName" };
+
+            Assert.IsNotNull(fastFilter);
+            Assert.IsTrue(expectedFilterKeys.SetEquals(fastFilter.FilterProperties.Keys));
+            Assert.IsTrue(fastFilter.IsFilteredOutWhenMatched);
+            Assert.IsTrue(fastFilter.FilterProperties["FullyQualifiedName"].SequenceEqual(new[] { "Test1" }));
+            Assert.IsTrue(fastFilter.FilterProperties["Category"].SequenceEqual(new[] { "IntegrationTest" }));
+
+            Assert.IsNull(filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName", "Category" }, null));
+            Assert.AreEqual("FullyQualifiedName", filterExpressionWrapper.ValidForProperties(new List<string>() { "Category" }, null).Single());
+
+            Assert.IsTrue(fastFilter.Evaluate((s) => s == "Category" ? new[] { "UnitTest" } : null));
+            Assert.IsFalse(fastFilter.Evaluate((s) => s == "Category" ? new[] { "UnitTest", "IntegrationTest" } : null));
+            Assert.IsFalse(fastFilter.Evaluate((s) => s == "Category" ? new[] { "IntegrationTest" } : null));
+            Assert.IsFalse(fastFilter.Evaluate((s) =>
+            {
+                switch (s)
+                {
+                    case "Category":
+                        return new[] { "UnitTest" };
+                    case "FullyQualifiedName":
+                        return new[] { "Test1" };
+                    default:
+                        return null;
+                }
+            }));
+            Assert.IsFalse(fastFilter.Evaluate((s) =>
+            {
+                switch (s)
+                {
+                    case "Category":
+                        return new[] { "IntegrationTest" };
+                    case "FullyQualifiedName":
+                        return new[] { "Test2" };
+                    default:
+                        return null;
+                }
+            }));
+            Assert.IsTrue(fastFilter.Evaluate((s) =>
+            {
+                switch (s)
+                {
+                    case "Category":
+                        return new[] { "UnitTest" };
+                    case "FullyQualifiedName":
+                        return new[] { "Test2" };
+                    default:
+                        return null;
+                }
+            }));
         }
     }
 }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/TestCaseFilterExpressionTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/TestCaseFilterExpressionTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Linq;
+
 namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
 {
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -17,7 +19,7 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
             var filterExpressionWrapper = new FilterExpressionWrapper("highlyunlikelyproperty=unused");
             var testCaseFilterExpression = new TestCaseFilterExpression(filterExpressionWrapper);
 
-            testCaseFilterExpression.ValidForProperties(new List<string>() { "TestCategory" }, (s) => { return null; });
+            Assert.AreEqual("highlyunlikelyproperty", testCaseFilterExpression.ValidForProperties(new List<string>() { "TestCategory" }, (s) => { return null; }).Single());
 
             TestCase dummyTestCase = new TestCase();
             bool result = testCaseFilterExpression.MatchTestCase(dummyTestCase, (s) => { return "unused"; });


### PR DESCRIPTION
## Description
Previously, we would only use the "fast" filter if the filter expression used a single property name in all sub-expressions.  To improve Live Unit Testing execution performance, we need to be able to support an expression like this:
```
    FQN!=Test1&FQN!=Test2&TestCategory!=SkipWhenLiveUnitTesting
```
This change allows for use of multiple property names with the ```FastFilter```.  In cases where a single property is used, the time complexity remains O(n).  For cases using multiple properties, the worst case is O(m*n), but this is still better than the "slow" case, and in general, I expect "m" (number of property names used in the filter) to be small.

## Related issue
https://github.com/dotnet/testimpact/pull/2557
