### PR TITLE
[For testing not for merge] Remove mscoreei.dll from default exclude module list

### DIFF
--- a/src/DataCollectors/TraceDataCollector/VanguardCollector/DefaultCodeCoverageConfig.xml
+++ b/src/DataCollectors/TraceDataCollector/VanguardCollector/DefaultCodeCoverageConfig.xml
@@ -23,7 +23,7 @@
         <ModulePath>.*clrjit.dll$</ModulePath>
         <ModulePath>.*clrjit.ni.dll$</ModulePath>
         <ModulePath>.*mscoree.dll$</ModulePath>
-        <ModulePath>.*mscoreei.dll$</ModulePath>
+        <!--<ModulePath>.*mscoreei.dll$</ModulePath> -->
         <ModulePath>.*mscoreei.ni.dll$</ModulePath>
         <ModulePath>.*mscorlib.dll$</ModulePath>
         <ModulePath>.*mscorlib.ni.dll$</ModulePath>

--- a/test/DataCollectors/TraceDataCollector.UnitTests/DefaultCodeCoverageConfig.xml
+++ b/test/DataCollectors/TraceDataCollector.UnitTests/DefaultCodeCoverageConfig.xml
@@ -21,7 +21,7 @@
         <ModulePath>.*clrjit.dll$</ModulePath>
         <ModulePath>.*clrjit.ni.dll$</ModulePath>
         <ModulePath>.*mscoree.dll$</ModulePath>
-        <ModulePath>.*mscoreei.dll$</ModulePath>
+        <!--<ModulePath>.*mscoreei.dll$</ModulePath> -->
         <ModulePath>.*mscoreei.ni.dll$</ModulePath>
         <ModulePath>.*mscorlib.dll$</ModulePath>
         <ModulePath>.*mscorlib.ni.dll$</ModulePath>

--- a/test/Microsoft.TestPlatform.AcceptanceTests/CodeCoverageTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/CodeCoverageTests.cs
@@ -28,10 +28,6 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
         public void CollectCodeCoverageWithCollectOption(RunnerInfo runnerInfo)
         {
-            if (runnerInfo.TargetFramework.StartsWith("netcore"))
-            {
-                this.SkipIfRuningInCI("Skipping for core code coverage with no runsettings.");
-            }
             this.CollectCodeCoverage(runnerInfo, "x86", withRunsettings: false);
         }
 


### PR DESCRIPTION
## Description
- Will get package from this changes to make https://github.com/dotnet/cli/pull/9355 green if we fix the crash issue.