### PR TITLE
Dev/shgu/crlf fix

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -379,8 +379,13 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
 
                 using (var fs = File.Open(trxFileName, FileMode.Create))
                 {
-                    rootElement.OwnerDocument.Save(fs);
+                    using (XmlWriter writer = XmlWriter.Create(fs, new XmlWriterSettings { NewLineHandling = NewLineHandling.Entitize }))
+                    {
+                        rootElement.OwnerDocument.Save(writer);
+                        writer.Flush();
+                    }
                 }
+
                 String resultsFileMessage = String.Format(CultureInfo.CurrentCulture, TrxLoggerResources.TrxLoggerResultsFile, trxFileName);
                 ConsoleOutput.Instance.Information(false, resultsFileMessage);
                 EqtTrace.Info(resultsFileMessage);


### PR DESCRIPTION
**Repro Steps:**

1. Using vstest.console.exe, user runs a test which has Trace.Writeline() statement with some line breaks, and generates a trx file 
2. Open the trx file in Visual Studio
3. Select the test result, right click --> View Test Results Details

**Result**: In the Results window, check the ‘Standard Console Output section’. Notice that the text is present in a single line and not in multiple lines.

**Issue**: Carriage Return character is not getting retained while generating TRX file

**Fix**: In TrxLogger, PopulateTrxFile(), while saving the file use XmlWriter and in its settings, specify NewLineHandling.Entitize option
