### PR TITLE
Vstest.console Should not message to Testhost process if it has exited

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -320,6 +320,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         /// <inheritdoc />
         public void SendTestRunCancel()
         {
+            if (this.IsOperationComplete())
+            {
+                EqtTrace.Verbose("TestRequestSender: SendTestRunCancel: Operation is already complete. Skip error message.");
+                return;
+            }
+
             if (EqtTrace.IsVerboseEnabled)
             {
                 EqtTrace.Verbose("TestRequestSender.SendTestRunCancel: Sending test run cancel.");
@@ -331,6 +337,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         /// <inheritdoc />
         public void SendTestRunAbort()
         {
+            if (this.IsOperationComplete())
+            {
+                EqtTrace.Verbose("TestRequestSender: SendTestRunAbort: Operation is already complete. Skip error message.");
+                return;
+            }
+
             if (EqtTrace.IsVerboseEnabled)
             {
                 EqtTrace.Verbose("TestRequestSender.SendTestRunAbort: Sending test run abort.");

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
@@ -178,6 +178,30 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
             this.mockDataSerializer.Verify(ds => ds.SerializeMessage(MessageType.SessionEnd), Times.Once);
         }
 
+        [TestMethod]
+        public void EndSessionShouldNotSendTestRunCancelMessageIfClientDisconnected()
+        {
+            this.SetupFakeCommunicationChannel();
+            this.testRequestSender.DiscoverTests(new DiscoveryCriteria(), this.mockDiscoveryEventsHandler.Object);
+            this.RaiseClientDisconnectedEvent();
+
+            this.testRequestSender.SendTestRunCancel();
+
+            this.mockChannel.Verify(mockChannel => mockChannel.Send(MessageType.CancelTestRun), Times.Never);
+        }
+
+        [TestMethod]
+        public void EndSessionShouldNotSendTestRunAbortMessageIfClientDisconnected()
+        {
+            this.SetupFakeCommunicationChannel();
+            this.testRequestSender.DiscoverTests(new DiscoveryCriteria(), this.mockDiscoveryEventsHandler.Object);
+            this.RaiseClientDisconnectedEvent();
+
+            this.testRequestSender.SendTestRunAbort();
+
+            this.mockChannel.Verify(mockChannel => mockChannel.Send(MessageType.CancelTestRun), Times.Never);
+        }
+
         [DataTestMethod]
         [DataRow("")]
         [DataRow(" ")]


### PR DESCRIPTION
In very remote cases, esp while debugging if testhost process aborts for some unexpected reeason, & user also triggers a Cancel Request, then sometimes before vstest.console can mark the event [testhostexited = true](https://github.com/Microsoft/vstest/blob/b53383b67b9331a2132bfafea5fc2c9de214c45a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs#L306), we get request on another thread to cancel the run.

In this case since the communication with testhost has already expired, we fail to write to the tcp channel, which results in an exception being thrown in vstest.console. This exception is caught, but we also mark current vstest.console session to be completed, & the process dies, this results in further messages from IDE to not execute, for which user has to restart VS.

Bugs:
https://developercommunity.visualstudio.com/content/problem/508748/cant-run-any-test-from-test-explorer-writeandflush.html
https://developercommunity.visualstudio.com/content/problem/532712/occasional-ioexception-while-unit-testing.html
https://developercommunity.visualstudio.com/content/problem/499747/test-execution-fails-with-an-ioexception.html
https://developercommunity.visualstudio.com/content/problem/528897/error-running-unit-test-case.html

Log file: 
[log.txt](https://github.com/Microsoft/vstest/files/3108314/log.txt)
