### PR TITLE
Allow external use of the TRX Logger

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
     /// </summary>
     [FriendlyName(TrxLoggerConstants.FriendlyName)]
     [ExtensionUri(TrxLoggerConstants.ExtensionUri)]
-    internal class TrxLogger : ITestLoggerWithParameters
+    public class TrxLogger : ITestLoggerWithParameters
     {
         #region Fields
 
@@ -185,7 +185,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
         /// <param name="e">
         /// Event args
         /// </param>
-        public void TestMessageHandler(object sender, TestRunMessageEventArgs e)
+        internal void TestMessageHandler(object sender, TestRunMessageEventArgs e)
         {
             ValidateArg.NotNull<object>(sender, "sender");
             ValidateArg.NotNull<TestRunMessageEventArgs>(e, "e");
@@ -220,7 +220,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
         /// <param name="e">
         /// The eventArgs.
         /// </param>
-        public void TestResultHandler(object sender, ObjectModel.Logging.TestResultEventArgs e)
+        internal void TestResultHandler(object sender, ObjectModel.Logging.TestResultEventArgs e)
         {
             // Create test run
             if (this.testRun == null)
@@ -280,7 +280,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
         /// <param name="e">
         /// Test run complete events arguments.
         /// </param>
-        public void TestRunCompleteHandler(object sender, TestRunCompleteEventArgs e)
+        internal void TestRunCompleteHandler(object sender, TestRunCompleteEventArgs e)
         {
             // Create test run
             // If abort occurs there is no call to TestResultHandler which results in testRun not created.


### PR DESCRIPTION
## Description
Make the TRX Logger public, as described in #1791
Only constructor and initialize methods ara being exposed with this change.

## Related issue
#1791
