### PR TITLE
[CC]Adding Coverage.Interop.dll dependency for x64 in TPv2

### DIFF
--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -22,7 +22,7 @@
 
     <JsonNetVersion>9.0.1</JsonNetVersion>
     <MoqVersion>4.7.63</MoqVersion>
-    <TestPlatformExternalsVersion>15.9.0-preview-2055449</TestPlatformExternalsVersion>
+    <TestPlatformExternalsVersion>15.9.1-preview-2124990</TestPlatformExternalsVersion>
 
   </PropertyGroup>
 </Project>

--- a/src/package/nuspec/Microsoft.TestPlatform.nuspec
+++ b/src/package/nuspec/Microsoft.TestPlatform.nuspec
@@ -231,6 +231,7 @@
     <file src="net451\$Runtime$\Extensions\Microsoft.VisualStudio.TestTools.DataCollection.MediaRecorder.Model.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestTools.DataCollection.MediaRecorder.Model.dll" />
     <file src="net451\$Runtime$\Extensions\Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorderCollector.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorderCollector.dll" />
     <file src="net451\$Runtime$\Extensions\Microsoft.VisualStudio.TraceDataCollector.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TraceDataCollector.dll" />
+    <file src="net451\$Runtime$\Extensions\Microsoft.VisualStudio.Coverage.Interop.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.Coverage.Interop.dll" />	
     <file src="net451\$Runtime$\Extensions\VideoRecorder\VSTestVideoRecorder.exe"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\VideoRecorder\VSTestVideoRecorder.exe" />
     <file src="net451\$Runtime$\Extensions\Cpp\dbghelp.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Cpp\dbghelp.dll" />
     <file src="net451\$Runtime$\Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.Discoverer.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.Discoverer.dll" />

--- a/src/package/sign/sign.proj
+++ b/src/package/sign/sign.proj
@@ -121,6 +121,7 @@
       <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.ArchitectureTools.PEReader.dll" />
       <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestPlatform.Fakes.dll" />
       <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Microsoft.VisualStudio.TraceDataCollector.dll" />
+      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Microsoft.VisualStudio.Coverage.Interop.dll" />
 
       <!-- CUIT related dlls -->
       <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.Diagnostics.Measurement.dll" />


### PR DESCRIPTION
## Description
Adding Microsoft.VisualStudio.Coverage.Interop.dll dependency in TestPlatform Vsix to work for x64 scenarios.

