### PR TITLE
Catch socket exceptions

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TcpClientExtensions.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TcpClientExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             catch (SocketException socketException)
             {
                 EqtTrace.Error(
-                        "Failed to access the endpoint due to socket error: {0}",
+                        "TcpClientExtensions.MessageLoopAsync: Failed to access the endpoint due to socket error: {0}",
                         socketException);
             }
 

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TcpClientExtensions.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TcpClientExtensions.cs
@@ -30,13 +30,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             var localEndPoint = string.Empty;
             try
             {
-                remoteEndPoint = client.Client.RemoteEndPoint.ToString();
-                localEndPoint = client.Client.LocalEndPoint.ToString();
+                remoteEndPoint = client.Client.RemoteEndPoint?.ToString();
+                localEndPoint = client.Client.LocalEndPoint?.ToString();
             }
             catch (SocketException socketException)
             {
                 EqtTrace.Error(
-                        "TcpClientExtensions.MessageLoopAsync: failed to access endpoint of the socket {0}",
+                        "Failed to access the endpoint due to socket error: {0}",
                         socketException);
             }
 

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TcpClientExtensions.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TcpClientExtensions.cs
@@ -25,8 +25,20 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 CancellationToken cancellationToken)
         {
             Exception error = null;
-            var remoteEndPoint = client.Client.RemoteEndPoint?.ToString();
-            var localEndPoint = client.Client.LocalEndPoint?.ToString();
+
+            var remoteEndPoint = string.Empty;
+            var localEndPoint = string.Empty;
+            try
+            {
+                remoteEndPoint = client.Client.RemoteEndPoint.ToString();
+                localEndPoint = client.Client.LocalEndPoint.ToString();
+            }
+            catch (SocketException socketException)
+            {
+                EqtTrace.Error(
+                        "TcpClientExtensions.MessageLoopAsync: failed to access endpoint of the socket {0}",
+                        socketException);
+            }
 
             // Set read timeout to avoid blocking receive raw message
             while (channel != null && !cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
## Description
When to access the endpoint , it may throw exceptions, according to [msdn](https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.socket.remoteendpoint?view=netframework-4.7.2#remarks). 
It indeed happened in my windows 10 machine, so it is better to catch it.

## Related issue
##1607 Failed to negotiate protocol. Wait for response timeout