### PR TITLE
Show code coverage not supported message on non windows

### DIFF
--- a/src/DataCollectors/TraceDataCollector/Interfaces/IEnvironment.cs
+++ b/src/DataCollectors/TraceDataCollector/Interfaces/IEnvironment.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TraceCollector.Interfaces
+{
+    /// <summary>
+    /// Operating system environment abstractions.
+    /// </summary>
+    internal interface IEnvironment
+    {
+        /// <summary>
+        /// Gets operating System.
+        /// </summary>
+        PlatformOperatingSystem OperatingSystem { get; }
+    }
+}

--- a/src/DataCollectors/TraceDataCollector/Interfaces/PlatformOperationSystem.cs
+++ b/src/DataCollectors/TraceDataCollector/Interfaces/PlatformOperationSystem.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.TraceCollector.Interfaces
     /// <summary>
     /// Available operating systems.
     /// </summary>
-    public enum PlatformOperatingSystem
+    internal enum PlatformOperatingSystem
     {
         Windows,
         Unix

--- a/src/DataCollectors/TraceDataCollector/Interfaces/PlatformOperationSystem.cs
+++ b/src/DataCollectors/TraceDataCollector/Interfaces/PlatformOperationSystem.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TraceCollector.Interfaces
+{
+    using System;
+
+    /// <summary>
+    /// Available operating systems.
+    /// </summary>
+    public enum PlatformOperatingSystem
+    {
+        Windows,
+        Unix
+    }
+}

--- a/src/DataCollectors/TraceDataCollector/PlatformEnvironment.cs
+++ b/src/DataCollectors/TraceDataCollector/PlatformEnvironment.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TraceCollector
+{
+    using System.Runtime.InteropServices;
+    using Interfaces;
+
+    /// <inheritdoc />
+    internal class PlatformEnvironment : IEnvironment
+    {/// <inheritdoc />
+        public PlatformOperatingSystem OperatingSystem
+        {
+            get
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    return PlatformOperatingSystem.Windows;
+                }
+
+                return PlatformOperatingSystem.Unix;
+            }
+        }
+    }
+}
+

--- a/src/DataCollectors/TraceDataCollector/PlatformEnvironment.cs
+++ b/src/DataCollectors/TraceDataCollector/PlatformEnvironment.cs
@@ -8,7 +8,8 @@ namespace Microsoft.VisualStudio.TraceCollector
 
     /// <inheritdoc />
     internal class PlatformEnvironment : IEnvironment
-    {/// <inheritdoc />
+    {
+        /// <inheritdoc />
         public PlatformOperatingSystem OperatingSystem
         {
             get

--- a/src/DataCollectors/TraceDataCollector/PlatformEnvironment.cs
+++ b/src/DataCollectors/TraceDataCollector/PlatformEnvironment.cs
@@ -23,4 +23,3 @@ namespace Microsoft.VisualStudio.TraceCollector
         }
     }
 }
-

