### PR TITLE
Adding node in runsettings

### DIFF
--- a/src/Microsoft.TestPlatform.Utilities/ClientUtilities.cs
+++ b/src/Microsoft.TestPlatform.Utilities/ClientUtilities.cs
@@ -15,6 +15,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
     {
         private const string TestSettingsFileXPath = "RunSettings/MSTest/SettingsFile";
         private const string ResultsDirectoryXPath = "RunSettings/RunConfiguration/ResultsDirectory";
+        private const string RunsettingsDirectory = "RunSettingsDirectory";
 
         /// <summary>
         /// Converts the relative paths in a runsetting file to absolue ones.
@@ -36,7 +37,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
 
             string root = Path.GetDirectoryName(path);
 
-            AddRelativePathNode(xmlDocument, root);
+            AddRunSettingsDirectoryNode(xmlDocument, root);
 
             var testRunSettingsNode = xmlDocument.SelectSingleNode(TestSettingsFileXPath);
             if (testRunSettingsNode != null)
@@ -51,9 +52,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
             }
         }
 
-        private static void AddRelativePathNode(XmlDocument doc, string path)
+        private static void AddRunSettingsDirectoryNode(XmlDocument doc, string path)
         {
-            var node = doc.CreateNode(XmlNodeType.Element, "RunsettingsDirectory", string.Empty);
+            var node = doc.CreateNode(XmlNodeType.Element, RunsettingsDirectory, string.Empty);
             node.InnerXml = path;
             doc.DocumentElement.AppendChild(node);
         }

--- a/src/Microsoft.TestPlatform.Utilities/ClientUtilities.cs
+++ b/src/Microsoft.TestPlatform.Utilities/ClientUtilities.cs
@@ -35,6 +35,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
             }
 
             string root = Path.GetDirectoryName(path);
+
+            AddRelativePathNode(xmlDocument, root);
+
             var testRunSettingsNode = xmlDocument.SelectSingleNode(TestSettingsFileXPath);
             if (testRunSettingsNode != null)
             {
@@ -46,6 +49,13 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
             {
                 FixNodeFilePath(resultsDirectoryNode, root);
             }
+        }
+
+        private static void AddRelativePathNode(XmlDocument doc, string path)
+        {
+            var node = doc.CreateNode(XmlNodeType.Element, "RunsettingsDirectory", string.Empty);
+            node.InnerXml = path;
+            doc.DocumentElement.AppendChild(node);
         }
 
         private static void FixNodeFilePath(XmlNode node, string root)

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/ClientUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/ClientUtilitiesTests.cs
@@ -41,7 +41,11 @@ namespace Microsoft.TestPlatform.Utilities.Tests
 
             var finalSettingsXml = doc.OuterXml;
 
-            Assert.AreEqual(runSettingsXML, finalSettingsXml);
+            var expectedRunSettingsXML = string.Concat("<RunSettings><RunsettingsDirectory>",
+                Path.GetDirectoryName(currentAssemblyLocation),
+                "</RunsettingsDirectory></RunSettings>");
+
+            Assert.AreEqual(expectedRunSettingsXML, finalSettingsXml);
         }
 
         [TestMethod]
@@ -63,7 +67,9 @@ namespace Microsoft.TestPlatform.Utilities.Tests
             var expectedSettingsXml = string.Concat(
                 "<RunSettings><MSTest><SettingsFile>",
                 expectedPath,
-                "</SettingsFile></MSTest></RunSettings>");
+                "</SettingsFile></MSTest><RunsettingsDirectory>",
+                Path.GetDirectoryName(currentAssemblyLocation),
+                "</RunsettingsDirectory></RunSettings>");
 
             Assert.AreEqual(expectedSettingsXml, finalSettingsXml);
         }
@@ -82,7 +88,11 @@ namespace Microsoft.TestPlatform.Utilities.Tests
 
             var finalSettingsXml = doc.OuterXml;
 
-            Assert.AreEqual(runSettingsXML, finalSettingsXml);
+            var expectedRunSettingsXML = string.Concat("<RunSettings><MSTest><SettingsFile>C:\\temp\\remote.testsettings</SettingsFile></MSTest><RunsettingsDirectory>",
+                Path.GetDirectoryName(currentAssemblyLocation),
+                "</RunsettingsDirectory></RunSettings>");
+
+            Assert.AreEqual(expectedRunSettingsXML, finalSettingsXml);
         }
 
         [TestMethod]
@@ -99,7 +109,11 @@ namespace Microsoft.TestPlatform.Utilities.Tests
 
             var finalSettingsXml = doc.OuterXml;
 
