### PR TITLE
Fix issue while deserializing null values

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/TestProperty/CustomKeyValueConverter.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TestProperty/CustomKeyValueConverter.cs
@@ -45,13 +45,13 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
                 {
                     // Converting Json data to array of KeyValuePairs with duplicate keys.
                     var serializer = new System.Runtime.Serialization.Json.DataContractJsonSerializer(typeof(TraitObject[]));
-                    var listOfTraitObjects = serializer.ReadObject(stream) as TraitObject[];                                        
+                    var listOfTraitObjects = serializer.ReadObject(stream) as TraitObject[];
 
-                    return listOfTraitObjects.Select(i => new KeyValuePair<string, string>(i.Key, i.Value)).ToArray();;
+                    return listOfTraitObjects.Select(i => new KeyValuePair<string, string>(i.Key, i.Value)).ToArray();
                 }
             }
 
-            return base.ConvertFrom(context, culture, value);
+            return null;
         }
 
         [System.Runtime.Serialization.DataContract]

--- a/src/Microsoft.TestPlatform.ObjectModel/TestProperty/CustomStringArrayConverter.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TestProperty/CustomStringArrayConverter.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
                 }
             }
 
-            return base.ConvertFrom(context, culture, value);
+            return null;
         }
     }
 }

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/CustomKeyValueConverterTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/CustomKeyValueConverterTests.cs
@@ -85,5 +85,13 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests
             Assert.AreEqual("key1", data[1].Key);
             Assert.AreEqual("val2", data[1].Value);
         }
+
+        [TestMethod]
+        public void CustomKeyValueConverterShouldDeserializeNullValue()
+        {
+            var data = this.customKeyValueConverter.ConvertFrom(null, CultureInfo.InvariantCulture, null) as KeyValuePair<string, string>[];
+
+            Assert.AreEqual(null, data);
+        }
     }
 }

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/CustomStringArrayConverterTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/CustomStringArrayConverterTests.cs
@@ -67,5 +67,14 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests
             Assert.AreEqual(string.Empty, data[0]);
             Assert.AreEqual(string.Empty, data[1]);
         }
+
+        
+        [TestMethod]
+        public void CustomStringArrayConverterShouldDeserializeNullValue()
+        {
+            var data = this.customStringArrayConverter.ConvertFrom(null, CultureInfo.InvariantCulture, null) as string[];
+
+            Assert.AreEqual(null, data);
+        }
     }
 }


### PR DESCRIPTION
## Description
Handle null values in TestCategory. 

C# throws exception if null value passed to ConvertFrom and with our custom handlers, we shouldn't call base when the value is null.
ref: https://referencesource.microsoft.com/#System/compmod/system/componentmodel/TypeConverter.cs,106


https://github.com/Microsoft/vstest/issues/1628