### PR TITLE
fix for settingsprovider.dll not being loaded in teshost

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -258,7 +258,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
 
         private void InitializeExtensions(IEnumerable<string> sources)
         {
-            var extensions = TestPluginCache.Instance.GetExtensionPaths(TestPlatformConstants.TestAdapterEndsWithPattern, this.skipDefaultAdapters);
+            var adapterExtensions = TestPluginCache.Instance.GetExtensionPaths(TestPlatformConstants.TestAdapterEndsWithPattern, this.skipDefaultAdapters);
+            var settingsProviderExtensions = TestPluginCache.Instance.GetExtensionPaths(TestPlatformConstants.SettingsProviderEndsWithPattern, this.skipDefaultAdapters);
+
+            var extensions = adapterExtensions.Union(settingsProviderExtensions);
 
             // Filter out non existing extensions
             var nonExistingExtensions = extensions.Where(extension => !this.fileHelper.Exists(extension));

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
@@ -734,7 +734,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         {
             TestPluginCache.Instance = null;
             TestPluginCache.Instance.DefaultExtensionPaths = new List<string> { "default1.dll", "default2.dll" };
-            TestPluginCache.Instance.UpdateExtensions(new List<string> { "filterTestAdapter.dll" }, false);
+            TestPluginCache.Instance.UpdateExtensions(new List<string> { "filterTestAdapter.dll", "filterTestAdapter.SettingsProvider.dll" }, false);
             TestPluginCache.Instance.UpdateExtensions(new List<string> { "unfilter.dll" }, true);
 
             try
@@ -742,7 +742,9 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
                 this.mockFileHelper.Setup(fh => fh.Exists(It.IsAny<string>())).Returns(true);
                 this.mockTestHostManager.Setup(th => th.GetTestPlatformExtensions(It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>())).Returns((IEnumerable<string> sources, IEnumerable<string> extensions) => extensions);
                 this.mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(true);
-                var expectedResult = TestPluginCache.Instance.GetExtensionPaths(TestPlatformConstants.TestAdapterEndsWithPattern, skipDefaultAdapters);
+                var adapterPaths = TestPluginCache.Instance.GetExtensionPaths(TestPlatformConstants.TestAdapterEndsWithPattern, skipDefaultAdapters);
+                var settingsProviderPaths = TestPluginCache.Instance.GetExtensionPaths(TestPlatformConstants.SettingsProviderEndsWithPattern, skipDefaultAdapters);
+                var expectedResult = adapterPaths.Union(settingsProviderPaths);
 
                 this.testExecutionManager.Initialize(skipDefaultAdapters);
                 this.testExecutionManager.StartTestRun(this.mockTestRunCriteria.Object, null);


### PR DESCRIPTION
load paths for SettingsProviderEndsWithPattern along with TestAapterEndsWithPattern in ProxyExecutionManager when initializing extensions
added tests for the same

## Description
SettingsProvider.dll paths are not sent to testhost.exe from vstest.console which causes settingsprovider.dll to not load in testhost

This is affected in case of --isolation and --platform:x64