### PR TITLE
Fix invalid XML in resource string

### DIFF
--- a/src/Microsoft.TestPlatform.Build/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.Build/Resources/Resources.Designer.cs
@@ -80,7 +80,7 @@ namespace Microsoft.TestPlatform.Build.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Skipping running test for project {0}. To run tests with dotnet test add &quot;&lt;IsTestProject&gt;true&lt;IsTestProject&gt;&quot; property to project file..
+        ///   Looks up a localized string similar to Skipping running test for project {0}. To run tests with dotnet test add &quot;&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;&quot; property to project file..
         /// </summary>
         internal static string NoIsTestProjectProperty {
             get {

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.cs.xlf
@@ -41,8 +41,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoIsTestProjectProperty">
-        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" property to project file.</source>
-        <target state="translated">Spuštění testu pro projekt {0} se přeskočí. Pokud chcete spustit testy s testem dotnet, přidejte do souboru projektu vlastnost &lt;IsTestProject&gt;true&lt;IsTestProject&gt;.</target>
+        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" property to project file.</source>
+        <target state="translated">Spuštění testu pro projekt {0} se přeskočí. Pokud chcete spustit testy s testem dotnet, přidejte do souboru projektu vlastnost &lt;IsTestProject&gt;true&lt;/IsTestProject&gt;.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.de.xlf
@@ -41,8 +41,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoIsTestProjectProperty">
-        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" property to project file.</source>
-        <target state="translated">Die Testausführung für das Projekt "{0}" wird übersprungen. Um Tests mit "dotnet test" auszuführen, fügen Sie der Projektdatei die Eigenschaft "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" hinzu.</target>
+        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" property to project file.</source>
+        <target state="translated">Die Testausführung für das Projekt "{0}" wird übersprungen. Um Tests mit "dotnet test" auszuführen, fügen Sie der Projektdatei die Eigenschaft "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" hinzu.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.es.xlf
@@ -41,8 +41,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoIsTestProjectProperty">
-        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" property to project file.</source>
-        <target state="translated">Omitiendo la ejecución de la prueba para el proyecto {0}. Para ejecutar pruebas con la prueba dotnet, agregue la propiedad "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" al archivo de proyecto.</target>
+        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" property to project file.</source>
+        <target state="translated">Omitiendo la ejecución de la prueba para el proyecto {0}. Para ejecutar pruebas con la prueba dotnet, agregue la propiedad "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" al archivo de proyecto.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.fr.xlf
@@ -41,8 +41,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoIsTestProjectProperty">
-        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" property to project file.</source>
-        <target state="translated">L’exécution du test pour le projet {0} est ignorée. Pour exécuter les tests avec dotnet test, ajoutez la propriété "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" au fichier projet.</target>
+        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" property to project file.</source>
+        <target state="translated">L’exécution du test pour le projet {0} est ignorée. Pour exécuter les tests avec dotnet test, ajoutez la propriété "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" au fichier projet.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.it.xlf
@@ -41,8 +41,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoIsTestProjectProperty">
-        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" property to project file.</source>
-        <target state="translated">L'esecuzione del test per il progetto {0} verrà ignorata. Per eseguire test con dotnet, aggiungere la proprietà "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" al file di progetto.</target>
+        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" property to project file.</source>
+        <target state="translated">L'esecuzione del test per il progetto {0} verrà ignorata. Per eseguire test con dotnet, aggiungere la proprietà "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" al file di progetto.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ja.xlf
@@ -41,8 +41,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoIsTestProjectProperty">
-        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" property to project file.</source>
-        <target state="translated">プロジェクト {0} のテストの実行をスキップしています。dotnet test を使用してテストを実行するには、プロジェクト ファイルに "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" プロパティを追加します。</target>
+        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" property to project file.</source>
+        <target state="translated">プロジェクト {0} のテストの実行をスキップしています。dotnet test を使用してテストを実行するには、プロジェクト ファイルに "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" プロパティを追加します。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ko.xlf
@@ -41,8 +41,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoIsTestProjectProperty">
-        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" property to project file.</source>
-        <target state="translated">프로젝트 {0}의 테스트 실행을 건너뜁니다. dotnet test로 테스트를 실행하려면 "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" 속성을 프로젝트 파일에 추가하세요.</target>
+        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" property to project file.</source>
+        <target state="translated">프로젝트 {0}의 테스트 실행을 건너뜁니다. dotnet test로 테스트를 실행하려면 "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" 속성을 프로젝트 파일에 추가하세요.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.pl.xlf
@@ -41,8 +41,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoIsTestProjectProperty">
-        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" property to project file.</source>
-        <target state="translated">Pomijanie uruchamiania testu dla projektu {0}. Aby uruchomić testy za pomocą polecenia dotnet test, dodaj właściwość „&lt;IsTestProject&gt;true&lt;IsTestProject&gt;” do pliku projektu.</target>
+        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" property to project file.</source>
+        <target state="translated">Pomijanie uruchamiania testu dla projektu {0}. Aby uruchomić testy za pomocą polecenia dotnet test, dodaj właściwość „&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;” do pliku projektu.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.pt-BR.xlf
@@ -41,8 +41,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoIsTestProjectProperty">
-        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" property to project file.</source>
-        <target state="translated">Ignorando a execução de teste do projeto {0}. Para executar testes com dotnet test, adicione a propriedade "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" ao arquivo de projeto.</target>
+        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" property to project file.</source>
+        <target state="translated">Ignorando a execução de teste do projeto {0}. Para executar testes com dotnet test, adicione a propriedade "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" ao arquivo de projeto.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ru.xlf
@@ -41,8 +41,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoIsTestProjectProperty">
-        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" property to project file.</source>
-        <target state="translated">Пропуск выполнения теста для проекта {0}. Чтобы выполнить тесты с тестом dotnet, добавьте свойство "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" в файл проекта.</target>
+        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" property to project file.</source>
+        <target state="translated">Пропуск выполнения теста для проекта {0}. Чтобы выполнить тесты с тестом dotnet, добавьте свойство "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" в файл проекта.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.tr.xlf
@@ -41,8 +41,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoIsTestProjectProperty">
-        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" property to project file.</source>
-        <target state="translated">{0} projesi için test çalıştırması atlanıyor. Dotnet test ile testleri çalıştırmak için proje dosyasına "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" özelliğini ekleyin.</target>
+        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" property to project file.</source>
+        <target state="translated">{0} projesi için test çalıştırması atlanıyor. Dotnet test ile testleri çalıştırmak için proje dosyasına "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" özelliğini ekleyin.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.xlf
@@ -23,8 +23,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="NoIsTestProjectProperty">
-        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" property to project file.</source>
-        <target state="new">Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" property to project file.</target>
+        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" property to project file.</source>
+        <target state="new">Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" property to project file.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.zh-Hans.xlf
@@ -41,8 +41,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoIsTestProjectProperty">
-        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" property to project file.</source>
-        <target state="translated">不对项目 {0} 运行测试。要运行带 dotnet 测试的测试，请向项目文件添加 "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;"。</target>
+        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" property to project file.</source>
+        <target state="translated">不对项目 {0} 运行测试。要运行带 dotnet 测试的测试，请向项目文件添加 "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;"。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.zh-Hant.xlf
@@ -41,8 +41,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoIsTestProjectProperty">
-        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" property to project file.</source>
-        <target state="translated">即將跳過為專案 {0} 執行測試。若要使用 dotnet 測試來執行測試，請在專案檔中新增 "&lt;IsTestProject&gt;true&lt;IsTestProject&gt;" 屬性。</target>
+        <source>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" property to project file.</source>
+        <target state="translated">即將跳過為專案 {0} 執行測試。若要使用 dotnet 測試來執行測試，請在專案檔中新增 "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" 屬性。</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
When the `NoIsTestProjectProperty` resource string is displayed, the XML shown is not valid XML for copying and pasting into a project file. This fixes that by adding the missing `/` from the second tag.

Looks like this was partially fixed in #1839 but missed from #1821.