### PR TITLE
Always look for adapters in Test Source directory

### DIFF
--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask.cs
@@ -131,7 +131,7 @@ namespace Microsoft.TestPlatform.Build.Tasks
 
         internal IEnumerable<string> CreateArgument()
         {
-            var initializeConsoleLogger = true;
+            var isConsoleLoggerEnabled = true;
             var allArgs = new List<string>();
 
             // TODO log arguments in task
@@ -145,14 +145,6 @@ namespace Microsoft.TestPlatform.Build.Tasks
                 foreach (var arg in this.VSTestTestAdapterPath)
                 {
                     allArgs.Add("--testAdapterPath:" + ArgumentEscaper.HandleEscapeSequenceInArgForProcessStart(arg));
-                }
-            }
-            else
-            {
-                // For Full CLR, add source directory as test adapter path.
-                if (this.VSTestFramework.StartsWith(".NETFramework", StringComparison.OrdinalIgnoreCase))
-                {
-                    allArgs.Add("--testAdapterPath:" + ArgumentEscaper.HandleEscapeSequenceInArgForProcessStart(Path.GetDirectoryName(this.TestFileFullPath)));
                 }
             }
 
@@ -180,7 +172,7 @@ namespace Microsoft.TestPlatform.Build.Tasks
 
                     if (arg.StartsWith("console", StringComparison.OrdinalIgnoreCase))
                     {
-                        initializeConsoleLogger = false;
+                        isConsoleLoggerEnabled = false;
                     }
                 }
             }
@@ -210,7 +202,7 @@ namespace Microsoft.TestPlatform.Build.Tasks
             }
 
             // Console logger was not specified by user, but verbosity was, hence add default console logger with verbosity as specified
-            if (!string.IsNullOrWhiteSpace(this.VSTestVerbosity) && initializeConsoleLogger)
+            if (!string.IsNullOrWhiteSpace(this.VSTestVerbosity) && isConsoleLoggerEnabled)
             {
                 var normalTestLogging = new List<string>() { "n", "normal", "d", "detailed", "diag", "diagnostic" };
                 var quietTestLogging = new List<string>() { "q", "quiet" };

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -58,7 +58,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
         private StringBuilder testHostProcessStdError;
         private IMessageLogger messageLogger;
         private bool hostExitedEventRaised;
-        private bool projectOutputExtensionsRequired;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultTestHostManager"/> class.
@@ -192,7 +191,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
         /// <inheritdoc/>
         public IEnumerable<string> GetTestPlatformExtensions(IEnumerable<string> sources, IEnumerable<string> extensions)
         {
-            if (sources != null && sources.Any() && this.projectOutputExtensionsRequired)
+            if (sources != null && sources.Any())
             {
                 extensions = extensions.Concat(sources.SelectMany(s => this.fileHelper.EnumerateFiles(Path.GetDirectoryName(s), SearchOption.TopDirectoryOnly, TestAdapterEndsWithPattern)));
             }
@@ -248,7 +247,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
             this.testHostProcess = null;
 
             this.Shared = !runConfiguration.DisableAppDomain;
-            this.projectOutputExtensionsRequired = !(runConfiguration.TestAdaptersPaths?.Length > 0);
             this.hostExitedEventRaised = false;
         }
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DataCollectionTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DataCollectionTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 IntegrationTestEnvironment.BuildConfiguration,
                 this.testEnvironment.RunnerFramework);
             var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), runSettings, this.FrameworkArgValue, runnerInfo.InIsolationValue);
-            arguments = string.Concat(arguments, $" /ResultsDirectory:{resultsDir}", $" /Diag:{diagFileName}", $" /TestAdapterPath:{extensionsPath}");
+            arguments = string.Concat(arguments, $" /ResultsDirectory:{resultsDir}", $" /Diag:{diagFileName}");
 
             this.InvokeVsTest(arguments);
 
@@ -74,7 +74,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 this.testEnvironment.RunnerFramework);
 
             var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), null, this.FrameworkArgValue, runnerInfo.InIsolationValue);
-            arguments = string.Concat(arguments, $" /ResultsDirectory:{resultsDir}", $" /Diag:{diagFileName}", $" /Collect:SampleDataCollector", $" /TestAdapterPath:{extensionsPath}");
+            arguments = string.Concat(arguments, $" /ResultsDirectory:{resultsDir}", $" /Diag:{diagFileName}", $" /Collect:SampleDataCollector");
 
             this.InvokeVsTest(arguments);
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DataCollectionTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DataCollectionTests.cs
@@ -48,8 +48,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 "bin",
                 IntegrationTestEnvironment.BuildConfiguration,
                 this.testEnvironment.RunnerFramework);
-            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), runSettings, this.FrameworkArgValue, runnerInfo.InIsolationValue);
-            arguments = string.Concat(arguments, $" /ResultsDirectory:{resultsDir}", $" /Diag:{diagFileName}");
+            var arguments = PrepareArguments(assemblyPaths, null, runSettings, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            arguments = string.Concat(arguments, $" /ResultsDirectory:{resultsDir}", $" /Diag:{diagFileName}", $" /TestAdapterPath:{extensionsPath}");
 
             this.InvokeVsTest(arguments);
 
@@ -73,8 +73,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 IntegrationTestEnvironment.BuildConfiguration,
                 this.testEnvironment.RunnerFramework);
 
