### PR TITLE
use log in VSTestLogsTask

### DIFF
--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestLogsTask.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestLogsTask.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.TestPlatform.Build.Tasks
 {
     using System;
+    using Microsoft.Build.Framework;
     using Microsoft.Build.Utilities;
     using Microsoft.TestPlatform.Build.Resources;
 
@@ -25,16 +26,15 @@ namespace Microsoft.TestPlatform.Build.Tasks
         {
             if (string.Equals(LogType, "BuildStarted", StringComparison.OrdinalIgnoreCase))
             {
-                Console.WriteLine(Resources.BuildStarted);
+                Log.LogMessage(MessageImportance.Normal, Resources.BuildStarted);
             }
             else if (string.Equals(LogType, "BuildCompleted", StringComparison.OrdinalIgnoreCase))
             {
-                Console.WriteLine(Resources.BuildCompleted);
-                Console.WriteLine();
+                Log.LogMessage(MessageImportance.Normal, Resources.BuildCompleted + Environment.NewLine);
             }
             else if (string.Equals(LogType, "NoIsTestProjectProperty", StringComparison.OrdinalIgnoreCase))
             {
-                Console.WriteLine(Resources.NoIsTestProjectProperty, ProjectFilePath);
+                Log.LogMessage(MessageImportance.Low, Resources.NoIsTestProjectProperty);
             }
             else
             {


### PR DESCRIPTION
## Description

See https://github.com/Microsoft/vstest/pull/1867/files#r240614971

Before this change, messages for build start/completion, and a missing `IsTestProject` property, are printed to the console only, and regardless of the current verbosity level.

After this change, these messages are printed to all configured loggers, with the build start/completion messages only at normal verbosity or higher, and the `IsTestProject` property message at detailed verbosity or higher.

## Related issue
