### PR TITLE
Do not show skip message always

### DIFF
--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
@@ -52,7 +52,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     />
   </Target>
 
-  <Target Name="ShowInfoMessageIfProjectHasNoIsTestProjectProperty" Condition="'$(IsTestProject)' != 'true'">
+  <Target Name="ShowInfoMessageIfProjectHasNoIsTestProjectProperty" Condition="'$(IsTestProject)' == ''">
     <Microsoft.TestPlatform.Build.Tasks.VSTestLogsTask LogType="NoIsTestProjectProperty" ProjectFilePath="$(MSBuildProjectFullPath)" />
   </Target>
 


### PR DESCRIPTION
Show skip message only when the IsTestProject is not defined

Fixes #1866
