### PR TITLE
Understanding category attribute from adapter

### DIFF
--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestDiscoveryExtensionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestDiscoveryExtensionManager.cs
@@ -8,6 +8,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
 
     using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework.Utilities;
     using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
+    using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
@@ -169,7 +170,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
         /// </summary>
         /// <param name="fileExtensions"> The file Extensions. </param>
         /// <param name="defaultExecutorUri"> The default Executor Uri. </param>
-        public TestDiscovererMetadata(IReadOnlyCollection<string> fileExtensions, string defaultExecutorUri)
+        public TestDiscovererMetadata(IReadOnlyCollection<string> fileExtensions, string defaultExecutorUri, AssemblyType assemblyType = default(AssemblyType))
         {
             if (fileExtensions != null && fileExtensions.Count > 0)
             {
@@ -180,6 +181,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
             {
                 this.DefaultExecutorUri = new Uri(defaultExecutorUri);
             }
+
+            this.AssemblyType = assemblyType;
         }
 
         /// <summary>
@@ -195,6 +198,15 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
         /// Gets the default executor Uri for this discoverer
         /// </summary>
         public Uri DefaultExecutorUri
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Gets assembly type supported by the discoverer.
+        /// </summary>
+        public AssemblyType AssemblyType
         {
             get;
             private set;

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestDiscovererPluginInformation.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestDiscovererPluginInformation.cs
@@ -5,9 +5,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework.Utilitie
 {
     using System;
     using System.Collections.Generic;
+    using System.ComponentModel;
     using System.Linq;
     using System.Reflection;
 
+    using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
     using ObjectModel;
 
     /// <summary>
@@ -26,6 +28,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework.Utilitie
             {
                 this.FileExtensions = GetFileExtensions(testDiscovererType);
                 this.DefaultExecutorUri = GetDefaultExecutorUri(testDiscovererType);
+                this.AssemblyType = GetAssemblyType(testDiscovererType);
             }
         }
 
@@ -36,7 +39,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework.Utilitie
         {
             get
             {
-                return new object[] { this.FileExtensions, this.DefaultExecutorUri };
+                return new object[] { this.FileExtensions, this.DefaultExecutorUri, this.AssemblyType };
             }
         }
 
@@ -53,6 +56,15 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework.Utilitie
         /// Gets the Uri identifying the executor
         /// </summary>
         public string DefaultExecutorUri
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Gets the assembly type supported by discoverer plugin.
+        /// </summary>
+        public AssemblyType AssemblyType
         {
             get;
             private set;
@@ -104,6 +116,26 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework.Utilitie
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Helper to get the supported assembly type from the CategoryAttribute on the discover plugin.
+        /// </summary>
+        /// <param name="testDiscovererType"> The test discoverer Type. </param>
+        /// <returns> Supported assembly type. </returns>
+        private AssemblyType GetAssemblyType(Type testDiscovererType)
+        {
+            var assemblyType = default(AssemblyType);
+
+            // Get Category
+            var attributes = testDiscovererType.GetTypeInfo().GetCustomAttributes(typeof(CategoryAttribute), false).ToArray();
+            var category = attributes != null && attributes.Length > 0 ?
+                ((CategoryAttribute)attributes[0]).Category :
+                default(string);
+
+            // Get assembly type from category.
+            Enum.TryParse(category, true, out assemblyType);
+            return assemblyType;
         }
     }
 }

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestDiscovererPluginInformation.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestDiscovererPluginInformation.cs
@@ -128,10 +128,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework.Utilitie
             var assemblyType = default(AssemblyType);
 
             // Get Category
-            var attributes = testDiscovererType.GetTypeInfo().GetCustomAttributes(typeof(CategoryAttribute), false).ToArray();
-            var category = attributes != null && attributes.Length > 0 ?
-                ((CategoryAttribute)attributes[0]).Category :
-                default(string);
+            var attribute = testDiscovererType.GetTypeInfo().GetCustomAttribute(typeof(CategoryAttribute));
+            var category = (attribute as CategoryAttribute)?.Category;
 
             // Get assembly type from category.
             Enum.TryParse(category, true, out assemblyType);

--- a/src/Microsoft.TestPlatform.Common/Interfaces/ITestDiscovererCapabilities.cs
+++ b/src/Microsoft.TestPlatform.Common/Interfaces/ITestDiscovererCapabilities.cs
@@ -6,6 +6,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Interfaces
     using System;
     using System.Collections.Generic;
 
+    using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
+
     /// <summary>
     /// Metadata that is available from Test Discoverers.
     /// </summary>
@@ -20,5 +22,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Interfaces
         /// Default executor Uri for this discoverer
         /// </summary>
         Uri DefaultExecutorUri { get; }
+
+        /// <summary>
+        /// Assembly type that the test discoverer supports.
+        /// </summary>
+        AssemblyType AssemblyType { get; }
     }
 }

--- a/src/Microsoft.TestPlatform.Common/Utilities/AssemblyType.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/AssemblyType.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
+{
+    public enum AssemblyType
+    {
+        NativeAndManaged,
+        Native,
+        Managed
+    }
+}

