### PR TITLE
Find ISettingsProvider in TestAdapter assembly

### DIFF
--- a/src/Microsoft.TestPlatform.Client/TestPlatform.cs
+++ b/src/Microsoft.TestPlatform.Client/TestPlatform.cs
@@ -225,7 +225,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client
                         continue;
                     }
 
-                    var extensionAssemblies = new List<string>(this.fileHelper.EnumerateFiles(adapterPath, SearchOption.AllDirectories, TestPlatformConstants.TestAdapterEndsWithPattern, TestPlatformConstants.TestLoggerEndsWithPattern, TestPlatformConstants.RunTimeEndsWithPattern, TestPlatformConstants.SettingsProviderEndsWithPattern));
+                    var extensionAssemblies = new List<string>(this.fileHelper.EnumerateFiles(adapterPath, SearchOption.AllDirectories, TestPlatformConstants.TestAdapterEndsWithPattern, TestPlatformConstants.TestLoggerEndsWithPattern, TestPlatformConstants.RunTimeEndsWithPattern));
                     if (extensionAssemblies.Count > 0)
                     {
                         this.UpdateExtensions(extensionAssemblies, skipExtensionFilters: false);

--- a/src/Microsoft.TestPlatform.Common/Constants.cs
+++ b/src/Microsoft.TestPlatform.Common/Constants.cs
@@ -63,10 +63,5 @@ namespace Microsoft.VisualStudio.TestPlatform.Common
         /// Pattern used to find the run time providers library using String.EndWith
         /// </summary>
         public const string RunTimeEndsWithPattern = @"RuntimeProvider.dll";
-
-        /// <summary>
-        /// Pattern used to find the settings providers library using String.EndWith
-        /// </summary>
-        public const string SettingsProviderEndsWithPattern = @"SettingsProvider.dll";
     }
 }

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginCache.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginCache.cs
@@ -97,9 +97,26 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
         {
             var extensions = this.GetFilteredExtensions(this.filterableExtensionPaths, endsWithPattern);
 
+            if (EqtTrace.IsVerboseEnabled)
+            {
+                EqtTrace.Verbose(
+                    "TestPluginCache.GetExtensionPaths: Filtered extension paths: {0}", string.Join(Environment.NewLine, extensions));
+            }
+
             if (!skipDefaultExtensions)
             {
                 extensions = extensions.Concat(this.defaultExtensionPaths);
+                if (EqtTrace.IsVerboseEnabled)
+                {
+                    EqtTrace.Verbose(
+                        "TestPluginCache.GetExtensionPaths: Added default extension paths: {0}", string.Join(Environment.NewLine, this.defaultExtensionPaths));
+                }
+            }
+
+            if (EqtTrace.IsVerboseEnabled)
+            {
+                EqtTrace.Verbose(
+                    "TestPluginCache.GetExtensionPaths: Added unfilterableExtensionPaths: {0}", string.Join(Environment.NewLine, this.unfilterableExtensionPaths));
             }
 
             return extensions.Concat(this.unfilterableExtensionPaths).ToList();
@@ -123,6 +140,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
         public Dictionary<string, TPluginInfo> DiscoverTestExtensions<TPluginInfo, TExtension>(string endsWithPattern)
             where TPluginInfo : TestPluginInformation
         {
+            EqtTrace.Verbose("TestPluginCache.DiscoverTestExtensions: finding test extensions in assemblies endswith: {0} TPluginInfo: {1} TExtension: {2}", endsWithPattern, typeof(TPluginInfo), typeof(TExtension));
             // Return the cached value if cache is valid.
             if (this.TestExtensions != null && this.TestExtensions.AreTestExtensionsCached<TPluginInfo>())
             {
@@ -142,10 +160,16 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
 
             try
             {
-                EqtTrace.Verbose("TestPluginCache: Discovering the extensions using extension path.");
+                EqtTrace.Verbose("TestPluginCache.DiscoverTestExtensions: Discovering the extensions using extension path.");
 
                 // Combine all the possible extensions - both default and additional.
                 var allExtensionPaths = this.GetExtensionPaths(endsWithPattern);
+
+                if (EqtTrace.IsVerboseEnabled)
+                {
+                    EqtTrace.Verbose(
+                        "TestPluginCache.DiscoverTestExtensions: Discovering the extensions using allExtensionPaths: {0}", string.Join(Environment.NewLine, allExtensionPaths));
+                }
 
                 // Discover the test extensions from candidate assemblies.
                 pluginInfos = this.GetTestExtensions<TPluginInfo, TExtension>(allExtensionPaths);

--- a/src/Microsoft.TestPlatform.Common/SettingsProvider/SettingsProviderExtensionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/SettingsProvider/SettingsProviderExtensionManager.cs
@@ -115,7 +115,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.SettingsProvider
 
                         TestPluginManager.Instance
                             .GetSpecificTestExtensions<TestSettingsProviderPluginInformation, ISettingsProvider, ISettingsProviderCapabilities, TestSettingsProviderMetadata>(
-                                TestPlatformConstants.SettingsProviderEndsWithPattern,
+                                TestPlatformConstants.TestAdapterEndsWithPattern,
                                 out unfilteredTestExtensions,
                                 out testExtensions);
 


### PR DESCRIPTION
## Description
- Fix Settings Provider named 'GoogleTestAdapterSettings' was not found.
- In Tpv1 we don't filter by `SettingsProvider.dll` [More details](https://devdiv.visualstudio.com/DevDiv/_git/VS?path=%2Fsrc%2Fvset%2FAgile%2FTestPlatform%2FCommon%2FSettingsProvider%2FSettingsProviderExtensionManager.cs&version=GBlab%2Fvsumain&line=100&lineStyle=plain&lineEnd=100&lineStartColumn=25&lineEndColumn=60)
```xml
<?xml version="1.0" encoding="utf-8"?>
<RunSettings>
  <GoogleTestAdapterSettings>
    <SolutionSettings>
      <Settings>
        <AdditionalTestExecutionParam>-testdirectory=$(TestDir)</AdditionalTestExecutionParam>
        <BatchForTestSetup>$(SolutionDir)Tests\Returns0.bat</BatchForTestSetup>
        <BatchForTestTeardown>$(SolutionDir)Tests\Returns1.bat</BatchForTestTeardown>
        <WorkingDir>$(SolutionDir)</WorkingDir>
      </Settings>
    </SolutionSettings>
    <ProjectSettings>
      <Settings ProjectRegex="LoadTests_gta\.exe|CrashingTests_gta\.exe">
        <TestDiscoveryRegex>.*Tests.*_gta.exe</TestDiscoveryRegex>
      </Settings>
      <Settings ProjectRegex=".*\\Tests_gta\.exe">
        <TestDiscoveryTimeoutInSeconds>60</TestDiscoveryTimeoutInSeconds>
      </Settings>
    </ProjectSettings>
  </GoogleTestAdapterSettings>
</RunSettings>
```

## Related issue
#1652 
https://github.com/Microsoft/vstest/issues/1673