-            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), null, this.FrameworkArgValue, runnerInfo.InIsolationValue);
-            arguments = string.Concat(arguments, $" /ResultsDirectory:{resultsDir}", $" /Diag:{diagFileName}", $" /Collect:SampleDataCollector");
+            var arguments = PrepareArguments(assemblyPaths, null, null, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            arguments = string.Concat(arguments, $" /ResultsDirectory:{resultsDir}", $" /Diag:{diagFileName}", $" /Collect:SampleDataCollector", $" /TestAdapterPath:{extensionsPath}");
 
             this.InvokeVsTest(arguments);
 

--- a/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.TestPlatform.Build.UnitTests
             // Add values for required properties.
             vstestTask.TestFileFullPath = "abc";
             vstestTask.VSTestFramework = "abc";
-            vstestTask.VSTestLogger = "Console;Verbosity=quiet";
+            vstestTask.VSTestLogger = new string[] { "Console;Verbosity=quiet" };
 
             var allArguments = vstestTask.CreateArgument().ToArray();
 
@@ -209,7 +209,7 @@ namespace Microsoft.TestPlatform.Build.UnitTests
             // Add values for required properties.
             vstestTask.TestFileFullPath = "abc";
             vstestTask.VSTestFramework = "abc";
-            vstestTask.VSTestLogger = "trx;LogFileName=foo bar.trx";
+            vstestTask.VSTestLogger = new string[] { "trx;LogFileName=foo bar.trx" };
 
 
             var allArguments = vstestTask.CreateArgument().ToArray();
@@ -233,6 +233,41 @@ namespace Microsoft.TestPlatform.Build.UnitTests
 
             Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--collect:name1")));
             Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--collect:\"name 2\"")));
+        }
+
+        [TestMethod]
+        public void CreateArgumentShouldAddMultipleTestAdapterPaths()
+        {
+            var vstestTask = new VSTestTask();
+
+            // Add values for required properties.
+            vstestTask.TestFileFullPath = "abc";
+            vstestTask.VSTestFramework = "abc";
+
+            vstestTask.VSTestTestAdapterPath = new string[] { "path1", "path2" };
+
+            var allArguments = vstestTask.CreateArgument().ToArray();
+
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--testAdapterPath:path1")));
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--testAdapterPath:path1")));
+        }
+
+        [TestMethod]
+        public void CreateArgumentShouldAddMultipleLoggers()
+        {
+            var vstestTask = new VSTestTask();
+
+            // Add values for required properties.
+            vstestTask.TestFileFullPath = "abc";
+            vstestTask.VSTestFramework = "abc";
+
+            vstestTask.VSTestLogger = new string[] { "trx;LogFileName=foo bar.trx", "console" };
+
+
+            var allArguments = vstestTask.CreateArgument().ToArray();
+
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:\"trx;LogFileName=foo bar.trx\"")));
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--logger:console")));
         }
     }
 }

--- a/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
@@ -249,7 +249,7 @@ namespace Microsoft.TestPlatform.Build.UnitTests
             var allArguments = vstestTask.CreateArgument().ToArray();
 
             Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--testAdapterPath:path1")));
-            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--testAdapterPath:path1")));
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--testAdapterPath:path2")));
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -219,8 +219,11 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
             List<string> extensionsList1 = new List<string> { @"C:\Source1\ext1.TestAdapter.dll", @"C:\Source1\ext2.TestAdapter.dll" };
             this.mockFileHelper.Setup(fh => fh.EnumerateFiles(sourcesDir[0], SearchOption.TopDirectoryOnly, "TestAdapter.dll")).Returns(extensionsList1);
 
+            this.mockFileHelper.Setup(fh => fh.GetFileVersion(extensionsList1[0])).Returns(new Version(2, 0));
+            this.mockFileHelper.Setup(fh => fh.GetFileVersion(extensionsList1[1])).Returns(new Version(5, 5));
+
             this.testHostManager.Initialize(this.mockMessageLogger.Object, $"<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings> <RunConfiguration><TestAdaptersPaths>C:\\Foo</TestAdaptersPaths></RunConfiguration> </RunSettings>");
-            List<string> currentList = new List<string> { @"FooExtension.dll" };
+            List<string> currentList = new List<string> { @"FooExtension.dll", @"C:\Source1\ext1.TestAdapter.dll", @"C:\Source1\ext2.TestAdapter.dll" };
 
             // Act
             var resultExtensions = this.testHostManager.GetTestPlatformExtensions(sources, currentList).ToList();

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -211,7 +211,7 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
         }
 
         [TestMethod]
-        public void GetTestPlatformExtensionsShouldExcludeOutputDirectoryExtensionsIfTestAdapterPathIsSet()
+        public void GetTestPlatformExtensionsShouldNotExcludeOutputDirectoryExtensionsIfTestAdapterPathIsSet()
         {
             List<string> sourcesDir = new List<string> { @"C:\Source1" };
             List<string> sources = new List<string> { @"C:\Source1\source1.dll" };


### PR DESCRIPTION
## Description

- Allow Testadapters to be picked from source dir for fullCLR projects
- Allow dotnet CLI to take multiple inputs for logger, & TAP

Dotnet CLI PR: https://github.com/dotnet/cli/pull/9198

## Related issue
Fixes https://github.com/Microsoft/vstest/issues/1319 