--- a/src/Microsoft.TestPlatform.Common/Utilities/AssemblyType.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/AssemblyType.cs
@@ -5,7 +5,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
 {
     public enum AssemblyType
     {
-        NativeAndManaged,
+        None,
         Native,
         Managed
     }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestDiscoveryExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestDiscoveryExtensionManagerTests.cs
@@ -8,6 +8,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
     using System.Reflection;
 
     using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
+    using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -123,6 +124,14 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             var metadata = new TestDiscovererMetadata(null, "executor://helloworld");
 
             Assert.AreEqual("executor://helloworld/", metadata.DefaultExecutorUri.AbsoluteUri);
+        }
+
+        [TestMethod]
+        public void TestDiscovererMetadataCtorSetsAssemblyType()
+        {
+            var metadata = new TestDiscovererMetadata(null, "executor://helloworld", AssemblyType.Native);
+
+            Assert.AreEqual(AssemblyType.Native, metadata.AssemblyType);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/LazyExtensionTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/LazyExtensionTests.cs
@@ -4,16 +4,18 @@
 namespace TestPlatform.Common.UnitTests.ExtensionFramework.Utilities
 {
     using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
     using System.Linq;
 
     using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework.Utilities;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
     using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
-    using Moq;
+    using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-    using System.Collections.Generic;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
 
     [TestClass]
     public class LazyExtensionTests
@@ -96,6 +98,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework.Utilities
             Assert.AreEqual(typeof(DummyDiscovererCapability), metadata.GetType());
             CollectionAssert.AreEqual(new List<string> { "csv" }, (metadata as ITestDiscovererCapabilities).FileExtension.ToArray());
             Assert.AreEqual("executor://unittestexecutor/", (metadata as ITestDiscovererCapabilities).DefaultExecutorUri.AbsoluteUri);
+            Assert.AreEqual(AssemblyType.Native, (metadata as ITestDiscovererCapabilities).AssemblyType);
         }
 
         #endregion
@@ -116,16 +119,24 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework.Utilities
                 private set;
             }
 
-            public DummyDiscovererCapability(List<string> fileExtensions, string executorURI)
+            public AssemblyType AssemblyType
+            {
+                get;
+                private set;
+            }
+
+            public DummyDiscovererCapability(List<string> fileExtensions, string executorURI, AssemblyType assemblyType)
             {
                 this.FileExtension = fileExtensions;
                 this.DefaultExecutorUri = new Uri(executorURI);
+                this.AssemblyType = assemblyType;
             }
         }
 
 
         [FileExtension("csv")]
         [DefaultExecutorUri("executor://unittestexecutor")]
+        [Category("native")]
         private class DummyExtension : ITestDiscoverer
         {
             public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink)

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/TestDiscovererPluginInformationTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/TestDiscovererPluginInformationTests.cs
@@ -4,13 +4,15 @@
 namespace TestPlatform.Common.UnitTests.ExtensionFramework.Utilities
 {
     using System;
-    using System.Linq;
     using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Linq;
 
     using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework.Utilities;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-    
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class TestDiscovererPluginInformationTests
     {
@@ -53,6 +55,41 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework.Utilities
         }
 
         [TestMethod]
+        public void AssemblyTypeShouldReturnNativeAndManagedIfDiscovererHasNoCategory()
+        {
+            this.testPluginInformation = new TestDiscovererPluginInformation(typeof(DummyTestDiscovereWithNoCategory));
+            Assert.AreEqual(AssemblyType.NativeAndManaged, this.testPluginInformation.AssemblyType);
+        }
+
+        [TestMethod]
+        public void AssemblyTypeShouldReturnNativeIfDiscovererHasNativeCategory()
+        {
+            this.testPluginInformation = new TestDiscovererPluginInformation(typeof(DummyTestDiscovereWithNativeCategory));
+            Assert.AreEqual(AssemblyType.Native, this.testPluginInformation.AssemblyType);
+        }
+
+        [TestMethod]
+        public void AssemblyTypeShouldReturnManagedIfDiscovererHasManagedCategory()
+        {
+            this.testPluginInformation = new TestDiscovererPluginInformation(typeof(DummyTestDiscovereWithManagedCategory));
+            Assert.AreEqual(AssemblyType.Managed, this.testPluginInformation.AssemblyType);
+        }
+
+        [TestMethod]
+        public void AssemblyTypeShouldReturnNativeAndManagedIfDiscovererHasUnknownCategory()
+        {
+            this.testPluginInformation = new TestDiscovererPluginInformation(typeof(DummyTestDiscovereWithUnknownCategory));
+            Assert.AreEqual(AssemblyType.NativeAndManaged, this.testPluginInformation.AssemblyType);
+        }
+
+        [TestMethod]
+        public void AssemblyTypeShouldReturnAssemblyTypeIfDiscovererHasCategoryInArbitCasing()
+        {
+            this.testPluginInformation = new TestDiscovererPluginInformation(typeof(DummyTestDiscovereWithArbitCasedCategory));
+            Assert.AreEqual(AssemblyType.Native, this.testPluginInformation.AssemblyType);
+        }
+
+        [TestMethod]
         public void DefaultExecutorUriShouldReturnEmptyListIfADiscovererDoesNotHaveOne()
         {
             this.testPluginInformation = new TestDiscovererPluginInformation(typeof(DummyTestDiscovererWithNoFileExtensions));
@@ -68,7 +105,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework.Utilities
         }
 
         [TestMethod]
-        public void MetadataShouldReturnFileExtensionsAndDefaultExecutorUri()
+        public void MetadataShouldReturnFileExtensionsAndDefaultExecutorUriAndAssemblyType()
         {
             this.testPluginInformation = new TestDiscovererPluginInformation(typeof(DummyTestDiscovererWithTwoFileExtensions));
 
@@ -77,12 +114,42 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework.Utilities
 
             CollectionAssert.AreEqual(expectedFileExtensions, (testPluginMetada[0] as List<string>).ToArray());
             Assert.AreEqual("csvexecutor", testPluginMetada[1] as string);
+            Assert.AreEqual(AssemblyType.Managed, Enum.Parse(typeof(AssemblyType), testPluginMetada[2].ToString()));
         }
     }
 
     #region Implementation
     
     public class DummyTestDiscovererWithNoFileExtensions
