### PR TITLE
Test platform externals version upgrade - Duplicate tests fix and mstest v1 hierarchical capabilities

### DIFF
--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -25,6 +25,6 @@
 
     <JsonNetVersion>9.0.1</JsonNetVersion>
     <MoqVersion>4.7.63</MoqVersion>
-    <TestPlatformExternalsVersion>15.7.0-preview-1570038</TestPlatformExternalsVersion>
+    <TestPlatformExternalsVersion>15.8.0-preview-1667498</TestPlatformExternalsVersion>
   </PropertyGroup>
 </Project>

--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -25,6 +25,6 @@
 
     <JsonNetVersion>9.0.1</JsonNetVersion>
     <MoqVersion>4.7.63</MoqVersion>
-    <TestPlatformExternalsVersion>15.8.0-preview-1667498</TestPlatformExternalsVersion>
+    <TestPlatformExternalsVersion>15.8.0-preview-1674842</TestPlatformExternalsVersion>
   </PropertyGroup>
 </Project>

--- a/test/Microsoft.TestPlatform.AcceptanceTests/OrderedTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/OrderedTests.cs
@@ -49,7 +49,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             this.ValidatePassedTests("PassingTest2");
             this.ValidateFailedTests("FailingTest1");
             this.ValidateSkippedTests("FailingTest2");
-            this.ValidateSummaryStatus(2, 1, 1);
+            // Parent test result should fail as inner results contain failing test.
+            this.ValidateSummaryStatus(2, 2, 1);
         }
 
     }


### PR DESCRIPTION
## Description
Bringing following adapter changes in TPv2:
1. [Pull Request 118254](https://devdiv.visualstudio.com/DevDiv/Automated%20Testing/_git/VS/pullrequest/118254?_a=overview): Multiple tests with same name throwing Duplicate key error.
2. [Pull Request 114448](https://devdiv.visualstudio.com/DevDiv/Automated%20Testing/_git/VS/pullrequest/114448?_a=overview): Port - Adding test case connection using PAT token
3. [Pull Request 100465](https://devdiv.visualstudio.com/DevDiv/Automated%20Testing/_git/VS/pullrequest/100465?_a=overview): Tmi and mstest v1 adapter Changes for making trx logger hierarchical
