### PR TITLE
Adding ARM64 support to the test console

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/Architecture.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Architecture.cs
@@ -9,6 +9,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         X86,
         X64,
         ARM,
-        AnyCPU
+        AnyCPU,
+        ARM64
     }
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
@@ -744,7 +744,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
                             try
                             {
                                 archType = (Architecture)Enum.Parse(typeof(Architecture), value, true);
-                                if (archType != Architecture.X64 && archType != Architecture.X86 && archType != Architecture.ARM)
+                                if (archType != Architecture.X64 && archType != Architecture.X86 && archType != Architecture.ARM && archType != Architecture.ARM64)
                                 {
                                     throw new SettingsException(
                                         string.Format(

--- a/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
@@ -34,6 +34,8 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
                         return ObjectModel.Architecture.X64;
                     case PlatformArchitecture.X86:
                         return ObjectModel.Architecture.X86;
+                    case PlatformArchitecture.ARM64:
+                        return ObjectModel.Architecture.ARM64;
                     default:
                         return ObjectModel.Architecture.ARM;
                 }

--- a/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
@@ -520,6 +520,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
             {
                 return;
             }
+            if (architecture == Architecture.ARM && osArchitecture == Architecture.ARM64)
+            {
+                return;
+            }
 
             if (architecture == osArchitecture)
             {

--- a/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
@@ -516,11 +516,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         {
             var osArchitecture = XmlRunSettingsUtilities.OSArchitecture;
 
-            if (architecture == Architecture.X86 && osArchitecture == Architecture.X64)
+            if (architecture == Architecture.X86 && (osArchitecture == Architecture.X64 || osArchitecture == Architecture.ARM64))
             {
                 return;
             }
-            if (architecture == Architecture.ARM && osArchitecture == Architecture.ARM64)
+            if ((architecture == Architecture.ARM || architecture == Architecture.X86) && osArchitecture == Architecture.ARM64)
             {
                 return;
             }

--- a/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs
+++ b/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs
@@ -166,7 +166,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
             const int IMAGE_FILE_MACHINE_ARM = 0x01c0; // ARM Little-Endian
             const int IMAGE_FILE_MACHINE_THUMB = 0x01c2; // ARM Thumb/Thumb-2 Little-Endian
             const int IMAGE_FILE_MACHINE_ARMNT = 0x01c4; // ARM Thumb-2 Little-Endian
-
+            const int IMAGE_FILE_MACHINE_ARM64 = 0xAA64; // ARM64 Little-Endian
 
             try
             {
@@ -234,6 +234,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities
                                 case IMAGE_FILE_MACHINE_THUMB:
                                 case IMAGE_FILE_MACHINE_ARMNT:
                                     archType = Architecture.ARM;
+                                    break;
+                                case IMAGE_FILE_MACHINE_ARM64:
+                                    archType = Architecture.ARM64;
                                     break;
                             }
                         }

--- a/src/vstest.console/Processors/PlatformArgumentProcessor.cs
+++ b/src/vstest.console/Processors/PlatformArgumentProcessor.cs
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             var validPlatform = Enum.TryParse(argument, true, out platform);
             if (validPlatform)
             {
-                validPlatform = platform == Architecture.X86 || platform == Architecture.X64 || platform == Architecture.ARM;
+                validPlatform = platform == Architecture.X86 || platform == Architecture.X64 || platform == Architecture.ARM || platform == Architecture.ARM64;
             }
 
             if (validPlatform)

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -336,7 +336,7 @@
     <value>The --ParentProcessId|/ParentProcessId argument requires the process id which is an integer. Specify the process id of the parent process that launched this process.</value>
   </data>
   <data name="InvalidPlatformType" xml:space="preserve">
-    <value>Invalid platform type:{0}. Valid platform types are x86, x64 and Arm.</value>
+    <value>Invalid platform type:{0}. Valid platform types are x86, x64, Arm and Arm64.</value>
   </data>
   <data name="InvalidPortArgument" xml:space="preserve">
     <value>The --Port|/Port argument requires the port number which is an integer. Specify the port for socket connection and receiving the event messages.</value>

--- a/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         {
             ExceptionUtilities.ThrowsException<CommandLineException>(
                 () => this.executor.Initialize("foo"),
-                "Invalid platform type:{0}. Valid platform types are x86, x64 and Arm.",
+                "Invalid platform type:{0}. Valid platform types are x86, x64, Arm and Arm64.",
                 "foo");
         }
 
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         {
             ExceptionUtilities.ThrowsException<CommandLineException>(
                 () => this.executor.Initialize("AnyCPU"),
-                "Invalid platform type:{0}. Valid platform types are x86, x64 and Arm.",
+                "Invalid platform type:{0}. Valid platform types are x86, x64, Arm and Arm64.",
                 "AnyCPU");
         }
 


### PR DESCRIPTION
## Description
I've found that I'm not able to run UWP ARM64 unit test on ARM64 devices.
Looking through the code, there's no indication ARM64 was ever supported, and the OS Architecture detection was getting the wrong values.
This is the beginnings of adding support for executing ARM64 unit tests.
I'm submitting as a draft for now, for feedback, and will also require some more testing at my end.

