### PR TITLE
Print start of testhost standard error message

### DIFF
--- a/src/Microsoft.TestPlatform.CoreUtilities/Constants.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Constants.cs
@@ -22,5 +22,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CoreUtilities
         /// Datacollector process name, without file extension(.exe/.dll)
         /// </summary>
         public const string DatacollectorProcessName = "datacollector";
+
+
+        /// <summary>
+        /// Number of character should be logged on child process exited with
+        /// error message on stadard error.
+        /// </summary>
+        public const int StandardErrorMaxLength = 20480; // 20 KB
     }
 }

--- a/src/Microsoft.TestPlatform.CoreUtilities/Constants.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Constants.cs
@@ -25,8 +25,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CoreUtilities
 
         /// <summary>
         /// Number of character should be logged on child process exited with
-        /// error message on stadard error.
+        /// error message on standard error.
         /// </summary>
-        public const int StandardErrorMaxLength = 20480; // 20 KB
+        public const int StandardErrorMaxLength = 8192; // 8 KB
     }
 }

--- a/src/Microsoft.TestPlatform.CoreUtilities/Constants.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Constants.cs
@@ -23,7 +23,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CoreUtilities
         /// </summary>
         public const string DatacollectorProcessName = "datacollector";
 
-
         /// <summary>
         /// Number of character should be logged on child process exited with
         /// error message on stadard error.

--- a/src/Microsoft.TestPlatform.CoreUtilities/Utilities/StringBuilderExtensions.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Utilities/StringBuilderExtensions.cs
@@ -6,19 +6,16 @@ namespace Microsoft.VisualStudio.TestPlatform.CoreUtilities.Extensions
     using System;
     using System.Text;
 
