### PR TITLE
Fix Few UWP VC++ unit tests are not executing

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/IDataSerializer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/IDataSerializer.cs
@@ -46,5 +46,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces
         /// <param name="version">version to be sent</param>
         /// <returns>Raw Serialized message</returns>
         string SerializePayload(string messageType, object payload, int version);
+
+        /// <summary>
+        /// Creates cloned object for given object.
+        /// </summary>
+        /// <typeparam name="T"> The type of object to be cloned. </typeparam>
+        /// <param name="obj">Object to be cloned.</param>
+        /// <returns>Newly cloned object.</returns>
+        T Clone<T>(T obj);
     }
 }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.cs
@@ -152,6 +152,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             return JsonConvert.SerializeObject(message);
         }
 
+        /// <inheritdoc/>
+        public T Clone<T>(T obj)
+        {
+            var stringObj = this.Serialize<T>(obj);
+            return this.Deserialize<T>(stringObj);
+        }
+
         /// <summary>
         /// Serialize an object to JSON using default serialization settings.
         /// </summary>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.cs
@@ -155,8 +155,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         /// <inheritdoc/>
         public T Clone<T>(T obj)
         {
-            var stringObj = this.Serialize<T>(obj);
-            return this.Deserialize<T>(stringObj);
+            if (obj == null)
+            {
+                return default(T);
+            }
+
+            var stringObj = this.Serialize<T>(obj, 2);
+            return this.Deserialize<T>(stringObj, 2);
         }
 
         /// <summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Adapter/TestExecutionRecorder.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Adapter/TestExecutionRecorder.cs
@@ -64,6 +64,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Adapter
         /// <param name="testCase">test case which will be started.</param>
         public void RecordStart(TestCase testCase)
         {
+            EqtTrace.Verbose("TestExecutionRecorder.RecordStart: Starting test: {0}.", testCase?.FullyQualifiedName);
             this.testRunCache.OnTestStarted(testCase);
 
             if (this.testCaseEventsHandler != null)
@@ -85,6 +86,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Adapter
         /// test result to the framework when the test(s) is canceled. </exception>  
         public void RecordResult(TestResult testResult)
         {
+            EqtTrace.Verbose("TestExecutionRecorder.RecordResult: Received result for test: {0}.", testResult?.TestCase?.FullyQualifiedName);
             if (this.testCaseEventsHandler != null)
             {
                 // Send TestCaseEnd in case RecordEnd was not called.
@@ -104,6 +106,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Adapter
         /// <param name="outcome">outcome of the test case.</param>
         public void RecordEnd(TestCase testCase, TestOutcome outcome)
         {
+            EqtTrace.Verbose("TestExecutionRecorder.RecordEnd: test: {0} execution completed.", testCase?.FullyQualifiedName);
             this.testRunCache.OnTestCompletion(testCase);
             this.SendTestCaseEnd(testCase, outcome);
         }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -586,13 +586,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
             }
         }
 
-        private void OnCacheHit(TestRunStatistics testRunStats, ICollection<TestResult> results, ICollection<TestCase> inProgressTests)
+        private void OnCacheHit(TestRunStatistics testRunStats, ICollection<TestResult> results, ICollection<TestCase> inProgressTestCases)
         {
             if (this.testRunEventsHandler != null)
             {
-                inProgressTests = UpdateTestResultsAndInProgressTests(results, inProgressTests, this.package);
+                inProgressTestCases = UpdateTestResultsAndInProgressTests(results, inProgressTestCases, this.package);
 
-                var testRunChangedEventArgs = new TestRunChangedEventArgs(testRunStats, results, inProgressTests);
+                var testRunChangedEventArgs = new TestRunChangedEventArgs(testRunStats, results, inProgressTestCases);
                 this.testRunEventsHandler.HandleTestRunStatsChange(testRunChangedEventArgs);
             }
             else
@@ -624,13 +624,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
         }
 
 
-        private static ICollection<TestCase> UpdateTestResultsAndInProgressTests(IEnumerable<TestResult> testResults, ICollection<TestCase> inProgressTests, string package)
+        private static ICollection<TestCase> UpdateTestResultsAndInProgressTests(IEnumerable<TestResult> testResults, ICollection<TestCase> inProgressTestCases, string package)
         {
 
             // No change required to testcases and testresults.
             if (string.IsNullOrEmpty(package))
             {
-                return inProgressTests;
+                return inProgressTestCases;
             }
 
             EqtTrace.Verbose("BaseRunTests.UpdateTestResultsAndInProgressTests: Update source details for testResults and testCases.");
@@ -641,12 +641,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
                 tr.TestCase.Source = package;
             }
 
-            return UpdateInProgressTests(inProgressTests, package);
+            return UpdateInProgressTests(inProgressTestCases, package);
         }
 
