### PR TITLE
Updated roadmap section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ VSTest platform is licensed under the [MIT license](https://github.com/Microsoft
 Please see [issue tracking](https://github.com/Microsoft/vstest-docs/blob/master/issuetracking.md) for a description of the workflow we use to process issues.
 
 ### Roadmap
-For details on our planned features and future direction please refer to our [roadmap](https://github.com/Microsoft/vstest-docs/blob/master/roadmap.md).
+For information on shipped and upcoming features please refer to our [Releases Roadmap](https://github.com/Microsoft/vstest-docs/blob/master/docs/releases.md).


### PR DESCRIPTION
Updated roadmap section to point to the release notes in the vstest-docs repo.
In a separate PR on the vstest-docs repo, I will reformat the release notes in roadmap-format, and delete the old roadmap.md file.
