### PR TITLE
Enable code coverage in release pipeline with 'dotnet vstest'

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -570,7 +570,7 @@ function Create-NugetPackages
                      "Microsoft.TestPlatform.Portable.nuspec",
                      "Microsoft.CodeCoverage.nuspec")
 
-    $targetFiles = @("Microsoft.Net.Test.Sdk.targets")
+    $targetFiles = @("Microsoft.Net.Test.Sdk.targets", "Microsoft.CodeCoverage.targets")
     $propFiles = @("Microsoft.Net.Test.Sdk.props", "Microsoft.CodeCoverage.props")
     # Nuget pack analysis emits warnings if binaries are packaged as content. It is intentional for the below packages.
     $skipAnalysis = @("TestPlatform.CLI.nuspec")

--- a/scripts/verify-nupkgs.ps1
+++ b/scripts/verify-nupkgs.ps1
@@ -12,7 +12,7 @@ function Unzip
 function Verify-Nuget-Packages($packageDirectory)
 {
     Write-Log "Starting Verify-Nuget-Packages."
-    $expectedNumOfFiles = @{"Microsoft.CodeCoverage" = 28;
+    $expectedNumOfFiles = @{"Microsoft.CodeCoverage" = 29;
                      "Microsoft.NET.Test.Sdk" = 10;
                      "Microsoft.TestPlatform" = 420;
                      "Microsoft.TestPlatform.Build" = 19;

--- a/src/package/nuspec/Microsoft.CodeCoverage.nuspec
+++ b/src/package/nuspec/Microsoft.CodeCoverage.nuspec
@@ -18,6 +18,7 @@
   <files>
 
     <file src="Microsoft.CodeCoverage.props" target="build\netstandard1.0\" />
+    <file src="Microsoft.CodeCoverage.targets" target="build\netstandard1.0\" />
     <file src="Microsoft.CodeCoverage\Microsoft.VisualStudio.TraceDataCollector.dll" target="build\netstandard1.0\" />
     <file src="Microsoft.CodeCoverage\CodeCoverage\CodeCoverage.config" target="build\netstandard1.0\CodeCoverage\" />
     <file src="Microsoft.CodeCoverage\CodeCoverage\CodeCoverage.exe" target="build\netstandard1.0\CodeCoverage\" />

--- a/src/package/nuspec/Microsoft.CodeCoverage.targets
+++ b/src/package/nuspec/Microsoft.CodeCoverage.targets
@@ -1,0 +1,26 @@
+<!--
+ ***********************************************************************************************
+ Microsoft.CodeCoverage.targets
+
+ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+           created a backup copy.  Incorrect changes to this file will make it
+           impossible to load or build your test projects from the command-line or the IDE.
+
+ Copyright (c) Microsoft. All rights reserved.
+ ***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- This target required to enable /collect:"Code Coverage" in "dotnet publish" scenario with "dotnet vstest".
+       E.g: Release pipelines where user/project nuget cache not available on current machine. -->
+  <Target Name="CopyTraceDataCollectorArtifacts" AfterTargets="ComputeFilesToPublish">
+
+    <ItemGroup>
+      <TraceDataCollectorArtifacts Include="$(MSBuildThisFileDirectory)\**\*.*" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(TraceDataCollectorArtifacts)" DestinationFolder="$(PublishDir)%(RecursiveDir)" />
+
+  </Target>
+</Project>


### PR DESCRIPTION
## Description
- Add target to copy TraceDataCollector dependencies to publish directory.

## Related issue
https://github.com/Microsoft/vstest/issues/981
