### PR TITLE
Use Culture Specified by User in case it differs with that of OS

### DIFF
--- a/src/Microsoft.TestPlatform.CoreUtilities/Constants.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Constants.cs
@@ -28,5 +28,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CoreUtilities
         /// error message on standard error.
         /// </summary>
         public const int StandardErrorMaxLength = 8192; // 8 KB
+
+        /// <summary>
+        /// Environment Variable Specified by user to setup Culture.
+        /// </summary>
+        public const string DotNetUserSpecifiedCulture = "DOTNET_CLI_UI_LANGUAGE";
     }
 }

--- a/src/datacollector/DataCollectorMain.cs
+++ b/src/datacollector/DataCollectorMain.cs
@@ -14,7 +14,6 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
     using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
-    using Microsoft.VisualStudio.TestPlatform.Utilities;
     using PlatformAbstractions.Interfaces;
     using CommunicationUtilitiesResources = Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources.Resources;
     using CoreUtilitiesConstants = Microsoft.VisualStudio.TestPlatform.CoreUtilities.Constants;
@@ -91,6 +90,8 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector
                 EqtTrace.DoNotInitailize = true;
             }
 
+            SetCultureSpecifiedByUser();
+
             EqtTrace.Info("DataCollectorMain.Run: Starting data collector run with args: {0}", string.Join(",", args));
 
             // Attach to exit of parent process
@@ -143,17 +144,18 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector
 
         private static void SetCultureSpecifiedByUser()
         {
-            var userCultureSpecified = Environment.GetEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE");
+            var userCultureSpecified = Environment.GetEnvironmentVariable(CoreUtilities.Constants.DotNetUserSpecifiedCulture);
             if (!string.IsNullOrWhiteSpace(userCultureSpecified))
             {
                 try
                 {
                     CultureInfo info = new CultureInfo(userCultureSpecified);
+                    CultureInfo.DefaultThreadCurrentCulture = info;
                     CultureInfo.DefaultThreadCurrentUICulture = info;
                 }
                 catch (Exception)
                 {
-                    ConsoleOutput.Instance.WriteLine(string.Format("Invalid Culture Info: {0}", userCultureSpecified), OutputLevel.Information);
+                    EqtTrace.Info(string.Format("Invalid Culture Info: {0}", userCultureSpecified));
                 }
             }
         }

--- a/src/datacollector/DataCollectorMain.cs
+++ b/src/datacollector/DataCollectorMain.cs
@@ -149,9 +149,7 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector
             {
                 try
                 {
-                    CultureInfo info = new CultureInfo(userCultureSpecified);
-                    CultureInfo.DefaultThreadCurrentCulture = info;
-                    CultureInfo.DefaultThreadCurrentUICulture = info;
+                    CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(userCultureSpecified);
                 }
                 catch (Exception)
                 {

--- a/src/datacollector/DataCollectorMain.cs
+++ b/src/datacollector/DataCollectorMain.cs
@@ -14,6 +14,7 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
     using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
+    using Microsoft.VisualStudio.TestPlatform.Utilities;
     using PlatformAbstractions.Interfaces;
     using CommunicationUtilitiesResources = Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources.Resources;
     using CoreUtilitiesConstants = Microsoft.VisualStudio.TestPlatform.CoreUtilities.Constants;
@@ -137,6 +138,23 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector
                 }
 
                 Debugger.Break();
+            }
+        }
+
+        private static void SetCultureSpecifiedByUser()
+        {
+            var userCultureSpecified = Environment.GetEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE");
+            if (!string.IsNullOrWhiteSpace(userCultureSpecified))
+            {
+                try
+                {
+                    CultureInfo info = new CultureInfo(userCultureSpecified);
+                    CultureInfo.DefaultThreadCurrentUICulture = info;
+                }
+                catch (Exception)
+                {
+                    ConsoleOutput.Instance.WriteLine(string.Format("Invalid Culture Info: {0}", userCultureSpecified), OutputLevel.Information);
+                }
             }
         }
 

--- a/src/testhost.x86/AppDomainEngineInvoker.cs
+++ b/src/testhost.x86/AppDomainEngineInvoker.cs
@@ -177,9 +177,7 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
             {
                 try
                 {
-                    CultureInfo info = new CultureInfo(userCultureSpecified);
-                    CultureInfo.DefaultThreadCurrentCulture = info;
-                    CultureInfo.DefaultThreadCurrentUICulture = info;
+                    CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.CreateSpecificCulture(userCultureSpecified);
                 }
                 // If an exception occurs, we'll just fall back to the system default.
                 catch (Exception)

--- a/src/testhost.x86/Program.cs
+++ b/src/testhost.x86/Program.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-
+    using System.Globalization;
     using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Helpers;
     using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Tracing;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -52,6 +52,7 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
         public static void Run(string[] args)
         {
             WaitForDebuggerIfEnabled();
+            SetCultureSpecifiedByUser();
             var argsDictionary = CommandLineArgumentsHelper.GetArgumentsDictionary(args);
             
             // Invoke the engine with arguments
@@ -101,6 +102,23 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
                 }
 
                 Debugger.Break();
+            }
+        }
+
+        private static void SetCultureSpecifiedByUser()
+        {
+            var userCultureSpecified = Environment.GetEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE");
+            if (!string.IsNullOrWhiteSpace(userCultureSpecified))
+            {
+                try
+                {
+                    CultureInfo info = new CultureInfo(userCultureSpecified);
+                    CultureInfo.DefaultThreadCurrentUICulture = info;
+                }
+                catch (Exception)
+                {
+                    ConsoleOutput.Instance.WriteLine(string.Format("Invalid Culture Info: {0}", userCultureSpecified), OutputLevel.Information);
+                }
             }
         }
     }

