### PR TITLE
Get msdia from vctools drops

### DIFF
--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -26,7 +26,7 @@
     <JsonNetVersion>9.0.1</JsonNetVersion>
     <MoqVersion>4.7.63</MoqVersion>
     <TestPlatformExternalsVersion>15.8.0-preview-1734347</TestPlatformExternalsVersion>
-    <MSInternalCodeCoverageVersion>1.0.9</MSInternalCodeCoverageVersion>
+    <MSInternalCodeCoverageVersion>1.0.8</MSInternalCodeCoverageVersion>
 
   </PropertyGroup>
 </Project>

--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -26,6 +26,6 @@
     <JsonNetVersion>9.0.1</JsonNetVersion>
     <MoqVersion>4.7.63</MoqVersion>
     <TestPlatformExternalsVersion>15.8.0-preview-1705516</TestPlatformExternalsVersion>
-    <MSInternalCodeCoverageVersion>1.0.7</MSInternalCodeCoverageVersion>
+    <MSInternalCodeCoverageVersion>1.0.8</MSInternalCodeCoverageVersion>
   </PropertyGroup>
 </Project>

--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -26,6 +26,6 @@
     <JsonNetVersion>9.0.1</JsonNetVersion>
     <MoqVersion>4.7.63</MoqVersion>
     <TestPlatformExternalsVersion>15.8.0-preview-1705516</TestPlatformExternalsVersion>
-    <MSInternalCodeCoverageVersion>1.0.8</MSInternalCodeCoverageVersion>
+    <MSInternalCodeCoverageVersion>1.0.9</MSInternalCodeCoverageVersion>
   </PropertyGroup>
 </Project>

--- a/test/Microsoft.Internal.CodeCoverage/Microsoft.Internal.CodeCoverage.nuspec
+++ b/test/Microsoft.Internal.CodeCoverage/Microsoft.Internal.CodeCoverage.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.Internal.CodeCoverage</id>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
     <title>Microsoft.Internal.CodeCoverage</title>
     <authors>Microsoft, vstest</authors>
     <owners>Microsoft, vstest</owners>

--- a/test/Microsoft.Internal.CodeCoverage/Microsoft.Internal.CodeCoverage.nuspec
+++ b/test/Microsoft.Internal.CodeCoverage/Microsoft.Internal.CodeCoverage.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.Internal.CodeCoverage</id>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <title>Microsoft.Internal.CodeCoverage</title>
     <authors>Microsoft, vstest</authors>
     <owners>Microsoft, vstest</owners>

--- a/test/Microsoft.TestPlatform.AcceptanceTests/CodeCoverageTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/CodeCoverageTests.cs
@@ -187,7 +187,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             // test command output is redirecting to file or writting to console.
             // If command output is redirecting to file, then Console.ForegroundColor can't be modified.
             // So that tests which assert Console.ForegroundColor should not run.
-            /* var previousColor = Console.ForegroundColor;
+            var previousColor = Console.ForegroundColor;
             var newColor = previousColor == ConsoleColor.Gray
                 ? ConsoleColor.Black
                 : ConsoleColor.Blue;
@@ -198,7 +198,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 Assert.Inconclusive(message);
             }
 
-            Console.ForegroundColor = previousColor; */
+            Console.ForegroundColor = previousColor;
 
             return false;
         }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/CodeCoverageTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/CodeCoverageTests.cs
@@ -180,13 +180,14 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 return Path.Combine(resultsDirectory, deploymentDir, "In", fileName);
             }
         }
+
         private bool SkipIfRuningInCI(string message)
         {
             // Setting Console.ForegroundColor to newColor which will be used to determine whether
             // test command output is redirecting to file or writting to console.
             // If command output is redirecting to file, then Console.ForegroundColor can't be modified.
             // So that tests which assert Console.ForegroundColor should not run.
-            var previousColor = Console.ForegroundColor;
+            /* var previousColor = Console.ForegroundColor;
             var newColor = previousColor == ConsoleColor.Gray
                 ? ConsoleColor.Black
                 : ConsoleColor.Blue;
@@ -197,7 +198,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 Assert.Inconclusive(message);
             }
 
-            Console.ForegroundColor = previousColor;
+            Console.ForegroundColor = previousColor; */
 
             return false;
         }


### PR DESCRIPTION
## Description
- Get msdia from vctools drops.
- After this PR we will use msdia release bits rather than private bits. 