+    {
+    }
+
+    [FileExtension(".dll")]
+    public class DummyTestDiscovereWithNoCategory
+    {
+    }
+
+    [FileExtension(".js")]
+    [Category("native")]
+    public class DummyTestDiscovereWithNativeCategory
+    {
+    }
+
+    [FileExtension(".dll")]
+    [Category("managed")]
+    public class DummyTestDiscovereWithManagedCategory
+    {
+    }
+
+    [FileExtension(".dll")]
+    [Category("arbitValue")]
+    public class DummyTestDiscovereWithUnknownCategory
+    {
+    }
+
+    [FileExtension(".dll")]
+    [Category("NatIVe")]
+    public class DummyTestDiscovereWithArbitCasedCategory
     {
     }
 
@@ -94,6 +161,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework.Utilities
 
     [FileExtension("csv")]
     [FileExtension("docx")]
+    [Category("managed")]
     [DefaultExecutorUri("csvexecutor")]
     public class DummyTestDiscovererWithTwoFileExtensions
     {

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/TestDiscovererPluginInformationTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/TestDiscovererPluginInformationTests.cs
@@ -55,10 +55,24 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework.Utilities
         }
 
         [TestMethod]
-        public void AssemblyTypeShouldReturnNativeAndManagedIfDiscovererHasNoCategory()
+        public void AssemblyTypeShouldReturnNoneIfDiscovererHasNoCategory()
         {
             this.testPluginInformation = new TestDiscovererPluginInformation(typeof(DummyTestDiscovereWithNoCategory));
-            Assert.AreEqual(AssemblyType.NativeAndManaged, this.testPluginInformation.AssemblyType);
+            Assert.AreEqual(AssemblyType.None, this.testPluginInformation.AssemblyType);
+        }
+
+        [TestMethod]
+        public void AssemblyTypeShouldReturnNoneIfDiscovererHasCategoryWithNoValue()
+        {
+            this.testPluginInformation = new TestDiscovererPluginInformation(typeof(DummyTestDiscovereWithCategoryHavingNoValue));
+            Assert.AreEqual(AssemblyType.None, this.testPluginInformation.AssemblyType);
+        }
+
+        [TestMethod]
+        public void AssemblyTypeShouldReturnNoneIfDiscovererHasCategoryWithEmptyValue()
+        {
+            this.testPluginInformation = new TestDiscovererPluginInformation(typeof(DummyTestDiscovereWithCategoryHavingEmptyValue));
+            Assert.AreEqual(AssemblyType.None, this.testPluginInformation.AssemblyType);
         }
 
         [TestMethod]
@@ -76,10 +90,10 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework.Utilities
         }
 
         [TestMethod]
-        public void AssemblyTypeShouldReturnNativeAndManagedIfDiscovererHasUnknownCategory()
+        public void AssemblyTypeShouldReturnNoneIfDiscovererHasUnknownCategory()
         {
             this.testPluginInformation = new TestDiscovererPluginInformation(typeof(DummyTestDiscovereWithUnknownCategory));
-            Assert.AreEqual(AssemblyType.NativeAndManaged, this.testPluginInformation.AssemblyType);
+            Assert.AreEqual(AssemblyType.None, this.testPluginInformation.AssemblyType);
         }
 
         [TestMethod]
@@ -126,6 +140,18 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework.Utilities
 
     [FileExtension(".dll")]
     public class DummyTestDiscovereWithNoCategory
+    {
+    }
+
+    [FileExtension(".dll")]
+    [Category]
+    public class DummyTestDiscovereWithCategoryHavingNoValue
+    {
+    }
+
+    [FileExtension(".dll")]
+    [Category]
+    public class DummyTestDiscovereWithCategoryHavingEmptyValue
     {
     }
 


### PR DESCRIPTION
Part 1 of [RFC](https://github.com/Microsoft/vstest-docs/pull/124):
Contains changes for understanding category attribute from adapter.