-        private static ICollection<TestCase> UpdateInProgressTests(ICollection<TestCase> inProgressTests, string package)
+        private static ICollection<TestCase> UpdateInProgressTests(ICollection<TestCase> inProgressTestCases, string package)
         {
-            if (inProgressTests == null)
+            if (inProgressTestCases == null)
             {
                 return null;
             }
@@ -654,10 +654,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
             EqtTrace.Verbose("BaseRunTests.UpdateInProgressTests: Updating source for inprogress tests.");
 
             ICollection<TestCase> updatedTestCases  = new List<TestCase>();
-            foreach (var tc in inProgressTests)
+            foreach (var inProgressTestCase in inProgressTestCases)
             {
-                var updatedTest = JsonDataSerializer.Instance.Clone<TestCase>(tc);
-                updatedTest.Source = package;
+                var updatedTestCase = JsonDataSerializer.Instance.Clone<TestCase>(inProgressTestCase);
+                updatedTestCase.Source = package;
+                updatedTestCases.Add(updatedTestCase);
             }
 
             return updatedTestCases;

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -571,7 +571,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
                 testRunCompleteEventArgs.Metrics = this.requestData.MetricsCollection.Metrics;
                 if (lastChunk.Any())
                 {
-                    UpdateTestResultsAndInProgressTests(lastChunk, null, this.package);
+                    UpdateTestResultsAndInProgressTestCases(lastChunk, null, this.package);
                 }
 
                 this.testRunEventsHandler.HandleTestRunComplete(
@@ -590,7 +590,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
         {
             if (this.testRunEventsHandler != null)
             {
-                inProgressTestCases = UpdateTestResultsAndInProgressTests(results, inProgressTestCases, this.package);
+                inProgressTestCases = UpdateTestResultsAndInProgressTestCases(results, inProgressTestCases, this.package);
 
                 var testRunChangedEventArgs = new TestRunChangedEventArgs(testRunStats, results, inProgressTestCases);
                 this.testRunEventsHandler.HandleTestRunStatsChange(testRunChangedEventArgs);
@@ -624,7 +624,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
         }
 
 
-        private static ICollection<TestCase> UpdateTestResultsAndInProgressTests(IEnumerable<TestResult> testResults, ICollection<TestCase> inProgressTestCases, string package)
+        private static ICollection<TestCase> UpdateTestResultsAndInProgressTestCases(IEnumerable<TestResult> testResults, ICollection<TestCase> inProgressTestCases, string package)
         {
 
             // No change required to testcases and testresults.

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/JsonDataSerializerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/JsonDataSerializerTests.cs
@@ -4,12 +4,21 @@
 namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
 {
     using System;
+    using System.Collections.Generic;
+    using System.Runtime.Serialization;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
     public class JsonDataSerializerTests
     {
+        private JsonDataSerializer jsonDataSerializer;
+
+        public JsonDataSerializerTests()
+        {
+            this.jsonDataSerializer = JsonDataSerializer.Instance;
+        }
+
         [TestMethod]
         public void SerializePayloadShouldSerializeAnObjectWithSelfReferencingLoop()
         {
@@ -17,10 +26,8 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
             classWithSelfReferencingLoop = new ClassWithSelfReferencingLoop(classWithSelfReferencingLoop);
             classWithSelfReferencingLoop.InfiniteRefernce.InfiniteRefernce = classWithSelfReferencingLoop;
 
-            var sut = JsonDataSerializer.Instance;
-
             // This line should not throw exception
-            sut.SerializePayload("dummy", classWithSelfReferencingLoop);
+            this.jsonDataSerializer.SerializePayload("dummy", classWithSelfReferencingLoop);
         }
 
         [TestMethod]
@@ -30,15 +37,40 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
             classWithSelfReferencingLoop = new ClassWithSelfReferencingLoop(classWithSelfReferencingLoop);
             classWithSelfReferencingLoop.InfiniteRefernce.InfiniteRefernce = classWithSelfReferencingLoop;
 
-            var sut = JsonDataSerializer.Instance;
-
-            var json = sut.SerializePayload("dummy", classWithSelfReferencingLoop);
+            var json = this.jsonDataSerializer.SerializePayload("dummy", classWithSelfReferencingLoop);
 
             // This line should deserialize properly
-            var result = sut.Deserialize<ClassWithSelfReferencingLoop>(json, 1);
+            var result = this.jsonDataSerializer.Deserialize<ClassWithSelfReferencingLoop>(json, 1);
 
             Assert.AreEqual(typeof(ClassWithSelfReferencingLoop), result.GetType());
             Assert.IsNull(result.InfiniteRefernce);
+        }
+
+        [TestMethod]
+        public void CloneShouldCloneNewObject()
+        {
+            var myClass = new MyClass()
+            {
+                Id = Guid.NewGuid(),
+                Name = "Name1",
+                Properties = new Dictionary<string, object>()
+                {
+                    { "PropKey1", 10 },
+                    { "PropKey2", "PropValue2" },
+                    { "PropKey3", new MyClass() { Id = Guid.NewGuid(), Name = "Name2" } },
+                }
+            };
+
+            var clonedMyClass = this.jsonDataSerializer.Clone<MyClass>(myClass);
+
+            Console.WriteLine("myClass.Properties[\"PropKey3\"].GetType(): " + myClass.Properties["PropKey3"].GetType());
+            Console.WriteLine("clonedMyClass.Properties[\"PropKey3\"].GetType(): " + clonedMyClass.Properties["PropKey3"].GetType());
+
+            Assert.AreNotEqual(myClass.GetHashCode(), clonedMyClass.GetHashCode());
+
+            clonedMyClass.Properties["PropKey1"] = 11;
+
+            Assert.AreEqual(10, myClass.Properties["PropKey1"]);
         }
 
         public class ClassWithSelfReferencingLoop
@@ -53,6 +85,19 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
                 get;
                 set;
             }
+        }
+
+        [DataContract]
+        private class MyClass
+        {
+            [DataMember]
+            public string Name { get; set; }
+
+            [DataMember]
+            public Guid Id { get; set; }
+
+            [DataMember]
+            public Dictionary<string, object> Properties { get; set; }
         }
     }
 }

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/JsonDataSerializerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/JsonDataSerializerTests.cs
@@ -50,6 +50,23 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
         }
 
         [TestMethod]
