### PR TITLE
Add missing Utilities dependency to netstandard1.5

### DIFF
--- a/scripts/verify-nupkgs.ps1
+++ b/scripts/verify-nupkgs.ps1
@@ -20,7 +20,7 @@ function Verify-Nuget-Packages($packageDirectory)
                      "Microsoft.TestPlatform.Extensions.TrxLogger" = 33;
                      "Microsoft.TestPlatform.ObjectModel" = 65;
                      "Microsoft.TestPlatform.Portable" = 472;
-                     "Microsoft.TestPlatform.TestHost" = 139;
+                     "Microsoft.TestPlatform.TestHost" = 140;
                      "Microsoft.TestPlatform.TranslationLayer" = 121}
 
     $nugetPackages = Get-ChildItem -Filter "*.nupkg" $packageDirectory | % { $_.FullName}

--- a/src/package/nuspec/TestPlatform.TestHost.nuspec
+++ b/src/package/nuspec/TestPlatform.TestHost.nuspec
@@ -37,6 +37,7 @@
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.TestPlatform.CommunicationUtilities.dll" target="lib\netstandard1.5\" />
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.TestPlatform.CrossPlatEngine.dll" target="lib\netstandard1.5\" />
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.VisualStudio.TestPlatform.Common.dll" target="lib\netstandard1.5\" />
+    <file src="Microsoft.TestPlatform.TestHost\netstandard1.4\Microsoft.TestPlatform.Utilities.dll" target="lib\netstandard1.5\" />
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp1.0\testhost.dll" target="lib\netstandard1.5\" />
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp1.0\testhost.deps.json" target="lib\netstandard1.5\" />
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp1.0\x86\msdia140.dll" target="lib\netstandard1.5\x86\" />


### PR DESCRIPTION
## Description
As discussed in #1790, adds the `Microsoft.TestPlatform.Utilities.dll` to the netstandard1.5 folder, since this is a dependent assembly to some of the other assemblies in that folder.

## Related issue
Fixes issue #1790
