### PR TITLE
Bug Fix running NETFramework 3.5 in compat mode

### DIFF
--- a/src/vstest.console/Resources/Resources.Designer.cs
+++ b/src/vstest.console/Resources/Resources.Designer.cs
@@ -658,7 +658,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode"..
+        ///   Looks up a localized string similar to Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in &quot;compatibility mode&quot;..
         /// </summary>
         public static string Framework35NotSupported
         {

--- a/src/vstest.console/Resources/Resources.Designer.cs
+++ b/src/vstest.console/Resources/Resources.Designer.cs
@@ -658,7 +658,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in &quot;compatibility mode&quot;..
+        ///  Looks up a localized string similar to Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 &quot;compatibility mode&quot;..
         /// </summary>
         public static string Framework35NotSupported
         {

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -277,7 +277,7 @@
     <value>'{0}' not found.</value>
   </data>
   <data name="Framework35NotSupported" xml:space="preserve">
-    <value>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</value>
+    <value>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</value>
   </data>
   <data name="FrameworkArgumentHelp" xml:space="preserve">
     <value>--Framework|/Framework:&lt;Framework Version&gt;

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -277,7 +277,7 @@
     <value>'{0}' not found.</value>
   </data>
   <data name="Framework35NotSupported" xml:space="preserve">
-    <value>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</value>
+    <value>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</value>
   </data>
   <data name="FrameworkArgumentHelp" xml:space="preserve">
     <value>--Framework|/Framework:&lt;Framework Version&gt;

--- a/src/vstest.console/Resources/xlf/Resources.cs.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.cs.xlf
@@ -1633,9 +1633,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
-        <target state="translated">Zadání Framework35 není podporováno. U projektů mířících na .Net Framework 3.5 prosím použijte Framework40, aby testy v CLR 4.0 běžely v režimu kompatibility.</target>
-        <note />
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <target state="new">Zadání Framework35 není podporováno. U projektů mířících na .Net Framework 3.5 prosím použijte Framework40, aby testy v CLR 4.0 běžely v režimu kompatibility.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.cs.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.cs.xlf
@@ -1633,7 +1633,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="new">Zadání Framework35 není podporováno. U projektů mířících na .Net Framework 3.5 prosím použijte Framework40, aby testy v CLR 4.0 běžely v režimu kompatibility.</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.de.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.de.xlf
@@ -1633,7 +1633,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 wird nicht unterstützt. Verwenden Sie für Projekte, die auf .Net Framework 3.5 ausgerichtet sind, Framework40 zum Ausführen von Tests im "Kompatibilitätsmodus" von CLR 4.0.</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.de.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.de.xlf
@@ -1633,9 +1633,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
-        <target state="translated">Framework35 wird nicht unterstützt. Verwenden Sie für Projekte, die auf .Net Framework 3.5 ausgerichtet sind, Framework40 zum Ausführen von Tests im "Kompatibilitätsmodus" von CLR 4.0.</target>
-        <note />
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <target state="new">Framework35 wird nicht unterstützt. Verwenden Sie für Projekte, die auf .Net Framework 3.5 ausgerichtet sind, Framework40 zum Ausführen von Tests im "Kompatibilitätsmodus" von CLR 4.0.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.es.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.es.xlf
@@ -1638,9 +1638,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
-        <target state="translated">No se admite Framework35. Para proyectos con destino .Net Framework 3.5, use Framework40 para ejecutar las pruebas en "modo de compatibilidad" de CLR 4.0.</target>
-        <note />
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <target state="new">No se admite Framework35. Para proyectos con destino .Net Framework 3.5, use Framework40 para ejecutar las pruebas en "modo de compatibilidad" de CLR 4.0.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.es.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.es.xlf
@@ -1638,7 +1638,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="new">No se admite Framework35. Para proyectos con destino .Net Framework 3.5, use Framework40 para ejecutar las pruebas en "modo de compatibilidad" de CLR 4.0.</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.fr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.fr.xlf
@@ -1633,7 +1633,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 n'est pas pris en charge. Pour les projets ciblant .Net Framework 3.5, utilisez Framework40 pour exécuter les tests dans CLR 4.0 en "mode compatibilité".</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.fr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.fr.xlf
@@ -1633,9 +1633,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
-        <target state="translated">Framework35 n'est pas pris en charge. Pour les projets ciblant .Net Framework 3.5, utilisez Framework40 pour exécuter les tests dans CLR 4.0 en "mode compatibilité".</target>
-        <note />
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <target state="new">Framework35 n'est pas pris en charge. Pour les projets ciblant .Net Framework 3.5, utilisez Framework40 pour exécuter les tests dans CLR 4.0 en "mode compatibilité".</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.it.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.it.xlf
@@ -1633,7 +1633,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 non è supportato. Per i progetti destinati a .NET Framework 3.5, usare Framework40 per eseguire i test nella modalità di compatibilità di CLR 4.0.</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.it.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.it.xlf
@@ -1633,9 +1633,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
-        <target state="translated">Framework35 non è supportato. Per i progetti destinati a .NET Framework 3.5, usare Framework40 per eseguire i test nella modalità di compatibilità di CLR 4.0.</target>
-        <note />
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <target state="new">Framework35 non è supportato. Per i progetti destinati a .NET Framework 3.5, usare Framework40 per eseguire i test nella modalità di compatibilità di CLR 4.0.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.ja.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ja.xlf
@@ -1633,7 +1633,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 はサポートされていません。.Net Framework 3.5 を対象とするプロジェクトでは、Framework40 を使用して CLR 4.0 の "互換モード" でテストを実行してください。</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.ja.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ja.xlf
@@ -1633,9 +1633,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
-        <target state="translated">Framework35 はサポートされていません。.Net Framework 3.5 を対象とするプロジェクトでは、Framework40 を使用して CLR 4.0 の "互換モード" でテストを実行してください。</target>
-        <note />
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <target state="new">Framework35 はサポートされていません。.Net Framework 3.5 を対象とするプロジェクトでは、Framework40 を使用して CLR 4.0 の "互換モード" でテストを実行してください。</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.ko.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ko.xlf
@@ -1633,7 +1633,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35는 지원되지 않습니다. .NET Framework 3.5를 대상으로 하는 프로젝트의 경우 Framework40을 사용하여 CLR 4.0 "호환 모드"에서 테스트를 실행하세요.</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.ko.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ko.xlf
@@ -1633,9 +1633,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
-        <target state="translated">Framework35는 지원되지 않습니다. .NET Framework 3.5를 대상으로 하는 프로젝트의 경우 Framework40을 사용하여 CLR 4.0 "호환 모드"에서 테스트를 실행하세요.</target>
-        <note />
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <target state="new">Framework35는 지원되지 않습니다. .NET Framework 3.5를 대상으로 하는 프로젝트의 경우 Framework40을 사용하여 CLR 4.0 "호환 모드"에서 테스트를 실행하세요.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.pl.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pl.xlf
@@ -1631,7 +1631,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="new">Wersja Framework35 nie jest obsługiwana. W przypadku projektów przeznaczonych dla programu .Net Framework 3.5 użyj wersji Framework40 do uruchamiania testów w „trybie zgodności” CLR 4.0.</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.pl.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pl.xlf
@@ -1631,9 +1631,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
-        <target state="translated">Wersja Framework35 nie jest obsługiwana. W przypadku projektów przeznaczonych dla programu .Net Framework 3.5 użyj wersji Framework40 do uruchamiania testów w „trybie zgodności” CLR 4.0.</target>
-        <note />
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <target state="new">Wersja Framework35 nie jest obsługiwana. W przypadku projektów przeznaczonych dla programu .Net Framework 3.5 użyj wersji Framework40 do uruchamiania testów w „trybie zgodności” CLR 4.0.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
@@ -1631,7 +1631,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="new">Não há suporte para Framework35. Para projetos com .Net Framework 3.5 de destino, use o Framework40 para executar testes em “modo de compatibilidade” CLR 4.0. </target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
@@ -1631,9 +1631,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
-        <target state="translated">Não há suporte para Framework35. Para projetos com .Net Framework 3.5 de destino, use o Framework40 para executar testes em “modo de compatibilidade” CLR 4.0. </target>
-        <note />
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <target state="new">Não há suporte para Framework35. Para projetos com .Net Framework 3.5 de destino, use o Framework40 para executar testes em “modo de compatibilidade” CLR 4.0. </target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.ru.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ru.xlf
@@ -1633,9 +1633,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
-        <target state="translated">Framework35 не поддерживается. В проектах для .Net Framework 3.5 запускайте тесты в режиме совместимости CLR 4.0 с использованием Framework40.</target>
-        <note />
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <target state="new">Framework35 не поддерживается. В проектах для .Net Framework 3.5 запускайте тесты в режиме совместимости CLR 4.0 с использованием Framework40.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.ru.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ru.xlf
@@ -1633,7 +1633,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 не поддерживается. В проектах для .Net Framework 3.5 запускайте тесты в режиме совместимости CLR 4.0 с использованием Framework40.</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.tr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.tr.xlf
@@ -1633,7 +1633,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 desteklenmiyor. .NET Framework 3.5’i hedefleyen projeler için lütfen Framework40 kullanarak testleri CLR 4.0’ın “uyumluluk modunda” çalıştırın.</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.tr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.tr.xlf
@@ -1633,9 +1633,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
-        <target state="translated">Framework35 desteklenmiyor. .NET Framework 3.5’i hedefleyen projeler için lütfen Framework40 kullanarak testleri CLR 4.0’ın “uyumluluk modunda” çalıştırın.</target>
-        <note />
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <target state="new">Framework35 desteklenmiyor. .NET Framework 3.5’i hedefleyen projeler için lütfen Framework40 kullanarak testleri CLR 4.0’ın “uyumluluk modunda” çalıştırın.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.xlf
@@ -815,7 +815,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.xlf
@@ -815,7 +815,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
         <target state="new">Framework35 not supported. Use Framework40 or above to run tests in CLR 4.0 "compatibly mode".</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
@@ -1633,9 +1633,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
-        <target state="translated">Framework35 不受支持。对于面向 .Net Framework 3.5 的项目，请使用 Framework40 在 CLR 4.0“兼容性模式”下运行测试。</target>
-        <note />
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <target state="new">Framework35 不受支持。对于面向 .Net Framework 3.5 的项目，请使用 Framework40 在 CLR 4.0“兼容性模式”下运行测试。</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
@@ -1633,7 +1633,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="new">Framework35 不受支持。对于面向 .Net Framework 3.5 的项目，请使用 Framework40 在 CLR 4.0“兼容性模式”下运行测试。</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
@@ -1633,9 +1633,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 "compatibility mode".</source>
-        <target state="translated">不支援 Framework35。若為以 .Net Framework 3.5 為目標的專案，請使用 Framework40 在 CLR 4.0「相容模式」中執行測試。</target>
-        <note />
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <target state="new">不支援 Framework35。若為以 .Net Framework 3.5 為目標的專案，請使用 Framework40 在 CLR 4.0「相容模式」中執行測試。</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
@@ -1633,7 +1633,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Framework35NotSupported">
-        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, tests are running in "compatibility mode".</source>
+        <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="new">不支援 Framework35。若為以 .Net Framework 3.5 為目標的專案，請使用 Framework40 在 CLR 4.0「相容模式」中執行測試。</target>
         <note></note>
       </trans-unit>

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -396,8 +396,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
 
                     if (Constants.DotNetFramework35.Equals(chosenFramework.Name))
                     {
-                        EqtTrace.Error("TestRequestManager.UpdateRunSettingsIfRequired: throw exception on /Framework:Framework35 option.");
-                        throw new TestPlatformException(Resources.Framework35NotSupported);
+                        EqtTrace.Warning("TestRequestManager.UpdateRunSettingsIfRequired: throw warning on /Framework:Framework35 option.");
+                        ConsoleLogger.RaiseTestRunWarning(Resources.Framework35NotSupported);
                     }
 
                     if (EqtTrace.IsInfoEnabled)

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -848,7 +848,7 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
         }
 
         [TestMethod]
-        public void RunTestsShouldThrowForFramework35()
+        public void RunTestsShouldNotThrowForFramework35()
         {
             var payload = new TestRunRequestPayload()
             {
@@ -870,9 +870,14 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
                     actualTestRunCriteria = runCriteria;
                 }).Returns(mockDiscoveryRequest.Object);
             this.mockAssemblyMetadataProvider.Setup(a => a.GetFrameWork(It.IsAny<string>())).Returns(new FrameworkName(Constants.DotNetFramework35));
-            var actualErrorMessage = Assert.ThrowsException<TestPlatformException>( () => this.testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, this.protocolConfig)).Message;
 
-            Assert.AreEqual("Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 \"compatibility mode\".", actualErrorMessage);
+            var mockRunEventsRegistrar = new Mock<ITestRunEventsRegistrar>();
+            var mockCustomlauncher = new Mock<ITestHostLauncher>();
+
+            this.testRequestManager.RunTests(payload, mockCustomlauncher.Object, mockRunEventsRegistrar.Object, this.protocolConfig);
+
+            mockTestPlatformEventSource.Verify(mt => mt.ExecutionRequestStart(), Times.Once);
+            mockTestPlatformEventSource.Verify(mt => mt.ExecutionRequestStop(), Times.Once);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description
Test projects targeting .NetFramework 3.5 throw error.
Change : We will run these tests in compat mode(default using .NetFramework 4.0)
We are unable to get information from assembly metadata for a .NetFramework 3.5 project, hence by default .NetFramework 4.0 is chosen as the running framework.

![image](https://user-images.githubusercontent.com/13175100/52055974-f2270680-2586-11e9-9bbe-22f9f0b4f567.png)


## Related issue
https://github.com/Microsoft/vstest/issues/1896