### PR TITLE
Show error message on Framework35

### DIFF
--- a/src/vstest.console/Resources/Resources.Designer.cs
+++ b/src/vstest.console/Resources/Resources.Designer.cs
@@ -658,6 +658,17 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode"..
+        /// </summary>
+        public static string Framework35NotSupported
+        {
+            get
+            {
+                return ResourceManager.GetString("Framework35NotSupported", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The /Framework argument requires the target .Net Framework version for the test run.   Example:  /Framework:&quot;.NETFramework,Version=v4.5.1&quot;.
         /// </summary>
         public static string FrameworkVersionRequired

--- a/src/vstest.console/Resources/Resources.Designer.cs
+++ b/src/vstest.console/Resources/Resources.Designer.cs
@@ -658,7 +658,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode"..
+        ///   Looks up a localized string similar to Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode"..
         /// </summary>
         public static string Framework35NotSupported
         {

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -276,6 +276,9 @@
   <data name="FileNotFound" xml:space="preserve">
     <value>'{0}' not found.</value>
   </data>
+  <data name="Framework35NotSupported" xml:space="preserve">
+    <value>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</value>
+  </data>
   <data name="FrameworkArgumentHelp" xml:space="preserve">
     <value>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -277,7 +277,7 @@
     <value>'{0}' not found.</value>
   </data>
   <data name="Framework35NotSupported" xml:space="preserve">
-    <value>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</value>
+    <value>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</value>
   </data>
   <data name="FrameworkArgumentHelp" xml:space="preserve">
     <value>--Framework|/Framework:&lt;Framework Version&gt;

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -283,7 +283,7 @@
     <value>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
       Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
-      Other supported values are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</value>
+      Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</value>
   </data>
   <data name="FrameworkVersionRequired" xml:space="preserve">
     <value>The /Framework argument requires the target .Net Framework version for the test run.   Example:  /Framework:".NETFramework,Version=v4.5.1"</value>
@@ -324,7 +324,7 @@
     <value>Argument {0} is not expected in the 'EnableCodeCoverage' command. Specify the command without the argument (Example: vstest.console.exe myTests.dll /EnableCodeCoverage) and try again.</value>
   </data>
   <data name="InvalidFrameworkVersion" xml:space="preserve">
-    <value>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</value>
+    <value>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</value>
   </data>
   <data name="InvalidInIsolationCommand" xml:space="preserve">
     <value>Argument {0} is not expected in the 'InIsolation' command. Specify the command without the argument (Example: vstest.console.exe myTests.dll /InIsolation) and try again.</value>

--- a/src/vstest.console/Resources/xlf/Resources.cs.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.cs.xlf
@@ -1619,7 +1619,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.cs.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.cs.xlf
@@ -738,12 +738,12 @@
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
       Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
-      Other supported values are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Verze rozhraní&gt;
+      Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <target state="new">--Framework|/Framework:&lt;Verze rozhraní&gt;
       Cílová verze rozhraní .NET Framework, která se použije k provedení testu. 
       Platné hodnoty jsou ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" atd.
       Další podporované hodnoty jsou Framework35, Framework40, Framework45, FrameworkCore10 a FrameworkUap10.</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">--Framework | / Framework: &lt; Framework verze &gt;
       Cílové rozhraní .net Framework verze pro spuštění testu. 
@@ -762,7 +762,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="16" adjWordcount="13.6" curWordcount="13.6"</note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkVersion">
-        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
         <target state="new">Neplatná verze rozhraní .NET Framework: {0}. Zadejte prosím úplný název cílového rozhraní. Další podporované verze jsou Framework35, Framework40, Framework45, FrameworkCore10 a FrameworkUap10.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/vstest.console/Resources/xlf/Resources.cs.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.cs.xlf
@@ -1618,6 +1618,11 @@
         <target state="new">Logger argument '{0}' is invalid.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="Framework35NotSupported">
+        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.de.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.de.xlf
@@ -738,12 +738,12 @@
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
       Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
-      Other supported values are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt; Frameworkversion &gt;
+      Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <target state="new">--Framework|/Framework:&lt; Frameworkversion &gt;
       Die .NET Framework-Zielversion, die für die Testausführung verwendet werden soll.
       Gültige Werte sind ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0 " usw.
       Weitere unterstützte Werte sind "Framework35", "Framework40", "Framework45", "FrameworkCore10" und "FrameworkUap10".</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">-Framework | / Framework: &lt; Frameworkversion &gt;
       Ziel von .net Framework-Version für die Ausführung verwendet werden. 
@@ -762,7 +762,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="16" adjWordcount="13.6" curWordcount="13.6"</note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkVersion">
-        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
         <target state="new">Ungültige .NET Framework-Version: {0}. Geben Sie den vollständigen Namen von TargetFramework an. Weitere unterstützte .NET Framework-Versionen sind "Framework35", "Framework40", "Framework45", "FrameworkCore10" und "FrameworkUap10".</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/vstest.console/Resources/xlf/Resources.de.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.de.xlf
@@ -1619,7 +1619,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.de.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.de.xlf
@@ -1618,6 +1618,11 @@
         <target state="new">Logger argument '{0}' is invalid.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="Framework35NotSupported">
+        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.es.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.es.xlf
@@ -740,12 +740,12 @@
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
       Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
-      Other supported values are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Versión de .NET Framework&gt;
+      Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <target state="new">--Framework|/Framework:&lt;Versión de .NET Framework&gt;
       Versión de .NET Framework de destino que se usará para la ejecución de pruebas. 
       Los valores válidos son: ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
       Otros valores admitidos son: Framework35, Framework40, Framework45, FrameworkCore10 y FrameworkUap10.</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">--Framework | / Framework: &lt; versión de Framework &gt;
       Trabajar en .net Framework versión que se utilizará para la ejecución de la prueba. 
@@ -764,7 +764,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="16" adjWordcount="13.6" curWordcount="13.6"</note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkVersion">
-        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
         <target state="new">Versión de .NET Framework no válida: {0}. Proporcione el nombre completo de TargetFramework. Otras versiones de .NET Framework admitidas son Framework35, Framework40, Framework45, FrameworkCore10 y FrameworkUap10.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/vstest.console/Resources/xlf/Resources.es.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.es.xlf
@@ -1624,7 +1624,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.es.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.es.xlf
@@ -1623,6 +1623,11 @@
         <target state="new">Logger argument '{0}' is invalid.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="Framework35NotSupported">
+        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.fr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.fr.xlf
@@ -738,12 +738,12 @@
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
       Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
-      Other supported values are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;version du framework&gt;
+      Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <target state="new">--Framework|/Framework:&lt;version du framework&gt;
       Version cible du .Net Framework à utiliser pour l'exécution des tests. 
       Les valeurs valides sont : ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0", etc.
       Les autres valeurs prises en charge sont Framework35, Framework40, Framework45, FrameworkCore10 et FrameworkUap10.</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">--Framework | / Framework : &lt; Version .NET Framework &gt;
       Ciblez .net version de Framework à utiliser pour l’exécution du test. 
@@ -762,7 +762,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="16" adjWordcount="13.6" curWordcount="13.6"</note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkVersion">
-        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
         <target state="new">Version non valide du .Net Framework : {0}. Indiquez le nom complet de TargetFramework. Les autres versions du .Net Framework prises en charge sont Framework35, Framework40, Framework45, FrameworkCore10 et FrameworkUap10.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/vstest.console/Resources/xlf/Resources.fr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.fr.xlf
@@ -1619,7 +1619,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.fr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.fr.xlf
@@ -1618,6 +1618,11 @@
         <target state="new">Logger argument '{0}' is invalid.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="Framework35NotSupported">
+        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.it.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.it.xlf
@@ -738,12 +738,12 @@
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
       Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
-      Other supported values are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Versione framework&gt;
+      Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <target state="new">--Framework|/Framework:&lt;Versione framework&gt;
       Versione di .NET Framework di destinazione da usare per l'esecuzione dei test. 
       Valori validi: ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" e così via.
       Altri valori supportati: Framework35, Framework40, Framework45, FrameworkCore10 e FrameworkUap10.</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">-Framework | / Framework: &lt; versione Framework &gt;
       Destinazione di .net Framework versione da utilizzare per l'esecuzione del test. 
@@ -762,7 +762,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="16" adjWordcount="13.6" curWordcount="13.6"</note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkVersion">
-        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
         <target state="new">La versione di .NET Framework {0} non è valida. Specificare il nome completo della versione di .NET Framework di destinazione. Altre versioni di .NET Framework supportate: Framework35, Framework40, Framework45, FrameworkCore10 e FrameworkUap10.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/vstest.console/Resources/xlf/Resources.it.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.it.xlf
@@ -1619,7 +1619,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.it.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.it.xlf
@@ -1618,6 +1618,11 @@
         <target state="new">Logger argument '{0}' is invalid.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="Framework35NotSupported">
+        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.ja.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ja.xlf
@@ -1619,7 +1619,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.ja.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ja.xlf
@@ -1618,6 +1618,11 @@
         <target state="new">Logger argument '{0}' is invalid.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="Framework35NotSupported">
+        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.ja.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ja.xlf
@@ -738,12 +738,12 @@
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
       Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
-      Other supported values are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Framework のバージョン&gt;
+      Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <target state="new">--Framework|/Framework:&lt;Framework のバージョン&gt;
       テストの実行に使用する対象の .Net Framework バージョンです。
      有効な値は ".NETFramework,Version=v4.5.1"、".NETCoreApp,Version=v1.0" などです。
       その他のサポートされる値は Framework35、Framework40、Framework45、FrameworkCore10、FrameworkUap10 です。</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">--フレームワーク |/フレームワーク: &lt; フレームワーク バージョン &gt;
       対象の .Net Framework のバージョンをテストの実行に使用します。
@@ -762,7 +762,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="16" adjWordcount="13.6" curWordcount="13.6"</note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkVersion">
-        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
         <target state="new">.Net Framework バージョンが無効です: {0}。TargetFramework の完全な名前を指定してください。その他のサポートされる .Net Framework バージョンは Framework35、Framework40、Framework45、FrameworkCore10、FrameworkUap10 です。</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/vstest.console/Resources/xlf/Resources.ko.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ko.xlf
@@ -738,12 +738,12 @@
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
       Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
-      Other supported values are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;프레임워크 버전&gt;
+      Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <target state="new">--Framework|/Framework:&lt;프레임워크 버전&gt;
       테스트 실행에 사용할 대상 .NET Framework 버전입니다. 
       유효한 값은 ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" 등입니다.
       지원되는 기타 값은 Framework35, Framework40, Framework45, FrameworkCore10 및 FrameworkUap10입니다.</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">-프레임 워크 | / 프레임 워크: &lt; 프레임 워크 버전 &gt;
       대상.Net Framework 버전 테스트 실행에 사용할 수 있습니다. 
@@ -762,7 +762,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="16" adjWordcount="13.6" curWordcount="13.6"</note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkVersion">
-        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
         <target state="new">.NET Framework 버전 {0}이(가) 잘못되었습니다. TargetFramework의 전체 경로를 지정하세요. 지원되는 다른 .NET Framework 버전은 Framework35, Framework40, Framework45, FrameworkCore10 및 FrameworkUap10입니다.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/vstest.console/Resources/xlf/Resources.ko.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ko.xlf
@@ -1619,7 +1619,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.ko.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ko.xlf
@@ -1618,6 +1618,11 @@
         <target state="new">Logger argument '{0}' is invalid.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="Framework35NotSupported">
+        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.pl.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pl.xlf
@@ -1617,7 +1617,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.pl.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pl.xlf
@@ -737,12 +737,12 @@
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
       Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
-      Other supported values are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;wersja struktury&gt;
+      Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <target state="new">--Framework|/Framework:&lt;wersja struktury&gt;
       Docelowa wersja programu .NET Framework, która zostanie użyta na potrzeby wykonania testu. 
       Prawidłowe wartości to ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" itp.
       Inne obsługiwane wartości to Framework35, Framework40, Framework45, FrameworkCore10 i FrameworkUap10.</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">--Framework | / Framework: &lt; Framework w wersji &gt;
       Cel systemu .net Framework w wersji używanego do wykonania testu. 
@@ -761,7 +761,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="16" adjWordcount="13.6" curWordcount="13.6"</note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkVersion">
-        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
         <target state="new">Nieprawidłowa wersja programu .NET Framework: {0}. Podaj pełną nazwę struktury docelowej. Inne obsługiwane wersje programu .NET Framework to Framework35, Framework40, Framework45, FrameworkCore10 i FrameworkUap10.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/vstest.console/Resources/xlf/Resources.pl.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pl.xlf
@@ -1616,6 +1616,11 @@
         <target state="new">Logger argument '{0}' is invalid.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="Framework35NotSupported">
+        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
@@ -1617,7 +1617,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
@@ -1616,6 +1616,11 @@
         <target state="new">Logger argument '{0}' is invalid.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="Framework35NotSupported">
+        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
@@ -737,12 +737,12 @@
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
       Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
-      Other supported values are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Framework Version&gt;
+      Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <target state="new">--Framework|/Framework:&lt;Framework Version&gt;
       Indique a versão de destino do .Net Framework a ser usada para a execução do teste. 
       Os valores válidos são ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
       Outros valores compatíveis são Framework35, Framework40, Framework45, FrameworkCore10 e FrameworkUap10.</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">-Framework | / Framework: &lt; versão do Framework &gt;
       Direcionar o .net Framework versão a ser usada para a execução do teste. 
@@ -761,7 +761,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="16" adjWordcount="13.6" curWordcount="13.6"</note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkVersion">
-        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
         <target state="new">Versão inválida do .Net Framework: {0}. Forneça o nome completo do TargetFramework. Outras versões compatíveis do .Net Framework são Framework35, Framework40, Framework45, FrameworkCore10 e FrameworkUap10.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/vstest.console/Resources/xlf/Resources.ru.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ru.xlf
@@ -1619,7 +1619,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.ru.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ru.xlf
@@ -1618,6 +1618,11 @@
         <target state="new">Logger argument '{0}' is invalid.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="Framework35NotSupported">
+        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.ru.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ru.xlf
@@ -738,12 +738,12 @@
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
       Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
-      Other supported values are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;версия платформы&gt;
+      Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <target state="new">--Framework|/Framework:&lt;версия платформы&gt;
       Целевая версия .NET Framework для выполнения тестов. 
       Допустимые значения: ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" и т. д.
       Другие поддерживаемые значения: Framework35, Framework40, Framework45, FrameworkCore10 и FrameworkUap10.</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">--Framework | / Framework: &lt; Framework версии &gt;
       Целевой .net Framework версии, используемый для выполнения теста. 
@@ -762,7 +762,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="16" adjWordcount="13.6" curWordcount="13.6"</note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkVersion">
-        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
         <target state="new">Недопустимая версия .NET Framework: {0}. Укажите полное имя целевой платформы. Другие поддерживаемые версии .NET Framework: Framework35, Framework40, Framework45, FrameworkCore10 и FrameworkUap10.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/vstest.console/Resources/xlf/Resources.tr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.tr.xlf
@@ -738,12 +738,12 @@
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
       Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
-      Other supported values are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Framework Sürümü&gt;
+      Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <target state="new">--Framework|/Framework:&lt;Framework Sürümü&gt;
       Test yürütmesi için kullanılacak hedef .NET Framework sürümü. 
       Geçerli değerler ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" vb.
       Framework35, Framework40, Framework45, FrameworkCore10 ve FrameworkUap10 desteklenen diğer değerlerdir.</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">--Framework | / Framework: &lt; Framework sürüm &gt;
       Hedef .net Framework sürümünü test yürütmesi için kullanılacak. 
@@ -762,7 +762,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="16" adjWordcount="13.6" curWordcount="13.6"</note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkVersion">
-        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
         <target state="new">Geçersiz .NET Framework sürümü: {0}. Lütfen TargetFramework tam adını belirtin. Desteklenen diğer .NET Framework sürümleri Framework35, Framework40, Framework45, FrameworkCore10 ve FrameworkUap10’dur.</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/vstest.console/Resources/xlf/Resources.tr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.tr.xlf
@@ -1619,7 +1619,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.tr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.tr.xlf
@@ -1618,6 +1618,11 @@
         <target state="new">Logger argument '{0}' is invalid.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="Framework35NotSupported">
+        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.xlf
@@ -814,6 +814,11 @@
         <target state="new">Logger argument '{0}' is invalid.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="Framework35NotSupported">
+        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.xlf
@@ -815,7 +815,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.xlf
@@ -312,7 +312,7 @@
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
       Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
-      Other supported values are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+      Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
         <note></note>
       </trans-unit>
       <trans-unit id="FrameworkVersionRequired">
@@ -320,7 +320,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkVersion">
-        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
         <note></note>
       </trans-unit>
       <trans-unit id="AppContainerTestPrerequisiteFail">

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
@@ -1619,7 +1619,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
@@ -1618,6 +1618,11 @@
         <target state="new">Logger argument '{0}' is invalid.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="Framework35NotSupported">
+        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
@@ -738,12 +738,12 @@
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
       Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
-      Other supported values are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Framework Version&gt;
+      Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <target state="new">--Framework|/Framework:&lt;Framework Version&gt;
       用于测试执行的目标 .Net Framework 版本。
       有效值为 ".NETFramework,Version=v4.5.1"、".NETCoreApp,Version=v1.0" 等。
       其他受支持的值为 Framework35、Framework40、Framework45、FrameworkCore10 和 FrameworkUap10。</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">— 框架 | / 框架︰ &lt; 框架版本 &gt;
       目标.Net Framework 版本以用于测试执行。
@@ -762,7 +762,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="16" adjWordcount="13.6" curWordcount="13.6"</note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkVersion">
-        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
         <target state="new">无效的 .Net Framework 版本: {0}。请提供 TargetFramework 的全名。其他支持的 .Net Framework 版本为 Framework35、Framework40、Framework45、FrameworkCore10 和 FrameworkUap10。</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
@@ -1619,7 +1619,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
@@ -1618,6 +1618,11 @@
         <target state="new">Logger argument '{0}' is invalid.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="Framework35NotSupported">
+        <source>Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</source>
+        <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
@@ -738,12 +738,12 @@
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
       Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
-      Other supported values are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Framework 版本&gt;
+      Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <target state="new">--Framework|/Framework:&lt;Framework 版本&gt;
       要用於測試執行的目標 .Net Framework 版本。 
       有效值為 ".NETFramework,Version=v4.5.1"、".NETCoreApp,Version=v1.0" 等等
       其他支援的值為 Framework35、Framework40、Framework45、FrameworkCore10 與 FrameworkUap10。</target>
-        <note />
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">— 框架 | / 框架︰ &lt; 框架版本 &gt;
       目标.Net Framework 版本以用于测试执行。
@@ -762,7 +762,7 @@
         <note from="bb-metadata">fuzzyMatch="15" wordcount="16" adjWordcount="13.6" curWordcount="13.6"</note>
       </trans-unit>
       <trans-unit id="InvalidFrameworkVersion">
-        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
+        <source>Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
         <target state="new">.Net Framework 版本無效:{0}。請提供 TargetFramework 的全名。其他支援的 .Net Framework 版本為 Framework35、Framework40、Framework45、FrameworkCore10 以及 FrameworkUap10。</target>
         <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -8,7 +8,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
     using System.IO;
     using System.Linq;
     using System.Reflection;
-    using System.Threading;
     using System.Threading.Tasks;
     using System.Xml;
     using System.Xml.XPath;
@@ -393,6 +392,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
                     {
                         EqtTrace.Info(incompatibleSettingWarning);
                         ConsoleLogger.RaiseTestRunWarning(incompatibleSettingWarning);
+                    }
+
+                    if (Constants.DotNetFramework35.Equals(chosenFramework.Name))
+                    {
+                        EqtTrace.Info("TestRequestManager.UpdateRunSettingsIfRequired: Show warning message on /Framework:Framework35 option.");
+                        throw new TestPlatformException("/Frmaeowrk:Frameowrk35 not supported.");
                     }
 
                     if (EqtTrace.IsInfoEnabled)

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -397,7 +397,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
                     if (Constants.DotNetFramework35.Equals(chosenFramework.Name))
                     {
                         EqtTrace.Info("TestRequestManager.UpdateRunSettingsIfRequired: Show warning message on /Framework:Framework35 option.");
-                        throw new TestPlatformException("/Frmaeowrk:Frameowrk35 not supported.");
+                        throw new TestPlatformException(Resources.Framework35NotSupported);
                     }
 
                     if (EqtTrace.IsInfoEnabled)

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -396,7 +396,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
 
                     if (Constants.DotNetFramework35.Equals(chosenFramework.Name))
                     {
-                        EqtTrace.Info("TestRequestManager.UpdateRunSettingsIfRequired: Show warning message on /Framework:Framework35 option.");
+                        EqtTrace.Error("TestRequestManager.UpdateRunSettingsIfRequired: throw exception on /Framework:Framework35 option.");
                         throw new TestPlatformException(Resources.Framework35NotSupported);
                     }
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
@@ -237,11 +237,11 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void ExecuteTestsForFramework35ShouldPrintErrorMessage(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
-            var expectedWarningContains = "Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 \"compatibly mode\".";
+            var expectedWarningContains = "Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 \"compatibility mode\".";
             var assemblyPaths = this.GetAssetFullPath("SimpleTestProject.dll");
 
             var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
-            arguments = string.Concat(arguments, " /Framework:Framework35");
+            arguments = string.Concat(arguments, " /Framework:.NETFramework,Version=v3.5");
 
             this.InvokeVsTest(arguments);
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
@@ -231,5 +231,23 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             // When both x64 & x86 DLL is passed x64 dll will be ignored.
             this.StdOutputContains(expectedWarningContains);
         }
+
+        [TestMethod]
+        [NetFullTargetFrameworkDataSource(useCoreRunner:false)]
+        public void ExecuteTestsForFramework35ShouldPrintErrorMessage(RunnerInfo runnerInfo)
+        {
+            AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var expectedWarningContains = @"/Frmaeowrk:Frameowrk35 not supported.";
+            var assemblyPaths = this.GetAssetFullPath("SimpleTestProject.dll");
+
+            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            arguments = string.Concat(arguments, " /Framework:Framework35");
+
+            this.InvokeVsTest(arguments);
+
+            this.ExitCodeEquals(1);
+
+            this.StdErrorContains(expectedWarningContains);
+        }
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
@@ -237,7 +237,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void ExecuteTestsForFramework35ShouldPrintErrorMessage(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
-            var expectedWarningContains = @"/Frmaeowrk:Frameowrk35 not supported.";
+            var expectedWarningContains = "Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 \"compatibly mode\".";
             var assemblyPaths = this.GetAssetFullPath("SimpleTestProject.dll");
 
             var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/DiscoverTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/DiscoverTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
     using Microsoft.VisualStudio.TestPlatform.Common.Telemetry;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using VisualStudio.TestPlatform.ObjectModel.Logging;
 
     [TestClass]
     public class DiscoverTests : AcceptanceTestBase
@@ -70,6 +71,34 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
             // Assert.
             Assert.AreEqual(6, this.discoveryEventHandler2.DiscoveredTestCases.Count);
             Assert.AreEqual(0, this.discoveryEventHandler2.Metrics.Count);
+        }
+
+        [TestMethod]
+        [NetFullTargetFrameworkDataSource]
+        public void DiscoverTestsShouldFailForFramework35(RunnerInfo runnerInfo)
+        {
+            AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            this.ExecuteNotSupportedRunnerFrameworkTests(runnerInfo.RunnerFramework, Netcoreapp, Message);
+            this.Setup();
+
+            string runSettingsXml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                                    <RunSettings>
+                                        <RunConfiguration>
+                                            <TargetFrameworkVersion>Framework35</TargetFrameworkVersion>
+                                            <DesignMode>true</DesignMode>
+                                        </RunConfiguration>
+                                    </RunSettings>";
+
+            this.vstestConsoleWrapper.DiscoverTests(
+                this.GetTestAssemblies(),
+                runSettingsXml,
+                new TestPlatformOptions() { CollectMetrics = false },
+                this.discoveryEventHandler2);
+
+            Assert.AreEqual(1, this.discoveryEventHandler2.Messages.Count);
+            StringAssert.Contains(this.discoveryEventHandler2.Messages[0], "/Frmaeowrk:Frameowrk35 not supported.");
+            Assert.AreEqual(1, this.discoveryEventHandler2.TestMessageLevels.Count);
+            Assert.AreEqual(TestMessageLevel.Error, this.discoveryEventHandler2.TestMessageLevels[0]);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/DiscoverTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/DiscoverTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
                 this.discoveryEventHandler2);
 
             Assert.AreEqual(1, this.discoveryEventHandler2.Messages.Count);
-            StringAssert.Contains(this.discoveryEventHandler2.Messages[0], "/Frmaeowrk:Frameowrk35 not supported.");
+            StringAssert.Contains(this.discoveryEventHandler2.Messages[0], "Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 \"compatibly mode\".");
             Assert.AreEqual(1, this.discoveryEventHandler2.TestMessageLevels.Count);
             Assert.AreEqual(TestMessageLevel.Error, this.discoveryEventHandler2.TestMessageLevels[0]);
         }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/DiscoverTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/DiscoverTests.cs
@@ -95,10 +95,9 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
                 new TestPlatformOptions() { CollectMetrics = false },
                 this.discoveryEventHandler2);
 
-            Assert.AreEqual(1, this.discoveryEventHandler2.Messages.Count);
-            StringAssert.Contains(this.discoveryEventHandler2.Messages[0], "Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 \"compatibly mode\".");
-            Assert.AreEqual(1, this.discoveryEventHandler2.TestMessageLevels.Count);
-            Assert.AreEqual(TestMessageLevel.Error, this.discoveryEventHandler2.TestMessageLevels[0]);
+            Assert.AreEqual(1, this.discoveryEventHandler2.testMessages.Count);
+            StringAssert.Contains(this.discoveryEventHandler2.testMessages[0].message, "Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 \"compatibility mode\".");
+            Assert.AreEqual(TestMessageLevel.Error, this.discoveryEventHandler2.testMessages[0].testMessageLevel);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/EventHandler/DiscoveryEventHandler.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/EventHandler/DiscoveryEventHandler.cs
@@ -58,6 +58,10 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
         /// </summary>
         public List<TestCase> DiscoveredTestCases { get; }
 
+        public List<TestMessageLevel> TestMessageLevels;
+
+        public List<string> Messages;
+
         /// <summary>
         /// Gets the metrics.
         /// </summary>
@@ -66,6 +70,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
         public DiscoveryEventHandler2()
         {
             this.DiscoveredTestCases = new List<TestCase>();
+            this.TestMessageLevels = new List<TestMessageLevel>();
+            this.Messages = new List<string>();
         }
 
         public void HandleRawMessage(string rawMessage)
@@ -75,7 +81,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
 
         public void HandleLogMessage(TestMessageLevel level, string message)
         {
-            // No Op
+            this.TestMessageLevels.Add(level);
+            this.Messages.Add(message);
         }
 
         public void HandleDiscoveryComplete(DiscoveryCompleteEventArgs discoveryCompleteEventArgs, IEnumerable<TestCase> lastChunk)

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/EventHandler/DiscoveryEventHandler.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/EventHandler/DiscoveryEventHandler.cs
@@ -50,6 +50,18 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
         }
     }
 
