### PR TITLE
Include traits from TestCase in TRX output

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestElement.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestElement.cs
@@ -249,6 +249,7 @@ internal abstract class TestElement : ITestElement, IXmlTestStore
         h.SaveSimpleField(element, "@priority", _priority, DefaultPriority);
         h.SaveSimpleField(element, "Owners/Owner/@name", _owner, string.Empty);
         h.SaveObject(_testCategories, element, "TestCategory", parameters);
+        h.SaveObject(_testProperties, element, "Properties", parameters);
 
         if (_executionId != null)
             h.SaveGuid(element, "Execution/@id", _executionId.Id);
@@ -273,7 +274,7 @@ internal abstract class TestElement : ITestElement, IXmlTestStore
         _parentExecutionId = TestExecId.Empty;
         _testCategories = new TestCategoryItemCollection();
         _workItems = new WorkItemCollection();
-		_testProperties = new TestPropertyItemCollection();
+        _testProperties = new TestPropertyItemCollection();
         _isRunnable = true;
         _catId = TestListCategoryId.Uncategorized;
     }

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestElement.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestElement.cs
@@ -34,6 +34,7 @@ internal abstract class TestElement : ITestElement, IXmlTestStore
     protected TestExecId _parentExecutionId;
     protected TestCategoryItemCollection _testCategories;
     protected WorkItemCollection _workItems;
+    protected TestPropertyItemCollection _testProperties;
     protected TestListCategoryId _catId;
 
     public TestElement(Guid id, string name, string adapter)
@@ -178,6 +179,16 @@ internal abstract class TestElement : ITestElement, IXmlTestStore
         }
     }
 
+    public TestPropertyItemCollection TestProperties
+    {
+        get { return _testProperties; }
+        set
+        {
+            EqtAssert.ParameterNotNull(value, "TestProperties");
+            _testProperties = value;
+        }
+    }
+
     /// <summary>
     /// Gets the adapter name.
     /// </summary>
@@ -262,6 +273,7 @@ internal abstract class TestElement : ITestElement, IXmlTestStore
         _parentExecutionId = TestExecId.Empty;
         _testCategories = new TestCategoryItemCollection();
         _workItems = new WorkItemCollection();
