### PR TITLE
Logging error messages from test host

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -365,6 +365,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             this.clientExitErrorMessage = stdError;
             this.clientExited.Set();
 
+            if (!this.IsOperationComplete() && stdError != string.Empty)
+            {
+                // Log error if any.
+                this.LogErrorMessage(string.Format(CommonResources.AbortedTestRun, stdError));
+                this.SetOperationComplete();
+            }
+
             // Break communication loop. In somecases(E.g: When tests creates child processes to testhost) communication channel won't break if testhost exits.
             this.communicationEndpoint.Stop();
         }

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
@@ -156,7 +156,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
 
             this.testRequestSender.EndSession();
 
-            this.mockDataSerializer.Verify(ds => ds.SerializeMessage(MessageType.SessionEnd), Times.Once);
+            this.mockDataSerializer.Verify(ds => ds.SerializeMessage(MessageType.SessionEnd), Times.Never);
         }
 
         [DataTestMethod]
@@ -196,6 +196,16 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
             this.RaiseClientDisconnectedEvent();
             this.mockDataSerializer.Verify(ds => ds.SerializePayload(MessageType.TestMessage, It.Is<TestMessagePayload>(p => p.Message.Contains("Dummy Stderr"))), Times.Never);
             this.mockExecutionEventsHandler.Verify(eh => eh.HandleRawMessage(It.IsAny<string>()), Times.Never);
+        }
+
+        [TestMethod]
+        public void OnClientProcessExitShouldSendErrorMessageIfStdErrorOnExit()
+        {
+            this.SetupFakeCommunicationChannel();
+            this.testRequestSender.StartTestRun(this.testRunCriteriaWithSources, this.mockExecutionEventsHandler.Object);
+            this.testRequestSender.OnClientProcessExit("Dummy Stderr");
+
+            this.mockExecutionEventsHandler.Verify(eh => eh.HandleLogMessage(TestMessageLevel.Error, It.Is<string>(s => s.Contains("Dummy Stderr"))), Times.Once);
         }
 
         #region Version Check Tests


### PR DESCRIPTION
## Logging error messages from test host
Stacktrace is available from the test host in some cases(like Access Violation) which were not being printed to the console, 
* Before fix 
```
PS C:\CodeBase\vstest\artifacts\Debug\net451\win7-x64> .\vstest.console.exe c:\CodeBase\MiniDumpTesting\MiniDumpTesting\
bin\Debug\MiniDumpTesting.dll /blame
Microsoft (R) Test Execution Command Line Tool Version 15.9.0-dev
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
Passed   PassingTest1
Passed   PassingTest2
Passed   PassingTest3
Passed   PassingTest4
Passed   PassingTest5
Passed   PassingTest6

Attachments:
  C:\CodeBase\vstest\artifacts\Debug\net451\win7-x64\TestResults\06809535-0280-4717-b33b-39acc80f8fd0\Sequence_238231b468b04b63bab4cea1a1b64b88.xml

Total tests: 6. Passed: 6. Failed: 0. Skipped: 0.
Test Run Successful.
Test execution time: 2.2858 Seconds
```

* After fix
```
PS C:\CodeBase\vstest\artifacts\Debug\net451\win7-x64> .\vstest.console.exe c:\CodeBase\MiniDumpTesting\MiniDumpTesting\
bin\Debug\MiniDumpTesting.dll /blame
Microsoft (R) Test Execution Command Line Tool Version 15.9.0-dev
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
Test host process exited. Standard error: Unhandled Exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
   at MiniDumpTesting.UnitTest1.CauseAV()
   at MiniDumpTesting.UnitTest1.AccessViolationExceptionTestMethod1() in C:\CodeBase\MiniDumpTesting\MiniDumpTesting\UnitTest1.cs:line 268
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions.MethodInfoExtensions.InvokeAsSynchronousTask(MethodInfo methodInfo, Object classInstance, Object[] parameters)
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestMethodInfo.<>c__DisplayClass39_0.<ExecuteInternal>b__0()
   at Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.ThreadOperations.ExecuteWithAbortSafety(Action action)
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestMethodInfo.ExecuteInternal(Object[] arguments)
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestMethodInfo.Invoke(Object[] arguments)
   at Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute.Execute(ITestMethod testMethod)
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestMethodRunner.RunTestMethod()
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestMethodRunner.Execute()
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.UnitTestRunner.RunSingleTest(TestMethod testMethod, IDictionary`2 testRunParameters)
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.UnitTestRunner.RunSingleTest(TestMethod testMethod, IDictionary`2 testRunParameters)
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestExecutionManager.ExecuteTestsWithTestRunner(IEnumerable`1 tests, IRunContext runContext, ITestExecutionRecorder testExecutionRecorder, String source, IDictionary`2 sourceLevelParameters, UnitTestRunner testRunner)
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestExecutionManager.ExecuteTestsInSource(IEnumerable`1 tests, IRunContext runContext, IFrameworkHandle frameworkHandle, String source, Boolean isDeploymentDone)
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestExecutionManager.ExecuteTests(IEnumerable`1 tests, IRunContext runContext, IFrameworkHandle frameworkHandle, Boolean isDeploymentDone)
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestExecutionManager.RunTests(IEnumerable`1 sources, IRunContext runContext, IFrameworkHandle frameworkHandle, TestRunCancellationToken cancellationToken)
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestExecutor.RunTests(IEnumerable`1 sources, IRunContext runContext, IFrameworkHandle frameworkHandle)
   at Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution.RunTestsWithSources.InvokeExecutor(LazyExtension`2 executor, Tuple`2 executorUriExtensionTuple, RunContext runContext, IFrameworkHandle frameworkHandle) in C:\CodeBase\vstest\src\Microsoft.TestPlatform.CrossPlatEngine\Execution\RunTestsWithSources.cs:line 113
   at Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution.BaseRunTests.<>c__DisplayClass45_1.<RunTestInternalWithExecutors>b__0() in C:\CodeBase\vstest\src\Microsoft.TestPlatform.CrossPlatEngine\Execution\BaseRunTests.cs:line 418
   at Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformThread.<>c__DisplayClass0_0.<Run>b__0() in C:\CodeBase\vstest\src\Microsoft.TestPlatform.PlatformAbstractions\net451\System\PlatformThread.cs:line 26
   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.ThreadHelper.ThreadStart()

Passed   PassingTest1
Passed   PassingTest2
Passed   PassingTest3
Passed   PassingTest4
Passed   PassingTest5
Passed   PassingTest6

Attachments:
  C:\CodeBase\vstest\artifacts\Debug\net451\win7-x64\TestResults\bbab10b4-8ba0-454f-9b89-b594d3b1aa91\Sequence_690e9685815743909800a3b83ff88ab7.xml

Total tests: 6. Passed: 6. Failed: 0. Skipped: 0.
Test Run Failed.
Test execution time: 2.3089 Seconds
```

