### PR TITLE
Fix no stacktrace information when net472 is installed

### DIFF
--- a/src/datacollector/app.config
+++ b/src/datacollector/app.config
@@ -5,6 +5,11 @@
   </startup>
   <runtime>
     <legacyUnhandledExceptionPolicy enabled="1" />
+
+    <!-- To get stacktrace information for portable and embedded pdbs when net472 installed on machine.
+          More details https://github.com/dotnet/designs/blob/master/accepted/diagnostics/debugging-with-symbols-and-sources.md#stack-traces -->
+    <AppContextSwitchOverrides value="Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces=false" />
+
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <!-- Test adapters compiled against version 11-14, need to be redirected to version 15. -->
       <dependentAssembly>

--- a/src/testhost.x86/app.config
+++ b/src/testhost.x86/app.config
@@ -5,6 +5,11 @@
   </startup>
   <runtime>
     <legacyUnhandledExceptionPolicy enabled="1"/>
+
+    <!-- To get stacktrace information for portable and embedded pdbs when net472 installed on machine.
+          More details https://github.com/dotnet/designs/blob/master/accepted/diagnostics/debugging-with-symbols-and-sources.md#stack-traces -->
+    <AppContextSwitchOverrides value="Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces=false" />
+
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <probing privatePath="Extensions" />
       <!-- Test adapters compiled against version 11-14, need to be redirected to version 15. -->

--- a/src/testhost/app.config
+++ b/src/testhost/app.config
@@ -5,6 +5,11 @@
   </startup>
   <runtime>
     <legacyUnhandledExceptionPolicy enabled="1" />
+
+    <!-- To get stacktrace information for portable and embedded pdbs when net472 installed on machine.
+          More details https://github.com/dotnet/designs/blob/master/accepted/diagnostics/debugging-with-symbols-and-sources.md#stack-traces -->
+    <AppContextSwitchOverrides value="Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces=false" />
+
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <probing privatePath="Extensions" />
       <!-- Test adapters compiled against version 11-14, need to be redirected to version 15. -->

--- a/src/vstest.console/app.config
+++ b/src/vstest.console/app.config
@@ -26,4 +26,38 @@
     <!-- This flag is added to support test execution for net35 tests through TMI adapter. -->
     <add key="TestProjectRetargetTo35Allowed" value="true" />
   </appSettings>
+
+  <!--
+        To collect logs for vstest.console and it's child processes, follow below steps.
+          1. Uncomment below system.diagnostics element content.
+          2. Replace "c:\tmp\log.txt" with valid filename. Make sure "c:\tmp" folder exists. log.txt file will be created by vstest.console if does not exists.
+          3. Restart vstest.console or it's client(VS, any other IDE).
+        More details: https://github.com/Microsoft/vstest-docs/blob/master/docs/diagnose.md#collect-trace-using-config-file
+  -->
+
+  <!--
+  <system.diagnostics>
+    <sources>
+      <source name="TpTrace"
+        switchName="sourceSwitch"
+        switchType="System.Diagnostics.SourceSwitch">
+        <listeners>
+          <add name="logfile"/>
+          <remove name="Default"/>
+        </listeners>
+      </source>
+    </sources>
+    <switches>
+      <add name="sourceSwitch" value="All"/>
+    </switches>
+    <sharedListeners>
+      <add name="logfile"
+        type="System.Diagnostics.TextWriterTraceListener"
+        initializeData="c:\tmp\log.txt">
+        <filter type="System.Diagnostics.EventTypeFilter"
+          initializeData="Verbose"/>
+      </add>
+    </sharedListeners>
+  </system.diagnostics> -->
+
 </configuration>

--- a/src/vstest.console/app.config
+++ b/src/vstest.console/app.config
@@ -5,6 +5,11 @@
   </startup>
   <runtime>
     <legacyUnhandledExceptionPolicy enabled="1" />
+
+    <!-- To get stacktrace information for portable and embedded pdbs when net472 installed on machine.
+          More details https://github.com/dotnet/designs/blob/master/accepted/diagnostics/debugging-with-symbols-and-sources.md#stack-traces -->
+    <AppContextSwitchOverrides value="Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces=false" />
+
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <!-- Test adapters compiled against version 11-14, need to be redirected to version 15. -->
       <dependentAssembly>

--- a/src/vstest.console/app.config
+++ b/src/vstest.console/app.config
@@ -35,12 +35,9 @@
         More details: https://github.com/Microsoft/vstest-docs/blob/master/docs/diagnose.md#collect-trace-using-config-file
   -->
 
-  <!--
-  <system.diagnostics>
+  <!-- <system.diagnostics>
     <sources>
-      <source name="TpTrace"
-        switchName="sourceSwitch"
-        switchType="System.Diagnostics.SourceSwitch">
+      <source name="TpTrace" switchName="sourceSwitch" switchType="System.Diagnostics.SourceSwitch">
         <listeners>
           <add name="logfile"/>
           <remove name="Default"/>
@@ -51,11 +48,8 @@
       <add name="sourceSwitch" value="All"/>
     </switches>
     <sharedListeners>
-      <add name="logfile"
-        type="System.Diagnostics.TextWriterTraceListener"
-        initializeData="c:\tmp\log.txt">
-        <filter type="System.Diagnostics.EventTypeFilter"
-          initializeData="Verbose"/>
+      <add name="logfile" type="System.Diagnostics.TextWriterTraceListener" initializeData="c:\tmp\log.txt">
+        <filter type="System.Diagnostics.EventTypeFilter" initializeData="Verbose"/>
       </add>
     </sharedListeners>
   </system.diagnostics> -->


### PR DESCRIPTION
## Description
- To get stacktrace information for portable and embedded pdbs when net472 installed on machine, Add `AppContextSwitchOverrides` element in appconfigs for all the applications(vstest.console, testhost and datacollector). More details: [here](https://github.com/dotnet/designs/blob/master/accepted/diagnostics/debugging-with-symbols-and-sources.md#stack-traces)
- Add `system.diagnostics` element to vstest.console appconfig. To make easy to user to enable logs.
## Related issue
 [DevDiv Issue](https://devdiv.visualstudio.com/DevDiv/VS.in%20Agile%20Testing%20IDE/_workitems/edit/586862).

**Testing**
Verified by installing net472.
![net472_sourceinfo](https://user-images.githubusercontent.com/4337332/38937953-114d7044-4342-11e8-829f-f214b4374e2e.PNG)

