### PR TITLE
VsTestTask Changes for enabling XPlat Code Coverage(via dotnet test)

### DIFF
--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
@@ -46,6 +46,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       VSTestCollect="$(VSTestCollect)"
       VSTestBlame="$(VSTestBlame)"
       VSTestTraceDataCollectorDirectoryPath="$(TraceDataCollectorDirectoryPath)"
+      VSTestXPlatDataCollectorDirectoryPath="$(XPlatDataCollectorDirectoryPath)"
       VSTestNoLogo="$(VSTestNoLogo)"
       Condition="'$(IsTestProject)' == 'true'"
     />
@@ -92,6 +93,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Message Text="VSTestCollect = $(VSTestCollect)" Importance="low" />
     <Message Text="VSTestBlame = $(VSTestBlame)" Importance="low" />
     <Message Text="VSTestTraceDataCollectorDirectoryPath = $(TraceDataCollectorDirectoryPath)" Importance="low" />
+    <Message Text="VSTestXPlatDataCollectorDirectoryPath = $(VSTestXPlatDataCollectorDirectoryPath)" Importance="low" />
     <Message Text="VSTestNoLogo = $(VSTestNoLogo)" Importance="low" />
   </Target>
 

--- a/src/Microsoft.TestPlatform.Build/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.Build/Resources/Resources.Designer.cs
@@ -98,6 +98,15 @@ namespace Microsoft.TestPlatform.Build.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Warning: Update the test project template and add reference to Microsoft.TestPlatform.Extensions.CoverletCoverageDataCollector to collect xplat code coverage.
+        /// </summary>
+        internal static string UpdateTemplateForCollectingXPlatCodeCoverage {
+            get {
+                return ResourceManager.GetString("UpdateTemplateForCollectingXPlatCodeCoverage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage..
         /// </summary>
         internal static string UpdateTestSdkForCollectingCodeCoverage {

--- a/src/Microsoft.TestPlatform.Build/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.Build/Resources/Resources.resx
@@ -129,6 +129,9 @@
   <data name="TestRunningSummary" xml:space="preserve">
     <value>Test run for {0}({1})</value>
   </data>
+  <data name="UpdateTemplateForCollectingXPlatCodeCoverage" xml:space="preserve">
+    <value>Warning: Update the test project template and add reference to Microsoft.TestPlatform.Extensions.CoverletCoverageDataCollector to collect xplat code coverage</value>
+  </data>
   <data name="UpdateTestSdkForCollectingCodeCoverage" xml:space="preserve">
     <value>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</value>
   </data>

--- a/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/VsTestTaskTests.cs
@@ -247,6 +247,19 @@ namespace Microsoft.TestPlatform.Build.UnitTests
         }
 
         [TestMethod]
+        public void CreateArgumentShouldAddXPlatCodeCoverageDataCollectorDirectoryPathAsTestAdapterForCodeCoverageCollect()
+        {
+            const string xplatDataCollectorDirectoryPath = @"c:\path\to\xplat datacollector";
+            this.vsTestTask.VSTestXPlatDataCollectorDirectoryPath = xplatDataCollectorDirectoryPath;
+            this.vsTestTask.VSTestCollect = new string[] { "xplat code coverage" };
+
+            var allArguments = this.vsTestTask.CreateArgument().ToArray();
+
+            const string expectedArg = "--testAdapterPath:\"c:\\path\\to\\xplat datacollector\"";
+            CollectionAssert.Contains(allArguments, expectedArg, $"Expected argument: '''{expectedArg}''' not present in [{string.Join(", ", allArguments)}]");
+        }
+
+        [TestMethod]
         public void CreateArgumentShouldNotAddTraceCollectorDirectoryPathAsTestAdapterForNonCodeCoverageCollect()
         {
             const string traceDataCollectorDirectoryPath = @"c:\path\to\tracedata collector";
@@ -274,6 +287,18 @@ namespace Microsoft.TestPlatform.Build.UnitTests
 
         [TestMethod]
         public void CreateArgumentShouldNotAddTestAdapterPathIfVSTestTraceDataCollectorDirectoryPathIsEmpty()
+        {
+            this.vsTestTask.VSTestXPlatDataCollectorDirectoryPath = string.Empty;
+            this.vsTestTask.VSTestSetting = @"c:\path\to\sample.runsettings";
+            this.vsTestTask.VSTestCollect = new string[] { "xplat code coverage" };
+
+            var allArguments = this.vsTestTask.CreateArgument().ToArray();
+
+            Assert.IsNull(allArguments.FirstOrDefault(arg => arg.Contains("--testAdapterPath:")));
+        }
+
+        [TestMethod]
+        public void CreateArgumentShouldNotAddTestAdapterPathIfVSTestXPlatDataCollectorDirectoryPathIsEmpty()
         {
             this.vsTestTask.VSTestTraceDataCollectorDirectoryPath = string.Empty;
             this.vsTestTask.VSTestSetting = @"c:\path\to\sample.runsettings";


### PR DESCRIPTION
## Description
Adding **VSTestXPlatDataCollectorDirectoryPath** to be added to test adapter path for picking XPlat code coverage data collector in case of `--collect:"xplat code coverage"`.
`XPlatDataCollectorDirectoryPath `variable is set by the data collector in its `props `file.