--- a/src/DataCollectors/TraceDataCollector/Resources/Resources.Designer.cs
+++ b/src/DataCollectors/TraceDataCollector/Resources/Resources.Designer.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.TraceDataCollector.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Currently code coverage support available only for Windows operating system. No code coverage data available for current test run..
+        ///   Looks up a localized string similar to No code coverage data available. Code coverage is currently supported only on Windows..
         /// </summary>
         internal static string CodeCoverageOnlySupportsWindows {
             get {

--- a/src/DataCollectors/TraceDataCollector/Resources/Resources.Designer.cs
+++ b/src/DataCollectors/TraceDataCollector/Resources/Resources.Designer.cs
@@ -62,6 +62,15 @@ namespace Microsoft.VisualStudio.TraceDataCollector.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Currently code coverage support available only for Windows operating system. No code coverage data available for current test run..
+        /// </summary>
+        internal static string CodeCoverageOnlySupportsWindows {
+            get {
+                return ResourceManager.GetString("CodeCoverageOnlySupportsWindows", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to create directory: {0} with error:{1}.
         /// </summary>
         internal static string FailedToCreateDirectory {

--- a/src/DataCollectors/TraceDataCollector/Resources/Resources.resx
+++ b/src/DataCollectors/TraceDataCollector/Resources/Resources.resx
@@ -133,6 +133,6 @@
     <value>Failed to receive running event from CodeCoverage.exe in {0} seconds, This may occur due to machine slowness, please set environment variable {1} to increase timeout.</value>
   </data>
   <data name="CodeCoverageOnlySupportsWindows" xml:space="preserve">
-    <value>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</value>
+    <value>No code coverage data available. Code coverage is currently supported only on Windows.</value>
   </data>
 </root>

--- a/src/DataCollectors/TraceDataCollector/Resources/Resources.resx
+++ b/src/DataCollectors/TraceDataCollector/Resources/Resources.resx
@@ -132,4 +132,7 @@
   <data name="VanguardConnectionTimeout" xml:space="preserve">
     <value>Failed to receive running event from CodeCoverage.exe in {0} seconds, This may occur due to machine slowness, please set environment variable {1} to increase timeout.</value>
   </data>
+  <data name="CodeCoverageOnlySupportsWindows" xml:space="preserve">
+    <value>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</value>
+  </data>
 </root>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.cs.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.cs.xlf
@@ -46,7 +46,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="CodeCoverageOnlySupportsWindows">
-        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <source>No code coverage data available. Code coverage is currently supported only on Windows.</source>
         <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
         <note></note>
       </trans-unit>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.cs.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.cs.xlf
@@ -45,6 +45,11 @@
         <target state="new">Failed to initialize code coverage datacollector with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CodeCoverageOnlySupportsWindows">
+        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.de.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.de.xlf
@@ -46,7 +46,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="CodeCoverageOnlySupportsWindows">
-        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <source>No code coverage data available. Code coverage is currently supported only on Windows.</source>
         <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
         <note></note>
       </trans-unit>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.de.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.de.xlf
@@ -45,6 +45,11 @@
         <target state="new">Failed to initialize code coverage datacollector with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CodeCoverageOnlySupportsWindows">
+        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.es.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.es.xlf
@@ -46,7 +46,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="CodeCoverageOnlySupportsWindows">
-        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <source>No code coverage data available. Code coverage is currently supported only on Windows.</source>
         <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
         <note></note>
       </trans-unit>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.es.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.es.xlf
@@ -45,6 +45,11 @@
         <target state="new">Failed to initialize code coverage datacollector with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CodeCoverageOnlySupportsWindows">
+        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.fr.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.fr.xlf
@@ -46,7 +46,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="CodeCoverageOnlySupportsWindows">
-        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <source>No code coverage data available. Code coverage is currently supported only on Windows.</source>
         <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
         <note></note>
       </trans-unit>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.fr.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.fr.xlf
@@ -45,6 +45,11 @@
         <target state="new">Failed to initialize code coverage datacollector with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CodeCoverageOnlySupportsWindows">
+        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.it.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.it.xlf
@@ -46,7 +46,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="CodeCoverageOnlySupportsWindows">
-        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <source>No code coverage data available. Code coverage is currently supported only on Windows.</source>
         <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
         <note></note>
       </trans-unit>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.it.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.it.xlf
@@ -45,6 +45,11 @@
         <target state="new">Failed to initialize code coverage datacollector with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CodeCoverageOnlySupportsWindows">
+        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.ja.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.ja.xlf
@@ -46,7 +46,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="CodeCoverageOnlySupportsWindows">
-        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <source>No code coverage data available. Code coverage is currently supported only on Windows.</source>
         <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
         <note></note>
       </trans-unit>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.ja.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.ja.xlf
@@ -45,6 +45,11 @@
         <target state="new">Failed to initialize code coverage datacollector with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CodeCoverageOnlySupportsWindows">
+        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.ko.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.ko.xlf
@@ -46,7 +46,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="CodeCoverageOnlySupportsWindows">
-        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <source>No code coverage data available. Code coverage is currently supported only on Windows.</source>
         <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
         <note></note>
       </trans-unit>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.ko.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.ko.xlf
@@ -45,6 +45,11 @@
         <target state="new">Failed to initialize code coverage datacollector with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CodeCoverageOnlySupportsWindows">
+        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.pl.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.pl.xlf
@@ -46,7 +46,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="CodeCoverageOnlySupportsWindows">
-        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <source>No code coverage data available. Code coverage is currently supported only on Windows.</source>
         <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
         <note></note>
       </trans-unit>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.pl.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.pl.xlf
@@ -45,6 +45,11 @@
         <target state="new">Failed to initialize code coverage datacollector with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CodeCoverageOnlySupportsWindows">
+        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.pt-BR.xlf
@@ -46,7 +46,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="CodeCoverageOnlySupportsWindows">
-        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <source>No code coverage data available. Code coverage is currently supported only on Windows.</source>
         <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
         <note></note>
       </trans-unit>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.pt-BR.xlf
@@ -45,6 +45,11 @@
         <target state="new">Failed to initialize code coverage datacollector with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CodeCoverageOnlySupportsWindows">
+        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.ru.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.ru.xlf
@@ -46,7 +46,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="CodeCoverageOnlySupportsWindows">
-        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <source>No code coverage data available. Code coverage is currently supported only on Windows.</source>
         <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
         <note></note>
       </trans-unit>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.ru.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.ru.xlf
@@ -45,6 +45,11 @@
         <target state="new">Failed to initialize code coverage datacollector with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CodeCoverageOnlySupportsWindows">
+        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.tr.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.tr.xlf
@@ -46,7 +46,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="CodeCoverageOnlySupportsWindows">
-        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <source>No code coverage data available. Code coverage is currently supported only on Windows.</source>
         <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
         <note></note>
       </trans-unit>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.tr.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.tr.xlf
@@ -45,6 +45,11 @@
         <target state="new">Failed to initialize code coverage datacollector with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CodeCoverageOnlySupportsWindows">
+        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.xlf
@@ -27,6 +27,11 @@
         <target state="new">Failed to initialize code coverage datacollector with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CodeCoverageOnlySupportsWindows">
+        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.xlf
@@ -28,7 +28,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="CodeCoverageOnlySupportsWindows">
-        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <source>No code coverage data available. Code coverage is currently supported only on Windows.</source>
         <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
         <note></note>
       </trans-unit>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.zh-Hans.xlf
@@ -46,7 +46,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="CodeCoverageOnlySupportsWindows">
-        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <source>No code coverage data available. Code coverage is currently supported only on Windows.</source>
         <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
         <note></note>
       </trans-unit>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.zh-Hans.xlf
@@ -45,6 +45,11 @@
         <target state="new">Failed to initialize code coverage datacollector with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CodeCoverageOnlySupportsWindows">
+        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.zh-Hant.xlf
@@ -46,7 +46,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="CodeCoverageOnlySupportsWindows">
-        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <source>No code coverage data available. Code coverage is currently supported only on Windows.</source>
         <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
         <note></note>
       </trans-unit>

--- a/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/DataCollectors/TraceDataCollector/Resources/xlf/Resources.zh-Hant.xlf
@@ -45,6 +45,11 @@
         <target state="new">Failed to initialize code coverage datacollector with error: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CodeCoverageOnlySupportsWindows">
+        <source>Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</source>
+        <target state="new">Currently code coverage support available only for Windows operating system. No code coverage data available for current test run.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/DataCollectors/TraceDataCollector/VanguardCollector/DynamicCoverageDataCollector.cs
+++ b/src/DataCollectors/TraceDataCollector/VanguardCollector/DynamicCoverageDataCollector.cs
@@ -7,6 +7,7 @@ namespace Microsoft.VisualStudio.Coverage
     using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
+    using System.Linq;
     using System.Xml;
     using Interfaces;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
@@ -130,6 +131,11 @@ namespace Microsoft.VisualStudio.Coverage
         /// <returns>Returns EnvironmentVariables required for code coverage profiler. </returns>
         protected override IEnumerable<KeyValuePair<string, string>> GetEnvironmentVariables()
         {
+            if (this.isWindowsOS == false)
+            {
+                return Enumerable.Empty<KeyValuePair<string, string>>();
+            }
+
             var vanguardDirectory = this.vanguardLocationProvider.GetVanguardDirectory();
             var vanguardX86ProfilerFullPath = Path.Combine(vanguardDirectory, VanguardX86ProfilerPath);
             var vanguardX64ProfilerFullPath = Path.Combine(vanguardDirectory, VanguardX64ProfilerPath);

--- a/src/DataCollectors/TraceDataCollector/VanguardCollector/DynamicCoverageDataCollector.cs
+++ b/src/DataCollectors/TraceDataCollector/VanguardCollector/DynamicCoverageDataCollector.cs
@@ -10,10 +10,9 @@ namespace Microsoft.VisualStudio.Coverage
     using System.Xml;
     using Interfaces;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
-    using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
     using Microsoft.VisualStudio.TraceCollector;
     using TestPlatform.ObjectModel;
-    using TestPlatform.PlatformAbstractions.Interfaces;
+    using TraceCollector.Interfaces;
     using TraceDataCollector.Resources;
 
     /// <summary>

--- a/test/DataCollectors/TraceDataCollector.UnitTests/DynamicCoverageDataCollectorTests.cs
+++ b/test/DataCollectors/TraceDataCollector.UnitTests/DynamicCoverageDataCollectorTests.cs
@@ -71,6 +71,7 @@ namespace Microsoft.VisualStudio.TraceDataCollector.UnitTests
         public void InitializeShouldThrowIfCurrentOperatingSystemIsUnix()
         {
             this.environmentMock.Setup(e => e.OperatingSystem).Returns(PlatformOperatingSystem.Unix);
+            this.collector = new TestableDynamicCoverageDataCollector(this.vanguardLocationProviderMock.Object, null, this.environmentMock.Object);
 
             var actualException = Assert.ThrowsException<VanguardException>(() =>
                 this.collector.Initialize(

--- a/test/DataCollectors/TraceDataCollector.UnitTests/DynamicCoverageDataCollectorTests.cs
+++ b/test/DataCollectors/TraceDataCollector.UnitTests/DynamicCoverageDataCollectorTests.cs
@@ -13,9 +13,8 @@ namespace Microsoft.VisualStudio.TraceDataCollector.UnitTests
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
     using TestPlatform.ObjectModel.DataCollection;
-    using TestPlatform.PlatformAbstractions;
-    using TestPlatform.PlatformAbstractions.Interfaces;
     using TraceCollector;
+    using TraceCollector.Interfaces;
     using IDataCollectionSink = TraceCollector.IDataCollectionSink;
 
     [TestClass]

--- a/test/DataCollectors/TraceDataCollector.UnitTests/DynamicCoverageDataCollectorTests.cs
+++ b/test/DataCollectors/TraceDataCollector.UnitTests/DynamicCoverageDataCollectorTests.cs
@@ -181,6 +181,24 @@ namespace Microsoft.VisualStudio.TraceDataCollector.UnitTests
         }
 
         [TestMethod]
+        public void GetEnvironmentVariablesShouldReturnNoEnvVaribles()
+        {
+            this.implMock = new Mock<IDynamicCoverageDataCollectorImpl>();
+            this.environmentMock.Setup(e => e.OperatingSystem).Returns(PlatformOperatingSystem.Unix);
+            this.collector = new TestableDynamicCoverageDataCollector(this.vanguardLocationProviderMock.Object, null, this.environmentMock.Object);
+
+            this.collector.Initialize(
+                null,
+                this.eventsMock.Object,
+                this.sinkMock.Object,
+                this.loggerMock.Object,
+                this.agentContextMock.Object);
+            var envVars = this.collector.GetEnvironmentVariables();
+
+            Assert.IsFalse(envVars.Any(), "No environment variables set on unix.");
+        }
+
+        [TestMethod]
         public void DisposeShouldDisposeImpl()
         {
             this.collector.Dispose();


### PR DESCRIPTION
## Description
- Display proper warning when user try to collect code coverage on Unix.

**Current warning**
```
Data collection : Data collector 'Code Coverage' threw an exception during type loading, construction, or initialization: System.Reflection.TargetInvocationException:Exception has been thrown by the target of an invocation. ---> System.DllNotFoundException: Unable to load shared library 'kernel32.dll' or one of its dependencies. In order to help diagnose loading problems, consider setting the LD_DEBUG environment variable: libkernel32.dll: cannot open shared object file: No such file or directory
   at Microsoft.VisualStudio.TraceCollector.ProcessJobObject.WinAPI.CreateJobObject(IntPtr jobAttributes, String name)
   at Microsoft.VisualStudio.TraceCollector.ProcessJobObject.CreateJobObject()
   at Microsoft.VisualStudio.Coverage.Vanguard..ctor()
   at Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollectorImpl..ctor()
   at Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector..ctor()
   --- End of inner exception stack trace ---
   at System.RuntimeTypeHandle.CreateInstance(RuntimeType type, Boolean publicOnly, Boolean wrapExceptions, Boolean& canBeCached, RuntimeMethodHandleInternal& ctor)
   at System.RuntimeType.CreateInstanceSlow(Boolean publicOnly, Boolean wrapExceptions, Boolean skipCheckThis, Boolean fillCache)
   at Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework.TestPluginManager.CreateTestExtension[T](Type extensionType)
   at Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework.Utilities.LazyExtension`2.get_Value()
   at Microsoft.VisualStudio.TestPlatform.Common.DataCollector.DataCollectionManager.TryGetTestExtension(String extensionUri)
   at Microsoft.VisualStudio.TestPlatform.Common.DataCollector.DataCollectionManager.LoadAndInitialize(DataCollectorSettings dataCollectorSettings, String settingsXml).
```