+    public struct TestMessage
+    {
+        public TestMessageLevel testMessageLevel;
+        public string message;
+
+        public TestMessage(TestMessageLevel testMessageLevel, string message)
+        {
+            this.testMessageLevel = testMessageLevel;
+            this.message = message;
+        }
+    }
+
     /// <inheritdoc />
     public class DiscoveryEventHandler2 : ITestDiscoveryEventsHandler2
     {
@@ -58,9 +70,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
         /// </summary>
         public List<TestCase> DiscoveredTestCases { get; }
 
-        public List<TestMessageLevel> TestMessageLevels;
-
-        public List<string> Messages;
+        public List<TestMessage> testMessages;
 
         /// <summary>
         /// Gets the metrics.
@@ -70,8 +80,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
         public DiscoveryEventHandler2()
         {
             this.DiscoveredTestCases = new List<TestCase>();
-            this.TestMessageLevels = new List<TestMessageLevel>();
-            this.Messages = new List<string>();
+            this.testMessages = new List<TestMessage>();
         }
 
         public void HandleRawMessage(string rawMessage)
@@ -81,8 +90,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
 
         public void HandleLogMessage(TestMessageLevel level, string message)
         {
-            this.TestMessageLevels.Add(level);
-            this.Messages.Add(message);
+            this.testMessages.Add(new TestMessage(level, message));
         }
 
         public void HandleDiscoveryComplete(DiscoveryCompleteEventArgs discoveryCompleteEventArgs, IEnumerable<TestCase> lastChunk)

--- a/test/vstest.console.UnitTests/Processors/FrameworkArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/FrameworkArgumentProcessorTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         {
             ExceptionUtilities.ThrowsException<CommandLineException>(
                 () => this.executor.Initialize("foo"),
-                "Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework35, Framework40, Framework45, FrameworkCore10 and FrameworkUap10.",
+                "Invalid .Net Framework version:{0}. Please give the fullname of the TargetFramework(Example: .NETCoreApp,Version=v2.0). Other supported .Net Framework versions are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.",
                 "foo");
         }
 

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -871,7 +871,7 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
             this.mockAssemblyMetadataProvider.Setup(a => a.GetFrameWork(It.IsAny<string>())).Returns(new FrameworkName(Constants.DotNetFramework35));
             var actualErrorMessage = Assert.ThrowsException<TestPlatformException>( () => this.testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, this.protocolConfig)).Message;
 
