### PR TITLE
Show proper warning message no tests to run because testcasefilter

### DIFF
--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -6,8 +6,8 @@
     <!-- Name of the elements must be in sync with test\Microsoft.TestPlatform.TestUtilities\IntegrationTestBase.cs -->
     <NETTestSdkPreviousVersion>15.5.0</NETTestSdkPreviousVersion>
 
-    <MSTestFrameworkVersion>1.3.2</MSTestFrameworkVersion>
-    <MSTestAdapterVersion>1.3.2</MSTestAdapterVersion>
+    <MSTestFrameworkVersion>1.3.1</MSTestFrameworkVersion>
+    <MSTestAdapterVersion>1.3.1</MSTestAdapterVersion>
     <MSTestAssertExtensionVersion>1.0.3-preview</MSTestAssertExtensionVersion>
     
     <XUnitFrameworkVersion>2.3.1</XUnitFrameworkVersion>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscovererEnumerator.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscovererEnumerator.cs
@@ -302,7 +302,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Discovery
 
             logger.SendMessage(
                 TestMessageLevel.Warning,
-                $"No test is available for testcase filter `{testCaseFilterToShow}` in {sourcesString}");
+                string.Format(CrossPlatEngineResources.NoTestsAvailableForGivenTestCaseFilter, testCaseFilterToShow, sourcesString));
         }
 
         private void SetAdapterLoggingSettings(IMessageLogger messageLogger, IRunSettings runSettings)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscovererEnumerator.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscovererEnumerator.cs
@@ -302,7 +302,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Discovery
 
             logger.SendMessage(
                 TestMessageLevel.Warning,
-                $"No test available for testcase filter `{testCaseFilterToShow}` in {sourcesString}");
+                $"No test is available for testcase filter `{testCaseFilterToShow}` in {sourcesString}");
         }
 
         private static string TestCaseFilterToShow(string testCaseFilter)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscovererEnumerator.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscovererEnumerator.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Discovery
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
     using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
-
+    using Utilities;
     using CrossPlatEngineResources = Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources.Resources;
 
     /// <summary>
@@ -298,28 +298,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Discovery
             IMessageLogger logger,
             string sourcesString)
         {
-            var testCaseFilterToShow = TestCaseFilterToShow(testCaseFilter);
+            var testCaseFilterToShow = TestCaseFilterDeterminer.ShortenTestCaseFilterIfRequired(testCaseFilter);
 
             logger.SendMessage(
                 TestMessageLevel.Warning,
                 $"No test is available for testcase filter `{testCaseFilterToShow}` in {sourcesString}");
-        }
-
-        private static string TestCaseFilterToShow(string testCaseFilter)
-        {
-            var maxTestCaseFilterToShowLength = 63;
-            string testCaseFilterToShow;
-
-            if (testCaseFilter.Length > maxTestCaseFilterToShowLength)
-            {
-                testCaseFilterToShow = testCaseFilter.Substring(0, 60) + "...";
-            }
-            else
-            {
-                testCaseFilterToShow = testCaseFilter;
-            }
-
-            return testCaseFilterToShow;
         }
 
         private void SetAdapterLoggingSettings(IMessageLogger messageLogger, IRunSettings runSettings)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/RunTestsWithSources.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/RunTestsWithSources.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
                 var testCaseFilterToShow = TestCaseFilterDeterminer.ShortenTestCaseFilterIfRequired(this.TestExecutionContext.TestCaseFilter);
                 this.TestRunEventsHandler?.HandleLogMessage(
                     TestMessageLevel.Warning,
-                    $"No test is available for testcase filter `{testCaseFilterToShow}` in {sourcesString}");
+                    string.Format(CrossPlatEngineResources.NoTestsAvailableForGivenTestCaseFilter, testCaseFilterToShow, sourcesString));
             }
             else
             {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/RunTestsWithSources.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/RunTestsWithSources.cs
@@ -62,11 +62,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
             if (!exceptionsHitDuringRunTests && this.executorUriVsSourceList?.Count > 0 && !this.IsCancellationRequested
                 && this.TestRunCache?.TotalExecutedTests <= 0)
             {
-                this.LogWarningOnNoTestsDiscovered();
+                this.LogWarningOnNoTestsExecuted();
             }
         }
 
-        private void LogWarningOnNoTestsDiscovered()
+        private void LogWarningOnNoTestsExecuted()
         {
             IEnumerable<string> sources = new List<string>();
             var sourcesArray = this.adapterSourceMap.Values

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/RunTestsWithSources.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/RunTestsWithSources.cs
@@ -66,12 +66,22 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
                 var sourcesArray = this.adapterSourceMap.Values.Aggregate(sources, (current, enumerable) => current.Concat(enumerable)).ToArray();
                 var sourcesString = string.Join(" ", sourcesArray);
 
-                this.TestRunEventsHandler?.HandleLogMessage(
-                    TestMessageLevel.Warning,
-                    string.Format(
-                        CultureInfo.CurrentUICulture,
-                        CrossPlatEngineResources.TestRunFailed_NoDiscovererFound_NoTestsAreAvailableInTheSources,
-                        sourcesString));
+                if (this.TestExecutionContext.TestCaseFilter != null)
+                {
+                    this.TestRunEventsHandler?.HandleLogMessage(
+                        TestMessageLevel.Warning,
+                        $"No test available for testcase filter `{this.TestExecutionContext.TestCaseFilter}` in {sourcesString}");
+                }
+                else
+                {
+
+                    this.TestRunEventsHandler?.HandleLogMessage(
+                        TestMessageLevel.Warning,
+                        string.Format(
+                            CultureInfo.CurrentUICulture,
+                            CrossPlatEngineResources.TestRunFailed_NoDiscovererFound_NoTestsAreAvailableInTheSources,
+                            sourcesString));
+                }
             }
         }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/RunTestsWithSources.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/RunTestsWithSources.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
 
     using ObjectModel.Client;
     using ObjectModel.Logging;
-
+    using Utilities;
     using CrossPlatEngineResources = Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources.Resources;
 
     internal class RunTestsWithSources : BaseRunTests
