### PR TITLE
Downgrade Microsoft.NET.Test.Sdk to net40 and fix casing of msbuild files

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -566,13 +566,13 @@ function Create-NugetPackages
                      "TestPlatform.CLI.nuspec",
                      "TestPlatform.Build.nuspec",
                      "TestPlatform.Extensions.TrxLogger.nuspec", 
-                     "Microsoft.Net.Test.Sdk.nuspec",
+                     "Microsoft.NET.Test.Sdk.nuspec",
                      "Microsoft.TestPlatform.nuspec",
                      "Microsoft.TestPlatform.Portable.nuspec",
                      "Microsoft.CodeCoverage.nuspec")
 
     $targetFiles = @("Microsoft.CodeCoverage.targets")
-    $propFiles = @("Microsoft.Net.Test.Sdk.props", "Microsoft.CodeCoverage.props")
+    $propFiles = @("Microsoft.NET.Test.Sdk.props", "Microsoft.CodeCoverage.props")
     $contentDirs = @("netcoreapp", "netfx")
 
     # Nuget pack analysis emits warnings if binaries are packaged as content. It is intentional for the below packages.

--- a/src/package/nuspec/Microsoft.NET.Test.Sdk.nuspec
+++ b/src/package/nuspec/Microsoft.NET.Test.Sdk.nuspec
@@ -34,11 +34,11 @@
   </metadata>
   <files>
     <file src="netcoreapp\*" target="build\netcoreapp1.0\" />
-    <file src="netfx\*" target="build\net45\" />
+    <file src="netfx\*" target="build\net40\" />
 
     <file src="Microsoft.NET.Test.Sdk.props" target="buildMultiTargeting\" />
     <file src="Microsoft.NET.Test.Sdk.props" target="build\netcoreapp1.0\" />
-    <file src="Microsoft.NET.Test.Sdk.props" target="build\net45\" />
+    <file src="Microsoft.NET.Test.Sdk.props" target="build\net40\" />
     <file src="Microsoft.NET.Test.Sdk.props" target="build\uap10.0\" />
 
   </files>


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vstest/issues/1850
Fixes https://github.com/Microsoft/vstest/issues/1863

There is still the dependency to `Microsoft.CodeCoverage` with net45 but a downgrade isn't possible here as `Microsoft.CodeCoverage` builds on netstandard1.0 which isn't supported with net40.

```
<group targetFramework="net45">
        <!-- TestHost gets shipped with vstest.console -->
        <dependency id="Microsoft.CodeCoverage" version="$Version$" />
      </group>
    </dependencies>
```