### PR TITLE
Do not set connected event if Connection is Faulted

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/Communication/ConnectedEventArgs.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/Communication/ConnectedEventArgs.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces
         public ICommunicationChannel Channel { get; private set; }
 
         /// <summary>
-        /// Gets true if it's connected.
+        /// Gets a value indicating whether channel is connected or not true if it's connected.
         /// </summary>
         public bool Connected { get; private set; }
 

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/Communication/ConnectedEventArgs.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/Communication/ConnectedEventArgs.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces
         public ICommunicationChannel Channel { get; private set; }
 
         /// <summary>
-        /// Gets a value indicating whether channel is connected or not true if it's connected.
+        /// Gets a value indicating whether channel is connected or not, true if it's connected.
         /// </summary>
         public bool Connected { get; private set; }
 

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketClient.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketClient.cs
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             {
                 if (connectAsyncTask.IsFaulted)
                 {
-                    this.Disconnected.SafeInvoke(this, new DisconnectedEventArgs() { Error = connectAsyncTask.Exception }, "SocketClient: Server Failed to Connect");
+                    this.Connected.SafeInvoke(this, new ConnectedEventArgs(connectAsyncTask.Exception), "SocketClient: Server Failed to Connect");
                     if (EqtTrace.IsVerboseEnabled)
                     {
                         EqtTrace.Verbose("Unable to connect to server, Exception occured : {0}", connectAsyncTask.Exception);

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketClient.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketClient.cs
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             {
                 if (connectAsyncTask.IsFaulted)
                 {
-                    this.Connected.SafeInvoke(this, new ConnectedEventArgs(connectAsyncTask.Exception), "SocketClient: ServerConnected");
+                    this.Disconnected.SafeInvoke(this, new DisconnectedEventArgs() { Error = connectAsyncTask.Exception }, "SocketClient: Server Failed to Connect");
                     if (EqtTrace.IsVerboseEnabled)
                     {
                         EqtTrace.Verbose("Unable to connect to server, Exception occured : {0}", connectAsyncTask.Exception);

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -120,12 +120,16 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             this.communicationEndpoint.Connected += (sender, args) =>
                 {
                     this.channel = args.Channel;
-                    this.connected.Set();
+
+                    if (args.Connected && this.channel != null)
+                    {
+                        this.connected.Set();
+                    }
                 };
             this.communicationEndpoint.Disconnected += (sender, args) =>
                 {
-                    // throw the exception accumulated from TCP/IP stack
-                    throw new TestPlatformException(args.Error.ToString());
+                    // If there's an disconnected event handler, call it
+                    this.onDisconnected?.Invoke(args);
                 };
 
             // Server start returns the listener port

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -124,8 +124,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 };
             this.communicationEndpoint.Disconnected += (sender, args) =>
                 {
-                    // If there's an disconnected event handler, call it
-                    this.onDisconnected?.Invoke(args);
+                    // throw the exception accumulated from TCP/IP stack
+                    throw new TestPlatformException(args.Error.ToString());
                 };
 
             // Server start returns the listener port

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
@@ -8,6 +8,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
     using System.Globalization;
     using System.Linq;
     using System.Net;
+    using System.Net.Sockets;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -34,13 +35,13 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
         private readonly Mock<IDataSerializer> mockDataSerializer;
         private readonly Mock<ICommunicationChannel> mockChannel;
 
-        private readonly ConnectedEventArgs connectedEventArgs;
         private readonly List<string> pathToAdditionalExtensions = new List<string> { "Hello", "World" };
         private readonly Mock<ITestDiscoveryEventsHandler2> mockDiscoveryEventsHandler;
         private readonly Mock<ITestRunEventsHandler> mockExecutionEventsHandler;
         private readonly TestRunCriteriaWithSources testRunCriteriaWithSources;
         private TestHostConnectionInfo connectionInfo;
         private ITestRequestSender testRequestSender;
+        private ConnectedEventArgs connectedEventArgs;
 
         public TestRequestSenderTests()
         {
@@ -83,6 +84,17 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
             var connected = this.testRequestSender.WaitForRequestHandlerConnection(1, It.IsAny<CancellationToken>());
 
             Assert.IsTrue(connected);
+        }
+
+        [TestMethod]
+        public void WaitForRequestHandlerConnectionShouldNotConnectIfExceptionWasThrownByTcpLayer()
+        {
+            this.connectedEventArgs = new ConnectedEventArgs(new SocketException());
+            this.SetupFakeCommunicationChannel();
+
+            var connected = this.testRequestSender.WaitForRequestHandlerConnection(1, It.IsAny<CancellationToken>());
+
+            Assert.IsFalse(connected);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description
When deployed to remote machines testhost sometimes refuses connection, in such cases when we receive `Connection.IsFaulted = true` , but we set connected event in TestRequestSender, which causes incorrect stack trace.

## Related issue
Fixes #1727 
