### PR TITLE
Trx Logger Fixes

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -284,6 +284,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
         {
             // Create test run
             // If abort occurs there is no call to TestResultHandler which results in testRun not created.
+            // This happens when some test aborts in the first batch of execution.
             if (this.testRun == null)
                 CreateTestRun();
 

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -282,72 +282,73 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
         /// </param>
         public void TestRunCompleteHandler(object sender, TestRunCompleteEventArgs e)
         {
-            if (this.testRun != null)
+            // Create test run
+            if (this.testRun == null)
+                CreateTestRun();
+
+            XmlPersistence helper = new XmlPersistence();
+            XmlTestStoreParameters parameters = XmlTestStoreParameters.GetParameters();
+            XmlElement rootElement = helper.CreateRootElement("TestRun");
+
+            // Save runId/username/creation time etc.
+            this.testRun.Finished = DateTime.UtcNow;
+            helper.SaveSingleFields(rootElement, this.testRun, parameters);
+
+            // Save test settings
+            helper.SaveObject(this.testRun.RunConfiguration, rootElement, "TestSettings", parameters);
+
+            // Save test results
+            helper.SaveIEnumerable(this.results.Values, rootElement, "Results", ".", null, parameters);
+
+            // Save test definitions
+            helper.SaveIEnumerable(this.testElements.Values, rootElement, "TestDefinitions", ".", null, parameters);
+
+            // Save test entries
+            helper.SaveIEnumerable(this.entries.Values, rootElement, "TestEntries", ".", "TestEntry", parameters);
+
+            // Save default categories
+            List<TestListCategory> categories = new List<TestListCategory>();
+            categories.Add(TestListCategory.UncategorizedResults);
+            categories.Add(TestListCategory.AllResults);
+            helper.SaveList<TestListCategory>(categories, rootElement, "TestLists", ".", "TestList", parameters);
+
+            // Save summary
+            if (this.testRunOutcome == TrxLoggerObjectModel.TestOutcome.Passed)
             {
-                XmlPersistence helper = new XmlPersistence();
-                XmlTestStoreParameters parameters = XmlTestStoreParameters.GetParameters();
-                XmlElement rootElement = helper.CreateRootElement("TestRun");
-
-                // Save runId/username/creation time etc.
-                this.testRun.Finished = DateTime.UtcNow;
-                helper.SaveSingleFields(rootElement, this.testRun, parameters);
-
-                // Save test settings
-                helper.SaveObject(this.testRun.RunConfiguration, rootElement, "TestSettings", parameters);
-
-                // Save test results
-                helper.SaveIEnumerable(this.results.Values, rootElement, "Results", ".", null, parameters);
-
-                // Save test definitions
-                helper.SaveIEnumerable(this.testElements.Values, rootElement, "TestDefinitions", ".", null, parameters);
-
-                // Save test entries
-                helper.SaveIEnumerable(this.entries.Values, rootElement, "TestEntries", ".", "TestEntry", parameters);
-
-                // Save default categories
-                List<TestListCategory> categories = new List<TestListCategory>();
-                categories.Add(TestListCategory.UncategorizedResults);
-                categories.Add(TestListCategory.AllResults);
-                helper.SaveList<TestListCategory>(categories, rootElement, "TestLists", ".", "TestList", parameters);
-
-                // Save summary
-                if (this.testRunOutcome == TrxLoggerObjectModel.TestOutcome.Passed)
-                {
-                    this.testRunOutcome = TrxLoggerObjectModel.TestOutcome.Completed;
-                }
-
-                List<string> errorMessages = new List<string>();
-                List<CollectorDataEntry> collectorEntries = Converter.ToCollectionEntries(e.AttachmentSets, this.testRun, this.testResultsDirPath);
-                IList<String> resultFiles = Converter.ToResultFiles(e.AttachmentSets, this.testRun, this.testResultsDirPath, errorMessages);
-
-                if (errorMessages.Count > 0)
-                {
-                    // Got some errors while attaching files, report them and set the outcome of testrun to be Error...
-                    this.testRunOutcome = TrxLoggerObjectModel.TestOutcome.Error;
-                    foreach (string msg in errorMessages)
-                    {
-                        RunInfo runMessage = new RunInfo(msg, null, Environment.MachineName, TrxLoggerObjectModel.TestOutcome.Error);
-                        this.runLevelErrorsAndWarnings.Add(runMessage);
-                    }
-                }
-
-                TestRunSummary runSummary = new TestRunSummary(
-                    this.totalTests,
-                    this.passTests + this.failTests,
-                    this.passTests,
-                    this.failTests,
-                    this.testRunOutcome,
-                    this.runLevelErrorsAndWarnings,
-                    this.runLevelStdOut.ToString(),
-                    resultFiles,
-                    collectorEntries);
-
-                helper.SaveObject(runSummary, rootElement, "ResultSummary", parameters);
-
-                //Save results to Trx file
-                this.DeriveTrxFilePath();
-                this.PopulateTrxFile(this.trxFilePath, rootElement);
+                this.testRunOutcome = TrxLoggerObjectModel.TestOutcome.Completed;
             }
+
+            List<string> errorMessages = new List<string>();
+            List<CollectorDataEntry> collectorEntries = Converter.ToCollectionEntries(e.AttachmentSets, this.testRun, this.testResultsDirPath);
+            IList<String> resultFiles = Converter.ToResultFiles(e.AttachmentSets, this.testRun, this.testResultsDirPath, errorMessages);
+
+            if (errorMessages.Count > 0)
+            {
+                // Got some errors while attaching files, report them and set the outcome of testrun to be Error...
+                this.testRunOutcome = TrxLoggerObjectModel.TestOutcome.Error;
+                foreach (string msg in errorMessages)
+                {
+                    RunInfo runMessage = new RunInfo(msg, null, Environment.MachineName, TrxLoggerObjectModel.TestOutcome.Error);
+                    this.runLevelErrorsAndWarnings.Add(runMessage);
+                }
+            }
+
+            TestRunSummary runSummary = new TestRunSummary(
+                this.totalTests,
+                this.passTests + this.failTests,
+                this.passTests,
+                this.failTests,
+                this.testRunOutcome,
+                this.runLevelErrorsAndWarnings,
+                this.runLevelStdOut.ToString(),
+                resultFiles,
+                collectorEntries);
+
+            helper.SaveObject(runSummary, rootElement, "ResultSummary", parameters);
+
+            //Save results to Trx file
+            this.DeriveTrxFilePath();
+            this.PopulateTrxFile(this.trxFilePath, rootElement);
         }
 
         /// <summary>

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -283,6 +283,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
         public void TestRunCompleteHandler(object sender, TestRunCompleteEventArgs e)
         {
             // Create test run
+            // If abort occurs there is no call to TestResultHandler which results in testRun not created.
             if (this.testRun == null)
                 CreateTestRun();
 

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
@@ -461,15 +461,26 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.Utility
 
                 // copy the source file to the target location
                 string targetFileName = FileHelper.GetNextIterationFileName(targetDirectory, Path.GetFileName(sourceFile), false);
-                CopyFile(sourceFile, targetFileName);
 
-                // Add the target file name to the collector files list.
-                // (Trx viewer automatically adds In\ to the collected file.
-                string fileName = Path.Combine(Environment.MachineName, Path.GetFileName(targetFileName));
-                Uri sourceFileUri = new Uri(fileName, UriKind.Relative);
-                TrxObjectModel.UriDataAttachment dataAttachment = new TrxObjectModel.UriDataAttachment(uriDataAttachment.Description, sourceFileUri);
+                try
+                {
+                    CopyFile(sourceFile, targetFileName);
 
-                uriDataAttachments.Add(dataAttachment);
+                    // Add the target file name to the collector files list.
+                    // (Trx viewer automatically adds In\ to the collected file.
+                    string fileName = Path.Combine(Environment.MachineName, Path.GetFileName(targetFileName));
+                    Uri sourceFileUri = new Uri(fileName, UriKind.Relative);
+                    TrxObjectModel.UriDataAttachment dataAttachment = new TrxObjectModel.UriDataAttachment(uriDataAttachment.Description, sourceFileUri);
+
+                    uriDataAttachments.Add(dataAttachment);
+                }
+                catch(Exception ex)
+                {
+                    if (ObjectModel.EqtTrace.IsErrorEnabled)
+                    {
+                        ObjectModel.EqtTrace.Error("Trxlogger: ToCollectorEntry: " + ex);
+                    }
+                }
             }
 
             return new CollectorDataEntry(
@@ -509,15 +520,25 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.Utility
 
                 string sourceFile = uriDataAttachment.Uri.LocalPath;
                 Debug.Assert(Path.IsPathRooted(sourceFile), "Source file is not rooted");
-
                 // copy the source file to the target location
                 string targetFileName = FileHelper.GetNextIterationFileName(testResultDirectory, Path.GetFileName(sourceFile), false);
-                CopyFile(sourceFile, targetFileName);
 
-                // Add the target file name to the result files list.
-                // (Trx viewer automatically adds In\<Guid> to the result file.
-                string fileName = Path.Combine(Environment.MachineName, Path.GetFileName(targetFileName));
-                resultFiles.Add(fileName);
+                try
+                {
+                    CopyFile(sourceFile, targetFileName);
+
+                    // Add the target file name to the result files list.
+                    // (Trx viewer automatically adds In\<Guid> to the result file.
+                    string fileName = Path.Combine(Environment.MachineName, Path.GetFileName(targetFileName));
+                    resultFiles.Add(fileName);
+                }
+                catch(Exception ex)
+                {
+                    if (ObjectModel.EqtTrace.IsErrorEnabled)
+                    {
+                        ObjectModel.EqtTrace.Error("Trxlogger: ToResultFiles: " + ex);
+                    }
+                }
             }
 
             return resultFiles;

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -516,6 +516,18 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
         }
 
         [TestMethod]
+        public void TestRunCompleteHandlerShouldReportFailedOutcomeIfTestRunIsAborted()
+        {
+            string message = "The information to test";
+            TestRunMessageEventArgs trme = new TestRunMessageEventArgs(TestMessageLevel.Error, message);
+            this.testableTrxLogger.TestMessageHandler(new object(), trme);
+
+            this.testableTrxLogger.TestRunCompleteHandler(new object(), new TestRunCompleteEventArgs(null, false, true, null, null, TimeSpan.Zero));
+
+            Assert.AreEqual(this.testableTrxLogger.TestResultOutcome, TrxLoggerObjectModel.TestOutcome.Failed);
+        }
+
+        [TestMethod]
         public void OutcomeOfRunWillBeFailIfAnyTestsFails()
         {
             ObjectModel.TestCase passTestCase1 = CreateTestCase("Pass1");


### PR DESCRIPTION
## Trx Logger Fixes
1. Trx file is not generated when test run aborts.
2. TRX Logger shouldn't fail if test result attachments are missing/Invalid #1705 