+        public void CloneShouldReturnNullForNull()
+        {
+            var clonedTestCase = this.jsonDataSerializer.Clone<TestCase>(null);
+
+            Assert.IsNull(clonedTestCase);
+        }
+
+        [TestMethod]
+        public void CloneShouldWorkForValueType()
+        {
+            var i = 2;
+            var clonedI = this.jsonDataSerializer.Clone<int>(i);
+
+            Assert.AreEqual(clonedI, i);
+        }
+
+        [TestMethod]
         public void CloneShouldCloneTestCaseObject()
         {
             var testCase = JsonDataSerializerTests.GetSampleTestCase(out var expectedTrait);

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/DataCollectionTestRunEventsHandlerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/DataCollectionTestRunEventsHandlerTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace TestPlatform.CommunicationUtilities.UnitTests.ObjectModel
+namespace Microsoft.TestPlatform.CrossPlatEngine.UnitTests.DataCollection
 {
     using System;
     using System.Collections.ObjectModel;

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Microsoft.TestPlatform.CrossPlatEngine.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Microsoft.TestPlatform.CrossPlatEngine.UnitTests.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <OutputType Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">Exe</OutputType>
     <AssemblyName>Microsoft.TestPlatform.CrossPlatEngine.UnitTests</AssemblyName>
-    <TargetFrameworks>netcoreapp1.0;net451</TargetFrameworks>
+    <TargetFrameworks>net451;netcoreapp1.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.TestHostProvider\Microsoft.TestPlatform.TestHostProvider.csproj" />


### PR DESCRIPTION
## Description
**RCA**  
Changing the testcase's object source for inprogress tests for clients(VS Test explorer) causing the issue in UWP C++ scenario as the adapter and testplatform share same testcase object by changing the testcase source the testcase becoming invalid in UWP C++ adapter.
## Related issue
https://github.com/Microsoft/vstest/issues/1642
