### PR TITLE
Reduced system.runtime.interopservices version dependency

### DIFF
--- a/src/package/nuspec/TestPlatform.ObjectModel.nuspec
+++ b/src/package/nuspec/TestPlatform.ObjectModel.nuspec
@@ -15,7 +15,7 @@
     <tags>vstest visual-studio unittest testplatform mstest microsoft test testing</tags>
     <dependencies>
       <group targetFramework="net451">
-        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="[4.3.0, )" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="[4.1.0, )" />
         <dependency id="System.Reflection.Metadata" version="[1.3.0, )" />
       </group>
       <group targetFramework="netstandard1.5">


### PR DESCRIPTION
## Description
Reduced system.runtime.interopservices version dependency in the nuspec file

## Related issue
https://github.com/Microsoft/vstest/issues/1764
