### PR TITLE
Move warning into a target to fix msbuild error

### DIFF
--- a/src/package/nuspec/netcoreapp/Microsoft.NET.Test.Sdk.targets
+++ b/src/package/nuspec/netcoreapp/Microsoft.NET.Test.Sdk.targets
@@ -10,7 +10,7 @@
  ***********************************************************************************************
 -->
 
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project InitialTargets="GenerateProgramFile" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
@@ -24,26 +24,31 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
-  <!--
-     ============================================================
-     GenerateProgramFile
-     Generates Program file which contains the Main entry point
-     ============================================================
-  -->
   <PropertyGroup>
     <GeneratedProgramFile Condition="'$(GeneratedProgramFile)' == ''">$(MSBuildThisFileDirectory)Microsoft.NET.Test.Sdk.Program$(DefaultLanguageSourceExtension)</GeneratedProgramFile>
     <GenerateProgramFile Condition="'$(GenerateProgramFile)' == ''">true</GenerateProgramFile>
   </PropertyGroup>
 
-  <ItemGroup Condition="('$(GenerateProgramFile)' == 'true') and ('$(Language)' == 'VB' or '$(Language)' == 'C#')">
-    <Compile Include="$(GeneratedProgramFile)"/>
-  </ItemGroup>
+  <!--
+    ============================================================
+    GenerateProgramFile
+    Generates Program file which contains the Main entry point
+    ============================================================
+  -->
+  <Target Name="GenerateProgramFile"
+          Condition="'$(GenerateProgramFile)' == 'true'">
 
-  <ItemGroup Condition="'$(GenerateProgramFile)' == 'true' and '$(Language)' == 'F#'">
-    <ProgramCompiles Include="@(Compile)" Condition="'%(Identity)' == 'Program.fs'" />
-    <CompileAfter Include="$(GeneratedProgramFile)" Condition="@(ProgramCompiles-&gt;Count()) == 0" />
-  </ItemGroup>
+    <ItemGroup Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'">
+      <Compile Include="$(GeneratedProgramFile)"/>
+    </ItemGroup>
 
-  <Warning Condition="@(ProgramCompiles-&gt;Count()) != 0" Text="A 'Program.fs' file can be automatically generated for F# .NET Core test projects. To fix this warning, either delete the file from the project, or set the &lt;GenerateProgramFile&gt; property to 'false'." />
+    <ItemGroup Condition="'$(Language)' == 'F#'">
+      <ProgramCompiles Include="@(Compile)" Condition="'%(Identity)' == 'Program.fs'" />
+      <CompileAfter Include="$(GeneratedProgramFile)" Condition="@(ProgramCompiles-&gt;Count()) == 0" />
+    </ItemGroup>
+
+    <Warning Condition="@(ProgramCompiles-&gt;Count()) != 0" Text="A 'Program.fs' file can be automatically generated for F# .NET Core test projects. To fix this warning, either delete the file from the project, or set the &lt;GenerateProgramFile&gt; property to 'false'." />
+
+  </Target>
 
 </Project>


### PR DESCRIPTION
Fixes msbuild error `The <Warning> tag is no longer supported as a
child of the <Project> element`.

Currently the Microsoft.Net.Test.Sdk nuget package can't be used with new msbuild versions as it throws if a Warning tag appears as a child of the Project element.. Found a related issue that talks about the change: https://github.com/Microsoft/msbuild/issues/3858. This issue already existed before my recent changes.

As the current package (https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.0.0-preview-20181128-01) is broken can we please publish a new one asap?

cc @singhsarab @mayankbansal018 @karanjitsingh 