-    public static class StringExtensions
+    public static class StringBuilderExtensions
     {
         /// <summary>
         /// Add double quote around string. Useful in case of path which has white space in between.
         /// </summary>
-        /// <param name="value"></param>
+        /// <param name="result">string builder</param>
+        /// /// <param name="data">data to be appended.</param>
         /// <returns></returns>
-        public static string AddDoubleQuote(this string value)
-        {
-            return "\"" + value + "\"";
-        }
 
-        public static void AppendToStringBuilderBasedOnMaxLength(this string data, StringBuilder result)
+        public static void AppendSafeWithNewLine(this StringBuilder result, string data)
         {
             if (!string.IsNullOrEmpty(data))
             {

--- a/src/Microsoft.TestPlatform.CoreUtilities/Utilities/StringBuilderExtensions.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Utilities/StringBuilderExtensions.cs
@@ -9,12 +9,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CoreUtilities.Extensions
     public static class StringBuilderExtensions
     {
         /// <summary>
-        /// Add double quote around string. Useful in case of path which has white space in between.
+        /// Append given data from to string builder with new line.
         /// </summary>
         /// <param name="result">string builder</param>
-        /// /// <param name="data">data to be appended.</param>
+        /// <param name="data">data to be appended.</param>
         /// <returns></returns>
-
         public static void AppendSafeWithNewLine(this StringBuilder result, string data)
         {
             if (!string.IsNullOrEmpty(data))
@@ -25,7 +24,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CoreUtilities.Extensions
                     return;
                 }
 
-                // Add newline for readbility.
+                // Add newline for readability.
                 data += Environment.NewLine;
 
                 // Append sub string of data if appending all the data exceeds max capacity.

--- a/src/Microsoft.TestPlatform.CoreUtilities/Utilities/StringExtensions.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Utilities/StringExtensions.cs
@@ -5,6 +5,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CoreUtilities.Extensions
 {
     using System;
     using System.Net;
+    using System.Text;
+    using ObjectModel;
 
     public static class StringExtensions
     {
@@ -16,6 +18,29 @@ namespace Microsoft.VisualStudio.TestPlatform.CoreUtilities.Extensions
         public static string AddDoubleQuote(this string value)
         {
             return "\"" + value + "\"";
+        }
+
+        public static void AppendToStringBuilderBasedOnMaxLength(this string data, StringBuilder result)
+        {
+            if (!string.IsNullOrEmpty(data))
+            {
+                // Don't append more data if already reached max length.
+                if (result.Length >= result.MaxCapacity)
+                {
+                    return;
+                }
+
+                // Add newline for readbility.
+                data += Environment.NewLine;
+
+                // Append sub string of data if appending all the data exceeds max capacity.
+                if (result.Length + data.Length >= result.MaxCapacity)
+                {
+                    data = data.Substring(0, result.MaxCapacity - result.Length);
+                }
+
+                result.Append(data);
+            }
         }
     }
 }

--- a/src/Microsoft.TestPlatform.CoreUtilities/Utilities/StringExtensions.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Utilities/StringExtensions.cs
@@ -17,28 +17,5 @@ namespace Microsoft.VisualStudio.TestPlatform.CoreUtilities.Extensions
         {
             return "\"" + value + "\"";
         }
-
-        public static void AppendToStringBuilderBasedOnMaxLength(this string data, StringBuilder result)
-        {
-            if (!string.IsNullOrEmpty(data))
-            {
-                // Don't append more data if already reached max length.
-                if (result.Length >= result.MaxCapacity)
-                {
-                    return;
-                }
-
-                // Add newline for readbility.
-                data += Environment.NewLine;
-
-                // Append sub string of data if appending all the data exceeds max capacity.
-                if (result.Length + data.Length >= result.MaxCapacity)
-                {
-                    data = data.Substring(0, result.MaxCapacity - result.Length);
-                }
-
-                result.Append(data);
-            }
-        }
     }
 }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -70,8 +70,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
 
         #region Properties
 
-        protected int ErrorLength { get; set; } = 1000;
-
         /// <summary>
         /// Gets or sets the server for communication.
         /// </summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionLauncher.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionLauncher.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
     using System;
     using System.Collections.Generic;
     using System.Text;
-    using CoreUtilities.Extensions;
+    using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Extensions;
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionLauncher.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionLauncher.cs
@@ -36,16 +36,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
         {
             this.processHelper = processHelper;
             this.messageLogger = messageLogger;
-            this.processStdError = new StringBuilder(this.ErrorLength, this.ErrorLength);
+            this.processStdError = new StringBuilder(0, CoreUtilities.Constants.StandardErrorMaxLength);
         }
 
         /// <inheritdoc />
         public int DataCollectorProcessId { get; protected set; }
-
-        /// <summary>
-        /// Gets or sets the error length for data collector error stream.
-        /// </summary>
-        protected int ErrorLength { get; set; } = 4096;
 
         /// <summary>
         /// Gets callback on process exit

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionLauncher.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionLauncher.cs
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
             // This is helpful in abnormal failure of datacollector.
             EqtTrace.Warning("DataCollectionLauncher.ErrorReceivedCallback datacollector standard error line: {0}", data);
 
-            data.AppendToStringBuilderBasedOnMaxLength(this.processStdError);
+            this.processStdError.AppendSafeWithNewLine(data);
         };
 
         /// <summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionLauncher.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionLauncher.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
     using System;
     using System.Collections.Generic;
     using System.Text;
-
+    using CoreUtilities.Extensions;
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -71,35 +71,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
         /// Gets callback to read from process error stream
         /// </summary>
         protected Action<object, string> ErrorReceivedCallback => (process, data) =>
-            {
-                if (!string.IsNullOrEmpty(data))
-                {
-                    // Log all standard error message because on too much data we ignore starting part.
-                    // This is helpful in abnormal failure of process.
-                    EqtTrace.Warning("DataCollectionLauncher.ErrorReceivedCallback: Data collector standard error line: {0}", data);
+        {
+            // Log all standard error message because on too much data we ignore starting part.
+            // This is helpful in abnormal failure of datacollector.
+            EqtTrace.Warning("DataCollectionLauncher.ErrorReceivedCallback datacollector standard error line: {0}", data);
 
-                    // Add newline for readbility.
-                    data += Environment.NewLine;
-
-                    // if incoming data stream is huge empty entire testError stream, & limit data stream to MaxCapacity
-                    if (data.Length > this.processStdError.MaxCapacity)
-                    {
-                        this.processStdError.Clear();
-                        data = data.Substring(data.Length - this.processStdError.MaxCapacity);
-                    }
-                    else
-                    {
-                        // remove only what is required, from beginning of error stream
-                        int required = data.Length + this.processStdError.Length - this.processStdError.MaxCapacity;
-                        if (required > 0)
-                        {
-                            this.processStdError.Remove(0, required);
-                        }
-                    }
-
-                    this.processStdError.Append(data);
-                }
-            };
+            data.AppendToStringBuilderBasedOnMaxLength(this.processStdError);
+        };
 
         /// <summary>
         /// The launch data collector.

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -97,11 +97,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
         public IDictionary<string, string> Properties => new Dictionary<string, string>();
 
         /// <summary>
-        /// Gets or sets the error length for runtime error stream.
-        /// </summary>
-        protected int ErrorLength { get; set; } = 4096;
-
-        /// <summary>
         /// Gets callback on process exit
         /// </summary>
         private Action<object> ExitCallBack => (process) =>
@@ -367,7 +362,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
 
         private bool LaunchHost(TestProcessStartInfo testHostStartInfo, CancellationToken cancellationToken)
         {
-            this.testHostProcessStdError = new StringBuilder(this.ErrorLength, this.ErrorLength);
+            this.testHostProcessStdError = new StringBuilder(0, CoreUtilities.Constants.StandardErrorMaxLength);
             EqtTrace.Verbose("Launching default test Host Process {0} with arguments {1}", testHostStartInfo.FileName, testHostStartInfo.Arguments);
 
             if (this.customTestHostLauncher == null)

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -114,11 +114,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
         internal bool MakeRunsettingsCompatible => this.hostPackageVersion.StartsWith("15.0.0-preview");
 
         /// <summary>
-        /// Gets or sets the error length for runtime error stream.
-        /// </summary>
-        protected int ErrorLength { get; set; } = 4096;
-
-        /// <summary>
         /// Gets callback on process exit
         /// </summary>
         private Action<object> ExitCallBack => (process) =>
@@ -326,7 +321,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
 
         private bool LaunchHost(TestProcessStartInfo testHostStartInfo, CancellationToken cancellationToken)
         {
-            this.testHostProcessStdError = new StringBuilder(this.ErrorLength, this.ErrorLength);
+            this.testHostProcessStdError = new StringBuilder(0, CoreUtilities.Constants.StandardErrorMaxLength);
             if (this.customTestHostLauncher == null)
             {
                 EqtTrace.Verbose("DotnetTestHostManager: Starting process '{0}' with command line '{1}'", testHostStartInfo.FileName, testHostStartInfo.Arguments);

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
@@ -20,24 +20,19 @@ namespace Microsoft.TestPlatform.TestHostProvider.Hosting
                 // This is helpful in abnormal failure of testhost.
                 EqtTrace.Warning("TestHostManagerCallbacks.ErrorReceivedCallback Test host standard error line: {0}", data);
 
+                // Don't append more data if already reached max length.
+                if (testHostProcessStdError.Length >= testHostProcessStdError.MaxCapacity)
+                {
+                    return;
+                }
+
                 // Add newline for readbility.
                 data += Environment.NewLine;
 
-                // if incoming data stream is huge empty entire testError stream, & limit data stream to MaxCapacity
-                if (data.Length > testHostProcessStdError.MaxCapacity)
+                // Append sub string of data if appending all the data exceeds max capacity.
+                if (testHostProcessStdError.Length + data.Length >= testHostProcessStdError.MaxCapacity)
                 {
-                    testHostProcessStdError.Clear();
-                    data = data.Substring(data.Length - testHostProcessStdError.MaxCapacity);
-                }
-
-                // remove only what is required, from beginning of error stream
-                else
-                {
-                    int required = data.Length + testHostProcessStdError.Length - testHostProcessStdError.MaxCapacity;
-                    if (required > 0)
-                    {
-                        testHostProcessStdError.Remove(0, required);
-                    }
+                    data = data.Substring(0, testHostProcessStdError.MaxCapacity - testHostProcessStdError.Length);
                 }
 
                 testHostProcessStdError.Append(data);

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
@@ -19,7 +19,7 @@ namespace Microsoft.TestPlatform.TestHostProvider.Hosting
             // This is helpful in abnormal failure of testhost.
             EqtTrace.Warning("TestHostManagerCallbacks.ErrorReceivedCallback Test host standard error line: {0}", data);
 
-            data.AppendToStringBuilderBasedOnMaxLength(testHostProcessStdError);
+            testHostProcessStdError.AppendSafeWithNewLine(data);
         }
 
         public static void ExitCallBack(

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
@@ -9,34 +9,17 @@ namespace Microsoft.TestPlatform.TestHostProvider.Hosting
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Host;
     using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
+    using VisualStudio.TestPlatform.CoreUtilities.Extensions;
 
     internal class TestHostManagerCallbacks
     {
         public static void ErrorReceivedCallback(StringBuilder testHostProcessStdError, string data)
         {
-            if (!string.IsNullOrEmpty(data))
-            {
-                // Log all standard error message because on too much data we ignore starting part.
-                // This is helpful in abnormal failure of testhost.
-                EqtTrace.Warning("TestHostManagerCallbacks.ErrorReceivedCallback Test host standard error line: {0}", data);
+            // Log all standard error message because on too much data we ignore starting part.
+            // This is helpful in abnormal failure of testhost.
+            EqtTrace.Warning("TestHostManagerCallbacks.ErrorReceivedCallback Test host standard error line: {0}", data);
 
-                // Don't append more data if already reached max length.
-                if (testHostProcessStdError.Length >= testHostProcessStdError.MaxCapacity)
-                {
-                    return;
-                }
-
-                // Add newline for readbility.
-                data += Environment.NewLine;
-
-                // Append sub string of data if appending all the data exceeds max capacity.
-                if (testHostProcessStdError.Length + data.Length >= testHostProcessStdError.MaxCapacity)
-                {
-                    data = data.Substring(0, testHostProcessStdError.MaxCapacity - testHostProcessStdError.Length);
-                }
-
-                testHostProcessStdError.Append(data);
-            }
+            data.AppendToStringBuilderBasedOnMaxLength(testHostProcessStdError);
         }
 
         public static void ExitCallBack(

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace TestPlatform.TestHostProvider.UnitTests.Hosting
+namespace TestPlatform.TestHostProvider.Hosting.UnitTests
 {
     using System;
     using System.Collections.Generic;
@@ -600,7 +600,6 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
                 IMessageLogger logger)
                 : base(processHelper, new FileHelper(), new PlatformEnvironment(), new DotnetHostHelper())
             {
-                this.ErrorLength = errorLength;
                 this.Initialize(logger, $"<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings> <RunConfiguration> <TargetPlatform>{architecture}</TargetPlatform> <TargetFrameworkVersion>{framework}</TargetFrameworkVersion> <DisableAppDomain>{!shared}</DisableAppDomain> </RunConfiguration> </RunSettings>");
             }
         }

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -40,7 +40,6 @@ namespace TestPlatform.TestHostProvider.Hosting.UnitTests
 
         private DefaultTestHostManager testHostManager;
         private TestableTestHostManager testableTestHostManager;
-        private int maxStdErrStringLength = 22;
         private string errorMessage;
         private int exitCode;
         private int testHostId;
@@ -344,7 +343,6 @@ namespace TestPlatform.TestHostProvider.Hosting.UnitTests
                 Framework.DefaultFramework,
                 this.mockProcessHelper.Object,
                 true,
-                this.maxStdErrStringLength,
                 this.mockMessageLogger.Object);
 
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
@@ -421,19 +419,6 @@ namespace TestPlatform.TestHostProvider.Hosting.UnitTests
             await this.testableTestHostManager.LaunchTestHostAsync(this.GetDefaultStartInfo(), CancellationToken.None);
 
             Assert.AreEqual(errorData, this.errorMessage);
-        }
-
-        [TestMethod]
-        public async Task ErrorMessageShouldBeTruncatedToMatchErrorLength()
-        {
-            string errorData = "Long Custom Error Strings";
-            this.ErrorCallBackTestHelper(errorData, -1);
-
-            await this.testableTestHostManager.LaunchTestHostAsync(this.GetDefaultStartInfo(), CancellationToken.None);
-
-            // Ignore new line chars
-            Assert.AreEqual(this.maxStdErrStringLength - Environment.NewLine.Length, this.errorMessage.Length);
-            Assert.AreEqual(errorData.Substring(5), this.errorMessage);
         }
 
         [TestMethod]
@@ -527,7 +512,6 @@ namespace TestPlatform.TestHostProvider.Hosting.UnitTests
                 Framework.DefaultFramework,
                 this.mockProcessHelper.Object,
                 true,
-                this.maxStdErrStringLength,
                 this.mockMessageLogger.Object);
 
             this.testableTestHostManager.HostExited += this.TestHostManagerHostExited;
@@ -560,7 +544,6 @@ namespace TestPlatform.TestHostProvider.Hosting.UnitTests
                 Framework.DefaultFramework,
                 this.mockProcessHelper.Object,
                 true,
-                this.maxStdErrStringLength,
                 this.mockMessageLogger.Object);
 
             this.testableTestHostManager.HostExited += this.TestableTestHostManagerHostExited;
@@ -596,7 +579,6 @@ namespace TestPlatform.TestHostProvider.Hosting.UnitTests
                 Framework framework,
                 IProcessHelper processHelper,
                 bool shared,
-                int errorLength,
                 IMessageLogger logger)
                 : base(processHelper, new FileHelper(), new PlatformEnvironment(), new DotnetHostHelper())
             {

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -781,7 +781,6 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
             public TestableDotnetTestHostManager(IProcessHelper processHelper, IFileHelper fileHelper, IDotnetHostHelper dotnetTestHostHelper, int errorLength)
                 : base(processHelper, fileHelper, dotnetTestHostHelper)
             {
-                this.ErrorLength = errorLength;
             }
         }
     }

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -49,7 +49,6 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
         private readonly TestableDotnetTestHostManager dotnetHostManager;
 
         private string errorMessage;
