### PR TITLE
Expand environment variables in codeBase before loading InProcDataCollector extension

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/InProcDataCollector.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/InProcDataCollector.cs
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
             Assembly assembly = null;
             try
             {
-                assembly = this.assemblyLoadContext.LoadAssemblyFromPath(codeBase);
+                assembly = this.assemblyLoadContext.LoadAssemblyFromPath(Environment.ExpandEnvironmentVariables(codeBase));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Description
Allow users to use environment variables in the `codeBase` field for `InProcDataCollector` definitions in .runsettings files.