### PR TITLE
Fix crash of x64 test process under code coverage on win server 2012 R2

### DIFF
--- a/scripts/vstest-codecoverage.runsettings
+++ b/scripts/vstest-codecoverage.runsettings
@@ -8,6 +8,18 @@
             <ModulePaths>
              <Exclude>
               <ModulePath>.*Tests.dll</ModulePath>
+              <ModulePath>.*msvcr.*dll$</ModulePath>
+              <ModulePath>.*msvcp.*dll$</ModulePath>
+              <ModulePath>.*clr.dll$</ModulePath>
+              <ModulePath>.*clr.ni.dll$</ModulePath>
+              <ModulePath>.*clrjit.dll$</ModulePath>
+              <ModulePath>.*clrjit.ni.dll$</ModulePath>
+              <ModulePath>.*mscoree.dll$</ModulePath>
+              <ModulePath>.*mscoreei.ni.dll$</ModulePath>
+              <ModulePath>.*mscorlib.dll$</ModulePath>
+              <ModulePath>.*mscorlib.ni.dll$</ModulePath>
+              <ModulePath>.*cryptbase.dll$</ModulePath>
+              <ModulePath>.*bcryptPrimitives.dll$</ModulePath>
              </Exclude>
             </ModulePaths>
 

--- a/src/DataCollectors/TraceDataCollector/VanguardCollector/DefaultCodeCoverageConfig.xml
+++ b/src/DataCollectors/TraceDataCollector/VanguardCollector/DefaultCodeCoverageConfig.xml
@@ -23,10 +23,12 @@
         <ModulePath>.*clrjit.dll$</ModulePath>
         <ModulePath>.*clrjit.ni.dll$</ModulePath>
         <ModulePath>.*mscoree.dll$</ModulePath>
-        <!--<ModulePath>.*mscoreei.dll$</ModulePath> -->
+        <ModulePath>.*mscoreei.dll$</ModulePath>
         <ModulePath>.*mscoreei.ni.dll$</ModulePath>
         <ModulePath>.*mscorlib.dll$</ModulePath>
         <ModulePath>.*mscorlib.ni.dll$</ModulePath>
+        <ModulePath>.*cryptbase.dll$</ModulePath>
+        <ModulePath>.*bcryptPrimitives.dll$</ModulePath>
       </Exclude>
     </ModulePaths>
     <UseVerifiableInstrumentation>True</UseVerifiableInstrumentation>

--- a/test/DataCollectors/TraceDataCollector.UnitTests/DefaultCodeCoverageConfig.xml
+++ b/test/DataCollectors/TraceDataCollector.UnitTests/DefaultCodeCoverageConfig.xml
@@ -21,10 +21,12 @@
         <ModulePath>.*clrjit.dll$</ModulePath>
         <ModulePath>.*clrjit.ni.dll$</ModulePath>
         <ModulePath>.*mscoree.dll$</ModulePath>
-        <!--<ModulePath>.*mscoreei.dll$</ModulePath> -->
+        <ModulePath>.*mscoreei.dll$</ModulePath>
         <ModulePath>.*mscoreei.ni.dll$</ModulePath>
         <ModulePath>.*mscorlib.dll$</ModulePath>
         <ModulePath>.*mscorlib.ni.dll$</ModulePath>
+        <ModulePath>.*cryptbase.dll$</ModulePath>
+        <ModulePath>.*bcryptPrimitives.dll$</ModulePath>
       </Exclude>
     </ModulePaths>
     <UseVerifiableInstrumentation>True</UseVerifiableInstrumentation>

