### PR TITLE
Procdump Arguments Changed

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Constants.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Constants.cs
@@ -42,5 +42,10 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
         /// Configuration key name for dump mode
         /// </summary>
         public const string DumpModeKey = "CollectDump";
+
+        /// <summary>
+        /// X86 Test Host Process Name
+        /// </summary>
+        public const string X86TestHostProcessName = "testhost.x86";
     }
 }

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Constants.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Constants.cs
@@ -44,8 +44,13 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
         public const string DumpModeKey = "CollectDump";
 
         /// <summary>
-        /// X86 Test Host Process Name
+        /// Procdump 32 bit version
         /// </summary>
-        public const string X86TestHostProcessName = "testhost.x86";
+        public const string ProcdumpProcessName = "procdump.exe";
+
+        /// <summary>
+        /// Procdump 64 bit version
+        /// </summary>
+        public const string Procdump64ProcessName = "procdump64.exe";
     }
 }

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Constants.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Constants.cs
@@ -46,12 +46,12 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
         /// <summary>
         /// Procdump 32 bit version
         /// </summary>
-        public const string ProcdumpProcessName = "procdump.exe";
+        public const string ProcdumpProcess = "procdump.exe";
 
         /// <summary>
         /// Procdump 64 bit version
         /// </summary>
-        public const string Procdump64ProcessName = "procdump64.exe";
+        public const string Procdump64Process = "procdump64.exe";
 
         ///<summary>
         /// Configuration key name for collect dump always

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Interfaces/INativeMethodsHelper.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Interfaces/INativeMethodsHelper.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.Interfaces
+{
+    using System;
+
+    public interface INativeMethodsHelper
+    {
+        /// <summary>
+        /// Returns if a process is 64 bit process
+        /// </summary>
+        /// <param name="processHandle">Process Handle</param>
+        /// <returns>Bool for Is64Bit</returns>
+        bool Is64Bit(IntPtr processHandle);
+    }
+}

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/NativeMethodsHelper.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/NativeMethodsHelper.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
+{
+    using System;
+    using System.ComponentModel;
+    using System.Runtime.InteropServices;
+    using Microsoft.TestPlatform.Extensions.BlameDataCollector.Interfaces;
+
+    public class NativeMethodsHelper : INativeMethodsHelper
+    {
+        /// <summary>
+        /// Returns if a process is 64 bit process
+        /// </summary>
+        /// <param name="processHandle">Process Handle</param>
+        /// <returns>Bool for Is64Bit</returns>
+        public bool Is64Bit(IntPtr processHandle)
+        {
+            // WOW64 is the x86 emulator that allows 32 bit Windows - based applications to run seamlessly on 64 bit Windows.
+            bool isWow64 = false;
+            if (!IsWow64Process(processHandle, out isWow64))
+            {
+                throw new Win32Exception();
+            }
+
+            return !isWow64;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true, CallingConvention = CallingConvention.Winapi)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool IsWow64Process([In] IntPtr process, [Out] out bool wow64Process);
+    }
+}

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/NativeMethodsHelper.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/NativeMethodsHelper.cs
@@ -4,9 +4,9 @@
 namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
 {
     using System;
-    using System.ComponentModel;
     using System.Runtime.InteropServices;
     using Microsoft.TestPlatform.Extensions.BlameDataCollector.Interfaces;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
     public class NativeMethodsHelper : INativeMethodsHelper
     {
@@ -19,14 +19,22 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
         {
             // WOW64 is the x86 emulator that allows 32 bit Windows - based applications to run seamlessly on 64 bit Windows.
             bool isWow64 = false;
+
+            // If the function succeeds, the return value is a nonzero value.
             if (!IsWow64Process(processHandle, out isWow64))
             {
-                throw new Win32Exception();
+                if (EqtTrace.IsVerboseEnabled)
+                {
+                    EqtTrace.Verbose("NativeMethodsHelper: The call to IsWow64Process failed.");
+                }
             }
 
             return !isWow64;
         }
 
+        // A pointer to a value that is set to TRUE if the process is running under WOW64.
+        // If the process is running under 32-bit Windows, the value is set to FALSE.
+        // If the process is a 64-bit application running under 64-bit Windows, the value is also set to FALSE.
         [DllImport("kernel32.dll", SetLastError = true, CallingConvention = CallingConvention.Winapi)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool IsWow64Process([In] IntPtr process, [Out] out bool wow64Process);

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/IProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/IProcessHelper.cs
@@ -109,6 +109,6 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces
         /// </summary>
         /// <param name="processId">process id</param>
         /// <returns>Process Handle</returns>
-        IntPtr GetProcessHandleById(int processId);
+        IntPtr GetProcessHandle(int processId);
     }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/IProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/IProcessHelper.cs
@@ -103,5 +103,12 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces
         /// </summary>
         /// <param name="process">Reference to process</param>
         void WaitForProcessExit(object process);
+
+        /// <summary>
+        /// Gets the process handle for given process Id.
+        /// </summary>
+        /// <param name="processId">process id</param>
+        /// <returns>Process Handle</returns>
+        IntPtr GetProcessHandleById(int processId);
     }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/ProcessHelper.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
+    using System;
+    using System.Diagnostics;
     using System.IO;
     using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
 
@@ -12,6 +14,11 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         public string GetCurrentProcessLocation()
         {
             return Path.GetDirectoryName(this.GetCurrentProcessFileName());
+        }
+
+        public IntPtr GetProcessHandleById(int processId)
+        {
+            return Process.GetProcessById(processId).Handle;
         }
     }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/ProcessHelper.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
             return Path.GetDirectoryName(this.GetCurrentProcessFileName());
         }
 