-            Assert.AreEqual("/Frmaeowrk:Frameowrk35 not supported.", actualErrorMessage);
+            Assert.AreEqual("Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 \"compatibly mode\".", actualErrorMessage);
         }
 
         [TestMethod]

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -871,7 +871,7 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
             this.mockAssemblyMetadataProvider.Setup(a => a.GetFrameWork(It.IsAny<string>())).Returns(new FrameworkName(Constants.DotNetFramework35));
             var actualErrorMessage = Assert.ThrowsException<TestPlatformException>( () => this.testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, this.protocolConfig)).Message;
 
-            Assert.AreEqual("Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 \"compatibly mode\".", actualErrorMessage);
+            Assert.AreEqual("Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 \"compatibility mode\".", actualErrorMessage);
         }
 
         [TestMethod]

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -7,7 +7,6 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 namespace vstest.console.UnitTests.TestPlatformHelpers
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
@@ -23,23 +22,18 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
     using Microsoft.VisualStudio.TestPlatform.Common.Logging;
     using Microsoft.VisualStudio.TestPlatform.Common.Telemetry;
     using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Tracing.Interfaces;
-    using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     using System.Runtime.Versioning;
-    using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities;
-    using Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.CommandLine;
     using Microsoft.VisualStudio.TestPlatform.CommandLineUtilities;