--- a/src/testhost.x86/Program.cs
+++ b/src/testhost.x86/Program.cs
@@ -107,12 +107,13 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
 
         private static void SetCultureSpecifiedByUser()
         {
-            var userCultureSpecified = Environment.GetEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE");
+            var userCultureSpecified = Environment.GetEnvironmentVariable(CoreUtilities.Constants.DotNetUserSpecifiedCulture);
             if (!string.IsNullOrWhiteSpace(userCultureSpecified))
             {
                 try
                 {
                     CultureInfo info = new CultureInfo(userCultureSpecified);
+                    CultureInfo.DefaultThreadCurrentCulture = info;
                     CultureInfo.DefaultThreadCurrentUICulture = info;
                 }
                 catch (Exception)

--- a/src/testhost.x86/Program.cs
+++ b/src/testhost.x86/Program.cs
@@ -112,9 +112,7 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
             {
                 try
                 {
-                    CultureInfo info = new CultureInfo(userCultureSpecified);
-                    CultureInfo.DefaultThreadCurrentCulture = info;
-                    CultureInfo.DefaultThreadCurrentUICulture = info;
+                    CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(userCultureSpecified);
                 }
                 catch (Exception)
                 {

--- a/src/vstest.console/Program.cs
+++ b/src/vstest.console/Program.cs
@@ -49,9 +49,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine
             {
                 try
                 {
-                    CultureInfo info = new CultureInfo(userCultureSpecified);
-                    CultureInfo.DefaultThreadCurrentCulture = info;
-                    CultureInfo.DefaultThreadCurrentUICulture = info;
+                    CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.CreateSpecificCulture(userCultureSpecified);
                 }
                 catch(Exception)
                 {

--- a/src/vstest.console/Program.cs
+++ b/src/vstest.console/Program.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine
 {
     using System;
+    using System.Globalization;
     using Microsoft.VisualStudio.TestPlatform.Utilities;
 
     /// <summary>
@@ -36,7 +37,26 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine
                 System.Diagnostics.Debugger.Break();
             }
 
+            SetCultureSpecifiedByUser();
+
             return new Executor(ConsoleOutput.Instance).Execute(args);
+        }
+
+        private static void SetCultureSpecifiedByUser()
+        {
+            var userCultureSpecified = Environment.GetEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE");
+            if(!string.IsNullOrWhiteSpace(userCultureSpecified))
+            {
+                try
+                {
+                    CultureInfo info = new CultureInfo(userCultureSpecified);
+                    CultureInfo.DefaultThreadCurrentUICulture = info;
+                }
+                catch(Exception)
+                {
+                    ConsoleOutput.Instance.WriteLine(string.Format("Invalid Culture Info: {0}", userCultureSpecified), OutputLevel.Information);
+                }
+            }
         }
     }
 }

--- a/src/vstest.console/Program.cs
+++ b/src/vstest.console/Program.cs
@@ -44,12 +44,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine
 
         private static void SetCultureSpecifiedByUser()
         {
-            var userCultureSpecified = Environment.GetEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE");
+            var userCultureSpecified = Environment.GetEnvironmentVariable(CoreUtilities.Constants.DotNetUserSpecifiedCulture);
             if(!string.IsNullOrWhiteSpace(userCultureSpecified))
             {
                 try
                 {
                     CultureInfo info = new CultureInfo(userCultureSpecified);
+                    CultureInfo.DefaultThreadCurrentCulture = info;
                     CultureInfo.DefaultThreadCurrentUICulture = info;
                 }
                 catch(Exception)

--- a/test/testhost.UnitTests/AppDomainEngineInvokerTests.cs
+++ b/test/testhost.UnitTests/AppDomainEngineInvokerTests.cs
@@ -47,7 +47,7 @@ namespace testhost.UnitTests
         public void AppDomainEngineInvokerShouldCreateNewAppDomain()
         {
             var tempFile = Path.GetTempFileName();
-            var appDomainInvoker = new TestableEngineInvoker(tempFile);
+            var appDomainInvoker = new TestableEngineInvoker(tempFile, AppDomain.CurrentDomain.BaseDirectory);
 
             Assert.IsNotNull(appDomainInvoker.NewAppDomain, "New AppDomain must be created.");
             Assert.IsNotNull(appDomainInvoker.ActualInvoker, "Invoker must be created.");
@@ -59,7 +59,7 @@ namespace testhost.UnitTests
         public void AppDomainEngineInvokerShouldInvokeEngineInNewDomainAndUseTestHostConfigFile()
         {
             var tempFile = Path.GetTempFileName();
-            var appDomainInvoker = new TestableEngineInvoker(tempFile);
+            var appDomainInvoker = new TestableEngineInvoker(tempFile, AppDomain.CurrentDomain.BaseDirectory);
 
             var newAppDomain = appDomainInvoker.NewAppDomain;
 
@@ -200,7 +200,11 @@ namespace testhost.UnitTests
 
         private class TestableEngineInvoker : AppDomainEngineInvoker<MockEngineInvoker>
         {
-            public TestableEngineInvoker(string testSourcePath) : base(testSourcePath)
+            public TestableEngineInvoker(string testSourcePath, string appBasePath) : base(testSourcePath, SetAppDomainCultures, appBasePath)
+            {
+            }
+
+            private static void SetAppDomainCultures(string[] args)
             {
             }
 


### PR DESCRIPTION
## Description
Set Current Culture to be the one propagated by dotnet via `DOTNET_CLI_UI_LANGUAGE`

Test:
set DOTNET_CLI_UI_LANGUAGE=fr
run vstest.console  /?

You should see help displayed in french

## Related issue
Fixes #821.
