### PR TITLE
Fixing the timeouts.

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketCommunicationManager.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketCommunicationManager.cs
@@ -11,6 +11,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
+    using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Helpers;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
 
@@ -19,11 +20,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
     /// </summary>
     public class SocketCommunicationManager : ICommunicationManager
     {
-        /// <summary>
-        /// Time for which the client wait for executor/runner process to start, and host server
-        /// </summary>
-        private const int CONNECTIONRETRYTIMEOUT = 50 * 1000;
-
         /// <summary>
         /// The server stream read timeout constant (in microseconds).
         /// </summary>
@@ -176,10 +172,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
             Stopwatch watch = new Stopwatch();
             watch.Start();
+            var connectionTimeout = EnvironmentHelper.GetConnectionTimeout();
             do
             {
                 try
                 {
+                    EqtTrace.Verbose("SocketCommunicationManager : SetupClientAsync : Attempting to connect to the server.");
                     await this.tcpClient.ConnectAsync(endpoint.Address, endpoint.Port);
 
                     if (this.tcpClient.Connected)
@@ -201,10 +199,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 }
                 catch (Exception ex)
                 {
-                    EqtTrace.Verbose("Connection Failed with error {0}, retrying", ex.ToString());
+                    EqtTrace.Error("Connection Failed with error {0}, retrying", ex.ToString());
                 }
             }
-            while ((this.tcpClient != null) && !this.tcpClient.Connected && watch.ElapsedMilliseconds < CONNECTIONRETRYTIMEOUT);
+            while ((this.tcpClient != null) && !this.tcpClient.Connected && watch.ElapsedMilliseconds < connectionTimeout);
         }
 
         /// <summary>

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
@@ -28,8 +28,6 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
     {
         #region Private Members
 
-        private const int ConnectionTimeout = 30 * 1000;
-
         private readonly IProcessManager vstestConsoleProcessManager;
 
         private readonly ITranslationLayerRequestSender requestSender;

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapperAsync.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapperAsync.cs
@@ -9,6 +9,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
     using System.Threading.Tasks;
 
     using Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces;
+    using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Helpers;
     using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Tracing;
     using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Tracing.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -22,8 +23,6 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
     public class VsTestConsoleWrapperAsync : IVsTestConsoleWrapperAsync
     {
         #region Private Members
-
-        private const int ConnectionTimeout = 30 * 1000;
 
         private readonly IProcessManager vstestConsoleProcessManager;
 
@@ -93,8 +92,9 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         {
             this.testPlatformEventSource.TranslationLayerInitializeStart();
 
+            var timeout = EnvironmentHelper.GetConnectionTimeout();
             // Start communication
-            var port = await this.requestSender.InitializeCommunicationAsync(ConnectionTimeout);
+            var port = await this.requestSender.InitializeCommunicationAsync(timeout * 1000);
 
             if (port > 0)
             {

--- a/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
@@ -245,7 +245,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
             this.InvokeVsTest(arguments);
 
-            this.ValidateSummaryStatus(1, 0, 0);
+            this.ValidateSummaryStatus(1, 1, 1);
             this.ExitCodeEquals(0);
 
             this.StdOutputContains(expectedWarningContains);

--- a/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
@@ -234,10 +234,10 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
         [TestMethod]
         [NetFullTargetFrameworkDataSource(useCoreRunner:false)]
-        public void ExecuteTestsForFramework35ShouldPrintErrorMessage(RunnerInfo runnerInfo)
+        public void ExecuteTestsForFramework35ShouldPrintWarningMessage(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
-            var expectedWarningContains = "Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 \"compatibility mode\".";
+            var expectedWarningContains = "Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 \"compatibility mode\".";
             var assemblyPaths = this.GetAssetFullPath("SimpleTestProject.dll");
 
             var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
@@ -245,9 +245,10 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
             this.InvokeVsTest(arguments);
 
-            this.ExitCodeEquals(1);
+            this.ValidateSummaryStatus(1, 0, 0);
+            this.ExitCodeEquals(0);
 
-            this.StdErrorContains(expectedWarningContains);
+            this.StdOutputContains(expectedWarningContains);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
@@ -231,24 +231,5 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             // When both x64 & x86 DLL is passed x64 dll will be ignored.
             this.StdOutputContains(expectedWarningContains);
         }
-
-        [TestMethod]
-        [NetFullTargetFrameworkDataSource(useCoreRunner:false)]
-        public void ExecuteTestsForFramework35ShouldPrintWarningMessage(RunnerInfo runnerInfo)
-        {
-            AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
-            var expectedWarningContains = "Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 \"compatibility mode\".";
-            var assemblyPaths = this.GetAssetFullPath("SimpleTestProject.dll");
-
-            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
-            arguments = string.Concat(arguments, " /Framework:.NETFramework,Version=v3.5");
-
-            this.InvokeVsTest(arguments);
-
-            this.ValidateSummaryStatus(1, 1, 1);
-            this.ExitCodeEquals(0);
-
-            this.StdOutputContains(expectedWarningContains);
-        }
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/DiscoverTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/DiscoverTests.cs
@@ -75,33 +75,6 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
 
         [TestMethod]
         [NetFullTargetFrameworkDataSource]
-        public void DiscoverTestsShouldFailForFramework35(RunnerInfo runnerInfo)
-        {
-            AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
-            this.ExecuteNotSupportedRunnerFrameworkTests(runnerInfo.RunnerFramework, Netcoreapp, Message);
-            this.Setup();
-
-            string runSettingsXml = @"<?xml version=""1.0"" encoding=""utf-8""?>
-                                    <RunSettings>
-                                        <RunConfiguration>
-                                            <TargetFrameworkVersion>Framework35</TargetFrameworkVersion>
-                                            <DesignMode>true</DesignMode>
-                                        </RunConfiguration>
-                                    </RunSettings>";
-
-            this.vstestConsoleWrapper.DiscoverTests(
-                this.GetTestAssemblies(),
-                runSettingsXml,
-                new TestPlatformOptions() { CollectMetrics = false },
-                this.discoveryEventHandler2);
-
-            Assert.AreEqual(1, this.discoveryEventHandler2.testMessages.Count);
-            StringAssert.Contains(this.discoveryEventHandler2.testMessages[0].message, "Framework35 is not supported. For projects targeting .Net Framework 3.5, please use Framework40 to run tests in CLR 4.0 \"compatibility mode\".");
-            Assert.AreEqual(TestMessageLevel.Error, this.discoveryEventHandler2.testMessages[0].testMessageLevel);
-        }
-
-        [TestMethod]
-        [NetFullTargetFrameworkDataSource]
         [NetCoreTargetFrameworkDataSource]
         public void DiscoverTestsUsingDiscoveryEventHandler2AndTelemetryOptedIn(RunnerInfo runnerInfo)
         {

--- a/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeClientTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeClientTests.cs
@@ -252,7 +252,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.DesignMode
         {
             this.mockCommunicationManager.Setup(cm => cm.WaitForServerConnection(It.IsAny<int>())).Returns(false);
 
-            Assert.ThrowsException<TimeoutException>(() => this.designModeClient.ConnectToClientAndProcessRequests(PortNumber, this.mockTestRequestManager.Object));
+            var ex = Assert.ThrowsException<TimeoutException>(() => this.designModeClient.ConnectToClientAndProcessRequests(PortNumber, this.mockTestRequestManager.Object));
+            Assert.AreEqual("vstest.console process failed to connect to translation layer process after 90 seconds. This may occur due to machine slowness, please set environment variable VSTEST_CONNECTION_TIMEOUT to increase timeout.", ex.Message);
 
             this.mockCommunicationManager.Verify(cm => cm.SetupClientAsync(new IPEndPoint(IPAddress.Loopback, PortNumber)), Times.Once);
             this.mockCommunicationManager.Verify(cm => cm.WaitForServerConnection(It.IsAny<int>()), Times.Once);


### PR DESCRIPTION
1. Made DesignModeClient timeout to connect to translation layer process configurable.
2. Removed redundant timeouts
3. ConnectionTimeout in VsTestConsoleWrapperAsync.

