### PR TITLE
Updating TestWindow.Interfaces assembly redirection 

### DIFF
--- a/src/testhost.x86/app.config
+++ b/src/testhost.x86/app.config
@@ -19,7 +19,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.TestWindow.Interfaces" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="11.0.0.0-14.0.0.0"  newVersion="15.0.0.0"/>
+        <bindingRedirect oldVersion="11.0.0.0-15.0.0.0"  newVersion="16.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.QualityTools.UnitTestFramework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/src/testhost/app.config
+++ b/src/testhost/app.config
@@ -19,7 +19,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.TestWindow.Interfaces" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="11.0.0.0-14.0.0.0" newVersion="15.0.0.0" />
+        <bindingRedirect oldVersion="11.0.0.0-15.0.0.0" newVersion="16.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.QualityTools.UnitTestFramework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />


### PR DESCRIPTION
Pointing this to 16.0.0.0 for the next version of VS. This fixes discovery/execution for Google Test Adapter and other 3rd party adapters. 
Please let me know if master is not the right branch for this.