### PR TITLE
Always Flush test results,even if RecordEnd is not called

### DIFF
--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Adapter/TestExecutionRecorderTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Adapter/TestExecutionRecorderTests.cs
@@ -178,13 +178,9 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Adapter
         }
 
         [TestMethod]
-        public void RecordResultShouldNotFlushIfTestCaseEndWasNotCalledBefore()
+        public void RecordResultShouldFlushEvenIfTestCaseEndWasCalledBefore()
         {
             this.testRecorderWithTestEventsHandler.RecordResult(this.testResult);
-            this.testRecorderWithTestEventsHandler.RecordResult(this.testResult);
-            Assert.IsFalse(this.testableTestRunCache.TestResultList.Contains(this.testResult));
-
-            this.testRecorderWithTestEventsHandler.RecordEnd(this.testCase, TestOutcome.Passed);
             Assert.IsTrue(this.testableTestRunCache.TestResultList.Contains(this.testResult));
         }
         #endregion


### PR DESCRIPTION
## Description
TestResults are not flushed if datacollection is enabled, & RecordEnd is not invoked.

## Related issue
Fixes #1519
