### PR TITLE
Fix - dotnet test on a multi-target projects logs only the last target

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestRun.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestRun.cs
@@ -191,7 +191,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         {
             // We use custom format string to make sure that runs are sorted in the same way on all intl machines.
             // This is both for directory names and for Data Warehouse.
-            return timeStamp.ToString("yyyy-MM-dd HH:mm:ss", DateTimeFormatInfo.InvariantInfo);
+            return timeStamp.ToString("yyyy-MM-dd HH:mm:ss:fff", DateTimeFormatInfo.InvariantInfo);
         }
 
         private void Initialize()

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -441,17 +441,13 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
 
         private void DeriveTrxFilePath()
         {
-            if (this.parametersDictionary != null)
+            if (this.parametersDictionary != null &&
+                this.parametersDictionary.TryGetValue(TrxLoggerConstants.LogFileNameKey, out string logFileNameValue) &&
+                !string.IsNullOrWhiteSpace(logFileNameValue))
             {
-                var isLogFileNameParameterExists = this.parametersDictionary.TryGetValue(TrxLoggerConstants.LogFileNameKey, out string logFileNameValue);
-                if (isLogFileNameParameterExists && !string.IsNullOrWhiteSpace(logFileNameValue))
-                {
-                    this.trxFilePath = Path.Combine(this.testResultsDirPath, logFileNameValue);
-                }
-                else
-                {
-                    this.SetDefaultTrxFilePath();
-                }
+                string logFileNameWithoutExt = Path.GetFileNameWithoutExtension(logFileNameValue);
+                logFileNameValue = logFileNameValue.Replace(logFileNameWithoutExt, logFileNameWithoutExt + DateTime.Now.ToString("_yyyy-MM-dd_HH-mm-ss-fff", DateTimeFormatInfo.InvariantInfo));
+                this.trxFilePath = Path.Combine(this.testResultsDirPath, logFileNameValue);
             }
             else
             {

--- a/test/Microsoft.TestPlatform.AcceptanceTests/LoggerTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/LoggerTests.cs
@@ -8,6 +8,7 @@ using System.Xml;
 namespace Microsoft.TestPlatform.AcceptanceTests
 {
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System.Linq;
 
     [TestClass]
     public class LoggerTests : AcceptanceTestBase
@@ -20,6 +21,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
             var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
             var trxFileName = "TestResults.trx";
+            var trxFileNamePattern = "TestResults*.trx";
             arguments = string.Concat(arguments, $" /logger:\"trx;LogFileName={trxFileName}\"");
             this.InvokeVsTest(arguments);
 
@@ -28,7 +30,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             arguments = string.Concat(arguments, " /testcasefilter:Name~Pass");
             this.InvokeVsTest(arguments);
 
-            var trxLogFilePath = Path.Combine(Directory.GetCurrentDirectory(), "TestResults",  trxFileName);
+            var trxLogFilePath = Directory.EnumerateFiles(Path.Combine(Directory.GetCurrentDirectory(), "TestResults"), trxFileNamePattern).First();
             Assert.IsTrue(IsValidXml(trxLogFilePath), "Invalid content in Trx log file");
         }
 
@@ -40,6 +42,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
             var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
             var trxFileName = "TestResults.trx";
+            var trxFileNamePattern = "TestResults*.trx";
             arguments = string.Concat(arguments, $" /logger:\"logger://Microsoft/TestPlatform/TrxLogger/v1;LogFileName{trxFileName}\"");
             this.InvokeVsTest(arguments);
 
@@ -48,7 +51,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             arguments = string.Concat(arguments, " /testcasefilter:Name~Pass");
             this.InvokeVsTest(arguments);
 
-            var trxLogFilePath = Path.Combine(Directory.GetCurrentDirectory(), "TestResults", trxFileName);
+            var trxLogFilePath = Directory.EnumerateFiles(Path.Combine(Directory.GetCurrentDirectory(), "TestResults"), trxFileNamePattern).First();
             Assert.IsTrue(IsValidXml(trxLogFilePath), "Invalid content in Trx log file");
         }
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/ResultsDirectoryTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/ResultsDirectoryTests.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.TestPlatform.AcceptanceTests
 {
     using System.IO;
+    using System.Linq;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -16,18 +17,22 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
             var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
-            var trxFileName = "TestResults.trx";
+            var trxFileName = "TestResultsbla.trx";
+            var trxFileNamePattern = "TestResultsbla*.trx";
             var resultsDir = Path.GetTempPath();
-            var trxFilePath = Path.Combine(resultsDir, trxFileName);
             arguments = string.Concat(arguments, $" /logger:\"trx;LogFileName={trxFileName}\"");
             arguments = string.Concat(arguments, $" /ResultsDirectory:{resultsDir}");
 
             // Delete if already exists
-            File.Delete(trxFilePath);
+            var dir = new DirectoryInfo(resultsDir);
+            foreach (var file in dir.EnumerateFiles(trxFileNamePattern))
+            {
+                file.Delete();
+            }
 
             this.InvokeVsTest(arguments);
 
-            Assert.IsTrue(File.Exists(trxFilePath), $"Expected Trx file: {trxFilePath} not created in results directory");
+            Assert.IsTrue(Directory.EnumerateFiles(resultsDir, trxFileNamePattern).Any(), $"Expected Trx file with pattern: {trxFileNamePattern} not created in results directory");
         }
 
         [TestMethod]
@@ -39,10 +44,10 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
             var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
             var trxFileName = "TestResults.trx";
+            var trxFileNamePattern = "TestResults*.trx";
             var relativeDirectory = @"relative\directory";
             var resultsDirectory = Path.Combine(Directory.GetCurrentDirectory(), relativeDirectory);
 
-            var trxFilePath = Path.Combine(resultsDirectory , trxFileName);
             arguments = string.Concat(arguments, $" /logger:\"trx;LogFileName={trxFileName}\"");
             arguments = string.Concat(arguments, $" /ResultsDirectory:{relativeDirectory}");
 
@@ -53,7 +58,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
             this.InvokeVsTest(arguments);
 
-            Assert.IsTrue(File.Exists(trxFilePath), $"Expected Trx file: {trxFilePath} not created in results directory");
+            Assert.IsTrue(Directory.EnumerateFiles(resultsDirectory, trxFileNamePattern).Any(), $"Expected Trx file with pattern: { trxFileNamePattern} not created in results directory");
         }
     }
 }

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -637,7 +637,12 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
         {
             this.MakeTestRunComplete();
 
-            Assert.AreEqual(Path.Combine(TrxLoggerTests.DefaultTestRunDirectory, TrxLoggerTests.DefaultLogFileNameParameterValue), this.testableTrxLogger.trxFile, "Wrong Trx file name");
+            string expectedFileNameWithoutTimestamp = Path.Combine(TrxLoggerTests.DefaultTestRunDirectory, TrxLoggerTests.DefaultLogFileNameParameterValue);
+            string fileName = Path.GetFileNameWithoutExtension(this.testableTrxLogger.trxFile);
+            string actualFileNameWithoutTimestamp = this.testableTrxLogger.trxFile.Replace(fileName, fileName.Split('_')[0]);
+
+            Assert.AreNotEqual(expectedFileNameWithoutTimestamp, this.testableTrxLogger.trxFile, "Expected time stamp to appear in file name");
+            Assert.AreEqual(expectedFileNameWithoutTimestamp, actualFileNameWithoutTimestamp, "Trx file name should construct from log file parameter");
         }
 
         /// <summary>


### PR DESCRIPTION
## Related issue
https://github.com/Microsoft/vstest/issues/1603

## Description
Timestamp is appended to trx filename with millisecond precision. Thus for multi-target projects, trx for both targets will be stored.

Example: `dotnet test testproject.csproj --logger:"trx;logFileName=E:\results.trx"` will save trx file `E:\results_2018-12-24_14-01-07-176.trx` where `2018-12-24_14-01-07-176` is the timestamp.