### PR TITLE
Reverting back app domain culture setup; Revert binding redirect for TW.Interfaces

### DIFF
--- a/src/testhost.x86/AppDomainEngineInvoker.cs
+++ b/src/testhost.x86/AppDomainEngineInvoker.cs
@@ -13,7 +13,6 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
     using System.Reflection;
     using System.Xml.Linq;
     using System.Collections.Generic;
-    using System.Globalization;
 
     /// <summary>
     /// Implementation for the Invoker which invokes engine in a new AppDomain
@@ -29,30 +28,15 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
 
         private string mergedTempConfigFile = null;
 
-        public AppDomainEngineInvoker(string testSourcePath, AppDomainInitializer initializer = null, string appBasePath = null)
+        public AppDomainEngineInvoker(string testSourcePath)
         {
             TestPlatformEventSource.Instance.TestHostAppDomainCreationStart();
 
-            this.appDomain = CreateNewAppDomain(testSourcePath, initializer, appBasePath);
-
-            // Setting appbase later, as AppDomain needs to load testhost.exe into the new Domain, to have access to AppDomainInitializer method.
-            // If we set appbase to testsource folder, then if fails to find testhost.exe resulting in FileNotFoundException for testhost.exe
-            this.UpdateAppBaseToTestSourceLocation(testSourcePath);
+            this.appDomain = CreateNewAppDomain(testSourcePath);
             this.actualInvoker = CreateInvokerInAppDomain(appDomain);
 
             TestPlatformEventSource.Instance.TestHostAppDomainCreationStop();
         }
-
-        private void UpdateAppBaseToTestSourceLocation(string testSourcePath)
-        {
-            // Set AppBase to TestAssembly location
-            var testSourceFolder = Path.GetDirectoryName(testSourcePath);
-            if (this.appDomain != null)
-            {
-                this.appDomain.SetData("APPBASE", testSourceFolder);
-            }
-        }
-
 
         /// <summary>
         /// Invokes the Engine with the arguments
@@ -70,9 +54,9 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
                 {
                     //if(appDomain != null)
                     //{
-                        // Donot unload appdomain as there are lot is issues reported against appdomain unload
-                        // any ways the process is going to die off.
-                        // AppDomain.Unload(appDomain);
+                    // Donot unload appdomain as there are lot is issues reported against appdomain unload
+                    // any ways the process is going to die off.
+                    // AppDomain.Unload(appDomain);
                     //}
 
                     if (!string.IsNullOrWhiteSpace(this.mergedTempConfigFile) && File.Exists(mergedTempConfigFile))
@@ -87,21 +71,14 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
             }
         }
 