+		_testProperties = new TestPropertyItemCollection();
         _isRunnable = true;
         _catId = TestListCategoryId.Uncategorized;
     }

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestPropertyItems.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestPropertyItems.cs
@@ -1,0 +1,244 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel;
+
+using System;
+using System.Text;
+
+using Utility;
+
+using XML;
+
+#region TestPropertyItem
+/// <summary>
+/// Stores a string which categorizes the Test
+/// </summary>
+internal sealed class TestPropertyItem : IXmlTestStore
+{
+    #region Fields
+    [StoreXmlSimpleField(Location = "Key", DefaultValue = "")]
+    private readonly string _key = string.Empty;
+
+    [StoreXmlSimpleField(Location = "Value", DefaultValue = "")]
+    private readonly string _value = string.Empty;
+
+    #endregion
+
+    #region Constructors
+    /// <summary>
+    /// Create a new item with the key/value set
+    /// </summary>
+    /// <param name="key">The key.</param>
+    /// <param name="value">The value.</param>
+    public TestPropertyItem(string key, string value)
+    {
+        // Treat null as empty.
+        if (string.IsNullOrEmpty(key))
+            throw new ArgumentNullException(nameof(key));
+
+        if (value == null)
+        {
+            value = String.Empty;
+        }
+
+        _key = key;
+        _value = value;
+    }
+
+    #endregion
+
+    #region Properties/Methods
+    /// <summary>
+    /// Gets the Key for this TestProperty
+    /// </summary>
+    public string Key
+    {
+        get
+        {
+            return _key;
+        }
+    }
+
+    /// <summary>
+    /// Gets the Value for this TestProperty
+    /// </summary>
+    public string Value
+    {
+        get
+        {
+            return _value;
+        }
+    }
+
+    #endregion
+
+    #region Methods - overrides
+    /// <summary>
+    /// Compare the values of the items
+    /// </summary>
+    /// <param name="other">Value being compared to.</param>
+    /// <returns>True if the values are the same and false otherwise.</returns>
+    public override bool Equals(object other)
+    {
+        TestPropertyItem otherItem = other as TestPropertyItem;
+        if (otherItem == null)
+        {
+            return false;
+        }
+        return String.Equals(_key, otherItem._key, StringComparison.OrdinalIgnoreCase) && String.Equals(_value, otherItem._value, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Convert the property name to a hashcode
+    /// </summary>
+    /// <returns>Hashcode of the category.</returns>
+    public override int GetHashCode()
+    {
+        return _key.ToUpperInvariant().GetHashCode() ^ _value.GetHashCode();
+    }
+
+    /// <summary>
+    /// Convert the property name to a string
+    /// </summary>
+    /// <returns>The property.</returns>
+    public override string ToString()
+    {
+        return _key + " = " + _value;
+    }
+    #endregion
+
+    #region IXmlTestStore Members
+
+    /// <summary>
+    /// Saves the class under the XmlElement.
+    /// </summary>
+    /// <param name="element"> XmlElement element </param>
+    /// <param name="parameters"> XmlTestStoreParameters parameters</param>
+    public void Save(System.Xml.XmlElement element, XmlTestStoreParameters parameters)
+    {
+        new XmlPersistence().SaveSingleFields(element, this, parameters);
+    }
+
+    #endregion
+}
+#endregion
+
+#region TestPropertyItemCollection
+/// <summary>
+/// A collection of strings which categorize the test.
+/// </summary>
+internal sealed class TestPropertyItemCollection : EqtBaseCollection<TestPropertyItem>
+{
+    #region Constructors
+    /// <summary>
+    /// Creates an empty TestPropertyItemCollection.
+    /// </summary>
+    public TestPropertyItemCollection()
+    {
+        _childElementName = "Property";
+    }
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    /// Adds the property.
+    /// </summary>
+    /// <param name="key">Key to be added.</param>
+    /// <param name="value">Value to be added.</param>
+    public void Add(string key, string value)
+    {
+        Add(new TestPropertyItem(key, value));
+    }
+
+    /// <summary>
+    /// Adds the property.
+    /// </summary>
+    /// <param name="item">Property to be added.</param>
+    public override void Add(TestPropertyItem item)
+    {
+        EqtAssert.ParameterNotNull(item, nameof(item));
+
+        // Don't add empty items.
+        if (!String.IsNullOrEmpty(item.Key))
+        {
+            base.Add(item);
+        }
+    }
+
+    /// <summary>
+    /// Convert the TestPropertyItemCollection to a string.
+    /// each item is surrounded by a comma (,)
+    /// </summary>
+    /// <returns></returns>
+    public override string ToString()
+    {
+        var returnString = new StringBuilder();
+        if (Count > 0)
+        {
+            returnString.Append(',');
+            foreach (TestPropertyItem item in this)
+            {
+                returnString.Append(item.ToString());
+                returnString.Append(',');
+            }
+        }
+
+        return returnString.ToString();
+    }
+
+    /// <summary>
+    /// Compare the collection items
+    /// </summary>
+    /// <param name="obj">other collection</param>
+    /// <returns>true if the collections contain the same items</returns>
+    public override bool Equals(object obj)
+    {
+        TestPropertyItemCollection other = obj as TestPropertyItemCollection;
+        bool result = false;
+
+        if (other == null)
+        {
+            // Other object is not a TestPropertyItemCollection.
+            result = false;
+        }
+        else if (Object.ReferenceEquals(this, other))
+        {
+            // The other object is the same object as this one.
+            result = true;
+        }
+        else if (Count != other.Count)
+        {
+            // The count of categories in the other object does not
+            // match this one, so they are not equal.
+            result = false;
+        }
+        else
+        {
+            // Check each item and return on the first mismatch.
+            foreach (TestPropertyItem item in this)
+            {
+                if (!other.Contains(item))
+                {
+                    result = false;
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Return the hash code of this collection
+    /// </summary>
+    /// <returns>The hashcode.</returns>
+    public override int GetHashCode()
+    {
+        return base.GetHashCode();
+    }
+    #endregion
+}
+#endregion

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Collection.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Collection.cs
@@ -61,7 +61,7 @@ internal class EqtBaseCollection<T> : ICollection<T>, IXmlTestStore
     #region Fields
     protected Hashtable _container;
 
-    private string _childElementName;
+    protected string _childElementName;
     #endregion
 
     #region Constructors

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
@@ -75,6 +75,11 @@ internal class Converter
             testElement.WorkItems.Add(workItem);
         }
 
+        foreach (var trait in rockSteadyTestCase.Traits)
+        {
+            testElement.TestProperties.Add(trait.Name, trait.Value);
+        }
+
         return testElement;
     }
 

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/Utility/ConverterTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/Utility/ConverterTests.cs
@@ -114,6 +114,24 @@ public class ConverterTests
         CollectionAssert.AreEquivalent(expected, unitTestElement.WorkItems.ToArray());
     }
 
+    [TestMethod]
+    public void ToTestElementShouldShouldAssignTraitsOfUnitTestElement()
+    {
+        var testCase = CreateTestCase("TestCaseWithTraits");
+        var result = new TestPlatformObjectModel.TestResult(testCase);
+
+        testCase.Traits.Add("Trait1", "Value1");
+        testCase.Traits.Add("Trait2", "Value2");
+
+        var unitTestElement = _converter.ToTestElement(testCase.Id, Guid.Empty, Guid.Empty, testCase.DisplayName, TrxLoggerConstants.UnitTestType, testCase);
+
+        // They only way to check for TestProperties is to cast the ITestElement object to UnitTestElement
+        Assert.IsInstanceOfType(unitTestElement, typeof(UnitTestElement));
+
+        var expected = new[] { new TestPropertyItem("Trait1", "Value1"), new TestPropertyItem("Trait2", "Value2") };
+        CollectionAssert.AreEquivalent(expected, ((UnitTestElement)unitTestElement).TestProperties.ToArray());
+    }
+
     /// <summary>
     /// Unit test for regression when there's no test categories.
     /// </summary>


### PR DESCRIPTION
In the current TRX logger implementation, traits on `TestCase` objects are mostly ignored when converting to the internal `ITestElement/UnitTestElement` representation. 

This PR adds a `TestPropertyItemCollection TestProperties` property on `TestElement` class which is populated when converting a `TestCase` in `Converter.ToTestElement()` method. `TestElement.Save()` method is then extended to store the test properties (traits) as Key/Value elements under a Properties element - this follows the XML schema from `vstst.xsd`.

Example of trx output with traits:

```xml
  <TestDefinitions>
    <UnitTest name="TestCaseWithTraits" storage="dummysourcefilename" id="0e9d09de-c08c-235d-bc82-88a161ff28aa">
      <Properties>
        <Property>
          <Key>Trait1</Key>
          <Value>Value1</Value>
        </Property>
        <Property>
          <Key>Trait2</Key>
          <Value>Value2</Value>
        </Property>
      </Properties>
      <Execution id="3612b533-5190-45e7-a28b-96a584ade89d" />
      <TestMethod codeBase="DummySourceFileName" adapterTypeName="some://uri/" className="DummySourceFileName" name="TestCaseWithTraits" />
    </UnitTest>
  </TestDefinitions>
```

Most of this work is based on @dotMorten's PR #1801.

## Tests
I have implemented a test for converting a `TestCase` with traits, and a test for validating the TRX output of a test with traits. 
