### PR TITLE
vstest to honor nologo input from dotnet.exe

### DIFF
--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
@@ -47,6 +47,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       VSTestCollect="$(VSTestCollect)"
       VSTestBlame="$(VSTestBlame)"
       VSTestTraceDataCollectorDirectoryPath="$(TraceDataCollectorDirectoryPath)"
+      VSTestNoLogo="$(VSTestNoLogo)"
     />
   </Target>
 
@@ -87,6 +88,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Message Text="VSTestCollect = $(VSTestCollect)" Importance="low" />
     <Message Text="VSTestBlame = $(VSTestBlame)" Importance="low" />
     <Message Text="VSTestTraceDataCollectorDirectoryPath = $(TraceDataCollectorDirectoryPath)" Importance="low" />
+    <Message Text="VSTestNoLogo = $(VSTestNoLogo)" Importance="low" />
   </Target>
 
 </Project>

--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask.cs
@@ -115,6 +115,12 @@ namespace Microsoft.TestPlatform.Build.Tasks
             set;
         }
 
+        public string VSTestNoLogo
+        {
+            get;
+            set;
+        }
+
         public override bool Execute()
         {
             var traceEnabledValue = Environment.GetEnvironmentVariable("VSTEST_BUILD_TRACE");
@@ -295,6 +301,11 @@ namespace Microsoft.TestPlatform.Build.Tasks
                         Console.WriteLine(Resources.UpdateTestSdkForCollectingCodeCoverage);
                     }
                 }
+            }
+
+            if(!string.IsNullOrWhiteSpace(this.VSTestNoLogo))
+            {
+                allArgs.Add("--nologo");
             }
 
             return allArgs;

--- a/src/vstest.console/CommandLine/Executor.cs
+++ b/src/vstest.console/CommandLine/Executor.cs
@@ -93,7 +93,16 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine
         {
             this.testPlatformEventSource.VsTestConsoleStart();
 
-            this.PrintSplashScreen();
+            // If User specifies --nologo via dotnet, donot print splat screen
+            if (args != null && args.Length !=0 && args.Contains("--nologo"))
+            {
+                // Sanitizing this list, as I don't think we should write Argument processor for this.
+                args = args.Where(val => val != "--nologo").ToArray();
+            }
+            else
+            {
+                this.PrintSplashScreen();
+            }
 
             int exitCode = 0;
 

--- a/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
@@ -283,5 +283,14 @@ namespace Microsoft.TestPlatform.Build.UnitTests
 
             Assert.IsNull(allArguments.FirstOrDefault(arg => arg.Contains("--testAdapterPath:")));
         }
+
+        [TestMethod]
+        public void CreateArgumentShouldAddNoLogoOptionIfSpecifiedByUser()
+        {
+            this.vsTestTask.VSTestNoLogo = "--nologo";
+            var allArguments = this.vsTestTask.CreateArgument().ToArray();
+
+            Assert.IsNotNull(allArguments.FirstOrDefault(arg => arg.Contains("--nologo")));
+        }
     }
 }


### PR DESCRIPTION
## Description
VSTest should honor /nologo user input from dotnet cli.
However we are not exposing it as first class argument for vstest.console CLI

dotnet/cli repo https://github.com/dotnet/cli/pull/9791

## Related issue
Fixes #1701.
