### PR TITLE
Add "!~" operator to test filter

### DIFF
--- a/src/Microsoft.TestPlatform.Common/Filtering/Condition.cs
+++ b/src/Microsoft.TestPlatform.Common/Filtering/Condition.cs
@@ -18,6 +18,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Filtering
         Equal,
         NotEqual,
         Contains,
+        NotContains
     }
 
     /// <summary>
@@ -148,6 +149,24 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Filtering
                         }
                     }
                     break;
+
+                case Operation.NotContains:
+                    // all values in multi-valued property should not contain 'this.Value' for NotContains to evaluate true.
+                    result = true;
+
+                    if (null != multiValue)
+                    {
+                        foreach (string propertyValue in multiValue)
+                        {
+                            Debug.Assert(null != propertyValue, "PropertyValue can not be null.");
+                            result = result && propertyValue.IndexOf(Value, StringComparison.OrdinalIgnoreCase) == -1;
+                            if (!result)
+                            {
+                                break;
+                            }
+                        }
+                    }
+                    break;
             }
             return result;
         } 
@@ -251,6 +270,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Filtering
 
                 case "~":
                     return Operation.Contains;
+
+                case "!~":
+                    return Operation.NotContains;
             }
             throw new FormatException(string.Format(CultureInfo.CurrentCulture, CommonResources.TestCaseFilterFormatException, string.Format(CultureInfo.CurrentCulture, CommonResources.InvalidOperator, operationString)));
         }
@@ -327,13 +349,19 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Filtering
                                     yield return tokenBuilder.ToString();
                                     tokenBuilder.Clear();
                                 }
-                                // Determine if this is a "!=" or just a single "!".
+                                // Determine if this is a "!=" or just a single "!" or "!~".
                                 var next = i + 1;
                                 if (next < s.Length && s[next] == '=')
                                 {
                                     i = next;
                                     current = '=';
                                     yield return "!=";
+                                }
+                                else if (next < s.Length && s[next] == '~')
+                                {
+                                    i = next;
+                                    current = '~';
+                                    yield return "!~";
                                 }
                                 else
                                 {

--- a/src/Microsoft.TestPlatform.Common/Filtering/Condition.cs
+++ b/src/Microsoft.TestPlatform.Common/Filtering/Condition.cs
@@ -349,7 +349,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Filtering
                                     yield return tokenBuilder.ToString();
                                     tokenBuilder.Clear();
                                 }
-                                // Determine if this is a "!=" or just a single "!" or "!~".
+                                // Determine if this is a "!=" or "!~" or just a single "!".
                                 var next = i + 1;
                                 if (next < s.Length && s[next] == '=')
                                 {

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/ConditionTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/ConditionTests.cs
@@ -97,6 +97,17 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
         }
 
         [TestMethod]
+        public void ParseShouldHandleEscapedNotTilde()
+        {
+            var conditionString = @"FullyQualifiedName!~TestClass1\(""\!\~""\).TestMethod\(1.5\)";
+
+            Condition condition = Condition.Parse(conditionString);
+            Assert.AreEqual("FullyQualifiedName", condition.Name);
+            Assert.AreEqual(Operation.NotContains, condition.Operation);
+            Assert.AreEqual(@"TestClass1(""!~"").TestMethod(1.5)", condition.Value);
+        }
+
+        [TestMethod]
         public void ParseStringWithSingleUnescapedBangThrowsFormatException1()
         {
 
@@ -183,6 +194,19 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
             Assert.AreEqual("FullyQualifiedName", tokens[0]);
             Assert.AreEqual("~", tokens[1]);
             Assert.AreEqual(@"TestMethod\(""\~""\)", tokens[2]);
+        }
+
+        [TestMethod]
+        public void TokenizeConditionShouldHandleEscapedNotTilde()
+        {
+            var conditionString = @"FullyQualifiedName!~TestMethod\(""\!\~""\)";
+
+            var tokens = Condition.TokenizeFilterConditionString(conditionString).ToArray();
+
+            Assert.AreEqual(3, tokens.Length);
+            Assert.AreEqual("FullyQualifiedName", tokens[0]);
+            Assert.AreEqual("!~", tokens[1]);
+            Assert.AreEqual(@"TestMethod\(""\!\~""\)", tokens[2]);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FastFilterTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FastFilterTests.cs
@@ -42,6 +42,15 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
         }
 
         [TestMethod]
+        public void NotContainsOperationShouldNotCreateFastFilter()
+        {
+            var filterExpressionWrapper = new FilterExpressionWrapper("Name!~TestClass1");
+            var fastFilter = filterExpressionWrapper.fastFilter;
+
+            Assert.IsTrue(fastFilter == null);
+        }
+
+        [TestMethod]
         public void AndOperatorAndEqualsOperationShouldNotCreateFastFilter()
         {
             var filterExpressionWrapper = new FilterExpressionWrapper("Name=Test1&Name=Test2");


### PR DESCRIPTION
## Description
With this pull request I have implemented the !~ (Not Contains) filter functionality. 

## Related issue
This implements the enhancement requested in #1794
I have implemented tests corresponding to the tests that already exist for ~ (Contains) and I have also tested running tests using the filters:
```
Excluding by FQDN
/TestCaseFilter:FullyQualifiedName!~Aaa.bbb
Including by FQDN
/TestCaseFilter:FullyQualifiedName~Aaa.bbb

Excluding by test name
/TestCaseFilter:Name!~ccc
Including by test name
/TestCaseFilter:Name~ccc

```
The expected tests were run in all cases.