-            Assert.AreEqual(runSettingsXML, finalSettingsXml);
+            var expectedRunSettingsXML = string.Concat("<RunSettings><MSTest><SettingsFile></SettingsFile></MSTest><RunsettingsDirectory>",
+                Path.GetDirectoryName(currentAssemblyLocation),
+                "</RunsettingsDirectory></RunSettings>");
+
+            Assert.AreEqual(expectedRunSettingsXML, finalSettingsXml);
         }
 
         [TestMethod]
@@ -121,7 +135,9 @@ namespace Microsoft.TestPlatform.Utilities.Tests
             var expectedSettingsXml = string.Concat(
                 "<RunSettings><RunConfiguration><ResultsDirectory>",
                 expectedPath,
-                "</ResultsDirectory></RunConfiguration></RunSettings>");
+                "</ResultsDirectory></RunConfiguration><RunsettingsDirectory>",
+                Path.GetDirectoryName(currentAssemblyLocation),
+                "</RunsettingsDirectory></RunSettings>");
 
             Assert.AreEqual(expectedSettingsXml, finalSettingsXml);
         }
@@ -140,7 +156,11 @@ namespace Microsoft.TestPlatform.Utilities.Tests
 
             var finalSettingsXml = doc.OuterXml;
 
-            Assert.AreEqual(runSettingsXML, finalSettingsXml);
+            var expectedRunSettingsXML = string.Concat("<RunSettings><RunConfiguration><ResultsDirectory>C:\\temp\\results</ResultsDirectory></RunConfiguration><RunsettingsDirectory>",
+                Path.GetDirectoryName(currentAssemblyLocation),
+                "</RunsettingsDirectory></RunSettings>");
+
+            Assert.AreEqual(expectedRunSettingsXML, finalSettingsXml);
         }
 
         [TestMethod]
@@ -157,7 +177,11 @@ namespace Microsoft.TestPlatform.Utilities.Tests
 
             var finalSettingsXml = doc.OuterXml;
 
-            Assert.AreEqual(runSettingsXML, finalSettingsXml);
+            var expectedRunSettingsXML = string.Concat("<RunSettings><RunConfiguration><ResultsDirectory></ResultsDirectory></RunConfiguration><RunsettingsDirectory>",
+                Path.GetDirectoryName(currentAssemblyLocation),
+                "</RunsettingsDirectory></RunSettings>");
+
+            Assert.AreEqual(expectedRunSettingsXML, finalSettingsXml);
         }
 
         [TestMethod]
@@ -179,7 +203,9 @@ namespace Microsoft.TestPlatform.Utilities.Tests
             var expectedSettingsXml = string.Concat(
                 "<RunSettings><RunConfiguration><ResultsDirectory>",
                 expectedPath,
-                "</ResultsDirectory></RunConfiguration></RunSettings>");
+                "</ResultsDirectory></RunConfiguration><RunsettingsDirectory>",
+                Path.GetDirectoryName(currentAssemblyLocation),
+                "</RunsettingsDirectory></RunSettings>");
 
             Assert.AreEqual(expectedSettingsXml, finalSettingsXml);
         }

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/ClientUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/ClientUtilitiesTests.cs
@@ -41,9 +41,9 @@ namespace Microsoft.TestPlatform.Utilities.Tests
 
             var finalSettingsXml = doc.OuterXml;
 
-            var expectedRunSettingsXML = string.Concat("<RunSettings><RunsettingsDirectory>",
+            var expectedRunSettingsXML = string.Concat("<RunSettings><RunSettingsDirectory>",
                 Path.GetDirectoryName(currentAssemblyLocation),
-                "</RunsettingsDirectory></RunSettings>");
+                "</RunSettingsDirectory></RunSettings>");
 
             Assert.AreEqual(expectedRunSettingsXML, finalSettingsXml);
         }
@@ -67,9 +67,9 @@ namespace Microsoft.TestPlatform.Utilities.Tests
             var expectedSettingsXml = string.Concat(
                 "<RunSettings><MSTest><SettingsFile>",
                 expectedPath,
-                "</SettingsFile></MSTest><RunsettingsDirectory>",
+                "</SettingsFile></MSTest><RunSettingsDirectory>",
                 Path.GetDirectoryName(currentAssemblyLocation),
-                "</RunsettingsDirectory></RunSettings>");
+                "</RunSettingsDirectory></RunSettings>");
 
             Assert.AreEqual(expectedSettingsXml, finalSettingsXml);
         }
@@ -88,9 +88,9 @@ namespace Microsoft.TestPlatform.Utilities.Tests
 
             var finalSettingsXml = doc.OuterXml;
 