-        private AppDomain CreateNewAppDomain(string testSourcePath, AppDomainInitializer initializer, string appBasePath)
+        private AppDomain CreateNewAppDomain(string testSourcePath)
         {
             var appDomainSetup = new AppDomainSetup();
             var testSourceFolder = Path.GetDirectoryName(testSourcePath);
 
-            if (!string.IsNullOrEmpty(appBasePath))
-            {
-                appDomainSetup.ApplicationBase = appBasePath;
-            }
-            
+            // Set AppBase to TestAssembly location
+            appDomainSetup.ApplicationBase = testSourceFolder;
             appDomainSetup.LoaderOptimization = LoaderOptimization.MultiDomainHost;
-
-            //Setup AppDomainInitialzier to set user defined Culture
-            appDomainSetup.AppDomainInitializer = initializer ?? SetAppDomainCulture;
-            appDomainSetup.AppDomainInitializerArguments = new string[] { };
 
             // Set User Config file as app domain config
             SetConfigurationFile(appDomainSetup, testSourcePath, testSourceFolder);
@@ -131,7 +108,7 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
 
             // Create Invoker object in new appdomain
             var invokerType = typeof(T);
-            return (IEngineInvoker) appDomain.CreateInstanceFromAndUnwrap(
+            return (IEngineInvoker)appDomain.CreateInstanceFromAndUnwrap(
                     invokerType.Assembly.Location,
                     invokerType.FullName,
                     false,
@@ -188,23 +165,6 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
             }
 
             return configFile;
-        }
-
-        private static void SetAppDomainCulture(string[] args)
-        {
-            var userCultureSpecified = Environment.GetEnvironmentVariable(CoreUtilities.Constants.DotNetUserSpecifiedCulture);
-            if (!string.IsNullOrWhiteSpace(userCultureSpecified))
-            {
-                try
-                {
-                    CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.CreateSpecificCulture(userCultureSpecified);
-                }
-                // If an exception occurs, we'll just fall back to the system default.
-                catch (Exception)
-                {
-                    EqtTrace.Verbose("Invalid Culture Info '{0}:'", userCultureSpecified);
-                }
-            }
         }
 
         protected static XDocument MergeApplicationConfigFiles(XDocument userConfigDoc, XDocument testHostConfigDoc)

--- a/src/testhost.x86/app.config
+++ b/src/testhost.x86/app.config
@@ -19,7 +19,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.TestWindow.Interfaces" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="11.0.0.0-15.0.0.0"  newVersion="16.0.0.0"/>
+        <bindingRedirect oldVersion="11.0.0.0-14.0.0.0"  newVersion="15.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.QualityTools.UnitTestFramework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/src/testhost/app.config
+++ b/src/testhost/app.config
@@ -19,7 +19,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.TestWindow.Interfaces" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="11.0.0.0-15.0.0.0" newVersion="16.0.0.0" />
+        <bindingRedirect oldVersion="11.0.0.0-14.0.0.0" newVersion="15.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.QualityTools.UnitTestFramework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/test/testhost.UnitTests/AppDomainEngineInvokerTests.cs
+++ b/test/testhost.UnitTests/AppDomainEngineInvokerTests.cs
@@ -6,7 +6,6 @@ namespace testhost.UnitTests
 #if NET451
     using Microsoft.VisualStudio.TestPlatform.TestHost;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Microsoft.VisualStudio.TestPlatform.CoreUtilities;
     using System;
     using System.IO;
     using System.Collections.Generic;
@@ -14,7 +13,6 @@ namespace testhost.UnitTests
     using System.Threading.Tasks;
     using System.Xml.Linq;
     using System.Text;
-    using System.Globalization;
 
     [TestClass]
     public class AppDomainEngineInvokerTests
@@ -49,7 +47,7 @@ namespace testhost.UnitTests
         public void AppDomainEngineInvokerShouldCreateNewAppDomain()
         {
             var tempFile = Path.GetTempFileName();
-            var appDomainInvoker = new TestableEngineInvoker(tempFile, AppDomain.CurrentDomain.BaseDirectory);
+            var appDomainInvoker = new TestableEngineInvoker(tempFile);
 
             Assert.IsNotNull(appDomainInvoker.NewAppDomain, "New AppDomain must be created.");
             Assert.IsNotNull(appDomainInvoker.ActualInvoker, "Invoker must be created.");
@@ -58,56 +56,10 @@ namespace testhost.UnitTests
         }
 
         [TestMethod]
-        public void AppDomainEngineInvokerShouldCreateNewAppDomainAndSetCultureAsPerUsersInput()
-        {
-            var cultureInfo = "fr-FR";
-            Environment.SetEnvironmentVariable(Constants.DotNetUserSpecifiedCulture, cultureInfo);
-            var tempFile = Path.GetTempFileName();
-            var appDomainInvoker = new TestableEngineInvoker(tempFile, AppDomain.CurrentDomain.BaseDirectory);
-            appDomainInvoker.Invoke(new Dictionary<string, string>());
-
-            Assert.IsNotNull(appDomainInvoker.NewAppDomain, "New AppDomain must be created.");
-            Assert.IsNotNull(appDomainInvoker.ActualInvoker, "Invoker must be created.");
-            
-            Assert.AreEqual((appDomainInvoker.ActualInvoker as MockEngineInvoker).CurrentCultureInfo, cultureInfo);
-        }
-
-        [TestMethod]
-        public void AppDomainEngineInvokerShouldCreateNewAppDomainAndSetAppBaseToSourceDirectory()
-        {
-            var cultureInfo = "fr-FR";
-            Environment.SetEnvironmentVariable(Constants.DotNetUserSpecifiedCulture, cultureInfo);
-            var tempFile = Path.GetTempFileName();
-            var appDomainInvoker = new TestableEngineInvoker(tempFile, AppDomain.CurrentDomain.BaseDirectory);
-
-            Assert.IsNotNull(appDomainInvoker.NewAppDomain, "New AppDomain must be created.");
-            Assert.IsNotNull(appDomainInvoker.ActualInvoker, "Invoker must be created.");
-            
-            Assert.AreEqual(appDomainInvoker.NewAppDomain.BaseDirectory, Path.GetDirectoryName(tempFile));
-        }
-
-        [TestMethod]
-        [DataRow("garbage-culture")]
-        [DataRow(" ")]
-        [DataRow(null)]
-        public void AppDomainEngineInvokerShouldCreateNewAppDomainAndSetCultureToEnglishIfUsersInputIncorrect(string cultureInfo)
-        {
-            Environment.SetEnvironmentVariable(Constants.DotNetUserSpecifiedCulture, cultureInfo);
-            var tempFile = Path.GetTempFileName();
-            var appDomainInvoker = new TestableEngineInvoker(tempFile, AppDomain.CurrentDomain.BaseDirectory);
-            appDomainInvoker.Invoke(new Dictionary<string, string>());
-
-            Assert.IsNotNull(appDomainInvoker.NewAppDomain, "New AppDomain must be created.");
-            Assert.IsNotNull(appDomainInvoker.ActualInvoker, "Invoker must be created.");
-
-            Assert.AreEqual((appDomainInvoker.ActualInvoker as MockEngineInvoker).CurrentCultureInfo, "en-US");
-        }
-
-        [TestMethod]
         public void AppDomainEngineInvokerShouldInvokeEngineInNewDomainAndUseTestHostConfigFile()
         {
             var tempFile = Path.GetTempFileName();
-            var appDomainInvoker = new TestableEngineInvoker(tempFile, AppDomain.CurrentDomain.BaseDirectory);
+            var appDomainInvoker = new TestableEngineInvoker(tempFile);
 
             var newAppDomain = appDomainInvoker.NewAppDomain;
 
@@ -248,24 +200,8 @@ namespace testhost.UnitTests
 
         private class TestableEngineInvoker : AppDomainEngineInvoker<MockEngineInvoker>
         {
-            public TestableEngineInvoker(string testSourcePath, string appBasePath) : base(testSourcePath, SetAppDomainCultures, appBasePath)
+            public TestableEngineInvoker(string testSourcePath) : base(testSourcePath)
             {
-            }
-
-            private static void SetAppDomainCultures(string[] args)
-            {
-                var userCultureSpecified = Environment.GetEnvironmentVariable(Constants.DotNetUserSpecifiedCulture);
-                if (!string.IsNullOrWhiteSpace(userCultureSpecified))
-                {
-                    try
-                    {
-                        CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.CreateSpecificCulture(userCultureSpecified);
-                    }
-                    // If an exception occurs, we'll just fall back to the system default.
-                    catch (Exception)
-                    {
-                    }
-                }
             }
 
             public static XDocument MergeConfigXmls(string userConfigText, string testHostConfigText)
@@ -283,11 +219,10 @@ namespace testhost.UnitTests
         private class MockEngineInvoker : MarshalByRefObject, IEngineInvoker
         {
             public string DomainFriendlyName { get; private set; }
-            public string CurrentCultureInfo { get; set; }
+
             public void Invoke(IDictionary<string, string> argsDictionary)
             {
                 this.DomainFriendlyName = AppDomain.CurrentDomain.FriendlyName;
-                this.CurrentCultureInfo = CultureInfo.CurrentUICulture.Name;
             }
         }
     }


### PR DESCRIPTION
Setting up culture on appdomain, causes NewtonSoft.Json to be loaded  from testhost, which can differ from user's version of NS.Json.