-    using Microsoft.VisualStudio.TestPlatform.CommandLine.Resources;
 
     using Moq;
 
     using vstest.console.UnitTests.TestDoubles;
     using Microsoft.VisualStudio.TestPlatform.Utilities;
-    using Microsoft.VisualStudio.TestPlatform.CommandLine.Internal;
 
     [TestClass]
     public class TestRequestManagerTests
@@ -850,6 +844,34 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
 
             this.testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, this.protocolConfig);
             Assert.AreEqual(15, actualTestRunCriteria.FrequencyOfRunStatsChangeEvent);
+        }
+
+        [TestMethod]
+        public void RunTestsShouldThrowForFramework35()
+        {
+            var payload = new TestRunRequestPayload()
+            {
+                Sources = new List<string>() { "a.dll" },
+                RunSettings =
+                    @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <RunSettings>
+                     <RunConfiguration>
+                       <TargetFrameworkVersion>Framework35</TargetFrameworkVersion>
+                     </RunConfiguration>
+                </RunSettings>"
+            };
+
+            TestRunCriteria actualTestRunCriteria = null;
+            var mockDiscoveryRequest = new Mock<ITestRunRequest>();
+            this.mockTestPlatform.Setup(mt => mt.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>())).Callback(
+                (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options) =>
+                {
+                    actualTestRunCriteria = runCriteria;
+                }).Returns(mockDiscoveryRequest.Object);
+            this.mockAssemblyMetadataProvider.Setup(a => a.GetFrameWork(It.IsAny<string>())).Returns(new FrameworkName(Constants.DotNetFramework35));
+            var actualErrorMessage = Assert.ThrowsException<TestPlatformException>( () => this.testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, this.protocolConfig)).Message;
+
+            Assert.AreEqual("/Frmaeowrk:Frameowrk35 not supported.", actualErrorMessage);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description
- Show error message when user pass `/Framework:Framework35` as we don't have testhost built for CLR 2.0

## Related issue
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/493289
