### PR TITLE
Data collector extensibility in Test Plugin Cache

### DIFF
--- a/src/Microsoft.TestPlatform.Client/TestPlatform.cs
+++ b/src/Microsoft.TestPlatform.Client/TestPlatform.cs
@@ -225,7 +225,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Client
                         continue;
                     }
 
-                    var extensionAssemblies = new List<string>(this.fileHelper.EnumerateFiles(adapterPath, SearchOption.AllDirectories, TestPlatformConstants.TestAdapterEndsWithPattern, TestPlatformConstants.TestLoggerEndsWithPattern, TestPlatformConstants.RunTimeEndsWithPattern));
+                    var extensionAssemblies = new List<string>(this.fileHelper.EnumerateFiles(adapterPath, SearchOption.AllDirectories, 
+                        TestPlatformConstants.TestAdapterEndsWithPattern,
+                        TestPlatformConstants.TestLoggerEndsWithPattern,
+                        TestPlatformConstants.DataCollectorEndsWithPattern,
+                        TestPlatformConstants.RunTimeEndsWithPattern));
+
                     if (extensionAssemblies.Count > 0)
                     {
                         this.UpdateExtensions(extensionAssemblies, skipExtensionFilters: false);

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -259,6 +259,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         private void InitializeExtensions(IEnumerable<string> sources)
         {
             var extensions = TestPluginCache.Instance.GetExtensionPaths(TestPlatformConstants.TestAdapterEndsWithPattern, this.skipDefaultAdapters);
+            extensions = extensions.Concat(TestPluginCache.Instance.GetExtensionPaths(TestPlatformConstants.DataCollectorEndsWithPattern, true)).ToList();
 
             // Filter out non existing extensions
             var nonExistingExtensions = extensions.Where(extension => !this.fileHelper.Exists(extension));

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/InProcDataCollectionExtensionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/InProcDataCollectionExtensionManager.cs
@@ -53,11 +53,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
         /// <param name="defaultCodeBase">
         /// The default codebase to be used by inproc data collector
         /// </param>
-        public InProcDataCollectionExtensionManager(string runSettings, ITestEventsPublisher testEventsPublisher, string defaultCodeBase)
-            : this(runSettings, testEventsPublisher, defaultCodeBase, new FileHelper())
+        public InProcDataCollectionExtensionManager(string runSettings, ITestEventsPublisher testEventsPublisher, string defaultCodeBase, TestPluginCache testPluginCache)
+            : this(runSettings, testEventsPublisher, defaultCodeBase, testPluginCache, new FileHelper())
         {}
 
-        protected InProcDataCollectionExtensionManager(string runSettings, ITestEventsPublisher testEventsPublisher, string defaultCodeBase, IFileHelper fileHelper)
+        protected InProcDataCollectionExtensionManager(string runSettings, ITestEventsPublisher testEventsPublisher, string defaultCodeBase, TestPluginCache testPluginCache, IFileHelper fileHelper)
         {
             this.InProcDataCollectors = new Dictionary<string, IInProcDataCollector>();
             this.inProcDataCollectionSink = new InProcDataCollectionSink();
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
             this.codeBasePaths = new List<string> { this.defaultCodeBase };
 
             // Get Datacollector codebase paths from test plugin cache
-            var extensionPaths = TestPluginCache.Instance.GetExtensionPaths(DataCollectorEndsWithPattern);
+            var extensionPaths = testPluginCache.GetExtensionPaths(DataCollectorEndsWithPattern);
             foreach (var extensionPath in extensionPaths)
             {
                 this.codeBasePaths.Add(Path.GetDirectoryName(extensionPath));
@@ -247,10 +247,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
             {
                 foreach (var extensionPath in this.codeBasePaths)
                 {
-                    var path = Path.Combine(extensionPath, codeBase);
-                    if (this.fileHelper.Exists(path))
+                    var assemblyPath = Path.Combine(extensionPath, codeBase);
+                    if (this.fileHelper.Exists(assemblyPath))
                     {
-                        return path;
+                        return assemblyPath;
                     }
                 }
             }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/InProcDataCollectionExtensionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/InProcDataCollectionExtensionManager.cs
@@ -9,12 +9,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
     using System.Linq;
     using System.Reflection;
     using System.Xml;
+    using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollector.InProcDataCollector;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.InProcDataCollector;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
+    using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
+    using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 
     /// <summary>
     /// The in process data collection extension manager.
@@ -25,7 +28,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
 
         private IDataCollectionSink inProcDataCollectionSink;
 
+        private const string DataCollectorEndsWithPattern = @"Collector.dll";
+
         private string defaultCodeBase;
+
+        private List<string> codeBasePaths;
+
+        private IFileHelper fileHelper;
 
         /// <summary>
         /// Loaded in-proc datacollectors collection
@@ -45,10 +54,23 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
         /// The default codebase to be used by inproc data collector
         /// </param>
         public InProcDataCollectionExtensionManager(string runSettings, ITestEventsPublisher testEventsPublisher, string defaultCodeBase)
+            : this(runSettings, testEventsPublisher, defaultCodeBase, new FileHelper())
+        {}
+
+        protected InProcDataCollectionExtensionManager(string runSettings, ITestEventsPublisher testEventsPublisher, string defaultCodeBase, IFileHelper fileHelper)
         {
             this.InProcDataCollectors = new Dictionary<string, IInProcDataCollector>();
             this.inProcDataCollectionSink = new InProcDataCollectionSink();
             this.defaultCodeBase = defaultCodeBase;
+            this.fileHelper = fileHelper;
+            this.codeBasePaths = new List<string> { this.defaultCodeBase };
+
+            // Get Datacollector codebase paths from test plugin cache
+            var extensionPaths = TestPluginCache.Instance.GetExtensionPaths(DataCollectorEndsWithPattern);
+            foreach (var extensionPath in extensionPaths)
+            {
+                this.codeBasePaths.Add(Path.GetDirectoryName(extensionPath));
+            }
 
             // Initialize InProcDataCollectors
             this.InitializeInProcDataCollectors(runSettings);
@@ -215,13 +237,25 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
 
         /// <summary>
         /// Gets codebase for inproc datacollector
-        /// Uses default codebase if given path is not absolute path of inproc datacollector
+        /// Uses all codebasePaths to check where the datacollector exists
         /// </summary>
-        /// <param name="codeBase">The run Settings.</param>
+        /// <param name="codeBase">The codebase.</param>
         /// <returns> Codebase </returns>
         private string GetCodebase(string codeBase)
         {
-            return Path.IsPathRooted(codeBase) ? codeBase : Path.Combine(this.defaultCodeBase, codeBase);
+            if (!Path.IsPathRooted(codeBase))
+            {
+                foreach (var extensionPath in this.codeBasePaths)
+                {
+                    var path = Path.Combine(extensionPath, codeBase);
+                    if (this.fileHelper.Exists(path))
+                    {
+                        return path;
+                    }
+                }
+            }
+
+            return codeBase;
         }
 
         private IDictionary<string, object> GetSessionStartProperties(SessionStartEventArgs sessionStartEventArgs)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/ExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/ExecutionManager.cs
@@ -219,7 +219,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
             // Initialize inproc data collectors if declared in run settings.
             if (XmlRunSettingsUtilities.IsInProcDataCollectionEnabled(runSettings))
             {
-                var inProcDataCollectionExtensionManager = new InProcDataCollectionExtensionManager(runSettings, testEventsPublisher, defaultCodeBase);
+                var inProcDataCollectionExtensionManager = new InProcDataCollectionExtensionManager(runSettings, testEventsPublisher, defaultCodeBase, TestPluginCache.Instance);
             }
         }
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -45,6 +45,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
         private const string DotnetTestHostUri = "HostProvider://DotnetTestHost";
         private const string DotnetTestHostFriendlyName = "DotnetTestHost";
         private const string TestAdapterRegexPattern = @"TestAdapter.dll";
+        private const string DataCollectorRegexPattern = @"Collector.dll";
 
         private IDotnetHostHelper dotnetHostHelper;
 
@@ -238,14 +239,20 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
         /// <inheritdoc/>
         public IEnumerable<string> GetTestPlatformExtensions(IEnumerable<string> sources, IEnumerable<string> extensions)
         {
+            List<string> extensionPaths = new List<string>();
             var sourceDirectory = Path.GetDirectoryName(sources.Single());
 
             if (!string.IsNullOrEmpty(sourceDirectory) && this.fileHelper.DirectoryExists(sourceDirectory))
             {
-                return this.fileHelper.EnumerateFiles(sourceDirectory, SearchOption.TopDirectoryOnly, TestAdapterRegexPattern);
+                extensionPaths.AddRange(this.fileHelper.EnumerateFiles(sourceDirectory, SearchOption.TopDirectoryOnly, TestAdapterRegexPattern));
             }
 
-            return Enumerable.Empty<string>();
+            if (extensions != null && extensions.Any())
+            {
+                extensionPaths.AddRange(extensions.Where(x => x.EndsWith(DataCollectorRegexPattern, StringComparison.OrdinalIgnoreCase)));
+            }
+
+            return extensionPaths;
         }
 
         /// <inheritdoc/>

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
@@ -275,6 +275,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         [TestMethod]
         public void StartTestRunShouldInitializeExtensionsWithExistingExtensionsOnly()
         {
+            TestPluginCache.Instance = null;
             TestPluginCache.Instance.UpdateExtensions(new List<string> { "abc.TestAdapter.dll", "def.TestAdapter.dll", "xyz.TestAdapter.dll" }, false);
             var expectedOutputPaths = new[] { "abc.TestAdapter.dll", "xyz.TestAdapter.dll" };
 
@@ -299,7 +300,36 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
             this.mockRequestSender.Verify(s => s.InitializeExecution(expectedOutputPaths), Times.Once);
         }
 
-    [TestMethod]
+        [TestMethod]
+        public void StartTestRunShouldInitializeExtensionsWithExistingDataCOllectorExtensions()
+        {
+            TestPluginCache.Instance = null;
+            TestPluginCache.Instance.UpdateExtensions(new List<string> { "abc.TestAdapter.dll", "def.TestAdapter.dll", "xyz.TestAdapter.dll", "abc.DataCollector.dll" }, false);
+            var expectedOutputPaths = new[] { "abc.TestAdapter.dll", "xyz.TestAdapter.dll", "abc.DataCollector.dll" };
+
+            this.mockTestHostManager.SetupGet(th => th.Shared).Returns(false);
+            this.mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(true);
+            this.mockTestHostManager.Setup(th => th.GetTestPlatformExtensions(It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>())).Returns((IEnumerable<string> sources, IEnumerable<string> extensions) =>
+            {
+                return extensions.Select(extension => { return Path.GetFileName(extension); });
+            });
+
+            this.mockFileHelper.Setup(fh => fh.Exists(It.IsAny<string>())).Returns((string extensionPath) =>
+            {
+                return !extensionPath.Contains("def.TestAdapter.dll");
+            });
+
+            this.mockFileHelper.Setup(fh => fh.Exists("abc.TestAdapter.dll")).Returns(true);
+            this.mockFileHelper.Setup(fh => fh.Exists("xyz.TestAdapter.dll")).Returns(true);
+            this.mockFileHelper.Setup(fh => fh.Exists("abc.DataCollector.dll")).Returns(true);
+
+            var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+            this.testExecutionManager.StartTestRun(this.mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
+
+            this.mockRequestSender.Verify(s => s.InitializeExecution(expectedOutputPaths), Times.Once);
+        }
+
+        [TestMethod]
         public void SetupChannelShouldThrowExceptionIfClientConnectionTimeout()
         {
             this.mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/InProcDataCollectionExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/InProcDataCollectionExtensionManagerTests.cs
@@ -40,19 +40,15 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
         private TestableInProcDataCollectionExtensionManager inProcDataCollectionManager;
         private string defaultCodebase = "E:\\repos\\MSTest\\src\\managed\\TestPlatform\\TestImpactListener.Tests\\bin\\Debug";
         private Mock<IFileHelper> mockFileHelper;
+        private TestPluginCache testPluginCache;
 
         [TestInitialize]
         public void TestInit()
         {
             this.mockTestEventsPublisher = new Mock<ITestEventsPublisher>();
             this.mockFileHelper = new Mock<IFileHelper>();
-            this.inProcDataCollectionManager = new TestableInProcDataCollectionExtensionManager(this.settingsXml, this.mockTestEventsPublisher.Object, this.defaultCodebase, this.mockFileHelper.Object);
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            TestPluginCache.Instance = null;
+            this.testPluginCache = TestPluginCache.Instance;
+            this.inProcDataCollectionManager = new TestableInProcDataCollectionExtensionManager(this.settingsXml, this.mockTestEventsPublisher.Object, this.defaultCodebase, this.testPluginCache, this.mockFileHelper.Object);
         }
 
         [TestMethod]
@@ -84,7 +80,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
                                 </RunSettings>";
 
             this.mockFileHelper.Setup(fh => fh.Exists(@"E:\repos\MSTest\src\managed\TestPlatform\TestImpactListener.Tests\bin\Debug\TestImpactListener.Tests.dll")).Returns(true);
-            this.inProcDataCollectionManager = new TestableInProcDataCollectionExtensionManager(settingsXml, this.mockTestEventsPublisher.Object, this.defaultCodebase, this.mockFileHelper.Object);
+            this.inProcDataCollectionManager = new TestableInProcDataCollectionExtensionManager(settingsXml, this.mockTestEventsPublisher.Object, this.defaultCodebase, this.testPluginCache, this.mockFileHelper.Object);
 
             var codebase = (inProcDataCollectionManager.InProcDataCollectors.Values.First() as MockDataCollector).CodeBase;
             Assert.AreEqual(codebase, @"E:\repos\MSTest\src\managed\TestPlatform\TestImpactListener.Tests\bin\Debug\TestImpactListener.Tests.dll");
@@ -105,10 +101,10 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
                                     </InProcDataCollectionRunSettings>
                                 </RunSettings>";
 
-            TestPluginCache.Instance.UpdateExtensions(new List<string> { @"E:\source\.nuget\TestImpactListenerDataCollector.dll" }, true);
+            this.testPluginCache.UpdateExtensions(new List<string> { @"E:\source\.nuget\TestImpactListenerDataCollector.dll" }, true);
             this.mockFileHelper.Setup(fh => fh.Exists(@"E:\source\.nuget\TestImpactListenerDataCollector.dll")).Returns(true);
 
-            this.inProcDataCollectionManager = new TestableInProcDataCollectionExtensionManager(settingsXml, this.mockTestEventsPublisher.Object, this.defaultCodebase, this.mockFileHelper.Object);
+            this.inProcDataCollectionManager = new TestableInProcDataCollectionExtensionManager(settingsXml, this.mockTestEventsPublisher.Object, this.defaultCodebase, this.testPluginCache, this.mockFileHelper.Object);
 
             var codebase = (inProcDataCollectionManager.InProcDataCollectors.Values.First() as MockDataCollector).CodeBase;
             Assert.AreEqual(codebase, @"E:\source\.nuget\TestImpactListenerDataCollector.dll");
@@ -128,7 +124,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
                                         </InProcDataCollectors>
                                     </InProcDataCollectionRunSettings>
                                 </RunSettings>";
-            this.inProcDataCollectionManager = new TestableInProcDataCollectionExtensionManager(settingsXml, this.mockTestEventsPublisher.Object, this.defaultCodebase, this.mockFileHelper.Object);
+            this.inProcDataCollectionManager = new TestableInProcDataCollectionExtensionManager(settingsXml, this.mockTestEventsPublisher.Object, this.defaultCodebase, this.testPluginCache, this.mockFileHelper.Object);
 
             var codebase = (inProcDataCollectionManager.InProcDataCollectors.Values.First() as MockDataCollector).CodeBase;
             Assert.AreEqual(codebase, "\\\\DummyPath\\TestImpactListener.Tests.dll");
@@ -154,7 +150,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
                                     </InProcDataCollectionRunSettings>
                                 </RunSettings>";
 
-            this.inProcDataCollectionManager = new TestableInProcDataCollectionExtensionManager(multiSettingsXml, this.mockTestEventsPublisher.Object, this.defaultCodebase, this.mockFileHelper.Object);
+            this.inProcDataCollectionManager = new TestableInProcDataCollectionExtensionManager(multiSettingsXml, this.mockTestEventsPublisher.Object, this.defaultCodebase, this.testPluginCache, this.mockFileHelper.Object);
             bool secondOne = false;
             MockDataCollector dataCollector1 = null;
             MockDataCollector dataCollector2 = null;
@@ -196,7 +192,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
                                     </InProcDataCollectionRunSettings>
                                 </RunSettings>";
 
-            var manager = new InProcDataCollectionExtensionManager(invalidSettingsXml, this.mockTestEventsPublisher.Object, this.defaultCodebase);
+            var manager = new InProcDataCollectionExtensionManager(invalidSettingsXml, this.mockTestEventsPublisher.Object, this.defaultCodebase, this.testPluginCache);
             Assert.IsFalse(manager.IsInProcDataCollectionEnabled, "InProcDataCollection must be disabled on invalid settings.");
         }
         [TestMethod]
@@ -271,8 +267,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
 
         internal class TestableInProcDataCollectionExtensionManager : InProcDataCollectionExtensionManager
         {
-            public TestableInProcDataCollectionExtensionManager(string runSettings, ITestEventsPublisher mockTestEventsPublisher, string defaultCodebase, IFileHelper fileHelper) 
-                : base(runSettings, mockTestEventsPublisher, defaultCodebase, fileHelper)
+            public TestableInProcDataCollectionExtensionManager(string runSettings, ITestEventsPublisher mockTestEventsPublisher, string defaultCodebase, TestPluginCache testPluginCache, IFileHelper fileHelper) 
+                : base(runSettings, mockTestEventsPublisher, defaultCodebase, testPluginCache, fileHelper)
             {
             }
 

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -388,6 +388,16 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
         }
 
         [TestMethod]
+        public void GetTestPlatformExtensionsShouldAddDataCollectorsExtensionsIfPresent()
+        {
+            this.mockFileHelper.Setup(fh => fh.DirectoryExists(It.IsAny<string>())).Returns(true);
+            this.mockFileHelper.Setup(fh => fh.EnumerateFiles(It.IsAny<string>(), SearchOption.TopDirectoryOnly, It.IsAny<string[]>())).Returns(new[] { "foo.dll" });
+            var extensions = this.dotnetHostManager.GetTestPlatformExtensions(this.testSource, new List<string> { "abc.datacollector.dll" });
+
+            Assert.AreEqual(1, extensions.Count());
+        }
+
+        [TestMethod]
         public async Task LaunchTestHostShouldLaunchProcessWithConnectionInfo()
         {
             var expectedArgs = "exec \"" + this.defaultTestHostPath + "\" --port 123 --endpoint 127.0.0.1:123 --role client --parentprocessid 0";


### PR DESCRIPTION
## Description
1. Adding datacollector extensions in test plugin cache and sending these to test host.
2. This enables the InProcDataCollectionExtensionManager  to be able to find the datacollector in all datacollector extension paths if inproc datacollector codebase path is not an absolute path.
