### PR TITLE
Fix for video datacollector throwing exception

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Adapter/TestExecutionRecorder.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Adapter/TestExecutionRecorder.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Adapter
         private ITestCaseEventsHandler testCaseEventsHandler;
 
         /// <summary>
-        /// Contains TestCase Ids for test cases  that are in progress
+        /// Contains TestCase Ids for test cases that are in progress
         /// Start has been recorded but End has not yet been recorded.
         /// </summary>
         private HashSet<Guid> testCaseInProgressMap;
@@ -75,10 +75,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Adapter
             {
                 lock (this.testCaseInProgressSyncObject)
                 {
-                    this.testCaseInProgressMap.Add(testCase.Id);
+                    // Do not send TestCaseStart for a test in progress
+                    if (!this.testCaseInProgressMap.Contains(testCase.Id))
+                    {
+                        this.testCaseInProgressMap.Add(testCase.Id);
+                        this.testCaseEventsHandler.SendTestCaseStart(testCase);
+                    }
                 }
-                
-                this.testCaseEventsHandler.SendTestCaseStart(testCase);
             }
         }
 
@@ -129,7 +132,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Adapter
                     // TestCaseEnd must always be preceded by TestCaseStart for a given test case id
                     if (this.testCaseInProgressMap.Contains(testCase.Id))
                     {
-                        
                         // Send test case end event to handler.
                         this.testCaseEventsHandler.SendTestCaseEnd(testCase, outcome);
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Adapter/TestExecutionRecorderTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Adapter/TestExecutionRecorderTests.cs
@@ -159,6 +159,18 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Adapter
         }
 
         [TestMethod]
+        public void RecordStartAndRecordEndShouldIgnoreRedundantTestCaseStartAndTestCaseEnd()
+        {
+            this.testRecorderWithTestEventsHandler.RecordStart(this.testCase);
+            this.testRecorderWithTestEventsHandler.RecordStart(this.testCase);
+            this.testRecorderWithTestEventsHandler.RecordEnd(this.testCase, TestOutcome.Passed);
+            this.testRecorderWithTestEventsHandler.RecordEnd(this.testCase, TestOutcome.Passed);
+
+            this.mockTestCaseEventsHandler.Verify(x => x.SendTestCaseStart(this.testCase), Times.Exactly(1));
+            this.mockTestCaseEventsHandler.Verify(x => x.SendTestCaseEnd(this.testCase, TestOutcome.Passed), Times.Exactly(1));
+        }
+
+        [TestMethod]
         public void RecordResultShouldPublishTestResultIfRecordStartAndRecordEndEventsAreNotPublished()
         {
             this.testRecorderWithTestEventsHandler.RecordResult(this.testResult);

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Adapter/TestExecutionRecorderTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Adapter/TestExecutionRecorderTests.cs
@@ -120,32 +120,42 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Adapter
         }
 
         [TestMethod]
-        public void SendTestCaseEndShouldInovkeTestCaseEndEventIfTestCaseStartWasCalledBefore()
+        public void RecordEndShouldInovkeTestCaseEndEventOnlyIfTestCaseStartWasCalledBefore()
         {
+            this.testRecorderWithTestEventsHandler.RecordStart(this.testCase);
             this.testRecorderWithTestEventsHandler.RecordEnd(this.testCase, TestOutcome.Passed);
 
             this.mockTestCaseEventsHandler.Verify(x => x.SendTestCaseEnd(this.testCase, TestOutcome.Passed), Times.Once);
         }
 
         [TestMethod]
-        public void SendTestCaseEndShouldNotInvokeTestCaseEndEventInCaseOfAMissingTestCaseStartInDataDrivenScenario()
+        public void RecordEndShouldNotInovkeTestCaseEndEventIfTestCaseStartWasNotCalledBefore()
+        {
+            this.testRecorderWithTestEventsHandler.RecordEnd(this.testCase, TestOutcome.Passed);
+
+            this.mockTestCaseEventsHandler.Verify(x => x.SendTestCaseEnd(this.testCase, TestOutcome.Passed), Times.Never);
+        }
+
+        [TestMethod]
+        public void RecordEndShouldNotInvokeTestCaseEndEventInCaseOfAMissingTestCaseStartInDataDrivenScenario()
         {
             this.testRecorderWithTestEventsHandler.RecordStart(this.testCase);
             this.testRecorderWithTestEventsHandler.RecordEnd(this.testCase, TestOutcome.Passed);
             this.testRecorderWithTestEventsHandler.RecordEnd(this.testCase, TestOutcome.Failed);
 
             this.mockTestCaseEventsHandler.Verify(x => x.SendTestCaseEnd(this.testCase, TestOutcome.Passed), Times.Once);
+            this.mockTestCaseEventsHandler.Verify(x => x.SendTestCaseEnd(this.testCase, TestOutcome.Failed), Times.Never);
         }
-
+        
         [TestMethod]
         public void RecordEndShouldInvokeSendTestCaseEndMultipleTimesInDataDrivenScenario()
         {
             this.testRecorderWithTestEventsHandler.RecordStart(this.testCase);
             this.testRecorderWithTestEventsHandler.RecordEnd(this.testCase, TestOutcome.Passed);
             this.testRecorderWithTestEventsHandler.RecordStart(this.testCase);
-            this.testRecorderWithTestEventsHandler.RecordEnd(this.testCase, TestOutcome.Failed);
+            this.testRecorderWithTestEventsHandler.RecordEnd(this.testCase, TestOutcome.Passed);
 
-            this.mockTestCaseEventsHandler.Verify(x => x.SendTestCaseEnd(this.testCase, TestOutcome.Passed), Times.Once);
+            this.mockTestCaseEventsHandler.Verify(x => x.SendTestCaseEnd(this.testCase, TestOutcome.Passed), Times.Exactly(2));
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description
Issue: Video data collector throwing unexpected exception for ordered tests.
RCA: Ordered tests contain other tests, ordered test adapter does not raise the TestCaseStart for these child test cases.
RecordResult records TestCaseEnd if not recorded previously but does not check if RecordStart happened.

Fix: Do not send TestCaseEnd for testcases whose TestCaseStart has not been recorded via adapter.

## Related issue
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/650935
