### PR TITLE
Display message to update Microsoft.NET.Test.Sdk

### DIFF
--- a/src/Microsoft.TestPlatform.Build/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.Build/Resources/Resources.Designer.cs
@@ -87,5 +87,14 @@ namespace Microsoft.TestPlatform.Build.Resources {
                 return ResourceManager.GetString("TestRunningSummary", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To collect code coverage update Microsoft.NET.Test.Sdk package version to latest..
+        /// </summary>
+        internal static string UpdateTestSdkForCollectingCodeCoverage {
+            get {
+                return ResourceManager.GetString("UpdateTestSdkForCollectingCodeCoverage", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Microsoft.TestPlatform.Build/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.Build/Resources/Resources.Designer.cs
@@ -87,9 +87,9 @@ namespace Microsoft.TestPlatform.Build.Resources {
                 return ResourceManager.GetString("TestRunningSummary", resourceCulture);
             }
         }
-        
+
         /// <summary>
-        ///   Looks up a localized string similar to To collect code coverage update Microsoft.NET.Test.Sdk package version to latest..
+        ///   Looks up a localized string similar to Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage..
         /// </summary>
         internal static string UpdateTestSdkForCollectingCodeCoverage {
             get {

--- a/src/Microsoft.TestPlatform.Build/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.Build/Resources/Resources.resx
@@ -127,6 +127,6 @@
     <value>Test run for {0}({1})</value>
   </data>
   <data name="UpdateTestSdkForCollectingCodeCoverage" xml:space="preserve">
-    <value>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</value>
+    <value>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</value>
   </data>
 </root>

--- a/src/Microsoft.TestPlatform.Build/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.Build/Resources/Resources.resx
@@ -126,4 +126,7 @@
   <data name="TestRunningSummary" xml:space="preserve">
     <value>Test run for {0}({1})</value>
   </data>
+  <data name="UpdateTestSdkForCollectingCodeCoverage" xml:space="preserve">
+    <value>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</value>
+  </data>
 </root>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.cs.xlf
@@ -35,6 +35,11 @@
         <target state="translated">Testovací běh pro: {0}({1})</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
+        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.cs.xlf
@@ -36,7 +36,7 @@
         <note />
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
-        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>
         <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.de.xlf
@@ -36,7 +36,7 @@
         <note />
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
-        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>
         <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.de.xlf
@@ -35,6 +35,11 @@
         <target state="translated">Testlauf für "{0}" ({1})</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
+        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.es.xlf
@@ -35,6 +35,11 @@
         <target state="translated">Serie de pruebas para {0}({1})</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
+        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.es.xlf
@@ -36,7 +36,7 @@
         <note />
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
-        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>
         <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.fr.xlf
@@ -36,7 +36,7 @@
         <note />
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
-        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>
         <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.fr.xlf
@@ -35,6 +35,11 @@
         <target state="translated">Série de tests pour {0}({1})</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
+        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.it.xlf
@@ -36,7 +36,7 @@
         <note />
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
-        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>
         <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.it.xlf
@@ -35,6 +35,11 @@
         <target state="translated">Esecuzione dei test per {0}({1})</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
+        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ja.xlf
@@ -35,6 +35,11 @@
         <target state="translated">{0}({1}) のテスト実行</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
+        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ja.xlf
@@ -36,7 +36,7 @@
         <note />
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
-        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>
         <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ko.xlf
@@ -35,6 +35,11 @@
         <target state="translated">{0}({1})에 대한 테스트 실행</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
+        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ko.xlf
@@ -36,7 +36,7 @@
         <note />
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
-        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>
         <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.pl.xlf
@@ -35,6 +35,11 @@
         <target state="translated">Przebieg testu dla: {0}({1})</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
+        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.pl.xlf
@@ -36,7 +36,7 @@
         <note />
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
-        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>
         <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.pt-BR.xlf
@@ -36,7 +36,7 @@
         <note />
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
-        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>
         <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.pt-BR.xlf
@@ -35,6 +35,11 @@
         <target state="translated">Execução de teste para {0}({1})</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
+        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ru.xlf
@@ -35,6 +35,11 @@
         <target state="translated">Тестовый запуск {0}({1})</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
+        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ru.xlf
@@ -36,7 +36,7 @@
         <note />
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
-        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>
         <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.tr.xlf
@@ -36,7 +36,7 @@
         <note />
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
-        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>
         <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.tr.xlf
@@ -35,6 +35,11 @@
         <target state="translated">{0}({1}) için test çalıştırması</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
+        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.xlf
@@ -18,7 +18,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
-        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>
         <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.xlf
@@ -17,6 +17,11 @@
         <target state="new">Test run for {0}({1})</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
+        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.zh-Hans.xlf
@@ -36,7 +36,7 @@
         <note />
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
-        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>
         <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.zh-Hans.xlf
@@ -35,6 +35,11 @@
         <target state="translated">{0} 的测试运行({1})</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
+        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.zh-Hant.xlf
@@ -36,7 +36,7 @@
         <note />
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
-        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>
         <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.zh-Hant.xlf
@@ -35,6 +35,11 @@
         <target state="translated">{0}({1}) 的測試回合</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
+        <source>To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</source>
+        <target state="new">To collect code coverage update Microsoft.NET.Test.Sdk package version to latest.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask.cs
@@ -229,13 +229,9 @@ namespace Microsoft.TestPlatform.Build.Tasks
                 allArgs.Add("--logger:Console;Verbosity=" + vsTestVerbosity);
             }
 
-            if (this.VSTestCLIRunSettings != null && this.VSTestCLIRunSettings.Length > 0)
+            if (!string.IsNullOrEmpty(this.VSTestBlame))
             {
-                allArgs.Add("--");
-                foreach (var arg in this.VSTestCLIRunSettings)
-                {
-                    allArgs.Add(ArgumentEscaper.HandleEscapeSequenceInArgForProcessStart(arg));
-                }
+                allArgs.Add("--Blame");
             }
 
             if (this.VSTestCollect != null && this.VSTestCollect.Length > 0)
@@ -264,12 +260,27 @@ namespace Microsoft.TestPlatform.Build.Tasks
                 {
                     allArgs.Add("--testAdapterPath:" + ArgumentEscaper.HandleEscapeSequenceInArgForProcessStart(this.VSTestTraceDataCollectorDirectoryPath));
                 }
+                else
+                {
+                    if (isCollectCodeCoverageEnabled)
+                    {
+                        // Not showing message in runsettings scenario, because we are not sure that code coverage is enabled.
+                        // User might be using older Microsoft.NET.Test.Sdk which don't have CodeCoverage infra.
+                        Console.WriteLine(Resources.UpdateTestSdkForCollectingCodeCoverage);
+                    }
+                }
             }
 
-            if (!string.IsNullOrEmpty(this.VSTestBlame))
+            if (this.VSTestCLIRunSettings != null && this.VSTestCLIRunSettings.Length > 0)
             {
-                allArgs.Add("--Blame");
+                allArgs.Add("--");
+                foreach (var arg in this.VSTestCLIRunSettings)
+                {
+                    allArgs.Add(ArgumentEscaper.HandleEscapeSequenceInArgForProcessStart(arg));
+                }
             }
+
+            // VSTestCLIRunSettings should always be last argument in allArgs. As vstest.console ignore options after "--"(CLIRunSettings option).
 
             return allArgs;
         }

--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask.cs
@@ -137,6 +137,28 @@ namespace Microsoft.TestPlatform.Build.Tasks
 
         internal IEnumerable<string> CreateArgument()
         {
+            var allArgs = this.AddArgs();
+
+            // VSTestCLIRunSettings should be last argument in allArgs as vstest.console ignore options after "--"(CLIRunSettings option).
+            this.AddCLIRunSettingsArgs(allArgs);
+
+            return allArgs;
+        }
+
+        private void AddCLIRunSettingsArgs(List<string> allArgs)
+        {
+            if (this.VSTestCLIRunSettings != null && this.VSTestCLIRunSettings.Length > 0)
+            {
+                allArgs.Add("--");
+                foreach (var arg in this.VSTestCLIRunSettings)
+                {
+                    allArgs.Add(ArgumentEscaper.HandleEscapeSequenceInArgForProcessStart(arg));
+                }
+            }
+        }
+
+        private List<string> AddArgs()
+        {
             var isConsoleLoggerEnabled = true;
             var isCollectCodeCoverageEnabled = false;
             var isRunSettingsEnabled = false;
@@ -170,7 +192,8 @@ namespace Microsoft.TestPlatform.Build.Tasks
 
             if (!string.IsNullOrEmpty(this.VSTestTestCaseFilter))
             {
-                allArgs.Add("--testCaseFilter:" + ArgumentEscaper.HandleEscapeSequenceInArgForProcessStart(this.VSTestTestCaseFilter));
+                allArgs.Add("--testCaseFilter:" +
+                            ArgumentEscaper.HandleEscapeSequenceInArgForProcessStart(this.VSTestTestCaseFilter));
             }
 
             if (this.VSTestLogger != null && this.VSTestLogger.Length > 0)
@@ -188,7 +211,8 @@ namespace Microsoft.TestPlatform.Build.Tasks
 
             if (!string.IsNullOrEmpty(this.VSTestResultsDirectory))
             {
-                allArgs.Add("--resultsDirectory:" + ArgumentEscaper.HandleEscapeSequenceInArgForProcessStart(this.VSTestResultsDirectory));
+                allArgs.Add("--resultsDirectory:" +
+                            ArgumentEscaper.HandleEscapeSequenceInArgForProcessStart(this.VSTestResultsDirectory));
             }
 
             if (!string.IsNullOrEmpty(this.VSTestListTests))
@@ -213,8 +237,8 @@ namespace Microsoft.TestPlatform.Build.Tasks
             // Console logger was not specified by user, but verbosity was, hence add default console logger with verbosity as specified
             if (!string.IsNullOrWhiteSpace(this.VSTestVerbosity) && isConsoleLoggerEnabled)
             {
-                var normalTestLogging = new List<string>() { "n", "normal", "d", "detailed", "diag", "diagnostic" };
-                var quietTestLogging = new List<string>() { "q", "quiet" };
+                var normalTestLogging = new List<string>() {"n", "normal", "d", "detailed", "diag", "diagnostic"};
+                var quietTestLogging = new List<string>() {"q", "quiet"};
 
                 string vsTestVerbosity = "minimal";
                 if (normalTestLogging.Contains(this.VSTestVerbosity))
@@ -242,13 +266,13 @@ namespace Microsoft.TestPlatform.Build.Tasks
                     {
                         isCollectCodeCoverageEnabled = true;
                     }
+
                     allArgs.Add("--collect:" + ArgumentEscaper.HandleEscapeSequenceInArgForProcessStart(arg));
                 }
             }
 
             if (isCollectCodeCoverageEnabled || isRunSettingsEnabled)
             {
-
                 // Pass TraceDataCollector path to vstest.console as TestAdapterPath if --collect "Code Coverage"
                 // or --settings (User can enable code coverage from runsettings) option given.
                 // Not parsing the runsettings for two reason:
@@ -258,7 +282,9 @@ namespace Microsoft.TestPlatform.Build.Tasks
                 // go code coverage x-plat.
                 if (!string.IsNullOrEmpty(this.VSTestTraceDataCollectorDirectoryPath))
                 {
-                    allArgs.Add("--testAdapterPath:" + ArgumentEscaper.HandleEscapeSequenceInArgForProcessStart(this.VSTestTraceDataCollectorDirectoryPath));
+                    allArgs.Add("--testAdapterPath:" +
+                                ArgumentEscaper.HandleEscapeSequenceInArgForProcessStart(this
+                                    .VSTestTraceDataCollectorDirectoryPath));
                 }
                 else
                 {
@@ -270,17 +296,6 @@ namespace Microsoft.TestPlatform.Build.Tasks
                     }
                 }
             }
-
-            if (this.VSTestCLIRunSettings != null && this.VSTestCLIRunSettings.Length > 0)
-            {
-                allArgs.Add("--");
-                foreach (var arg in this.VSTestCLIRunSettings)
-                {
-                    allArgs.Add(ArgumentEscaper.HandleEscapeSequenceInArgForProcessStart(arg));
-                }
-            }
-
-            // VSTestCLIRunSettings should always be last argument in allArgs. As vstest.console ignore options after "--"(CLIRunSettings option).
 
             return allArgs;
         }

--- a/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs
@@ -48,6 +48,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
         [System.Security.SecurityCritical]
         public AssemblyResolver(IEnumerable<string> directories)
         {
+            if (EqtTrace.IsInfoEnabled)
+            {
+                EqtTrace.Info($"AssemblyResolver.ctor: Creating AssemblyResolver with searchDirectories {string.Join(",", directories)}");
+            }
+
             this.resolvedAssemblies = new Dictionary<string, Assembly>();
 
             if (directories == null || !directories.Any())
@@ -72,6 +77,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
         [System.Security.SecurityCritical]
         internal void AddSearchDirectories(IEnumerable<string> directories)
         {
+            if (EqtTrace.IsInfoEnabled)
+            {
+                EqtTrace.Info($"AssemblyResolver.AddSearchDirectories: Adding more searchDirectories {string.Join(",", directories)}");
+            }
+
             foreach (var directory in directories)
             {
                 this.searchDirectories.Add(directory);
@@ -99,14 +109,14 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
                 return null;
             }
 
-            EqtTrace.Info("AssemblyResolver: {0}: Resolving assembly.", args.Name);
+            EqtTrace.Info("AssemblyResolver.OnResolve: {0}: Resolving assembly.", args.Name);
 
             // args.Name is like: "Microsoft.VisualStudio.TestTools.Common, Version=[VersionMajor].0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a".
             lock (this.resolvedAssemblies)
             {
                 if (this.resolvedAssemblies.TryGetValue(args.Name, out var assembly))
                 {
-                    EqtTrace.Info("AssemblyResolver: {0}: Resolved from cache.", args.Name);
+                    EqtTrace.Info("AssemblyResolver.OnResolve: {0}: Resolved from cache.", args.Name);
                     return assembly;
                 }
 
@@ -120,7 +130,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
                 {
                     if (EqtTrace.IsInfoEnabled)
                     {
-                        EqtTrace.Info("AssemblyResolver: {0}: Failed to create assemblyName. Reason:{1} ", args.Name, ex);
+                        EqtTrace.Info("AssemblyResolver.OnResolve: {0}: Failed to create assemblyName. Reason:{1} ", args.Name, ex);
                     }
 
                     this.resolvedAssemblies[args.Name] = null;
@@ -156,13 +166,13 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
                             assembly = this.platformAssemblyLoadContext.LoadAssemblyFromPath(assemblyPath);
                             this.resolvedAssemblies[args.Name] = assembly;
 
-                            EqtTrace.Info("AssemblyResolver: {0}: Resolved assembly. ", args.Name);
+                            EqtTrace.Info("AssemblyResolver.OnResolve: Resolved assembly: {0}, from path: {1}", args.Name, assemblyPath);
 
                             return assembly;
                         }
                         catch (FileLoadException ex)
                         {
-                            EqtTrace.Info("AssemblyResolver: {0}: Failed to load assembly. Reason:{1} ", args.Name, ex);
+                            EqtTrace.Info("AssemblyResolver.OnResolve: {0}: Failed to load assembly. Reason:{1} ", args.Name, ex);
 
                             // Rethrow FileLoadException, because this exception means that the assembly
                             // was found, but could not be loaded. This will allow us to report a more
@@ -172,14 +182,14 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
                         catch (Exception ex)
                         {
                             // For all other exceptions, try the next extension.
-                            EqtTrace.Info("AssemblyResolver: {0}: Failed to load assembly. Reason:{1} ", args.Name, ex);
+                            EqtTrace.Info("AssemblyResolver.OnResolve: {0}: Failed to load assembly. Reason:{1} ", args.Name, ex);
                         }
                     }
                 }
 
                 if (EqtTrace.IsInfoEnabled)
                 {
-                    EqtTrace.Info("AssemblyResolver: {0}: Failed to load assembly.", args.Name);
+                    EqtTrace.Info("AssemblyResolver.OnResolve: {0}: Failed to load assembly.", args.Name);
                 }
 
                 this.resolvedAssemblies[args.Name] = null;

--- a/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
@@ -34,9 +34,31 @@ namespace Microsoft.TestPlatform.Build.UnitTests
 
             var result = this.vsTestTask.CreateArgument().ToArray();
 
-            // First, second and third args would be --framework:abc, testfilepath and -- respectively.
+            // First, second and third args would be framework:.NETCoreapp,Version2.0, testfilepath and -- respectively.
             Assert.AreEqual($"\"{arg1}\"", result[3]);
             Assert.AreEqual($"{arg2}", result[4]);
+        }
+
+        [TestMethod]
+        public void CreateArgumentShouldAddCLIRunSettingsArgAtEnd()
+        {
+            const string codeCoverageOption = "Code Coverage";
+
+            this.vsTestTask.VSTestCollect = new string[] { codeCoverageOption };
+            this.vsTestTask.VSTestBlame = "Blame";
+
+            const string arg1 = "RunConfiguration.ResultsDirectory=Path having Space";
+            const string arg2 = "MSTest.DeploymentEnabled";
+
+            this.vsTestTask.VSTestCLIRunSettings = new string[2];
+            this.vsTestTask.VSTestCLIRunSettings[0] = arg1;
+            this.vsTestTask.VSTestCLIRunSettings[1] = arg2;
+
+            var result = this.vsTestTask.CreateArgument().ToArray();
+
+            // Following are expected  --framework:abc, testfilepath, blame, collect:"Code coverage" -- respectively.
+            Assert.AreEqual($"\"{arg1}\"", result[5]);
+            Assert.AreEqual($"{arg2}", result[6]);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
@@ -34,6 +34,8 @@ namespace Microsoft.TestPlatform.Build.UnitTests
 
             var result = this.vsTestTask.CreateArgument().ToArray();
 
+            Assert.Equals(5, result.Length);
+
             // First, second and third args would be framework:".NETCoreapp,Version2.0", testfilepath and -- respectively.
             Assert.AreEqual($"\"{arg1}\"", result[3]);
             Assert.AreEqual($"{arg2}", result[4]);
@@ -55,6 +57,8 @@ namespace Microsoft.TestPlatform.Build.UnitTests
             this.vsTestTask.VSTestCLIRunSettings[1] = arg2;
 
             var result = this.vsTestTask.CreateArgument().ToArray();
+
+            Assert.Equals(7, result.Length);
 
             // Following are expected  --framework:".NETCoreapp,Version2.0", testfilepath, blame, collect:"Code coverage" -- respectively.
             Assert.AreEqual($"\"{arg1}\"", result[5]);

--- a/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.TestPlatform.Build.UnitTests
 
             var result = this.vsTestTask.CreateArgument().ToArray();
 
-            Assert.Equals(5, result.Length);
+            Assert.AreEqual(5, result.Length);
 
             // First, second and third args would be framework:".NETCoreapp,Version2.0", testfilepath and -- respectively.
             Assert.AreEqual($"\"{arg1}\"", result[3]);
@@ -58,7 +58,7 @@ namespace Microsoft.TestPlatform.Build.UnitTests
 
             var result = this.vsTestTask.CreateArgument().ToArray();
 
-            Assert.Equals(7, result.Length);
+            Assert.AreEqual(7, result.Length);
 
             // Following are expected  --framework:".NETCoreapp,Version2.0", testfilepath, blame, collect:"Code coverage" -- respectively.
             Assert.AreEqual($"\"{arg1}\"", result[5]);

--- a/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.TestPlatform.Build.UnitTests
 
             var result = this.vsTestTask.CreateArgument().ToArray();
 
-            // First, second and third args would be framework:.NETCoreapp,Version2.0, testfilepath and -- respectively.
+            // First, second and third args would be framework:".NETCoreapp,Version2.0", testfilepath and -- respectively.
             Assert.AreEqual($"\"{arg1}\"", result[3]);
             Assert.AreEqual($"{arg2}", result[4]);
         }
@@ -56,7 +56,7 @@ namespace Microsoft.TestPlatform.Build.UnitTests
 
             var result = this.vsTestTask.CreateArgument().ToArray();
 
-            // Following are expected  --framework:abc, testfilepath, blame, collect:"Code coverage" -- respectively.
+            // Following are expected  --framework:".NETCoreapp,Version2.0", testfilepath, blame, collect:"Code coverage" -- respectively.
             Assert.AreEqual($"\"{arg1}\"", result[5]);
             Assert.AreEqual($"{arg2}", result[6]);
         }


### PR DESCRIPTION
- Display message to update test.sdk if user try to collect cc with old test.sdk

Following are combinations possible with dotnet sdk and Microsoft.Net.Test.Sdk


| Dotnet sdk version | Microsoft.Net.Test.Sdk  version| Output on --collect "Code Coverage" |
-----------------------|--------------------------|------------------------
2.0 |  15.7.0 | Data collection : Could not find data collector 'Code Coverage'
2.0 | 15.8.0 | Data collection : Could not find data collector 'Code Coverage'
2.1.400 | 15.7.0 |  To collect code coverage update Microsoft.NET.Test.Sdk package version to latest. (**Addressing in this PR**)
2.1.400 | 15.8.0 | Code coverage file gets generated. 