### PR TITLE
Stop trying to connect if the test host exits unexpectedly 

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -146,9 +146,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 EqtTrace.Verbose("TestRequestSender.WaitForRequestHandlerConnection: waiting for connection with timeout: {0}", connectionTimeout);
             }
 
-            var waitIndex = WaitHandle.WaitAny(new WaitHandle[] { this.connected.WaitHandle, cancellationToken.WaitHandle }, connectionTimeout);
+            // Wait until either connection is successful, handled by connected.WaitHandle
+            // or operation is cancelled, handled by cancellationToken.WaitHandle
+            // or testhost exits unexpectedly, handled by clientExited.WaitHandle
+            var waitIndex = WaitHandle.WaitAny(new WaitHandle[] { this.connected.WaitHandle, cancellationToken.WaitHandle, this.clientExited.WaitHandle }, connectionTimeout);
 
-            // Return true if wait is because of waitHandle.
+            // Return true if connection was successful.
             return waitIndex == 0;
         }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -155,7 +155,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                     connTimeout *= 5;
                 }
 
-                // Wait for a timeout for the client to connect.
+                // If TestHost does not launch then throw exception
+                // If Testhost launches, wait for connection.
                 if (!this.testHostLaunched ||
                     !this.RequestSender.WaitForRequestHandlerConnection(connTimeout * 1000, this.CancellationTokenSource.Token))
                 {
@@ -302,9 +303,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             this.testHostProcessStdError = e.Data;
             this.RequestSender.OnClientProcessExit(this.testHostProcessStdError);
 
-            // Invoke cancel on the cancellation token. this is required if the testhost exits unexpectedly
-            // Cancel the current request, and stop trying to connect in SetupChannel.
-            this.CancellationTokenSource.Cancel();
             this.testHostExited.Set();
         }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -300,9 +300,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         private void TestHostManagerHostExited(object sender, HostProviderEventArgs e)
         {
             this.testHostProcessStdError = e.Data;
-
             this.RequestSender.OnClientProcessExit(this.testHostProcessStdError);
 
+            // Invoke cancel on the cancellation token. this is required if the testhost exits unexpectedly
+            // Cancel the current request, and stop trying to connect in SetupChannel.
+            this.CancellationTokenSource.Cancel();
             this.testHostExited.Set();
         }
 

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
@@ -98,14 +98,33 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
         }
 
         [TestMethod]
-        public void WaitForRequestHandlerConnectionWithInfiniteTimeoutShouldReturnImmediatelyWhenCancellationRequested()
+        public void WaitForRequestHandlerConnectionWithTimeoutShouldReturnImmediatelyWhenCancellationRequested()
         {
             var cancellationTokenSource = new CancellationTokenSource();
             cancellationTokenSource.Cancel();
 
-            var connected = this.testRequestSender.WaitForRequestHandlerConnection(-1, cancellationTokenSource.Token);
+            var connectionTimeout = 5000;
+            var watch = System.Diagnostics.Stopwatch.StartNew();
+            var connected = this.testRequestSender.WaitForRequestHandlerConnection(connectionTimeout, cancellationTokenSource.Token);
+            watch.Stop();
 
             Assert.IsFalse(connected);
+            Assert.IsTrue(watch.ElapsedMilliseconds < connectionTimeout);
+        }
+
+        [TestMethod]
+        public void WaitForRequestHandlerConnectionWithTimeoutShouldReturnImmediatelyIfHostExitedUnexpectedly()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+            this.testRequestSender.OnClientProcessExit("DummyError");
+
+            var connectionTimeout = 5000;
+            var watch = System.Diagnostics.Stopwatch.StartNew();
+            var connected = this.testRequestSender.WaitForRequestHandlerConnection(connectionTimeout, cancellationTokenSource.Token);
+            watch.Stop();
+
+            Assert.IsFalse(connected);
+            Assert.IsTrue(watch.ElapsedMilliseconds < connectionTimeout);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
@@ -285,13 +285,13 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
 
         [TestMethod]
-        public void SetupChannelShouldThrowTestPlatformExceptionIfHostExitsPostLaunchDuringWaitForHandlerConnection()
+        public void SetupChannelShouldThrowTestPlatformExceptionIfRequestCancelledPostHostLaunchDuringWaitForHandlerConnection()
         {
             SetupTestHostLaunched(true);
             this.mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(this.connectionTimeout, It.IsAny<CancellationToken>())).Returns(false);
 
             var cancellationTokenSource = new CancellationTokenSource();
-            this.mockTestHostManager.Setup(rs => rs.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>())).Callback(() => this.mockTestHostManager.Raise(x => x.HostExited += null, new HostProviderEventArgs("")));
+            this.mockTestHostManager.Setup(rs => rs.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>())).Callback(() => cancellationTokenSource.Cancel());
 
             var operationManager = new TestableProxyOperationManager(this.mockRequestData.Object, this.mockRequestSender.Object, this.mockTestHostManager.Object, cancellationTokenSource);
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
@@ -283,19 +283,6 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
             StringAssert.Equals("Cancelling the operation as requested.", message);
         }
 
-        [TestMethod]
-        public void SetupChannelShouldThrowTestPlatformExceptionIfRequestCancelledPostHostLaunchDuringWaitForHandlerConnection()
-        {
-            SetupTestHostLaunched(true);
-            this.mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(this.connectionTimeout, It.IsAny<CancellationToken>())).Returns(false);
-
-            var cancellationTokenSource = new CancellationTokenSource();
-            this.mockTestHostManager.Setup(rs => rs.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>())).Callback(() => cancellationTokenSource.Cancel());
-            var operationManager = new TestableProxyOperationManager(this.mockRequestData.Object, this.mockRequestSender.Object, this.mockTestHostManager.Object, cancellationTokenSource);
-
-            var message = Assert.ThrowsException<TestPlatformException>(() => operationManager.SetupChannel(Enumerable.Empty<string>())).Message;
-            StringAssert.Equals("Cancelling the operation as requested.", message);
-        }
 
         [TestMethod]
         public void SetupChannelShouldThrowTestPlatformExceptionIfHostExitsPostLaunchDuringWaitForHandlerConnection()

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
@@ -283,7 +283,6 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
             StringAssert.Equals("Cancelling the operation as requested.", message);
         }
 
-
         [TestMethod]
         public void SetupChannelShouldThrowTestPlatformExceptionIfRequestCancelledPostHostLaunchDuringWaitForHandlerConnection()
         {
@@ -292,7 +291,6 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
 
             var cancellationTokenSource = new CancellationTokenSource();
             this.mockTestHostManager.Setup(rs => rs.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>())).Callback(() => cancellationTokenSource.Cancel());
-
             var operationManager = new TestableProxyOperationManager(this.mockRequestData.Object, this.mockRequestSender.Object, this.mockTestHostManager.Object, cancellationTokenSource);
 
             var message = Assert.ThrowsException<TestPlatformException>(() => operationManager.SetupChannel(Enumerable.Empty<string>())).Message;


### PR DESCRIPTION
Taking into consideration host launch failures while waiting to setup connection, so we bail out sooner.

## Related issue
#1689
