### PR TITLE
Upgrade VSSDK

### DIFF
--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VSSdkBuildToolsVersion>15.0.26201</VSSdkBuildToolsVersion>
+    <VSSdkBuildToolsVersion>15.8.3247</VSSdkBuildToolsVersion>
 
     <!-- Name of the elements must be in sync with test\Microsoft.TestPlatform.TestUtilities\IntegrationTestBase.cs -->
     <NETTestSdkPreviousVersion>15.5.0</NETTestSdkPreviousVersion>

--- a/src/package/external/external.csproj
+++ b/src/package/external/external.csproj
@@ -81,7 +81,7 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>15.0.26201</Version>
+      <Version>15.8.3247</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Telemetry">


### PR DESCRIPTION
## Description
Upgrading the version of VSSDK Build tools nuget, because the older one is incompatible with the latest VSSDK.

## Related issue
https://github.com/Microsoft/vstest/issues/1760