-        public IntPtr GetProcessHandleById(int processId)
+        public IntPtr GetProcessHandle(int processId)
         {
             return Process.GetProcessById(processId).Handle;
         }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
@@ -17,8 +17,11 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
             return Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
         }
 
-        public IntPtr GetProcessHandleById(int processId)
+        /// <inheritdoc/>
+        public IntPtr GetProcessHandle(int processId)
         {
+            // An IntPtr representing the value of the handle field.
+            // If the handle has been marked invalid with SetHandleAsInvalid, this method still returns the original handle value, which can be a stale value.
             return Process.GetProcessById(processId).SafeHandle.DangerousGetHandle();
         }
     }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
+    using System;
+    using System.Diagnostics;
     using System.IO;
     using System.Reflection;
     using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
@@ -13,6 +15,11 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         public string GetCurrentProcessLocation()
         {
             return Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+        }
+
+        public IntPtr GetProcessHandleById(int processId)
+        {
+            return Process.GetProcessById(processId).SafeHandle.DangerousGetHandle();
         }
     }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard1.0/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard1.0/System/ProcessHelper.cs
@@ -5,7 +5,6 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
     using System.Collections.Generic;
-
     using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
 
     /// <summary>
@@ -93,6 +92,11 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 
         /// <inheritdoc/>
         public void WaitForProcessExit(object process)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IntPtr GetProcessHandleById(int processId)
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard1.0/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard1.0/System/ProcessHelper.cs
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
             throw new NotImplementedException();
         }
 
-        public IntPtr GetProcessHandleById(int processId)
+        public IntPtr GetProcessHandle(int processId)
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/ProcessHelper.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
     /// <summary>
     /// Helper class to deal with process related functionality.
     /// </summary>
-    public class ProcessHelper : IProcessHelper
+    public partial class ProcessHelper : IProcessHelper
     {
         /// <inheritdoc/>
         public object LaunchProcess(
@@ -98,6 +98,11 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 
         /// <inheritdoc/>
         public void WaitForProcessExit(object process)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IntPtr GetProcessHandleById(int processId)
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/ProcessHelper.cs
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
             throw new NotImplementedException();
         }
 
-        public IntPtr GetProcessHandleById(int processId)
+        public IntPtr GetProcessHandle(int processId)
         {
             throw new NotImplementedException();
         }

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/ProcessDumpUtilityTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/ProcessDumpUtilityTests.cs
@@ -226,7 +226,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             var testResultsDirectory = "D:\\TestResults";
 
             this.mockPlatformEnvironment.Setup(x => x.Architecture).Returns(PlatformArchitecture.X86);
-            this.mockProcessHelper.Setup(x => x.GetProcessHandleById(processId))
+            this.mockProcessHelper.Setup(x => x.GetProcessHandle(processId))
                                 .Returns(new IntPtr(0));
 
             var processDumpUtility = new ProcessDumpUtility(
@@ -250,7 +250,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             int processId = 1234;
             this.mockPlatformEnvironment.Setup(x => x.Architecture).Returns(PlatformArchitecture.X64);
 
-            this.mockProcessHelper.Setup(x => x.GetProcessHandleById(processId))
+            this.mockProcessHelper.Setup(x => x.GetProcessHandle(processId))
                                 .Returns(x64ProcessHandle);
             this.mockNativeMethodsHelper.Setup(x => x.Is64Bit(x64ProcessHandle))
                                 .Returns(true);
@@ -276,7 +276,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             int processId = 12345;
             this.mockPlatformEnvironment.Setup(x => x.Architecture).Returns(PlatformArchitecture.X64);
 
-            this.mockProcessHelper.Setup(x => x.GetProcessHandleById(processId))
+            this.mockProcessHelper.Setup(x => x.GetProcessHandle(processId))
                                 .Returns(x86ProcessHandle);
             this.mockNativeMethodsHelper.Setup(x => x.Is64Bit(x86ProcessHandle))
                                 .Returns(false);


### PR DESCRIPTION
## Description
1. Procdump options enhanced to handle crash scenorios in test host.` STACK_OVERFLOW` and `ACCESS_VIOLATION` filter added to get dumps on these crashes.
2. Procdump is launched according to the process. The version of the procdump chosen is now depending on the bitness of the test host. 
3. Validated the scenarios on 32 bit OS as well as 64 bit OS.

Using procdump options as
For mini dump :  `-accepteula -e 1 -g -t -f STACK_OVERFLOW -f ACCESS_VIOLATION`
For full dump : `-accepteula -e 1 -g -t -ma -f STACK_OVERFLOW -f ACCESS_VIOLATION`

-accepteula: Auto accept end-user license agreement
-e: Write a dump when the process encounters an unhandled exception. Include the 1 to create dump on first chance exceptions.
-g: Run as a native debugger in a managed process (no interop).
-t: Write a dump when the process terminates.
-ma: Full dump argument.
 -f: Filter the exceptions.