### PR TITLE
Minor fix to ensure we provide a message with the data that the test …

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.Designer.cs
@@ -100,9 +100,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources {
         /// <summary>
         ///   Looks up a localized string similar to Test host process crashed.
         /// </summary>
-        public static string TestHostProcessExitedDuringExecution {
+        public static string TestHostProcessCrashed {
             get {
-                return ResourceManager.GetString("TestHostProcessExitedDuringExecution", resourceCulture);
+                return ResourceManager.GetString("TestHostProcessCrashed", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.Designer.cs
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test Host process exited during the execution of tests..
+        ///   Looks up a localized string similar to Test host process crashed.
         /// </summary>
         public static string TestHostProcessExitedDuringExecution {
             get {

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.Designer.cs
@@ -98,6 +98,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Test Host process exited during the execution of tests..
+        /// </summary>
+        public static string TestHostProcessExitedDuringExecution {
+            get {
+                return ResourceManager.GetString("TestHostProcessExitedDuringExecution", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to communicate with test host process..
         /// </summary>
         public static string UnableToCommunicateToTestHost {

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.resx
@@ -141,4 +141,7 @@
   <data name="ConnectionTimeoutErrorMessage" xml:space="preserve">
     <value>{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</value>
   </data>
+  <data name="TestHostProcessExitedDuringExecution" xml:space="preserve">
+    <value>Test Host process exited during the execution of tests.</value>
+  </data>
 </root>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.resx
@@ -141,7 +141,7 @@
   <data name="ConnectionTimeoutErrorMessage" xml:space="preserve">
     <value>{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</value>
   </data>
-  <data name="TestHostProcessExitedDuringExecution" xml:space="preserve">
+  <data name="TestHostProcessCrashed" xml:space="preserve">
     <value>Test host process crashed</value>
   </data>
 </root>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.resx
@@ -142,6 +142,6 @@
     <value>{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</value>
   </data>
   <data name="TestHostProcessExitedDuringExecution" xml:space="preserve">
-    <value>Test Host process exited during the execution of tests.</value>
+    <value>Test host process crashed</value>
   </data>
 </root>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.cs.xlf
@@ -76,9 +76,9 @@
         <target state="translated">Procesu {0} se nepovedlo připojit k procesu {1} ani po {2} s. Důvodem může být pomalý počítač. Nastavením proměnné prostředí {3} prosím časový limit prodlužte.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessExitedDuringExecution">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
-        <target state="new">Test host process crashed </target>
+        <target state="new">Test host process crashed</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.cs.xlf
@@ -76,6 +76,11 @@
         <target state="translated">Procesu {0} se nepovedlo připojit k procesu {1} ani po {2} s. Důvodem může být pomalý počítač. Nastavením proměnné prostředí {3} prosím časový limit prodlužte.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestHostProcessExitedDuringExecution">
+        <source>Test host process crashed</source>
+        <target state="new">Test host process crashed </target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.de.xlf
@@ -76,6 +76,11 @@
         <target state="translated">Fehler beim Herstellen einer Verbindung des Prozesses "{0}" mit dem Prozess "{1}" nach {2} Sekunden. Möglicherweise ist der Computer langsam. Legen Sie die Umgebungsvariable "{3}" fest, um den Timeoutwert zu erhöhen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestHostProcessExitedDuringExecution">
+        <source>Test host process crashed</source>
+        <target state="new">Test host process crashed </target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.de.xlf
@@ -76,9 +76,9 @@
         <target state="translated">Fehler beim Herstellen einer Verbindung des Prozesses "{0}" mit dem Prozess "{1}" nach {2} Sekunden. Möglicherweise ist der Computer langsam. Legen Sie die Umgebungsvariable "{3}" fest, um den Timeoutwert zu erhöhen.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessExitedDuringExecution">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
-        <target state="new">Test host process crashed </target>
+        <target state="new">Test host process crashed</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.es.xlf
@@ -76,9 +76,9 @@
         <target state="translated">El proceso {0} no pudo conectar con el proceso {1} después de {2} segundos. Esto puede deberse a la lentitud de la máquina, configure la variable de entorno {3} para aumentar el tiempo de espera.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessExitedDuringExecution">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
-        <target state="new">Test host process crashed </target>
+        <target state="new">Test host process crashed</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.es.xlf
@@ -76,6 +76,11 @@
         <target state="translated">El proceso {0} no pudo conectar con el proceso {1} después de {2} segundos. Esto puede deberse a la lentitud de la máquina, configure la variable de entorno {3} para aumentar el tiempo de espera.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestHostProcessExitedDuringExecution">
+        <source>Test host process crashed</source>
+        <target state="new">Test host process crashed </target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.fr.xlf
@@ -76,9 +76,9 @@
         <target state="translated">Le processus {0} n’a pas réussi à se connecter au processus {1} après {2} secondes. Cette situation peut se produire à cause de la lenteur de la machine. Définissez la variable d’environnement {3} de sorte à augmenter le délai d’expiration.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessExitedDuringExecution">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
-        <target state="new">Test host process crashed </target>
+        <target state="new">Test host process crashed</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.fr.xlf
@@ -76,6 +76,11 @@
         <target state="translated">Le processus {0} n’a pas réussi à se connecter au processus {1} après {2} secondes. Cette situation peut se produire à cause de la lenteur de la machine. Définissez la variable d’environnement {3} de sorte à augmenter le délai d’expiration.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestHostProcessExitedDuringExecution">
+        <source>Test host process crashed</source>
+        <target state="new">Test host process crashed </target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.it.xlf
@@ -76,6 +76,11 @@
         <target state="translated">Il processo {0} non è riuscito a connettersi al processo {1} dopo {2} secondi. Questo problema può verificarsi a causa della lentezza del computer. Impostare la variabile di ambiente {3} in modo da incrementare il timeout.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestHostProcessExitedDuringExecution">
+        <source>Test host process crashed</source>
+        <target state="new">Test host process crashed </target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.it.xlf
@@ -76,9 +76,9 @@
         <target state="translated">Il processo {0} non è riuscito a connettersi al processo {1} dopo {2} secondi. Questo problema può verificarsi a causa della lentezza del computer. Impostare la variabile di ambiente {3} in modo da incrementare il timeout.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessExitedDuringExecution">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
-        <target state="new">Test host process crashed </target>
+        <target state="new">Test host process crashed</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ja.xlf
@@ -76,9 +76,9 @@
         <target state="translated">{0} プロセスでは、{2} 秒後に {1} プロセスへ接続できませんでした。これは、マシンの遅さが原因で発生する可能性があるため、環境変数 {3} を設定してタイムアウト時間を増やしてください。</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessExitedDuringExecution">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
-        <target state="new">Test host process crashed </target>
+        <target state="new">Test host process crashed</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ja.xlf
@@ -76,6 +76,11 @@
         <target state="translated">{0} プロセスでは、{2} 秒後に {1} プロセスへ接続できませんでした。これは、マシンの遅さが原因で発生する可能性があるため、環境変数 {3} を設定してタイムアウト時間を増やしてください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestHostProcessExitedDuringExecution">
+        <source>Test host process crashed</source>
+        <target state="new">Test host process crashed </target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ko.xlf
@@ -76,6 +76,11 @@
         <target state="translated">{0} 프로세스가 {2}초 후 {1} 프로세스에 연결하지 못했습니다. 이런 오류는 컴퓨터가 느려서 발생할 수 있습니다. 환경 변수 {3}을(를) 설정하여 시간 제한을 늘리세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestHostProcessExitedDuringExecution">
+        <source>Test host process crashed</source>
+        <target state="new">Test host process crashed </target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ko.xlf
@@ -76,9 +76,9 @@
         <target state="translated">{0} 프로세스가 {2}초 후 {1} 프로세스에 연결하지 못했습니다. 이런 오류는 컴퓨터가 느려서 발생할 수 있습니다. 환경 변수 {3}을(를) 설정하여 시간 제한을 늘리세요.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessExitedDuringExecution">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
-        <target state="new">Test host process crashed </target>
+        <target state="new">Test host process crashed</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pl.xlf
@@ -76,9 +76,9 @@
         <target state="translated">Proces {0} nie mógł połączyć się z procesem {1} w ciągu {2} sekund. Przyczyną może być wolne działanie maszyny. Zwiększ limit czasu, ustawiając zmienną środowiskową {3}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessExitedDuringExecution">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
-        <target state="new">Test host process crashed </target>
+        <target state="new">Test host process crashed</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pl.xlf
@@ -76,6 +76,11 @@
         <target state="translated">Proces {0} nie mógł połączyć się z procesem {1} w ciągu {2} sekund. Przyczyną może być wolne działanie maszyny. Zwiększ limit czasu, ustawiając zmienną środowiskową {3}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestHostProcessExitedDuringExecution">
+        <source>Test host process crashed</source>
+        <target state="new">Test host process crashed </target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pt-BR.xlf
@@ -76,6 +76,11 @@
         <target state="translated">O processo {0} falha ao se conectar ao processo {1} após {2} segundos. Isso pode ocorrer devido à lentidão do computador. Defina a variável de ambiente {3} para aumentar o tempo limite.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestHostProcessExitedDuringExecution">
+        <source>Test host process crashed</source>
+        <target state="new">Test host process crashed </target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pt-BR.xlf
@@ -76,9 +76,9 @@
         <target state="translated">O processo {0} falha ao se conectar ao processo {1} após {2} segundos. Isso pode ocorrer devido à lentidão do computador. Defina a variável de ambiente {3} para aumentar o tempo limite.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessExitedDuringExecution">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
-        <target state="new">Test host process crashed </target>
+        <target state="new">Test host process crashed</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ru.xlf
@@ -76,9 +76,9 @@
         <target state="translated">Процесс {0} не смог подключиться к процессу {1} по прошествии {2} с. Это может происходить из-за медленной работы компьютера. Увеличьте время ожидания в переменной среды {3}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessExitedDuringExecution">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
-        <target state="new">Test host process crashed </target>
+        <target state="new">Test host process crashed</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ru.xlf
@@ -76,6 +76,11 @@
         <target state="translated">Процесс {0} не смог подключиться к процессу {1} по прошествии {2} с. Это может происходить из-за медленной работы компьютера. Увеличьте время ожидания в переменной среды {3}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestHostProcessExitedDuringExecution">
+        <source>Test host process crashed</source>
+        <target state="new">Test host process crashed </target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.tr.xlf
@@ -76,6 +76,11 @@
         <target state="translated">{0} işlemi, {2} saniye sonra {1} işlemine bağlanamadı. Bu durum makinenin yavaşlığından kaynaklanıyor olabilir, zaman aşımı süresini artırmak için lütfen ortam değişkenini {3} olarak ayarlayın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestHostProcessExitedDuringExecution">
+        <source>Test host process crashed</source>
+        <target state="new">Test host process crashed </target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.tr.xlf
@@ -76,9 +76,9 @@
         <target state="translated">{0} işlemi, {2} saniye sonra {1} işlemine bağlanamadı. Bu durum makinenin yavaşlığından kaynaklanıyor olabilir, zaman aşımı süresini artırmak için lütfen ortam değişkenini {3} olarak ayarlayın.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessExitedDuringExecution">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
-        <target state="new">Test host process crashed </target>
+        <target state="new">Test host process crashed</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.xlf
@@ -38,9 +38,9 @@
         <target state="new">{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="TestHostProcessExitedDuringExecution">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
-        <target state="new">Test host process crashed </target>
+        <target state="new">Test host process crashed</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.xlf
@@ -38,6 +38,11 @@
         <target state="new">{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="TestHostProcessExitedDuringExecution">
+        <source>Test host process crashed</source>
+        <target state="new">Test host process crashed </target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hans.xlf
@@ -76,6 +76,11 @@
         <target state="translated">{0} 进程未能在 {2} 秒后连接到 {1} 进程。出现此问题可能是因为计算机性能较低，请设置环境变量 {3}，增加超时时间值。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestHostProcessExitedDuringExecution">
+        <source>Test host process crashed</source>
+        <target state="new">Test host process crashed </target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hans.xlf
@@ -76,9 +76,9 @@
         <target state="translated">{0} 进程未能在 {2} 秒后连接到 {1} 进程。出现此问题可能是因为计算机性能较低，请设置环境变量 {3}，增加超时时间值。</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessExitedDuringExecution">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
-        <target state="new">Test host process crashed </target>
+        <target state="new">Test host process crashed</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hant.xlf
@@ -76,9 +76,9 @@
         <target state="translated">在 {2} 秒後，{0} 處理序無法連線到 {1} 處理序。原因可能是電腦太慢，請設定環境變數 {3}，加長逾時。</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessExitedDuringExecution">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
-        <target state="new">Test host process crashed </target>
+        <target state="new">Test host process crashed</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hant.xlf
@@ -76,6 +76,11 @@
         <target state="translated">在 {2} 秒後，{0} 處理序無法連線到 {1} 處理序。原因可能是電腦太慢，請設定環境變數 {3}，加長逾時。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestHostProcessExitedDuringExecution">
+        <source>Test host process crashed</source>
+        <target state="new">Test host process crashed </target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -568,7 +568,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 {
                     // Set a default message of test host process exited and additionally specify the error if present
                     EqtTrace.Info("TestRequestSender: GetAbortErrorMessage: Received test host error message.");
-                    reason = CommonResources.TestHostProcessExitedDuringExecution;
+                    reason = CommonResources.TestHostProcessCrashed;
                     if (!string.IsNullOrWhiteSpace(this.clientExitErrorMessage))
                     {
                         reason = $"{reason} : {this.clientExitErrorMessage}";

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
@@ -189,7 +189,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
 
             this.testRequestSender.OnClientProcessExit(stderr);
 
-            var expectedErrorMessage = "Reason: " + stderr;
+            var expectedErrorMessage = "Reason: Test host process crashed";
             this.RaiseClientDisconnectedEvent();
             this.mockDiscoveryEventsHandler.Verify(eh => eh.HandleLogMessage(TestMessageLevel.Error, It.Is<string>(s => s.EndsWith(expectedErrorMessage))), Times.Once);
         }
@@ -198,7 +198,6 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
         public void OnClientProcessExitShouldNotSendErrorMessageIfOperationNotStarted()
         {
             this.SetupFakeCommunicationChannel();
-
             this.testRequestSender.OnClientProcessExit("Dummy Stderr");
 
             this.RaiseClientDisconnectedEvent();
@@ -720,7 +719,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
 
             this.RaiseClientDisconnectedEvent();
 
-            var expectedErrorMessage = "Reason: Dummy Stderr";
+            var expectedErrorMessage = "Reason: Test host process crashed : Dummy Stderr";
             this.mockExecutionEventsHandler.Verify(eh => eh.HandleLogMessage(TestMessageLevel.Error, It.Is<string>(s => s.Contains(expectedErrorMessage))), Times.Once);
         }
 


### PR DESCRIPTION
## Description
Minor fix to ensure we provide a message with the data that the test host process has exited when applicable.

## Related issue
#1932
