### PR TITLE
Fixed type in the XML code reference tag

### DIFF
--- a/src/Microsoft.TestPlatform.Common/Utilities/AssemblyProperties.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/AssemblyProperties.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PEReaderHelper"/> class.
+        /// Initializes a new instance of the <see cref="AssemblyProperties"/> class.
         /// </summary>
         /// <param name="fileHelper">File helper.</param>
         public AssemblyProperties(IFileHelper fileHelper)


### PR DESCRIPTION
## Description
Replaced the referenced PEReaderHelper type with the correct AssemblyProperties type that is actually being constructed