-        private int maxStdErrStringLength = 22;
 
         private int exitCode;
 
@@ -69,8 +68,7 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
             this.dotnetHostManager = new TestableDotnetTestHostManager(
                                          this.mockProcessHelper.Object,
                                          this.mockFileHelper.Object,
-                                         new DotnetHostHelper(this.mockFileHelper.Object, mockEnvironment.Object),
-                                         this.maxStdErrStringLength);
+                                         new DotnetHostHelper(this.mockFileHelper.Object, mockEnvironment.Object));
             this.dotnetHostManager.Initialize(this.mockMessageLogger.Object, string.Empty);
 
             this.dotnetHostManager.HostExited += this.DotnetHostManagerHostExited;
@@ -621,19 +619,6 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
         }
 
         [TestMethod]
-        public async Task DotNetCoreErrorMessageShouldBeTruncatedToMatchErrorLength()
-        {
-            var errorData = "Long Custom Error Strings";
-            this.ErrorCallBackTestHelper(errorData, -1);
-
-            await this.dotnetHostManager.LaunchTestHostAsync(this.defaultTestProcessStartInfo, CancellationToken.None);
-
-            // Ignore new line chars
-            Assert.AreEqual(this.maxStdErrStringLength - Environment.NewLine.Length, this.errorMessage.Length);
-            Assert.AreEqual(errorData.Substring(5), this.errorMessage);
-        }
-
-        [TestMethod]
         public async Task DotNetCoreNoErrorMessageIfExitCodeZero()
         {
             string errorData = string.Empty;
@@ -778,7 +763,10 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
 
         internal class TestableDotnetTestHostManager : DotnetTestHostManager
         {
-            public TestableDotnetTestHostManager(IProcessHelper processHelper, IFileHelper fileHelper, IDotnetHostHelper dotnetTestHostHelper, int errorLength)
+            public TestableDotnetTestHostManager(
+                IProcessHelper processHelper,
+                IFileHelper fileHelper,
+                IDotnetHostHelper dotnetTestHostHelper)
                 : base(processHelper, fileHelper, dotnetTestHostHelper)
             {
             }

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/TestHostManagerCallbacksTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/TestHostManagerCallbacksTests.cs
@@ -37,6 +37,15 @@ namespace TestPlatform.TestHostProvider.Hosting.UnitTests
         }
 
         [TestMethod]
+        public void ErrorReceivedCallbackShouldAppendWhiteSpaceString()
+        {
+            this.testHostProcessStdError.Append("OldData");
+            TestHostManagerCallbacks.ErrorReceivedCallback(this.testHostProcessStdError, " ");
+
+            Assert.AreEqual("OldData " + Environment.NewLine, this.testHostProcessStdError.ToString());
+        }
+
+        [TestMethod]
         public void ErrorReceivedCallbackShouldAppendGivenData()
         {
             this.testHostProcessStdError.Append("NoDataShouldAppend");

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/TestHostManagerCallbacksTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/TestHostManagerCallbacksTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace TestPlatform.TestHostProvider.Hosting.UnitTests
+{
+    using System;
+    using System.Text;
+    using Microsoft.TestPlatform.TestHostProvider.Hosting;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class TestHostManagerCallbacksTests
+    {
+        private StringBuilder testHostProcessStdError;
+
+        public TestHostManagerCallbacksTests()
+        {
+            this.testHostProcessStdError = new StringBuilder(0, Microsoft.VisualStudio.TestPlatform.CoreUtilities.Constants.StandardErrorMaxLength);
+        }
+
+        [TestMethod]
+        public void ErrorReceivedCallbackShouldAppendNoDataOnNullDataReceived()
+        {
+            this.testHostProcessStdError.Append("NoDataShouldAppend");
+            TestHostManagerCallbacks.ErrorReceivedCallback(this.testHostProcessStdError, null);
+
+            Assert.AreEqual("NoDataShouldAppend", this.testHostProcessStdError.ToString());
+        }
+
+        [TestMethod]
+        public void ErrorReceivedCallbackShouldAppendNoDataOnEmptyDataReceived()
+        {
+            this.testHostProcessStdError.Append("NoDataShouldAppend");
+            TestHostManagerCallbacks.ErrorReceivedCallback(this.testHostProcessStdError, string.Empty);
+
+            Assert.AreEqual("NoDataShouldAppend", this.testHostProcessStdError.ToString());
+        }
+
+        [TestMethod]
+        public void ErrorReceivedCallbackShouldAppendGivenData()
+        {
+            this.testHostProcessStdError.Append("NoDataShouldAppend");
+            TestHostManagerCallbacks.ErrorReceivedCallback(this.testHostProcessStdError, "new data");
+
+            Assert.AreEqual("NoDataShouldAppendnew data" + Environment.NewLine, this.testHostProcessStdError.ToString());
+        }
+
+        [TestMethod]
+        public void ErrorReceivedCallbackShouldNotAppendNewDataIfErrorMessageAlreadyReachedMaxLength()
+        {
+            this.testHostProcessStdError = new StringBuilder(0, 5);
+            this.testHostProcessStdError.Append("12345");
+            TestHostManagerCallbacks.ErrorReceivedCallback(this.testHostProcessStdError, "678");
+
+            Assert.AreEqual("12345", this.testHostProcessStdError.ToString());
+        }
+
+        [TestMethod]
+        public void ErrorReceivedCallbackShouldAppendSubStringOfDataIfErrorMessageReachedMaxLength()
+        {
+            this.testHostProcessStdError = new StringBuilder(0, 5);
+            this.testHostProcessStdError.Append("1234");
+            TestHostManagerCallbacks.ErrorReceivedCallback(this.testHostProcessStdError, "5678");
+
+            Assert.AreEqual("12345", this.testHostProcessStdError.ToString());
+        }
+
+        [TestMethod]
+        public void ErrorReceivedCallbackShouldAppendEntireStringEvenItReachesToMaxLength()
+        {
+            this.testHostProcessStdError = new StringBuilder(0, 5);
+            this.testHostProcessStdError.Append("12");
+            TestHostManagerCallbacks.ErrorReceivedCallback(this.testHostProcessStdError, "3");
+
+            Assert.AreEqual("123" + Environment.NewLine, this.testHostProcessStdError.ToString());
+        }
+
+        [TestMethod]
+        public void ErrorReceivedCallbackShouldAppendNewLineApproprioritlyWhenReachingMaxLength()
+        {
+            this.testHostProcessStdError = new StringBuilder(0, 5);
+            this.testHostProcessStdError.Append("123");
+            TestHostManagerCallbacks.ErrorReceivedCallback(this.testHostProcessStdError, "4");
+
+            Assert.AreEqual("1234" + Environment.NewLine.Substring(0, 1), this.testHostProcessStdError.ToString());
+        }
+    }
+}


### PR DESCRIPTION
## Description
- Prints start of stderr stacktrace
- Increase max length of stderr message.

## Related issue
Fixes #1688
