### PR TITLE
Fix vstest.console.exe grabs exclusive read access to its test container

### DIFF
--- a/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs
+++ b/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs
@@ -26,7 +26,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
 
         internal AssemblyMetadataProvider(IFileHelper fileHelper)
         {
-
             this.fileHelper = fileHelper;
         }
 
@@ -36,14 +35,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
             FrameworkName frameworkName = new FrameworkName(Framework.DefaultFramework.Name);
             try
             {
-                using (var assemblyStream = this.fileHelper.GetStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                using (var assemblyStream = this.fileHelper.GetStream(filePath, FileMode.Open, FileAccess.Read))
                 {
                     frameworkName = AssemblyMetadataProvider.GetFrameworkNameFromAssemblyMetadata(assemblyStream);
                 }
             }
             catch (Exception ex)
             {
-                EqtTrace.Warning("AssemblyMetadataProvider.GetFrameWork: failed to determine TargetFrameworkVersion: {0} for assembly: {1}", ex, filePath);
+                EqtTrace.Warning("AssemblyMetadataProvider.GetFrameWork: failed to determine TargetFrameworkVersion exception: {0} for assembly: {1}", ex, filePath);
             }
 
             if (EqtTrace.IsInfoEnabled)
@@ -172,7 +171,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
             try
             {
                 //get the input stream
-                using (Stream fs = this.fileHelper.GetStream(imagePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                using (Stream fs = this.fileHelper.GetStream(imagePath, FileMode.Open, FileAccess.Read))
                 using (var reader = new BinaryReader(fs))
                 {
                     var validImage = true;

--- a/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs
+++ b/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
         /// <summary>
         /// Gets the instance.
         /// </summary>
-        internal static AssemblyMetadataProvider Instance => instance ?? (instance = new AssemblyMetadataProvider(new FileHelper()));
+        public static AssemblyMetadataProvider Instance => instance ?? (instance = new AssemblyMetadataProvider(new FileHelper()));
 
         internal AssemblyMetadataProvider(IFileHelper fileHelper)
         {

--- a/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs
+++ b/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs
@@ -11,15 +11,24 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
     using System.Runtime.Versioning;
     using System.Text;
     using ObjectModel;
+    using TestPlatform.Utilities.Helpers;
+    using TestPlatform.Utilities.Helpers.Interfaces;
 
     internal class AssemblyMetadataProvider : IAssemblyMetadataProvider
     {
         private static AssemblyMetadataProvider instance;
+        private IFileHelper fileHelper;
 
         /// <summary>
         /// Gets the instance.
         /// </summary>
-        internal static AssemblyMetadataProvider Instance => instance ?? (instance = new AssemblyMetadataProvider());
+        internal static AssemblyMetadataProvider Instance => instance ?? (instance = new AssemblyMetadataProvider(new FileHelper()));
+
+        internal AssemblyMetadataProvider(IFileHelper fileHelper)
+        {
+
+            this.fileHelper = fileHelper;
+        }
 
         /// <inheritdoc />
         public FrameworkName GetFrameWork(string filePath)
@@ -27,14 +36,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
             FrameworkName frameworkName = new FrameworkName(Framework.DefaultFramework.Name);
             try
             {
-                using (var assemblyStream = File.Open(filePath, FileMode.Open, FileAccess.Read))
+                using (var assemblyStream = this.fileHelper.GetStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 {
-                    frameworkName = GetFrameworkNameFromAssemblyMetadata(assemblyStream);
+                    frameworkName = AssemblyMetadataProvider.GetFrameworkNameFromAssemblyMetadata(assemblyStream);
                 }
             }
             catch (Exception ex)
             {
-                EqtTrace.Warning("GetFrameWorkFromMetadata: failed to determine TargetFrameworkVersion: {0} for assembly: {1}", ex, filePath);
+                EqtTrace.Warning("AssemblyMetadataProvider.GetFrameWork: failed to determine TargetFrameworkVersion: {0} for assembly: {1}", ex, filePath);
             }
 
             if (EqtTrace.IsInfoEnabled)
@@ -86,7 +95,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
             return archType;
         }
 
-        private static FrameworkName GetFrameworkNameFromAssemblyMetadata(FileStream assemblyStream)
+        private static FrameworkName GetFrameworkNameFromAssemblyMetadata(Stream assemblyStream)
         {
             FrameworkName frameworkName = new FrameworkName(Framework.DefaultFramework.Name);
             using (var peReader = new PEReader(assemblyStream))
@@ -163,7 +172,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
             try
             {
                 //get the input stream
-                using (Stream fs = new FileStream(imagePath, FileMode.Open, FileAccess.Read))
+                using (Stream fs = this.fileHelper.GetStream(imagePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 using (var reader = new BinaryReader(fs))
                 {
                     var validImage = true;

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
                   TestPlatformFactory.GetTestPlatform(),
                   TestRunResultAggregator.Instance,
                   TestPlatformEventSource.Instance,
-                  new InferHelper(new AssemblyMetadataProvider()),
+                  new InferHelper(AssemblyMetadataProvider.Instance),
                   MetricsPublisherFactory.GetMetricsPublisher(IsTelemetryOptedIn(), CommandLineOptions.Instance.IsDesignMode))
         {
         }

--- a/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Helpers/FileHelperTests.cs
+++ b/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Helpers/FileHelperTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.TestPlatform.CoreUtilities.UnitTests.Helpers
+{
+    using System.IO;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using VisualStudio.TestPlatform.Utilities.Helpers;
+
+    [TestClass]
+    public class FileHelperTests
+    {
+        private readonly FileHelper fileHelper;
+        private readonly string tempFile;
+
+        public FileHelperTests()
+        {
+            this.tempFile = Path.GetTempFileName();
+            File.AppendAllText(this.tempFile, "Some content..");
+            this.fileHelper = new FileHelper();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            File.Delete(this.tempFile);
+        }
+
+        [TestMethod]
+        public void GetStreamShouldAbleToGetTwoStreamSimultanouslyIfFileAccessIsRead()
+        {
+            using (var stream1 = this.fileHelper.GetStream(this.tempFile, FileMode.Open, FileAccess.Read))
+            {
+                using (var stream2 =
+                    this.fileHelper.GetStream(this.tempFile, FileMode.Open, FileAccess.Read))
+                {
+                }
+            }
+        }
+    }
+}

--- a/test/vstest.console.PlatformTests/AssemblyMetadataProviderTests.cs
+++ b/test/vstest.console.PlatformTests/AssemblyMetadataProviderTests.cs
@@ -37,8 +37,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.PlatformTests
             this.assemblyMetadataProvider = new AssemblyMetadataProvider(this.fileHelperMock.Object);
 
             this.fileHelperMock.Setup(f =>
-                    f.GetStream(It.IsAny<string>(), FileMode.Open, FileAccess.Read, FileShare.Read))
-                .Returns<string, FileMode, FileAccess, FileShare>((filePath, mode, access, share) => this.fileHelper.GetStream(filePath, mode, access, share));
+                    f.GetStream(It.IsAny<string>(), FileMode.Open, FileAccess.Read))
+                .Returns<string, FileMode, FileAccess>((filePath, mode, access) => this.fileHelper.GetStream(filePath, mode, access));
         }
 
         [TestCleanup]
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.PlatformTests
             if (this.isManagedAssemblyArchitectureTest == false)
             {
                 this.fileHelperMock.Verify(
-                    f => f.GetStream(It.IsAny<string>(), FileMode.Open, FileAccess.Read, FileShare.Read), Times.Once);
+                    f => f.GetStream(It.IsAny<string>(), FileMode.Open, FileAccess.Read), Times.Once);
             }
         }
 


### PR DESCRIPTION
## Description
- Use FileStream API to create stream.
- Default FileShare for [FileStream .ctor](https://github.com/dotnet/corefx/blob/master/src/Common/src/CoreLib/System/IO/FileStream.cs#L15) is FileShare.Read where as [File.Open()](https://github.com/dotnet/corefx/blob/master/src/System.IO.FileSystem/src/System/IO/File.cs#L146) default FileShare value is FileShare.None

## Related issue
https://github.com/Microsoft/vstest/issues/1638