--- a/test/Microsoft.TestPlatform.AcceptanceTests/CodeCoverageTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/CodeCoverageTests.cs
@@ -26,9 +26,17 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         [TestMethod]
         [NetFullTargetFrameworkDataSource(useDesktopRunner: false)]
         [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
-        public void CollectCodeCoverageWithCollectOption(RunnerInfo runnerInfo)
+        public void CollectCodeCoverageWithCollectOptionForx86(RunnerInfo runnerInfo)
         {
             this.CollectCodeCoverage(runnerInfo, "x86", withRunsettings: false);
+        }
+
+        [TestMethod]
+        [NetFullTargetFrameworkDataSource(useDesktopRunner: false)]
+        [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
+        public void CollectCodeCoverageWithCollectOptionForx64(RunnerInfo runnerInfo)
+        {
+            this.CollectCodeCoverage(runnerInfo, "x64", withRunsettings: false);
         }
 
         [TestMethod]
@@ -44,11 +52,6 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
         public void CollectCodeCoverageX64WithRunSettings(RunnerInfo runnerInfo)
         {
-            if (runnerInfo.TargetFramework.Equals("net451"))
-            {
-                this.SkipIfRuningInCI("Skipping for x64 Desktop tests. tracking here: https://github.com/Microsoft/vstest/pull/1594");
-            }
-
             this.CollectCodeCoverage(runnerInfo, "x64", withRunsettings: true);
         }
 


### PR DESCRIPTION
## Description
- Issue: Below was the callstack when .NET Core process is crashed.

```
//
    // When this function runs, the DllBase field in the
    // LDR_DATA_TABLE_ENTRY is still null (as described below),
    // which causes LdrpProcessMappedModule to fail immediately
    // with STATUS_INVALID_PARAMETER.
    //
    // In this specific environment, the error "gets lost" and the
    // module is allowed to load.  (As described below, a variety
    // of ntdll invariants have been violated at this point, and
    // asserts would be firing like crazy in a checked build of the
    // OS.  One of the broken invariants creates a disconnect
    // between where one piece of code puts the error code and
    // where another piece of code checks for it.)
    //
    // Allowing the module to load after skipping all of
    // LdrpProcessMappedModule is what causes the specific
    // RtlGuardCheckImageBase failure mentioned in the call stack
    // at the bottom of this thread.  Specifically, the failure
    // happened because CRYPTBASE.dll loaded without ever running
    // the following lines
    //
    //      RtlInsertInvertedFunctionTable(DllBase, Entry->SizeOfImage);
    //      Entry->Flags |= LDRP_IN_EXCEPTION_TABLE | LDRP_LOAD_CONFIG_PROCESSED;
    //
    // which is something that can never happen (unless some ntdll
    // invariants are broken by a bug like they are in this case).
    //

ntdll!LdrpProcessMappedModule+0x2c
ntdll!LdrpMapAndSnapModules+0xa0
ntdll!LdrpPrepareModuleForExecution+0xcc

    //
   // In this frame, instead of triggering a brand new module
    // load, the reentrant CRYPTBASE.dll load binds to the existing
    // partially constructed LDR_DATA_TABLE_ENTRY that is described
    // below.
    //
    // This happens on the following stack, and is possible because
    // ntdll always runs LdrpInsertDataTableEntry before calling
    // out to LdrpMapViewOfSection:
    //
    //      LdrpFindLoadedDllByName
    //      LdrpFindOrMapDll
    //      LdrpFindOrMapDependency
    //      LdrpGetDelayloadExportDll
    //      ...
    //
    // #BUG
    //
    // At this point, many ntdll invariants are broken and the
    // process is very likely to crash.
    //
    // The code in ntdll has no support for the case where
    // LdrpFindOrMapDependency returns the kind of partially
    // built LDR_DATA_TABLE_ENTRY that is returned here.
    //
    // The top-level load holds a CRITICAL_SECTION when it calls
    // LdrpMapViewOfSection.  This prevents racing threads from
    // "seeing" the partially built LDR_DATA_TABLE_ENTRY, but does
    // not help in the reentrant case since CRITICAL_SECTIONs can
    // be recursively acquired.
    //
    // The synchronization model used for DLL loads was changed
    // dramatically in Win10, which probably explains why you are
    // only seeing this specific crash on pre-Win10 OSes.
    //

ntdll!LdrpGetDelayloadExportDll+0x10c
ntdll!LdrpHandleProtectedDelayload+0x4a
ntdll!LdrResolveDelayLoadedAPI+0xd6
RPCRT4!__delayLoadHelper2+0x30
RPCRT4!_tailMerge_CRYPTBASE_dll+0x3f

    //
    // The top-level delay-load is not finished (i.e., has not
    // replaced the initial delay-load thunk fields with the
    // addresses of the real loaded functions), so another
    // reentrant delay-load occurs here.
    //

RPCRT4!GenerateRandomNumber+0xe
RPCRT4!UuidCreate+0x14

    //
    // While hijacking the NtMapViewOfSection call, covrun64 now
    // triggers another call to the same RPCRT4!GenerateRandomNumber
    // function that was called further down the stack.
    //

covrun64!vanguard::runtime::native::module::module+0x23e
covrun64!vanguard::runtime::engine::on_module_load+0x636
covrun64!vanguard::runtime::engine::map_view_of_section+0x1ea
ntdll!LdrpMapViewOfSection+0x137

    //
    // At this point, the initial NtCreateSection call has
    // completed for CRYPTBASE.dll.
    //
    // Inside ntdll, a "partially constructed" LDR_DATA_TABLE_ENTRY
    // has been constructed for CRYPTBASE.dll.
    //
    // This LDR_DATA_TABLE_ENTRY has the following properties:
    //
    //    - The DllBase field is still null (because the result from
    //      NtMapViewOfSection has not yet been returned back to the
    //      ntdll code).
    //
    //    - The entry itself is "discoverable" by all other ntdll code
    //      paths because it has already been passed to
    //      LdrpInsertDataTableEntry.
    //

ntdll!LdrpFindOrMapDll+0xa79
ntdll!LdrpFindOrMapDependency+0x1fb
ntdll!LdrpGetDelayloadExportDll+0xac
ntdll!LdrpHandleProtectedDelayload+0x4a
ntdll!LdrResolveDelayLoadedAPI+0xd6
RPCRT4!__delayLoadHelper2+0x30
RPCRT4!_tailMerge_CRYPTBASE_dll+0x3f

    //
    // The top-level call to RPCRT4!GenerateRandomNumber needs to
    // delay-load CRYPTBASE.dll before it can run.
    //

RPCRT4!GenerateRandomNumber+0xe
RPCRT4!UuidCreate+0x14
covrun64!vanguard::runtime::engine::initialize+0x22d
covrun64!vanguard::runtime::engine::Initialize+0xcf
coreclr!EEToProfInterfaceImpl::Initialize+0x90
coreclr!ProfilingAPIUtility::LoadProfiler+0x383
coreclr!ProfilingAPIUtility::AttemptLoadProfilerForStartup+0x1b9
coreclr!ProfilingAPIUtility::InitializeProfiling+0x63
coreclr!EEStartupHelper+0xae4
coreclr!EEStartup+0x2c
coreclr!EnsureEEStarted+0xa0
coreclr!InitializeEE+0xe5

```
- Fix
  Adding `cryptbase.dll` and `bcryptPrimitives.dll` to default exclude list. 