@@ -75,10 +75,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
 
             if (this.TestExecutionContext.TestCaseFilter != null)
             {
-                var testCaseFilterToShow = TestCaseFilterToShow(this.TestExecutionContext.TestCaseFilter);
+                var testCaseFilterToShow = TestCaseFilterDeterminer.ShortenTestCaseFilterIfRequired(this.TestExecutionContext.TestCaseFilter);
                 this.TestRunEventsHandler?.HandleLogMessage(
                     TestMessageLevel.Warning,
-                    $"No test available for testcase filter `{testCaseFilterToShow}` in {sourcesString}");
+                    $"No test is available for testcase filter `{testCaseFilterToShow}` in {sourcesString}");
             }
             else
             {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/RunTestsWithTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/RunTestsWithTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
         protected override IEnumerable<Tuple<Uri, string>> GetExecutorUriExtensionMap(IFrameworkHandle testExecutorFrameworkHandle, RunContext runContext)
         {
             this.executorUriVsTestList = this.GetExecutorVsTestCaseList(this.testCases);
-            
+
             Debug.Assert(this.TestExecutionContext.TestCaseFilter == null, "TestCaseFilter should be null for specific tests.");
             runContext.FilterExpressionWrapper = null;
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Microsoft.TestPlatform.CrossPlatEngine.csproj
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Microsoft.TestPlatform.CrossPlatEngine.csproj
@@ -11,7 +11,10 @@
     <!--<EnableCodeAnalysis>true</EnableCodeAnalysis>-->
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Resources\Resources.resx" />
+    <EmbeddedResource Include="Resources\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.TestPlatform.CommunicationUtilities\Microsoft.TestPlatform.CommunicationUtilities.csproj" />

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
@@ -78,18 +78,16 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources {
                 return ResourceManager.GetString("DataCollectorDebuggerWarning", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details..
         /// </summary>
-        internal static string DeprecatedAdapterPath
-        {
-            get
-            {
+        internal static string DeprecatedAdapterPath {
+            get {
                 return ResourceManager.GetString("DeprecatedAdapterPath", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Exception occurred while instantiating discoverer : {0}.
         /// </summary>
@@ -224,7 +222,16 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources {
                 return ResourceManager.GetString("NonExistingExtensions", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No test is available for testcase filter `{0}` in {1}.
+        /// </summary>
+        internal static string NoTestsAvailableForGivenTestCaseFilter {
+            get {
+                return ResourceManager.GetString("NoTestsAvailableForGivenTestCaseFilter", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to None of the specified source(s) &apos;{0}&apos; is valid. Fix the above errors/warnings and then try again. .
         /// </summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
@@ -195,4 +195,7 @@
   <data name="DeprecatedAdapterPath" xml:space="preserve">
     <value>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</value>
   </data>
+  <data name="NoTestsAvailableForGivenTestCaseFilter" xml:space="preserve">
+    <value>No test is available for testcase filter `{0}` in {1}</value>
+  </data>
 </root>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.cs.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx" build-num="1496413687">
     <header>
@@ -200,6 +200,11 @@
         <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
         <target state="translated">Mění se vyhledávání adaptéru. Další informace najdete tady: https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">
+        <source>No test is available for testcase filter `{0}` in {1}</source>
+        <target state="new">No test is available for testcase filter `{0}` in {1}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.de.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx" build-num="-1605532954">
     <header>
@@ -200,6 +200,11 @@
         <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
         <target state="translated">Die Adaptersuche wird gerade geändert. Weitere Informationen finden Sie unter https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">
+        <source>No test is available for testcase filter `{0}` in {1}</source>
+        <target state="new">No test is available for testcase filter `{0}` in {1}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.es.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx" build-num="1392533617">
     <header>
@@ -200,6 +200,11 @@
         <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
         <target state="translated">Se está cambiando la búsqueda de adaptador. Siga https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap para obtener más detalles.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">
+        <source>No test is available for testcase filter `{0}` in {1}</source>
+        <target state="new">No test is available for testcase filter `{0}` in {1}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.fr.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx" build-num="-1747068205">
     <header>
@@ -200,6 +200,11 @@
         <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
         <target state="translated">La fonctionnalité de recherche d’adaptateur fait actuellement l’objet de modifications. Pour plus d’informations, consultez https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">
+        <source>No test is available for testcase filter `{0}` in {1}</source>
+        <target state="new">No test is available for testcase filter `{0}` in {1}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.it.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx" build-num="-2078370022">
     <header>
@@ -200,6 +200,11 @@
         <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
         <target state="translated">La ricerca degli adattatori verrà modificata a breve. Per maggiori dettagli, vedere https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">
+        <source>No test is available for testcase filter `{0}` in {1}</source>
+        <target state="new">No test is available for testcase filter `{0}` in {1}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ja.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx" build-num="-1298029716">
     <header>
@@ -200,6 +200,11 @@
         <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
         <target state="translated">アダプター検索は変更中です。詳細については、https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap をご覧ください。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">
+        <source>No test is available for testcase filter `{0}` in {1}</source>
+        <target state="new">No test is available for testcase filter `{0}` in {1}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ko.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx" build-num="1470250083">
     <header>
@@ -200,6 +200,11 @@
         <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
         <target state="translated">어댑터 조회가 변경됩니다. 자세한 내용은 https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap을 참조하세요.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">
+        <source>No test is available for testcase filter `{0}` in {1}</source>
+        <target state="new">No test is available for testcase filter `{0}` in {1}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pl.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx" build-num="1548376603">
     <header>
@@ -200,6 +200,11 @@
         <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
         <target state="translated">Wyszukiwanie adaptera jest zmieniane, zobacz https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmapw celu uzyskania dalszych szczegółów.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">
+        <source>No test is available for testcase filter `{0}` in {1}</source>
+        <target state="new">No test is available for testcase filter `{0}` in {1}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pt-BR.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx" build-num="1733331294">
     <header>
@@ -200,6 +200,11 @@
         <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
         <target state="translated">A pesquisa do adaptador está sendo alterada, siga https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap para obter mais detalhes.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">
+        <source>No test is available for testcase filter `{0}` in {1}</source>
+        <target state="new">No test is available for testcase filter `{0}` in {1}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ru.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx" build-num="-1103770912">
     <header>
@@ -200,6 +200,11 @@
         <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
         <target state="translated">Изменяется поиск адаптеров. Дополнительные сведения: https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">
+        <source>No test is available for testcase filter `{0}` in {1}</source>
+        <target state="new">No test is available for testcase filter `{0}` in {1}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.tr.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx" build-num="1612553793">
     <header>
@@ -200,6 +200,11 @@
         <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
         <target state="translated">Bağdaştırıcı arama değiştiriliyor. Ayrıntılar için lütfen https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap sayfasını takip edin.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">
+        <source>No test is available for testcase filter `{0}` in {1}</source>
+        <target state="new">No test is available for testcase filter `{0}` in {1}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf
@@ -112,6 +112,11 @@
         <target state="new">Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">
+        <source>No test is available for testcase filter `{0}` in {1}</source>
+        <target state="new">No test is available for testcase filter `{0}` in {1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hans.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx" build-num="-1038642004">
     <header>
@@ -200,6 +200,11 @@
         <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
         <target state="translated">适配器查找发生了变化，请转到 https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap，了解详细信息。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">
+        <source>No test is available for testcase filter `{0}` in {1}</source>
+        <target state="new">No test is available for testcase filter `{0}` in {1}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hant.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx" build-num="1380117387">
     <header>
@@ -200,6 +200,11 @@
         <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
         <target state="translated">目前正在變更配接器查閱，請遵循 https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap，以取得詳細資料。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">
+        <source>No test is available for testcase filter `{0}` in {1}</source>
+        <target state="new">No test is available for testcase filter `{0}` in {1}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Utilities/TestCaseFilterDeterminer.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Utilities/TestCaseFilterDeterminer.cs
@@ -5,14 +5,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Utilities
 {
     internal class TestCaseFilterDeterminer
     {
+        private const int MaxLengthOfTestCaseFilterToShow = 256;
+
         internal static string ShortenTestCaseFilterIfRequired(string testCaseFilter)
         {
-            var maxLength = 256;
             string shortenTestCaseFilter;
 
-            if (testCaseFilter.Length > maxLength)
+            if (testCaseFilter.Length > MaxLengthOfTestCaseFilterToShow)
             {
-                shortenTestCaseFilter = testCaseFilter.Substring(0, maxLength) + "...";
+                shortenTestCaseFilter = testCaseFilter.Substring(0, MaxLengthOfTestCaseFilterToShow) + "...";
             }
             else
             {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Utilities/TestCaseFilterDeterminer.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Utilities/TestCaseFilterDeterminer.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Utilities
+{
+    internal class TestCaseFilterDeterminer
+    {
+        internal static string ShortenTestCaseFilterIfRequired(string testCaseFilter)
+        {
+            var maxLength = 256;
+            string shortenTestCaseFilter;
+
+            if (testCaseFilter.Length > maxLength)
+            {
+                shortenTestCaseFilter = testCaseFilter.Substring(0, maxLength) + "...";
+            }
+            else
+            {
+                shortenTestCaseFilter = testCaseFilter;
+            }
+
+            return shortenTestCaseFilter;
+        }
+    }
+}

--- a/src/SettingsMigrator/Resources/xlf/Resources.cs.xlf
+++ b/src/SettingsMigrator/Resources/xlf/Resources.cs.xlf
@@ -41,13 +41,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ValidUsage">
-        <source>Valid usage: SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
-Example: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
-Example: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</source>
-        <target state="translated">Platné použití: SettingsMigrator.exe &lt;kompletní cesta k souboru testsettings nebo runsettings, který se má migrovat&gt;
+        <source>Valid usage:
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt; &lt;Full path to runsettings file to be created&gt;
+Examples:
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings E:\MyTest\MyNewRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings E:\MyTest\MyNewRunSettings.runsettings</source>
+        <target state="new">Platné použití: SettingsMigrator.exe &lt;kompletní cesta k souboru testsettings nebo runsettings, který se má migrovat&gt;
 Příklad: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
 Příklad: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</target>
-        <note />
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/SettingsMigrator/Resources/xlf/Resources.de.xlf
+++ b/src/SettingsMigrator/Resources/xlf/Resources.de.xlf
@@ -41,13 +41,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ValidUsage">
-        <source>Valid usage: SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
-Example: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
-Example: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</source>
-        <target state="translated">Gültige Syntax: SettingsMigrator.exe &lt;Vollständiger Pfad zur Datei "testsettings" oder "runsettings", die migriert werden soll&gt;
+        <source>Valid usage:
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt; &lt;Full path to runsettings file to be created&gt;
+Examples:
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings E:\MyTest\MyNewRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings E:\MyTest\MyNewRunSettings.runsettings</source>
+        <target state="new">Gültige Syntax: SettingsMigrator.exe &lt;Vollständiger Pfad zur Datei "testsettings" oder "runsettings", die migriert werden soll&gt;
 Beispiel: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
 Beispiel: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</target>
-        <note />
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/SettingsMigrator/Resources/xlf/Resources.es.xlf
+++ b/src/SettingsMigrator/Resources/xlf/Resources.es.xlf
@@ -41,13 +41,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ValidUsage">
-        <source>Valid usage: SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
-Example: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
-Example: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</source>
-        <target state="translated">Uso válido: SettingsMigrator.exe &lt;Ruta de acceso completa al archivo testsettings o runsettings que se migrará&gt;
+        <source>Valid usage:
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt; &lt;Full path to runsettings file to be created&gt;
+Examples:
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings E:\MyTest\MyNewRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings E:\MyTest\MyNewRunSettings.runsettings</source>
+        <target state="new">Uso válido: SettingsMigrator.exe &lt;Ruta de acceso completa al archivo testsettings o runsettings que se migrará&gt;
 Ejemplo: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
 Ejemplo: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</target>
-        <note />
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/SettingsMigrator/Resources/xlf/Resources.fr.xlf
+++ b/src/SettingsMigrator/Resources/xlf/Resources.fr.xlf
@@ -41,13 +41,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ValidUsage">
-        <source>Valid usage: SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
-Example: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
-Example: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</source>
-        <target state="translated">Utilisation valide : SettingsMigrator.exe &lt;Chemin complet vers le fichier testsettings ou runsettings à migrer&gt;
+        <source>Valid usage:
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt; &lt;Full path to runsettings file to be created&gt;
+Examples:
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings E:\MyTest\MyNewRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings E:\MyTest\MyNewRunSettings.runsettings</source>
+        <target state="new">Utilisation valide : SettingsMigrator.exe &lt;Chemin complet vers le fichier testsettings ou runsettings à migrer&gt;
 Exemple : SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
 Exemple : SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</target>
-        <note />
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/SettingsMigrator/Resources/xlf/Resources.it.xlf
+++ b/src/SettingsMigrator/Resources/xlf/Resources.it.xlf
@@ -41,13 +41,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ValidUsage">
-        <source>Valid usage: SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
-Example: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
-Example: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</source>
-        <target state="translated">Sintassi valida: SettingsMigrator.exe &lt;percorso completo del file testsettings o del file runsettings di cui eseguire la migrazione&gt;
+        <source>Valid usage:
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt; &lt;Full path to runsettings file to be created&gt;
+Examples:
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings E:\MyTest\MyNewRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings E:\MyTest\MyNewRunSettings.runsettings</source>
+        <target state="new">Sintassi valida: SettingsMigrator.exe &lt;percorso completo del file testsettings o del file runsettings di cui eseguire la migrazione&gt;
 Esempio: SettingsMigrator.exe E:\MyTest\MyTestSettings.testsettings 
 Esempio: SettingsMigrator.exe E:\MyTest\MyOldRunSettings.runsettings</target>
-        <note />
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/SettingsMigrator/Resources/xlf/Resources.ja.xlf
+++ b/src/SettingsMigrator/Resources/xlf/Resources.ja.xlf
@@ -41,13 +41,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ValidUsage">
-        <source>Valid usage: SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
-Example: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
-Example: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</source>
-        <target state="translated">有効な使用法: SettingsMigrator.exe &lt;移行する testsettings ファイルまたは runsettings ファイルの完全なパス&gt;
+        <source>Valid usage:
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt; &lt;Full path to runsettings file to be created&gt;
+Examples:
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings E:\MyTest\MyNewRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings E:\MyTest\MyNewRunSettings.runsettings</source>
+        <target state="new">有効な使用法: SettingsMigrator.exe &lt;移行する testsettings ファイルまたは runsettings ファイルの完全なパス&gt;
 例: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
 例: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</target>
-        <note />
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/SettingsMigrator/Resources/xlf/Resources.ko.xlf
+++ b/src/SettingsMigrator/Resources/xlf/Resources.ko.xlf
@@ -41,13 +41,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ValidUsage">
-        <source>Valid usage: SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
-Example: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
-Example: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</source>
-        <target state="translated">유효한 사용: SettingsMigrator.exe &lt;마이그레이션할 testsettings 파일 또는 runsettings 파일의 전체 경로&gt;
+        <source>Valid usage:
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt; &lt;Full path to runsettings file to be created&gt;
+Examples:
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings E:\MyTest\MyNewRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings E:\MyTest\MyNewRunSettings.runsettings</source>
+        <target state="new">유효한 사용: SettingsMigrator.exe &lt;마이그레이션할 testsettings 파일 또는 runsettings 파일의 전체 경로&gt;
 Example: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
 Example: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</target>
-        <note />
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/SettingsMigrator/Resources/xlf/Resources.pl.xlf
+++ b/src/SettingsMigrator/Resources/xlf/Resources.pl.xlf
@@ -41,13 +41,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ValidUsage">
-        <source>Valid usage: SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
-Example: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
-Example: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</source>
-        <target state="translated">Prawidłowe użycie: SettingsMigrator.exe &lt;pełna ścieżka do pliku testsettings lub runsettings do zmigrowania&gt;
+        <source>Valid usage:
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt; &lt;Full path to runsettings file to be created&gt;
+Examples:
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings E:\MyTest\MyNewRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings E:\MyTest\MyNewRunSettings.runsettings</source>
+        <target state="new">Prawidłowe użycie: SettingsMigrator.exe &lt;pełna ścieżka do pliku testsettings lub runsettings do zmigrowania&gt;
 Przykład: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
 Przykład: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</target>
-        <note />
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/SettingsMigrator/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/SettingsMigrator/Resources/xlf/Resources.pt-BR.xlf
@@ -41,13 +41,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ValidUsage">
-        <source>Valid usage: SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
-Example: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
-Example: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</source>
-        <target state="translated">Uso válido: SettingsMigrator.exe &lt;Caminho completo para o arquivo testsettings ou o arquivo runsettings será migrado&gt;
+        <source>Valid usage:
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt; &lt;Full path to runsettings file to be created&gt;
+Examples:
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings E:\MyTest\MyNewRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings E:\MyTest\MyNewRunSettings.runsettings</source>
+        <target state="new">Uso válido: SettingsMigrator.exe &lt;Caminho completo para o arquivo testsettings ou o arquivo runsettings será migrado&gt;
 Exemplo: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
 Exemplo: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</target>
-        <note />
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/SettingsMigrator/Resources/xlf/Resources.ru.xlf
+++ b/src/SettingsMigrator/Resources/xlf/Resources.ru.xlf
@@ -41,13 +41,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ValidUsage">
-        <source>Valid usage: SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
-Example: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
-Example: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</source>
-        <target state="translated">Допустимое использование: SettingsMigrator.exe &lt;Полный путь к переносимому файлу testsettings или runsettings&gt;
+        <source>Valid usage:
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt; &lt;Full path to runsettings file to be created&gt;
+Examples:
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings E:\MyTest\MyNewRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings E:\MyTest\MyNewRunSettings.runsettings</source>
+        <target state="new">Допустимое использование: SettingsMigrator.exe &lt;Полный путь к переносимому файлу testsettings или runsettings&gt;
 Пример: SettingsMigrator.exe E:\MyTest\MyTestSettings.testsettings 
 Пример: SettingsMigrator.exe E:\MyTest\MyOldRunSettings.runsettings</target>
-        <note />
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/SettingsMigrator/Resources/xlf/Resources.tr.xlf
+++ b/src/SettingsMigrator/Resources/xlf/Resources.tr.xlf
@@ -41,13 +41,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ValidUsage">
-        <source>Valid usage: SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
-Example: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
-Example: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</source>
-        <target state="translated">Geçerli kullanım: SettingsMigrator.exe &lt;Geçirilecek testsettings dosyasının veya runsettings dosyasının tam yolu&gt;
+        <source>Valid usage:
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt; &lt;Full path to runsettings file to be created&gt;
+Examples:
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings E:\MyTest\MyNewRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings E:\MyTest\MyNewRunSettings.runsettings</source>
+        <target state="new">Geçerli kullanım: SettingsMigrator.exe &lt;Geçirilecek testsettings dosyasının veya runsettings dosyasının tam yolu&gt;
 Örnek: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
 Örnek: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</target>
-        <note />
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/SettingsMigrator/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/SettingsMigrator/Resources/xlf/Resources.zh-Hans.xlf
@@ -41,13 +41,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ValidUsage">
-        <source>Valid usage: SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
-Example: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
-Example: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</source>
-        <target state="translated">有效用法: SettingsMigrator.exe &lt;要迁移的 testsettings 文件或 runsettings 文件的完整路径&gt;
+        <source>Valid usage:
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt; &lt;Full path to runsettings file to be created&gt;
+Examples:
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings E:\MyTest\MyNewRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings E:\MyTest\MyNewRunSettings.runsettings</source>
+        <target state="new">有效用法: SettingsMigrator.exe &lt;要迁移的 testsettings 文件或 runsettings 文件的完整路径&gt;
 示例: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
 Example: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</target>
-        <note />
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/SettingsMigrator/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/SettingsMigrator/Resources/xlf/Resources.zh-Hant.xlf
@@ -41,13 +41,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ValidUsage">
-        <source>Valid usage: SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
-Example: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
-Example: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</source>
-        <target state="translated">有效用法: SettingsMigrator.exe &lt;到達 testsettings 檔案或要移轉之 runsettings 檔案的完整路徑&gt;
+        <source>Valid usage:
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt;
+SettingsMigrator.exe &lt;Full path to testsettings file or runsettings file to be migrated&gt; &lt;Full path to runsettings file to be created&gt;
+Examples:
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings E:\MyTest\MyNewRunSettings.runsettings
+SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings E:\MyTest\MyNewRunSettings.runsettings</source>
+        <target state="new">有效用法: SettingsMigrator.exe &lt;到達 testsettings 檔案或要移轉之 runsettings 檔案的完整路徑&gt;
 範例: SettingsMigrator.exe  E:\MyTest\MyTestSettings.testsettings 
 範例: SettingsMigrator.exe  E:\MyTest\MyOldRunSettings.runsettings</target>
-        <note />
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -151,7 +151,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
             // Register for the discovery events.
             events.DiscoveryMessage += this.TestMessageHandler;
 
-            // TODO Get change from https://github.com/Microsoft/vstest/pull/1111/
+            // TODO Get changes from https://github.com/Microsoft/vstest/pull/1111/
             // events.DiscoveredTests += DiscoveredTestsHandler;
         }
 

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -147,6 +147,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
             events.TestRunMessage += this.TestMessageHandler;
             events.TestResult += this.TestResultHandler;
             events.TestRunComplete += this.TestRunCompleteHandler;
+
+            // Register for the discovery events.
+            events.DiscoveryMessage += this.TestMessageHandler;
+
+            // TODO Get change from https://github.com/Microsoft/vstest/pull/1111/
+            // events.DiscoveredTests += DiscoveredTestsHandler;
         }
 
         public void Initialize(TestLoggerEvents events, Dictionary<string, string> parameters)

--- a/src/vstest.console/Processors/RunTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunTestsArgumentProcessor.cs
@@ -129,7 +129,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             this.runSettingsManager = runSettingsProvider;
             this.testRequestManager = testRequestManager;
             this.output = output;
-            this.testRunEventsRegistrar = new TestRunRequestEventsRegistrar(this.output);
+            this.testRunEventsRegistrar = new TestRunRequestEventsRegistrar(this.output, this.commandLineOptions);
         }
 
         #endregion
@@ -206,10 +206,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
         private class TestRunRequestEventsRegistrar : ITestRunEventsRegistrar
         {
             private IOutput output;
+            private CommandLineOptions commandLineOptions;
 
-            public TestRunRequestEventsRegistrar(IOutput output)
+            public TestRunRequestEventsRegistrar(IOutput output, CommandLineOptions commandLineOptions)
             {
                 this.output = output;
+                this.commandLineOptions = commandLineOptions;
             }
 
             public void RegisterTestRunEvents(ITestRunRequest testRunRequest)
@@ -236,7 +238,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
                     var testsFoundInAnySource = (e.TestRunStatistics == null) ? false : (e.TestRunStatistics.ExecutedTests > 0);
 
                     // Indicate the user to use testadapterpath command if there are no tests found
-                    if (!testsFoundInAnySource && string.IsNullOrEmpty(CommandLineOptions.Instance.TestAdapterPath))
+                    if (!testsFoundInAnySource && string.IsNullOrEmpty(CommandLineOptions.Instance.TestAdapterPath) && this.commandLineOptions.TestCaseFilterValue == null) 
                     {
                         this.output.Warning(false, CommandLineResources.SuggestTestAdapterPathIfNoTestsIsFound);
                     }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DiscoveryTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DiscoveryTests.cs
@@ -77,8 +77,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
 
-            var assemblyPaths = this.BuildMultipleAssemblyPath("SimpleTestProject2.dll", "SimpleTestProject3.dll").Trim('\"');
-            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, this.testEnvironment.InIsolationValue);
+            var assetFullPath = this.GetAssetFullPath("SimpleTestProject2.dll");
+            var arguments = PrepareArguments(assetFullPath, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, this.testEnvironment.InIsolationValue);
             arguments = string.Concat(arguments, " /listtests" );
             arguments = string.Concat(arguments, " /testcasefilter:NonExistTestCaseName");
             arguments = string.Concat(arguments, " /logger:\"console;prefix=true\"");
@@ -86,7 +86,6 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
             StringAssert.Contains(this.StdOut, "Warning: No test available for testcase filter `NonExistTestCaseName` in");
 
-            StringAssert.Contains(this.StdOut, "SimpleTestProject3.dll");
             StringAssert.Contains(this.StdOut, "SimpleTestProject2.dll");
 
             this.ExitCodeEquals(0);

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DiscoveryTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DiscoveryTests.cs
@@ -69,5 +69,27 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 File.Delete(this.dummyFilePath);
             }
         }
+
+        [TestMethod]
+        [NetFullTargetFrameworkDataSource]
+        [NetCoreTargetFrameworkDataSource]
+        public void DiscoverTestsShouldShowProperWarningIfNoTestsOnTestCaseFilter(RunnerInfo runnerInfo)
+        {
+            AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+
+            var assemblyPaths = this.BuildMultipleAssemblyPath("SimpleTestProject2.dll", "SimpleTestProject3.dll").Trim('\"');
+            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, this.testEnvironment.InIsolationValue);
+            arguments = string.Concat(arguments, " /listtests" );
+            arguments = string.Concat(arguments, " /testcasefilter:NonExistTestCaseName");
+            arguments = string.Concat(arguments, " /logger:\"console;prefix=true\"");
+            this.InvokeVsTest(arguments);
+
+            StringAssert.Contains(this.StdOut, "Warning: No test available for testcase filter `NonExistTestCaseName` in");
+
+            StringAssert.Contains(this.StdOut, "SimpleTestProject3.dll");
+            StringAssert.Contains(this.StdOut, "SimpleTestProject2.dll");
+
+            this.ExitCodeEquals(0);
+        }
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DiscoveryTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DiscoveryTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             arguments = string.Concat(arguments, " /logger:\"console;prefix=true\"");
             this.InvokeVsTest(arguments);
 
-            StringAssert.Contains(this.StdOut, "Warning: No test available for testcase filter `NonExistTestCaseName` in");
+            StringAssert.Contains(this.StdOut, "Warning: No test is available for testcase filter `NonExistTestCaseName` in");
 
             StringAssert.Contains(this.StdOut, "SimpleTestProject2.dll");
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/RunTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/RunTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
             this.Setup();
 
-            var expectedAssemblyName = "SimpleTestProject3.dll";
+            var expectedAssemblyName = "SimpleTestProject2.dll";
             var source = new List<string>() {this.GetAssetFullPath(expectedAssemblyName)};
 
             var veryLongTestCaseFilter =

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/RunTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/RunTests.cs
@@ -148,22 +148,27 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
             this.Setup();
 
-            var expectedAssemblyName = "SimpleTestProject2.dll";
-            var source = new List<string>() {this.GetAssetFullPath(expectedAssemblyName)};
+            var testAssemblyName = "SimpleTestProject2.dll";
+            var source = new List<string>() {this.GetAssetFullPath(testAssemblyName)};
 
             var veryLongTestCaseFilter =
-                "FullyQualifiedName=VeryLongTestCaseNameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+                "FullyQualifiedName=VeryLongTestCaseNameeeeeeeeeeeeee" +
+                "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" +
+                "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" +
+                "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" +
+                "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
             this.vstestConsoleWrapper.RunTests(
                 source,
                 this.GetDefaultRunSettings(),
                 new TestPlatformOptions() { TestCaseFilter = veryLongTestCaseFilter },
                 this.runEventHandler);
 
-            var expectedFilter = veryLongTestCaseFilter.Substring(0, 60) + "...";
+            var expectedFilter = veryLongTestCaseFilter.Substring(0, 256) + "...";
 
             // Assert
-            StringAssert.StartsWith(this.runEventHandler.LogMessage, $"No test available for testcase filter `{expectedFilter}` in");
-            StringAssert.EndsWith(this.runEventHandler.LogMessage, expectedAssemblyName);
+            StringAssert.StartsWith(this.runEventHandler.LogMessage, $"No test is available for testcase filter `{expectedFilter}` in");
+            StringAssert.EndsWith(this.runEventHandler.LogMessage, testAssemblyName);
 
             Assert.AreEqual(TestMessageLevel.Warning , this.runEventHandler.TestMessageLevel);
         }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Discovery/DiscovererEnumeratorTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Discovery/DiscovererEnumeratorTests.cs
@@ -10,8 +10,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
     using System.Linq;
     using System.Reflection;
 
-    using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
+    using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.Common.Telemetry;
     using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
     using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Tracing.Interfaces;
@@ -35,9 +35,10 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
         private Mock<IRequestData> mockRequestData;
         private Mock<IMetricsCollection> mockMetricsCollection;
         private Mock<IAssemblyProperties> mockAssemblyProperties;
+        private Mock<IRunSettings> runSettingsMock;
+        private Mock<IMessageLogger> messageLoggerMock;
 
-        [TestInitialize]
-        public void TestInit()
+        public DiscovererEnumeratorTests()
         {
             this.mockTestPlatformEventSource = new Mock<ITestPlatformEventSource>();
             this.discoveryResultCache = new DiscoveryResultCache(1000, TimeSpan.FromHours(1), (tests) => { });
@@ -46,8 +47,18 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
             this.mockAssemblyProperties = new Mock<IAssemblyProperties>();
             this.mockRequestData.Setup(rd => rd.MetricsCollection).Returns(this.mockMetricsCollection.Object);
             this.discovererEnumerator = new DiscovererEnumerator(this.mockRequestData.Object, this.discoveryResultCache, this.mockTestPlatformEventSource.Object, this.mockAssemblyProperties.Object);
-
+            this.runSettingsMock = new Mock<IRunSettings>();
+            this.messageLoggerMock = new Mock<IMessageLogger>();
             TestDiscoveryExtensionManager.Destroy();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            ManagedDllTestDiscoverer.Reset();
+            NativeDllTestDiscoverer.Reset();
+            JsonTestDiscoverer.Reset();
+            NotImplementedTestDiscoverer.Reset();
         }
 
         [TestMethod]
@@ -57,18 +68,17 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
                 new string[] { typeof(TestPluginCache).GetTypeInfo().Assembly.Location },
                 () => { });
             var sources = new List<string> { typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location };
-            var mockLogger = new Mock<IMessageLogger>();
 
             var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
             extensionSourceMap.Add("_none_", sources);
 
-            this.discovererEnumerator.LoadTests(extensionSourceMap, new Mock<IRunSettings>().Object, null, mockLogger.Object);
+            this.discovererEnumerator.LoadTests(extensionSourceMap, this.runSettingsMock.Object, null, this.messageLoggerMock.Object);
 
             var messageFormat =
                 "No test is available in {0}. Make sure that test discoverer & executors are registered and platform & framework version settings are appropriate and try again.";
             var message = string.Format(messageFormat, string.Join(" ", sources));
 
-            mockLogger.Verify(
+            this.messageLoggerMock.Verify(
                 l =>
                 l.SendMessage(TestMessageLevel.Warning, message), Times.Once);
         }
@@ -84,491 +94,383 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
             var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
             extensionSourceMap.Add("_none_", sources);
 
-            this.discovererEnumerator.LoadTests(extensionSourceMap, new Mock<IRunSettings>().Object, null, new Mock<IMessageLogger>().Object);
+            this.discovererEnumerator.LoadTests(extensionSourceMap, this.runSettingsMock.Object, null, this.messageLoggerMock.Object);
 
             Assert.IsFalse(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
             Assert.IsFalse(NativeDllTestDiscoverer.IsNativeDiscoverTestCalled);
-
-            this.ResetDiscoverers();
         }
 
         [TestMethod]
         public void LoadTestsShouldCallOnlyNativeDiscovererIfNativeAssembliesPassed()
         {
-            try
-            {
-                TestPluginCacheTests.SetupMockExtensions(
-                    new string[] { typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location },
-                    () => { });
+            TestPluginCacheTests.SetupMockExtensions(
+                new string[] { typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location },
+                () => { });
 
-                mockAssemblyProperties.Setup(pe => pe.GetAssemblyType("native.dll")).Returns(AssemblyType.Native);
+            this.mockAssemblyProperties.Setup(pe => pe.GetAssemblyType("native.dll")).Returns(AssemblyType.Native);
 
-                var sources = new List<string>
-                                  {
-                                      "native.dll"
-                                  };
+            var sources = new List<string>
+                              {
+                                  "native.dll"
+                              };
 
-                var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
-                extensionSourceMap.Add("_none_", sources);
+            var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
+            extensionSourceMap.Add("_none_", sources);
 
-                var settings = new Mock<IRunSettings>().Object;
-                var logger = new Mock<IMessageLogger>().Object;
-                string testCaseFilter = "TestFilter";
+            string testCaseFilter = "TestFilter";
 
-                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, testCaseFilter, logger);
+            this.discovererEnumerator.LoadTests(extensionSourceMap, this.runSettingsMock.Object, testCaseFilter, this.messageLoggerMock.Object);
 
-                Assert.IsTrue(NativeDllTestDiscoverer.IsNativeDiscoverTestCalled);
-                CollectionAssert.AreEqual(sources, NativeDllTestDiscoverer.Sources.ToList());
+            Assert.IsTrue(NativeDllTestDiscoverer.IsNativeDiscoverTestCalled);
+            CollectionAssert.AreEqual(sources, NativeDllTestDiscoverer.Sources.ToList());
 
-                Assert.IsFalse(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
-                Assert.IsFalse(JsonTestDiscoverer.IsDiscoverTestCalled);
-            }
-            finally
-            {
-                this.ResetDiscoverers();
-            }
+            Assert.IsFalse(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
+            Assert.IsFalse(JsonTestDiscoverer.IsDiscoverTestCalled);
         }
 
         [TestMethod]
         public void LoadTestsShouldCallOnlyManagedDiscovererIfManagedAssembliesPassed()
         {
-            try
-            {
-                TestPluginCacheTests.SetupMockExtensions(
-                    new string[] { typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location },
-                    () => { });
+            TestPluginCacheTests.SetupMockExtensions(
+                new string[] { typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location },
+                () => { });
 
-                mockAssemblyProperties.Setup(pe => pe.GetAssemblyType("managed.dll")).Returns(AssemblyType.Managed);
+            this.mockAssemblyProperties.Setup(pe => pe.GetAssemblyType("managed.dll")).Returns(AssemblyType.Managed);
 
-                var sources = new List<string>
-                                  {
-                                      "managed.dll"
-                                  };
+            var sources = new List<string>
+                              {
+                                  "managed.dll"
+                              };
 
-                var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
-                extensionSourceMap.Add("_none_", sources);
+            var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
+            extensionSourceMap.Add("_none_", sources);
 
-                var settings = new Mock<IRunSettings>().Object;
-                var logger = new Mock<IMessageLogger>().Object;
-                string testCaseFilter = "TestFilter";
+            string testCaseFilter = "TestFilter";
 
-                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, testCaseFilter, logger);
+            this.discovererEnumerator.LoadTests(extensionSourceMap, this.runSettingsMock.Object, testCaseFilter, this.messageLoggerMock.Object);
 
-                Assert.IsTrue(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
-                CollectionAssert.AreEqual(sources, ManagedDllTestDiscoverer.Sources.ToList());
+            Assert.IsTrue(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
+            CollectionAssert.AreEqual(sources, ManagedDllTestDiscoverer.Sources.ToList());
 
-                Assert.IsFalse(NativeDllTestDiscoverer.IsNativeDiscoverTestCalled);
-                Assert.IsFalse(JsonTestDiscoverer.IsDiscoverTestCalled);
-            }
-            finally
-            {
-                this.ResetDiscoverers();
-            }
+            Assert.IsFalse(NativeDllTestDiscoverer.IsNativeDiscoverTestCalled);
+            Assert.IsFalse(JsonTestDiscoverer.IsDiscoverTestCalled);
         }
 
         [TestMethod]
         public void LoadTestsShouldCallBothNativeAndManagedDiscoverersWithCorrectSources()
         {
-            try
-            {
-                TestPluginCacheTests.SetupMockExtensions(
-                    new string[] { typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location },
-                    () => { });
+            TestPluginCacheTests.SetupMockExtensions(
+                new string[] { typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location },
+                () => { });
 
-                mockAssemblyProperties.Setup(pe => pe.GetAssemblyType("native.dll")).Returns(AssemblyType.Native);
-                mockAssemblyProperties.Setup(pe => pe.GetAssemblyType("managed.dll")).Returns(AssemblyType.Managed);
+            this.mockAssemblyProperties.Setup(pe => pe.GetAssemblyType("native.dll")).Returns(AssemblyType.Native);
+            this.mockAssemblyProperties.Setup(pe => pe.GetAssemblyType("managed.dll")).Returns(AssemblyType.Managed);
 
-                var nativeSources = new List<string>
-                                  {
-                                      "native.dll"
-                                  };
-                var managedSources = new List<string>
-                                  {
-                                      "managed.dll"
-                                  };
+            var nativeSources = new List<string>
+                              {
+                                  "native.dll"
+                              };
+            var managedSources = new List<string>
+                              {
+                                  "managed.dll"
+                              };
 
-                var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
-                extensionSourceMap.Add("_none_", nativeSources.Concat(managedSources));
+            var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
+            extensionSourceMap.Add("_none_", nativeSources.Concat(managedSources));
 
-                var settings = new Mock<IRunSettings>().Object;
-                var logger = new Mock<IMessageLogger>().Object;
-                string testCaseFilter = "TestFilter";
+            string testCaseFilter = "TestFilter";
 
-                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, testCaseFilter, logger);
+            this.discovererEnumerator.LoadTests(extensionSourceMap, this.runSettingsMock.Object, testCaseFilter, this.messageLoggerMock.Object);
 
-                Assert.IsTrue(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
-                CollectionAssert.AreEqual(managedSources, ManagedDllTestDiscoverer.Sources.ToList());
+            Assert.IsTrue(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
+            CollectionAssert.AreEqual(managedSources, ManagedDllTestDiscoverer.Sources.ToList());
 
-                Assert.IsTrue(NativeDllTestDiscoverer.IsNativeDiscoverTestCalled);
-                CollectionAssert.AreEqual(nativeSources, NativeDllTestDiscoverer.Sources.ToList());
+            Assert.IsTrue(NativeDllTestDiscoverer.IsNativeDiscoverTestCalled);
+            CollectionAssert.AreEqual(nativeSources, NativeDllTestDiscoverer.Sources.ToList());
 
-                Assert.IsFalse(JsonTestDiscoverer.IsDiscoverTestCalled);
-            }
-            finally
-            {
-                this.ResetDiscoverers();
-            }
+            Assert.IsFalse(JsonTestDiscoverer.IsDiscoverTestCalled);
         }
 
         [TestMethod]
         public void LoadTestsShouldCallIntoADiscovererThatMatchesTheSources()
         {
-            try
-            {
-                TestPluginCacheTests.SetupMockExtensions(
-                    new string[] { typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location },
-                    () => { });
+            TestPluginCacheTests.SetupMockExtensions(
+                new string[] { typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location },
+                () => { });
 
-                var sources = new List<string>
-                                  {
-                                      typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location,
-                                      typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location
-                                  };
+            var sources = new List<string>
+                              {
+                                  typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location,
+                                  typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location
+                              };
 
-                var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
-                extensionSourceMap.Add("_none_", sources);
+            var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
+            extensionSourceMap.Add("_none_", sources);
+            string testCaseFilter = "TestFilter";
 
-                var settings = new Mock<IRunSettings>().Object;
-                var logger = new Mock<IMessageLogger>().Object;
-                string testCaseFilter = "TestFilter";
+            this.discovererEnumerator.LoadTests(extensionSourceMap, this.runSettingsMock.Object, testCaseFilter, this.messageLoggerMock.Object);
 
-                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, testCaseFilter, logger);
+            Assert.IsTrue(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
+            Assert.IsFalse(JsonTestDiscoverer.IsDiscoverTestCalled);
 
-                Assert.IsTrue(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
-                Assert.IsFalse(JsonTestDiscoverer.IsDiscoverTestCalled);
-
-                // Also validate that the right set of arguments were passed on to the discoverer.
-                CollectionAssert.AreEqual(sources, ManagedDllTestDiscoverer.Sources.ToList());
-                Assert.AreEqual(settings, ManagedDllTestDiscoverer.DiscoveryContext.RunSettings);
-                Assert.AreEqual(testCaseFilter, (ManagedDllTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
-                Assert.AreEqual(logger, ManagedDllTestDiscoverer.MessageLogger);
-                Assert.IsNotNull(ManagedDllTestDiscoverer.DiscoverySink);
-            }
-            finally
-            {
-                this.ResetDiscoverers();
-            }
+            // Also validate that the right set of arguments were passed on to the discoverer.
+            CollectionAssert.AreEqual(sources, ManagedDllTestDiscoverer.Sources.ToList());
+            Assert.AreEqual(this.runSettingsMock.Object, ManagedDllTestDiscoverer.DiscoveryContext.RunSettings);
+            Assert.AreEqual(testCaseFilter, (ManagedDllTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
+            Assert.AreEqual(this.messageLoggerMock.Object, ManagedDllTestDiscoverer.MessageLogger);
+            Assert.IsNotNull(ManagedDllTestDiscoverer.DiscoverySink);
         }
 
         [TestMethod]
         public void LoadTestsShouldCallIntoMultipleDiscoverersThatMatchesTheSources()
         {
-            try
-            {
-                TestPluginCacheTests.SetupMockExtensions(
-                    new string[] { typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location },
-                    () => { });
+            TestPluginCacheTests.SetupMockExtensions(
+                new string[] { typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location },
+                () => { });
 
-                var dllsources = new List<string>
-                                  {
-                                      typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location,
-                                      typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location
-                                  };
-                var jsonsources = new List<string>
-                                  {
-                                      "test1.json",
-                                      "test2.json"
-                                  };
-                var sources = new List<string>(dllsources);
-                sources.AddRange(jsonsources);
+            var dllsources = new List<string>
+                              {
+                                  typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location,
+                                  typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location
+                              };
+            var jsonsources = new List<string>
+                              {
+                                  "test1.json",
+                                  "test2.json"
+                              };
+            var sources = new List<string>(dllsources);
+            sources.AddRange(jsonsources);
 
-                var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
-                extensionSourceMap.Add("_none_", sources);
+            var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
+            extensionSourceMap.Add("_none_", sources);
 
-                var settings = new Mock<IRunSettings>().Object;
-                var logger = new Mock<IMessageLogger>().Object;
-                string testCaseFilter = "TestFilter";
+            var runSettings = this.runSettingsMock.Object;
 
-                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, testCaseFilter, logger);
+            string testCaseFilter = "TestFilter";
 
-                Assert.IsTrue(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
-                Assert.IsTrue(JsonTestDiscoverer.IsDiscoverTestCalled);
+            this.discovererEnumerator.LoadTests(extensionSourceMap, runSettings, testCaseFilter, this.messageLoggerMock.Object);
 
-                // Also validate that the right set of arguments were passed on to the discoverer.
-                CollectionAssert.AreEqual(dllsources, ManagedDllTestDiscoverer.Sources.ToList());
-                Assert.AreEqual(settings, ManagedDllTestDiscoverer.DiscoveryContext.RunSettings);
-                Assert.AreEqual(testCaseFilter, (ManagedDllTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
-                Assert.AreEqual(logger, ManagedDllTestDiscoverer.MessageLogger);
-                Assert.IsNotNull(ManagedDllTestDiscoverer.DiscoverySink);
+            Assert.IsTrue(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
+            Assert.IsTrue(JsonTestDiscoverer.IsDiscoverTestCalled);
 
-                CollectionAssert.AreEqual(jsonsources, JsonTestDiscoverer.Sources.ToList());
-                Assert.AreEqual(settings, JsonTestDiscoverer.DiscoveryContext.RunSettings);
-                Assert.AreEqual(testCaseFilter, (JsonTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
-                Assert.AreEqual(logger, JsonTestDiscoverer.MessageLogger);
-                Assert.IsNotNull(JsonTestDiscoverer.DiscoverySink);
-            }
-            finally
-            {
-                this.ResetDiscoverers();
-            }
+            // Also validate that the right set of arguments were passed on to the discoverer.
+            CollectionAssert.AreEqual(dllsources, ManagedDllTestDiscoverer.Sources.ToList());
+            Assert.AreEqual(runSettings, ManagedDllTestDiscoverer.DiscoveryContext.RunSettings);
+            Assert.AreEqual(testCaseFilter, (ManagedDllTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
+            Assert.AreEqual(this.messageLoggerMock.Object, ManagedDllTestDiscoverer.MessageLogger);
+            Assert.IsNotNull(ManagedDllTestDiscoverer.DiscoverySink);
+
+            CollectionAssert.AreEqual(jsonsources, JsonTestDiscoverer.Sources.ToList());
+            Assert.AreEqual(runSettings, JsonTestDiscoverer.DiscoveryContext.RunSettings);
+            Assert.AreEqual(testCaseFilter, (JsonTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
+            Assert.AreEqual(this.messageLoggerMock.Object, JsonTestDiscoverer.MessageLogger);
+            Assert.IsNotNull(JsonTestDiscoverer.DiscoverySink);
         }
 
         [TestMethod]
         public void LoadTestsShouldCallIntoOtherDiscoverersWhenCreatingOneFails()
         {
-            try
-            {
-                TestPluginCacheTests.SetupMockExtensions(
-                    new string[] { typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location },
-                    () => { });
+            TestPluginCacheTests.SetupMockExtensions(
+                new string[] { typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location },
+                () => { });
 
-                var sources = new List<string>
-                                  {
-                                      "test1.csv",
-                                      typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location
-                                  };
+            var sources = new List<string>
+                              {
+                                  "test1.csv",
+                                  typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location
+                              };
 
-                var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
-                extensionSourceMap.Add("_none_", sources);
+            var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
+            extensionSourceMap.Add("_none_", sources);
 
-                var settings = new Mock<IRunSettings>().Object;
-                var logger = new Mock<IMessageLogger>().Object;
-                string testCaseFilter = "TestFilter";
+            var runSettings = this.runSettingsMock.Object;
 
-                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, testCaseFilter, logger);
+            string testCaseFilter = "TestFilter";
 
-                Assert.IsTrue(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
-                Assert.IsFalse(SingletonTestDiscoverer.IsDiscoverTestCalled);
+            this.discovererEnumerator.LoadTests(extensionSourceMap, runSettings, testCaseFilter, this.messageLoggerMock.Object);
 
-                // Also validate that the right set of arguments were passed on to the discoverer.
-                CollectionAssert.AreEqual(new List<string> { sources[1] }, ManagedDllTestDiscoverer.Sources.ToList());
-                Assert.AreEqual(settings, ManagedDllTestDiscoverer.DiscoveryContext.RunSettings);
-                Assert.AreEqual(testCaseFilter, (ManagedDllTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
-                Assert.AreEqual(logger, ManagedDllTestDiscoverer.MessageLogger);
-                Assert.IsNotNull(ManagedDllTestDiscoverer.DiscoverySink);
-            }
-            finally
-            {
-                this.ResetDiscoverers();
-            }
+            Assert.IsTrue(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
+            Assert.IsFalse(SingletonTestDiscoverer.IsDiscoverTestCalled);
+
+            // Also validate that the right set of arguments were passed on to the discoverer.
+            CollectionAssert.AreEqual(new List<string> { sources[1] }, ManagedDllTestDiscoverer.Sources.ToList());
+            Assert.AreEqual(runSettings, ManagedDllTestDiscoverer.DiscoveryContext.RunSettings);
+            Assert.AreEqual(testCaseFilter, (ManagedDllTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
+            Assert.AreEqual(this.messageLoggerMock.Object, ManagedDllTestDiscoverer.MessageLogger);
+            Assert.IsNotNull(ManagedDllTestDiscoverer.DiscoverySink);
         }
 
         [TestMethod]
         public void LoadTestsShouldCallIntoOtherDiscoverersEvenIfDiscoveryInOneFails()
         {
-            try
-            {
-                TestPluginCacheTests.SetupMockExtensions(
-                    new string[] { typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location },
-                    () => { });
+            TestPluginCacheTests.SetupMockExtensions(
+                new string[] { typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location },
+                () => { });
 
-                var sources = new List<string>
-                                  {
-                                      "test1.cs",
-                                      typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location
-                                  };
+            var sources = new List<string>
+                              {
+                                  "test1.cs",
+                                  typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location
+                              };
 
-                var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
-                extensionSourceMap.Add("_none_", sources);
+            var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
+            extensionSourceMap.Add("_none_", sources);
 
-                var settings = new Mock<IRunSettings>().Object;
-                var mocklogger = new Mock<IMessageLogger>();
-                string testCaseFilter = "TestFilter";
+            var runSettings = this.runSettingsMock.Object;
 
-                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, testCaseFilter, mocklogger.Object);
+            string testCaseFilter = "TestFilter";
 
-                Assert.IsTrue(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
-                Assert.IsTrue(NotImplementedTestDiscoverer.IsDiscoverTestCalled);
+            this.discovererEnumerator.LoadTests(extensionSourceMap, runSettings, testCaseFilter, this.messageLoggerMock.Object);
 
-                // Also validate that the right set of arguments were passed on to the discoverer.
-                CollectionAssert.AreEqual(new List<string> { sources[1] }, ManagedDllTestDiscoverer.Sources.ToList());
-                Assert.AreEqual(settings, ManagedDllTestDiscoverer.DiscoveryContext.RunSettings);
-                Assert.AreEqual(testCaseFilter, (ManagedDllTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
-                Assert.AreEqual(mocklogger.Object, ManagedDllTestDiscoverer.MessageLogger);
-                Assert.IsNotNull(ManagedDllTestDiscoverer.DiscoverySink);
+            Assert.IsTrue(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
+            Assert.IsTrue(NotImplementedTestDiscoverer.IsDiscoverTestCalled);
 
-                // Check if we log the failure.
-                var message = string.Format(
-                        CultureInfo.CurrentUICulture,
-                        "An exception occurred while test discoverer '{0}' was loading tests. Exception: {1}",
-                        typeof(NotImplementedTestDiscoverer).Name,
-                        "The method or operation is not implemented.");
+            // Also validate that the right set of arguments were passed on to the discoverer.
+            CollectionAssert.AreEqual(new List<string> { sources[1] }, ManagedDllTestDiscoverer.Sources.ToList());
+            Assert.AreEqual(runSettings, ManagedDllTestDiscoverer.DiscoveryContext.RunSettings);
+            Assert.AreEqual(testCaseFilter, (ManagedDllTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
+            Assert.AreEqual(this.messageLoggerMock.Object, ManagedDllTestDiscoverer.MessageLogger);
+            Assert.IsNotNull(ManagedDllTestDiscoverer.DiscoverySink);
 
-                mocklogger.Verify(l => l.SendMessage(TestMessageLevel.Error, message), Times.Once);
-            }
-            finally
-            {
-                this.ResetDiscoverers();
-            }
+            // Check if we log the failure.
+            var message = string.Format(
+                    CultureInfo.CurrentUICulture,
+                    "An exception occurred while test discoverer '{0}' was loading tests. Exception: {1}",
+                    typeof(NotImplementedTestDiscoverer).Name,
+                    "The method or operation is not implemented.");
+
+            this.messageLoggerMock.Verify(l => l.SendMessage(TestMessageLevel.Error, message), Times.Once);
         }
 
         [TestMethod]
         public void LoadTestsShouldCollectMetrics()
         {
-            try
-            {
-                var mockMetricsCollector = new Mock<IMetricsCollection>();
-                var dict = new Dictionary<string, object>();
-                dict.Add("DummyMessage", "DummyValue");
+            var mockMetricsCollector = new Mock<IMetricsCollection>();
+            var dict = new Dictionary<string, object>();
+            dict.Add("DummyMessage", "DummyValue");
 
-                TestPluginCacheTests.SetupMockExtensions(
-                    new string[] { typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location },
-                    () => { });
+            TestPluginCacheTests.SetupMockExtensions(
+                new string[] { typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location },
+                () => { });
 
-                var sources = new List<string>
-                                  {
-                                      typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location,
-                                      typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location
-                                  };
+            var sources = new List<string>
+                              {
+                                  typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location,
+                                  typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location
+                              };
 
-                var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
-                extensionSourceMap.Add("_none_", sources);
+            var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
+            extensionSourceMap.Add("_none_", sources);
 
-                var settings = new Mock<IRunSettings>().Object;
-                var logger = new Mock<IMessageLogger>().Object;
+            mockMetricsCollector.Setup(mc => mc.Metrics).Returns(dict);
+            this.mockRequestData.Setup(rd => rd.MetricsCollection).Returns(mockMetricsCollector.Object);
 
-                mockMetricsCollector.Setup(mc => mc.Metrics).Returns(dict);
-                this.mockRequestData.Setup(rd => rd.MetricsCollection).Returns(mockMetricsCollector.Object);
+            string testCaseFilter = "TestFilter";
+            this.discovererEnumerator.LoadTests(extensionSourceMap, this.runSettingsMock.Object, testCaseFilter, this.messageLoggerMock.Object);
 
-                string testCaseFilter = "TestFilter";
-                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, testCaseFilter, logger);
-
-                // Verify.
-                mockMetricsCollector.Verify(rd => rd.Add(TelemetryDataConstants.TimeTakenInSecByAllAdapters, It.IsAny<object>()), Times.Once);
-                mockMetricsCollector.Verify(rd => rd.Add(TelemetryDataConstants.NumberOfAdapterUsedToDiscoverTests, It.IsAny<object>()), Times.Once);
-                mockMetricsCollector.Verify(rd => rd.Add(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringDiscovery, It.IsAny<object>()), Times.Once);
-                mockMetricsCollector.Verify(rd => rd.Add(TelemetryDataConstants.TotalTestsByAdapter + ".discoverer://manageddlldiscoverer/", It.IsAny<object>()), Times.Once);
-                mockMetricsCollector.Verify(rd => rd.Add(TelemetryDataConstants.TimeTakenToDiscoverTestsByAnAdapter + ".discoverer://manageddlldiscoverer/", It.IsAny<object>()), Times.Once);
-                mockMetricsCollector.Verify(rd => rd.Add(TelemetryDataConstants.TotalTestsByAdapter + ".discoverer://nativedlldiscoverer/", It.IsAny<object>()), Times.Once);
-                mockMetricsCollector.Verify(rd => rd.Add(TelemetryDataConstants.TimeTakenToDiscoverTestsByAnAdapter + ".discoverer://nativedlldiscoverer/", It.IsAny<object>()), Times.Once);
-                mockMetricsCollector.Verify(rd => rd.Add(TelemetryDataConstants.TimeTakenToLoadAdaptersInSec, It.IsAny<object>()), Times.Once);
-            }
-            finally
-            {
-                this.ResetDiscoverers();
-            }
+            // Verify.
+            mockMetricsCollector.Verify(rd => rd.Add(TelemetryDataConstants.TimeTakenInSecByAllAdapters, It.IsAny<object>()), Times.Once);
+            mockMetricsCollector.Verify(rd => rd.Add(TelemetryDataConstants.NumberOfAdapterUsedToDiscoverTests, It.IsAny<object>()), Times.Once);
+            mockMetricsCollector.Verify(rd => rd.Add(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringDiscovery, It.IsAny<object>()), Times.Once);
+            mockMetricsCollector.Verify(rd => rd.Add(TelemetryDataConstants.TotalTestsByAdapter + ".discoverer://manageddlldiscoverer/", It.IsAny<object>()), Times.Once);
+            mockMetricsCollector.Verify(rd => rd.Add(TelemetryDataConstants.TimeTakenToDiscoverTestsByAnAdapter + ".discoverer://manageddlldiscoverer/", It.IsAny<object>()), Times.Once);
+            mockMetricsCollector.Verify(rd => rd.Add(TelemetryDataConstants.TotalTestsByAdapter + ".discoverer://nativedlldiscoverer/", It.IsAny<object>()), Times.Once);
+            mockMetricsCollector.Verify(rd => rd.Add(TelemetryDataConstants.TimeTakenToDiscoverTestsByAnAdapter + ".discoverer://nativedlldiscoverer/", It.IsAny<object>()), Times.Once);
+            mockMetricsCollector.Verify(rd => rd.Add(TelemetryDataConstants.TimeTakenToLoadAdaptersInSec, It.IsAny<object>()), Times.Once);
         }
 
         [TestMethod]
         public void LoadTestsShouldCallIntoTheAdapterWithTheRightTestCaseSink()
         {
-            try
-            {
-                this.InvokeLoadTestWithMockSetup();
+             this.InvokeLoadTestWithMockSetup();
 
-                Assert.IsTrue(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
-                Assert.AreEqual(2, this.discoveryResultCache.Tests.Count);
-            }
-            finally
-            {
-                this.ResetDiscoverers();
-            }
+             Assert.IsTrue(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
+             Assert.AreEqual(2, this.discoveryResultCache.Tests.Count);
         }
 
         [TestMethod]
         public void LoadTestShouldInstrumentDiscoveryStart()
         {
-            try
-            {
-                this.InvokeLoadTestWithMockSetup();
-                this.mockTestPlatformEventSource.Verify(x => x.DiscoveryStart(), Times.Once);
-            }
-            finally
-            {
-                this.ResetDiscoverers();
-            }
+            this.InvokeLoadTestWithMockSetup();
+            this.mockTestPlatformEventSource.Verify(x => x.DiscoveryStart(), Times.Once);
         }
 
         [TestMethod]
         public void LoadTestShouldInstrumentDiscoveryStop()
         {
-            try
-            {
-                this.InvokeLoadTestWithMockSetup();
-                this.mockTestPlatformEventSource.Verify(x => x.DiscoveryStop(It.IsAny<long>()), Times.Once);
-            }
-            finally
-            {
-                this.ResetDiscoverers();
-            }
+            this.InvokeLoadTestWithMockSetup();
+            this.mockTestPlatformEventSource.Verify(x => x.DiscoveryStop(It.IsAny<long>()), Times.Once);
         }
 
         [TestMethod]
         public void LoadTestShouldInstrumentAdapterDiscoveryStart()
         {
-            try
-            {
-                this.InvokeLoadTestWithMockSetup();
-                this.mockTestPlatformEventSource.Verify(x => x.AdapterDiscoveryStart(It.IsAny<string>()), Times.AtLeastOnce);
-            }
-            finally
-            {
-                this.ResetDiscoverers();
-            }
+            this.InvokeLoadTestWithMockSetup();
+            this.mockTestPlatformEventSource.Verify(x => x.AdapterDiscoveryStart(It.IsAny<string>()), Times.AtLeastOnce);
         }
 
         [TestMethod]
         public void LoadTestShouldInstrumentAdapterDiscoveryStop()
         {
-            try
-            {
-                this.InvokeLoadTestWithMockSetup();
-                this.mockTestPlatformEventSource.Verify(x => x.AdapterDiscoveryStop(It.IsAny<long>()), Times.AtLeastOnce);
-            }
-            finally
-            {
-                this.ResetDiscoverers();
-            }
+            this.InvokeLoadTestWithMockSetup();
+            this.mockTestPlatformEventSource.Verify(x => x.AdapterDiscoveryStop(It.IsAny<long>()), Times.AtLeastOnce);
         }
 
         [TestMethod]
         public void LoadTestsShouldIterateOverAllExtensionsInTheMapAndDiscoverTests()
         {
-            try
-            {
-                TestPluginCacheTests.SetupMockExtensions(
-                    new string[] { typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location },
-                    () => { });
+            TestPluginCacheTests.SetupMockExtensions(
+                new string[] { typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location },
+                () => { });
 
-                var dllsources = new List<string>
-                                  {
-                                      typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location,
-                                      typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location
-                                  };
-                var jsonsources = new List<string>
-                                  {
-                                      "test1.json",
-                                      "test2.json"
-                                  };
+            var dllsources = new List<string>
+                              {
+                                  typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location,
+                                  typeof(DiscoveryResultCacheTests).GetTypeInfo().Assembly.Location
+                              };
+            var jsonsources = new List<string>
+                              {
+                                  "test1.json",
+                                  "test2.json"
+                              };
 
-                var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
-                extensionSourceMap.Add(typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location, jsonsources);
-                extensionSourceMap.Add("_none_", dllsources);
+            var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
+            extensionSourceMap.Add(typeof(DiscovererEnumeratorTests).GetTypeInfo().Assembly.Location, jsonsources);
+            extensionSourceMap.Add("_none_", dllsources);
 
-                var settings = new Mock<IRunSettings>().Object;
-                var logger = new Mock<IMessageLogger>().Object;
-                string testCaseFilter = "TestFilter";
+            var runSettings = this.runSettingsMock.Object;
 
-                this.discovererEnumerator.LoadTests(extensionSourceMap, settings, testCaseFilter, logger);
+            string testCaseFilter = "TestFilter";
 
-                Assert.IsTrue(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
-                Assert.IsTrue(JsonTestDiscoverer.IsDiscoverTestCalled);
+            this.discovererEnumerator.LoadTests(extensionSourceMap, runSettings, testCaseFilter, this.messageLoggerMock.Object);
 
-                // Also validate that the right set of arguments were passed on to the discoverer.
-                CollectionAssert.AreEqual(dllsources, ManagedDllTestDiscoverer.Sources.ToList());
-                Assert.AreEqual(settings, ManagedDllTestDiscoverer.DiscoveryContext.RunSettings);
-                Assert.AreEqual(testCaseFilter, (ManagedDllTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
-                Assert.AreEqual(logger, ManagedDllTestDiscoverer.MessageLogger);
-                Assert.IsNotNull(ManagedDllTestDiscoverer.DiscoverySink);
+            Assert.IsTrue(ManagedDllTestDiscoverer.IsManagedDiscoverTestCalled);
+            Assert.IsTrue(JsonTestDiscoverer.IsDiscoverTestCalled);
 
-                CollectionAssert.AreEqual(jsonsources, JsonTestDiscoverer.Sources.ToList());
-                Assert.AreEqual(settings, JsonTestDiscoverer.DiscoveryContext.RunSettings);
-                Assert.AreEqual(testCaseFilter, (JsonTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
-                Assert.AreEqual(logger, JsonTestDiscoverer.MessageLogger);
-                Assert.IsNotNull(JsonTestDiscoverer.DiscoverySink);
-            }
-            finally
-            {
-                this.ResetDiscoverers();
-            }
+            // Also validate that the right set of arguments were passed on to the discoverer.
+            CollectionAssert.AreEqual(dllsources, ManagedDllTestDiscoverer.Sources.ToList());
+            Assert.AreEqual(runSettings, ManagedDllTestDiscoverer.DiscoveryContext.RunSettings);
+            Assert.AreEqual(testCaseFilter, (ManagedDllTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
+            Assert.AreEqual(this.messageLoggerMock.Object, ManagedDllTestDiscoverer.MessageLogger);
+            Assert.IsNotNull(ManagedDllTestDiscoverer.DiscoverySink);
+
+            CollectionAssert.AreEqual(jsonsources, JsonTestDiscoverer.Sources.ToList());
+            Assert.AreEqual(runSettings, JsonTestDiscoverer.DiscoveryContext.RunSettings);
+            Assert.AreEqual(testCaseFilter, (JsonTestDiscoverer.DiscoveryContext as DiscoveryContext).FilterExpressionWrapper.FilterString);
+            Assert.AreEqual(this.messageLoggerMock.Object, JsonTestDiscoverer.MessageLogger);
+            Assert.IsNotNull(JsonTestDiscoverer.DiscoverySink);
         }
-
-        private void ResetDiscoverers()
+        private void SetupForNoTestsAvailableInGivenAssemblies()
         {
-            ManagedDllTestDiscoverer.Reset();
-            NativeDllTestDiscoverer.Reset();
-            JsonTestDiscoverer.Reset();
-            NotImplementedTestDiscoverer.Reset();
+            var corssPlatEngineAssembly = typeof(DiscovererEnumerator).GetTypeInfo().Assembly.Location;
+            var objectModelAssembly = typeof(TestCase).GetTypeInfo().Assembly.Location;
+            var sources = new string[] { corssPlatEngineAssembly, objectModelAssembly };
+            TestPluginCacheTests.SetupMockExtensions(sources, () => { });
+
+            var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
+            extensionSourceMap.Add("_none_", sources);
+
+            this.discovererEnumerator.LoadTests(extensionSourceMap, this.runSettingsMock.Object, null, this.messageLoggerMock.Object);
         }
 
         private void InvokeLoadTestWithMockSetup()
@@ -585,12 +487,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
             var extensionSourceMap = new Dictionary<string, IEnumerable<string>>();
             extensionSourceMap.Add("_none_", sources);
 
-            var settings = new Mock<IRunSettings>().Object;
-            var logger = new Mock<IMessageLogger>().Object;
-
-            this.discovererEnumerator.LoadTests(extensionSourceMap, settings, null, logger);
+            this.discovererEnumerator.LoadTests(extensionSourceMap, this.runSettingsMock.Object, null, this.messageLoggerMock.Object);
         }
-
 
         #region implementation
 
@@ -644,7 +542,6 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
             public static bool IsManagedDiscoverTestCalled { get; private set; }
 
             public static IEnumerable<string> Sources { get; set; }
-
 
             public override void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink)
             {

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Discovery/DiscovererEnumeratorTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Discovery/DiscovererEnumeratorTests.cs
@@ -502,15 +502,18 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
         }
 
         [TestMethod]
-        public void LoadTestsShouldShortenTheTestCaseFilterWhenNoTestsDiscovered()
+        public void LoadTestsShouldShortenTheLongTestCaseFilterWhenNoTestsDiscovered()
         {
             DiscovererEnumeratorTests.SetupForNoTestsAvailableInGivenAssemblies(out var extensionSourceMap, out var sourcesString);
 
-            var testCaseFilter = "Name~LongTestCaseNameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+            var veryLengthyTestCaseFilter = "FullyQualifiedName=TestPlatform.CrossPlatEngine" +
+                                            ".UnitTests.Discovery.DiscovererEnumeratorTests." +
+                                            "LoadTestsShouldShortenTheLongTestCaseFilterWhenNoTestsDiscovered" +
+                                            "TestCaseFilterWithVeryLengthTestCaseNameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 
-            this.discovererEnumerator.LoadTests(extensionSourceMap, this.runSettingsMock.Object, testCaseFilter, this.messageLoggerMock.Object);
+            this.discovererEnumerator.LoadTests(extensionSourceMap, this.runSettingsMock.Object, veryLengthyTestCaseFilter, this.messageLoggerMock.Object);
 
-            var expectedTestCaseFilter = testCaseFilter.Substring(0, 60) + "...";
+            var expectedTestCaseFilter = veryLengthyTestCaseFilter.Substring(0, 256) + "...";
             var expectedMessage =
                 $"No test is available for testcase filter `{expectedTestCaseFilter}` in {sourcesString}";
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/RunTestsWithSourcesTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/RunTestsWithSourcesTests.cs
@@ -93,7 +93,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
                 this.mockTestRunEventsHandler.Object,
                 executorUriVsSourceList,
                 this.mockRequestData.Object);
-            
+
             this.runTestsInstance.CallBeforeRaisingTestRunComplete(false);
 
             var messageFormat =
@@ -198,7 +198,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
 
             bool isExecutorCalled = false;
             RunTestWithSourcesExecutor.RunTestsWithSourcesCallback = (s, rc, fh) => { isExecutorCalled = true; };
-            
+
             this.runTestsInstance.RunTests();
 
             Assert.IsTrue(isExecutorCalled);
@@ -207,6 +207,74 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
                     It.IsAny<TestRunChangedEventArgs>(),
                     It.IsAny<ICollection<AttachmentSet>>(),
                     It.IsAny<ICollection<string>>()), Times.Once);
+        }
+
+        [TestMethod]
+        public void RunTestsShouldLogWarningOnNoTestsAvailableInAssembly()
+        {
+            string testCaseFilter = null;
+            this.SetupForNoTestsAvailable(testCaseFilter, out var sourcesString);
+
+            this.runTestsInstance.RunTests();
+
+            var expectedMessage =
+                $"No test is available in {sourcesString}. Make sure that test discoverer & executors are registered and platform & framework version settings are appropriate and try again.";
+            this.mockTestRunEventsHandler.Verify(treh => treh.HandleLogMessage(TestMessageLevel.Warning, expectedMessage), Times.Once);
+        }
+
+        [TestMethod]
+        public void RunTestsShouldLogWarningOnNoTestsAvailableInAssemblyWithTestCaseFilter()
+        {
+            var testCaseFilter = "Name~TestMethod1";
+            this.SetupForNoTestsAvailable(testCaseFilter, out var sourcesString);
+
+            this.runTestsInstance.RunTests();
+
+            var expectedMessage =
+                $"No test is available for testcase filter `{testCaseFilter}` in {sourcesString}";
+            this.mockTestRunEventsHandler.Verify(treh => treh.HandleLogMessage(TestMessageLevel.Warning, expectedMessage), Times.Once);
+        }
+
+        [TestMethod]
+        public void RunTestsShouldLogWarningOnNoTestsAvailableInAssemblyWithLongTestCaseFilter()
+        {
+            var veryLengthyTestCaseFilter = "FullyQualifiedName=TestPlatform.CrossPlatEngine" +
+                                 ".UnitTests.Execution.RunTestsWithSourcesTests." +
+                                 "RunTestsShouldLogWarningOnNoTestsAvailableInAssemblyWithLongTestCaseFilter" +
+                                 "WithVeryLengthTestCaseNameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+            this.SetupForNoTestsAvailable(veryLengthyTestCaseFilter, out var sourcesString);
+
+            this.runTestsInstance.RunTests();
+
+            var expectedTestCaseFilter = veryLengthyTestCaseFilter.Substring(0, 256)+ "...";
+
+            var expectedMessage =
+                $"No test is available for testcase filter `{expectedTestCaseFilter}` in {sourcesString}";
+            this.mockTestRunEventsHandler.Verify(treh => treh.HandleLogMessage(TestMessageLevel.Warning, expectedMessage), Times.Once);
+        }
+
+        private void SetupForNoTestsAvailable(string testCaseFilter, out string sourcesString)
+        {
+            var testAssemblyLocation = typeof(TestCase).GetTypeInfo().Assembly.Location;
+
+            var adapterAssemblyLocation = typeof(RunTestsWithSourcesTests).GetTypeInfo().Assembly.Location;
+
+            var adapterSourceMap = new Dictionary<string, IEnumerable<string>>();
+
+            var sources = new[] {testAssemblyLocation, "a"};
+            sourcesString = string.Join(" ", sources);
+
+            adapterSourceMap.Add(adapterAssemblyLocation, sources);
+
+            this.testExecutionContext.TestCaseFilter = testCaseFilter;
+
+            this.runTestsInstance = new TestableRunTestsWithSources(
+                adapterSourceMap,
+                null,
+                testExecutionContext,
+                null,
+                this.mockTestRunEventsHandler.Object,
+                this.mockRequestData.Object);
         }
 
         #region Testable Implemetations

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Microsoft.TestPlatform.CrossPlatEngine.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Microsoft.TestPlatform.CrossPlatEngine.UnitTests.csproj
@@ -9,6 +9,8 @@
     <OutputType Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">Exe</OutputType>
     <AssemblyName>Microsoft.TestPlatform.CrossPlatEngine.UnitTests</AssemblyName>
     <TargetFrameworks>netcoreapp1.0;net451</TargetFrameworks>
+    <!--<WarningsAsErrors>true</WarningsAsErrors>
+    <EnableCodeAnalysis>true</EnableCodeAnalysis> -->
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.TestHostProvider\Microsoft.TestPlatform.TestHostProvider.csproj" />

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -50,6 +50,10 @@ namespace Microsoft.TestPlatform.TestUtilities
             this.testEnvironment = new IntegrationTestEnvironment();
         }
 
+        public string StdOut => this.standardTestOutput;
+
+        public string StdErr => this.standardTestError;
+
         /// <summary>
         /// Prepare arguments for <c>vstest.console.exe</c>.
         /// </summary>
@@ -403,7 +407,19 @@ namespace Microsoft.TestPlatform.TestUtilities
         /// <returns></returns>
         public IVsTestConsoleWrapper GetVsTestConsoleWrapper()
         {
-            var vstestConsoleWrapper = new VsTestConsoleWrapper(this.GetConsoleRunnerPath());
+            var logFileName = Path.GetFileName(Path.GetTempFileName());
+            var logFileDir = Path.Combine(Path.GetTempPath(), "VSTestConsoleWrapperLogs");
+
+            if (Directory.Exists(logFileDir) == false)
+            {
+                Directory.CreateDirectory(logFileDir);
+            }
+
+            var logFilePath = Path.Combine(logFileDir, logFileName);
+
+            Console.WriteLine($"Logging diagnostics in {logFilePath}");
+
+            var vstestConsoleWrapper = new VsTestConsoleWrapper(this.GetConsoleRunnerPath(), new ConsoleParameters(){LogFilePath = logFilePath});
             vstestConsoleWrapper.StartSession();
 
             return vstestConsoleWrapper;

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -133,17 +133,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
         }
 
         [TestMethod]
-        public void TestMessageHandlerShouldWriteToConsoleIfTestRunEventsAreRaised()
+        public void TestMessageHandlerShouldWriteToConsoleWhenTestRunMessageIsRaised()
         {
             var count = 0;
             this.mockOutput.Setup(o => o.WriteLine(It.IsAny<string>(), It.IsAny<OutputLevel>())).Callback<string, OutputLevel>(
                 (s, o) => { count++; });
 
-            var loggerEvents = new InternalTestLoggerEvents(TestSessionMessageLogger.Instance);
-            loggerEvents.EnableEvents();
-            var parameters = new Dictionary<string, string>();
-            parameters.Add("verbosity", "normal");
-            this.consoleLogger.Initialize(loggerEvents, parameters);
+            this.SetupForTestMessageHandler(out var loggerEvents);
 
             loggerEvents.RaiseTestRunMessage(new TestRunMessageEventArgs(TestMessageLevel.Informational, "Informational123"));
             loggerEvents.RaiseTestRunMessage(new TestRunMessageEventArgs(TestMessageLevel.Error, "Error123"));
@@ -152,9 +148,42 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
             // Added this for synchronization
             SpinWait.SpinUntil(() => count == 3, 300);
 
+            this.AssertsForTestMessageHandler();
+        }
+
+        [TestMethod]
+        public void TestMessageHandlerShouldWriteToConsoleWhenTestDiscoveryMessageIsRaised()
+        {
+            var count = 0;
+            this.mockOutput.Setup(o => o.WriteLine(It.IsAny<string>(), It.IsAny<OutputLevel>())).Callback<string, OutputLevel>(
+                (s, o) => { count++; });
+
+            this.SetupForTestMessageHandler(out var loggerEvents);
+
+            loggerEvents.RaiseDiscoveryMessage(new TestRunMessageEventArgs(TestMessageLevel.Informational, "Informational123"));
+            loggerEvents.RaiseDiscoveryMessage(new TestRunMessageEventArgs(TestMessageLevel.Error, "Error123"));
+            loggerEvents.RaiseDiscoveryMessage(new TestRunMessageEventArgs(TestMessageLevel.Warning, "Warning123"));
+
+            // Added this for synchronization
+            SpinWait.SpinUntil(() => count == 3, 300);
+
+            this.AssertsForTestMessageHandler();
+        }
+
+        private void AssertsForTestMessageHandler()
+        {
             this.mockOutput.Verify(o => o.WriteLine("Informational123", OutputLevel.Information), Times.Once());
             this.mockOutput.Verify(o => o.WriteLine("Warning123", OutputLevel.Warning), Times.Once());
             this.mockOutput.Verify(o => o.WriteLine("Error123", OutputLevel.Error), Times.Once());
+        }
+
+        private void SetupForTestMessageHandler(out InternalTestLoggerEvents loggerEvents)
+        {
+            loggerEvents = new InternalTestLoggerEvents(TestSessionMessageLogger.Instance);
+            loggerEvents.EnableEvents();
+            var parameters = new Dictionary<string, string>();
+            parameters.Add("verbosity", "normal");
+            this.consoleLogger.Initialize(loggerEvents, parameters);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description
For #1643
- Show better warning message on no tests discover/run when testcasefilter provided.
- As the testcasefilter can be really lengthy in LUT scenarion. 
   1. Showing entire testcasefilter can cause following issues.
      a. Small scrollpane for `output` -> `test`
      b. Lengthy message can impact the performance of VS
   2. Showing no given testcasefilter can lead to no proper logging/diagnostic information for user.  Having proper logging/diagnostic info can help the user to understand the issue and help themselves.
[Example issue](https://developercommunity.visualstudio.com/content/problem/257779/live-unit-testing-does-not-work-with-nunit-testcas.html) 

First I have chosen 60 character as max testcasefilter length. While testing realized that max length 256 characters looks good.

For #1569
- I have to fix this issue in current PR to write acceptance tests.
- Ported required change from https://github.com/Microsoft/vstest/pull/1111
## Related issue
https://github.com/Microsoft/vstest/issues/1643
https://github.com/Microsoft/vstest/issues/1569