### PR TITLE
Fix NRE of TcpClient.Client.RemoteEndPoint

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TcpClientExtensions.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TcpClientExtensions.cs
@@ -25,8 +25,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 CancellationToken cancellationToken)
         {
             Exception error = null;
-            var remoteEndPoint = client.Client.RemoteEndPoint.ToString();
-            var localEndPoint = client.Client.LocalEndPoint.ToString();
+            var remoteEndPoint = client.Client.RemoteEndPoint?.ToString();
+            var localEndPoint = client.Client.LocalEndPoint?.ToString();
 
             // Set read timeout to avoid blocking receive raw message
             while (channel != null && !cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
## Description
> It's a NullReference exception and RemoteEndpoint is null !!! I set a breakpoint to see its IsConncted value and the value is true. I don't know how could it happen when IsConnected is true why RemoteEndpoint null.
- Fixing based on https://github.com/Microsoft/vstest/issues/1607#issuecomment-395824567
 
## Related issue
#1607
