### PR TITLE
 Make Test.Sdk dependent on same version Microsoft.CodeCoverage

### DIFF
--- a/src/DataCollectors/TraceDataCollector/VanguardCollector/DefaultCodeCoverageConfig.xml
+++ b/src/DataCollectors/TraceDataCollector/VanguardCollector/DefaultCodeCoverageConfig.xml
@@ -23,7 +23,7 @@
         <ModulePath>.*clrjit.dll$</ModulePath>
         <ModulePath>.*clrjit.ni.dll$</ModulePath>
         <ModulePath>.*mscoree.dll$</ModulePath>
-        <ModulePath>.*mscoreei.dll$</ModulePath>
+        <!--<ModulePath>.*mscoreei.dll$</ModulePath> -->
         <ModulePath>.*mscoreei.ni.dll$</ModulePath>
         <ModulePath>.*mscorlib.dll$</ModulePath>
         <ModulePath>.*mscorlib.ni.dll$</ModulePath>

--- a/src/package/nuspec/Microsoft.NET.Test.Sdk.nuspec
+++ b/src/package/nuspec/Microsoft.NET.Test.Sdk.nuspec
@@ -24,11 +24,11 @@
       </group>
       <group targetFramework="netcoreapp1.0">
         <dependency id="Microsoft.TestPlatform.TestHost" version="$Version$" />
-        <dependency id="Microsoft.CodeCoverage" version="1.0.3" />
+        <dependency id="Microsoft.CodeCoverage" version="$Version$" />
       </group>
       <group targetFramework="net45">
         <!-- TestHost gets shipped with vstest.console -->
-        <dependency id="Microsoft.CodeCoverage" version="1.0.3" />
+        <dependency id="Microsoft.CodeCoverage" version="$Version$" />
       </group>
     </dependencies>
   </metadata>

--- a/test/DataCollectors/TraceDataCollector.UnitTests/DefaultCodeCoverageConfig.xml
+++ b/test/DataCollectors/TraceDataCollector.UnitTests/DefaultCodeCoverageConfig.xml
@@ -21,7 +21,7 @@
         <ModulePath>.*clrjit.dll$</ModulePath>
         <ModulePath>.*clrjit.ni.dll$</ModulePath>
         <ModulePath>.*mscoree.dll$</ModulePath>
-        <ModulePath>.*mscoreei.dll$</ModulePath>
+        <!--<ModulePath>.*mscoreei.dll$</ModulePath> -->
         <ModulePath>.*mscoreei.ni.dll$</ModulePath>
         <ModulePath>.*mscorlib.dll$</ModulePath>
         <ModulePath>.*mscorlib.ni.dll$</ModulePath>

--- a/test/Microsoft.TestPlatform.AcceptanceTests/CodeCoverageTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/CodeCoverageTests.cs
@@ -28,10 +28,6 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
         public void CollectCodeCoverageWithCollectOption(RunnerInfo runnerInfo)
         {
-            if (runnerInfo.TargetFramework.StartsWith("netcore"))
-            {
-                this.SkipIfRuningInCI("Skipping for core code coverage with no runsettings.");
-            }
             this.CollectCodeCoverage(runnerInfo, "x86", withRunsettings: false);
         }
 


### PR DESCRIPTION
## Description
- After this change Microsoft.Net.Test.Sdk automatically same version Microsoft.CodeCoverage.
#981 