-            var expectedRunSettingsXML = string.Concat("<RunSettings><MSTest><SettingsFile>C:\\temp\\remote.testsettings</SettingsFile></MSTest><RunsettingsDirectory>",
+            var expectedRunSettingsXML = string.Concat("<RunSettings><MSTest><SettingsFile>C:\\temp\\remote.testsettings</SettingsFile></MSTest><RunSettingsDirectory>",
                 Path.GetDirectoryName(currentAssemblyLocation),
-                "</RunsettingsDirectory></RunSettings>");
+                "</RunSettingsDirectory></RunSettings>");
 
             Assert.AreEqual(expectedRunSettingsXML, finalSettingsXml);
         }
@@ -109,9 +109,9 @@ namespace Microsoft.TestPlatform.Utilities.Tests
 
             var finalSettingsXml = doc.OuterXml;
 
-            var expectedRunSettingsXML = string.Concat("<RunSettings><MSTest><SettingsFile></SettingsFile></MSTest><RunsettingsDirectory>",
+            var expectedRunSettingsXML = string.Concat("<RunSettings><MSTest><SettingsFile></SettingsFile></MSTest><RunSettingsDirectory>",
                 Path.GetDirectoryName(currentAssemblyLocation),
-                "</RunsettingsDirectory></RunSettings>");
+                "</RunSettingsDirectory></RunSettings>");
 
             Assert.AreEqual(expectedRunSettingsXML, finalSettingsXml);
         }
@@ -135,9 +135,9 @@ namespace Microsoft.TestPlatform.Utilities.Tests
             var expectedSettingsXml = string.Concat(
                 "<RunSettings><RunConfiguration><ResultsDirectory>",
                 expectedPath,
-                "</ResultsDirectory></RunConfiguration><RunsettingsDirectory>",
+                "</ResultsDirectory></RunConfiguration><RunSettingsDirectory>",
                 Path.GetDirectoryName(currentAssemblyLocation),
-                "</RunsettingsDirectory></RunSettings>");
+                "</RunSettingsDirectory></RunSettings>");
 
             Assert.AreEqual(expectedSettingsXml, finalSettingsXml);
         }
@@ -156,9 +156,9 @@ namespace Microsoft.TestPlatform.Utilities.Tests
 
             var finalSettingsXml = doc.OuterXml;
 
-            var expectedRunSettingsXML = string.Concat("<RunSettings><RunConfiguration><ResultsDirectory>C:\\temp\\results</ResultsDirectory></RunConfiguration><RunsettingsDirectory>",
+            var expectedRunSettingsXML = string.Concat("<RunSettings><RunConfiguration><ResultsDirectory>C:\\temp\\results</ResultsDirectory></RunConfiguration><RunSettingsDirectory>",
                 Path.GetDirectoryName(currentAssemblyLocation),
-                "</RunsettingsDirectory></RunSettings>");
+                "</RunSettingsDirectory></RunSettings>");
 
             Assert.AreEqual(expectedRunSettingsXML, finalSettingsXml);
         }
@@ -177,9 +177,9 @@ namespace Microsoft.TestPlatform.Utilities.Tests
 
             var finalSettingsXml = doc.OuterXml;
 
-            var expectedRunSettingsXML = string.Concat("<RunSettings><RunConfiguration><ResultsDirectory></ResultsDirectory></RunConfiguration><RunsettingsDirectory>",
+            var expectedRunSettingsXML = string.Concat("<RunSettings><RunConfiguration><ResultsDirectory></ResultsDirectory></RunConfiguration><RunSettingsDirectory>",
                 Path.GetDirectoryName(currentAssemblyLocation),
-                "</RunsettingsDirectory></RunSettings>");
+                "</RunSettingsDirectory></RunSettings>");
 
             Assert.AreEqual(expectedRunSettingsXML, finalSettingsXml);
         }
@@ -203,9 +203,9 @@ namespace Microsoft.TestPlatform.Utilities.Tests
             var expectedSettingsXml = string.Concat(
                 "<RunSettings><RunConfiguration><ResultsDirectory>",
                 expectedPath,
-                "</ResultsDirectory></RunConfiguration><RunsettingsDirectory>",
+                "</ResultsDirectory></RunConfiguration><RunSettingsDirectory>",
                 Path.GetDirectoryName(currentAssemblyLocation),
-                "</RunsettingsDirectory></RunSettings>");
+                "</RunSettingsDirectory></RunSettings>");
 
             Assert.AreEqual(expectedSettingsXml, finalSettingsXml);
         }


### PR DESCRIPTION
## Description
Adding a node in runsettings to point to the location, that can be used by adapters down the line.
