### PR TITLE
[Revert] Fix for dotnet test on a multi-target projects logs only the last target 

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestRun.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestRun.cs
@@ -191,7 +191,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         {
             // We use custom format string to make sure that runs are sorted in the same way on all intl machines.
             // This is both for directory names and for Data Warehouse.
-            return timeStamp.ToString("yyyy-MM-dd HH:mm:ss:fff", DateTimeFormatInfo.InvariantInfo);
+            return timeStamp.ToString("yyyy-MM-dd HH:mm:ss", DateTimeFormatInfo.InvariantInfo);
         }
 
         private void Initialize()

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -441,13 +441,17 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
 
         private void DeriveTrxFilePath()
         {
-            if (this.parametersDictionary != null &&
-                this.parametersDictionary.TryGetValue(TrxLoggerConstants.LogFileNameKey, out string logFileNameValue) &&
-                !string.IsNullOrWhiteSpace(logFileNameValue))
+            if (this.parametersDictionary != null)
             {
-                string logFileNameWithoutExt = Path.GetFileNameWithoutExtension(logFileNameValue);
-                logFileNameValue = logFileNameValue.Replace(logFileNameWithoutExt, logFileNameWithoutExt + DateTime.Now.ToString("_yyyy-MM-dd_HH-mm-ss-fff", DateTimeFormatInfo.InvariantInfo));
-                this.trxFilePath = Path.Combine(this.testResultsDirPath, logFileNameValue);
+                var isLogFileNameParameterExists = this.parametersDictionary.TryGetValue(TrxLoggerConstants.LogFileNameKey, out string logFileNameValue);
+                if (isLogFileNameParameterExists && !string.IsNullOrWhiteSpace(logFileNameValue))
+                {
+                    this.trxFilePath = Path.Combine(this.testResultsDirPath, logFileNameValue);
+                }
+                else
+                {
+                    this.SetDefaultTrxFilePath();
+                }
             }
             else
             {

--- a/test/Microsoft.TestPlatform.AcceptanceTests/LoggerTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/LoggerTests.cs
@@ -8,7 +8,6 @@ using System.Xml;
 namespace Microsoft.TestPlatform.AcceptanceTests
 {
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using System.Linq;
 
     [TestClass]
     public class LoggerTests : AcceptanceTestBase
@@ -21,7 +20,6 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
             var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
             var trxFileName = "TestResults.trx";
-            var trxFileNamePattern = "TestResults*.trx";
             arguments = string.Concat(arguments, $" /logger:\"trx;LogFileName={trxFileName}\"");
             this.InvokeVsTest(arguments);
 
@@ -30,7 +28,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             arguments = string.Concat(arguments, " /testcasefilter:Name~Pass");
             this.InvokeVsTest(arguments);
 
-            var trxLogFilePath = Directory.EnumerateFiles(Path.Combine(Directory.GetCurrentDirectory(), "TestResults"), trxFileNamePattern).First();
+            var trxLogFilePath = Path.Combine(Directory.GetCurrentDirectory(), "TestResults",  trxFileName);
             Assert.IsTrue(IsValidXml(trxLogFilePath), "Invalid content in Trx log file");
         }
 
@@ -42,7 +40,6 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
             var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
             var trxFileName = "TestResults.trx";
-            var trxFileNamePattern = "TestResults*.trx";
             arguments = string.Concat(arguments, $" /logger:\"logger://Microsoft/TestPlatform/TrxLogger/v1;LogFileName{trxFileName}\"");
             this.InvokeVsTest(arguments);
 
@@ -51,7 +48,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             arguments = string.Concat(arguments, " /testcasefilter:Name~Pass");
             this.InvokeVsTest(arguments);
 
-            var trxLogFilePath = Directory.EnumerateFiles(Path.Combine(Directory.GetCurrentDirectory(), "TestResults"), trxFileNamePattern).First();
+            var trxLogFilePath = Path.Combine(Directory.GetCurrentDirectory(), "TestResults", trxFileName);
             Assert.IsTrue(IsValidXml(trxLogFilePath), "Invalid content in Trx log file");
         }
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/ResultsDirectoryTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/ResultsDirectoryTests.cs
@@ -4,7 +4,6 @@
 namespace Microsoft.TestPlatform.AcceptanceTests
 {
     using System.IO;
-    using System.Linq;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -17,22 +16,18 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
             var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
-            var trxFileName = "TestResultsbla.trx";
-            var trxFileNamePattern = "TestResultsbla*.trx";
+            var trxFileName = "TestResults.trx";
             var resultsDir = Path.GetTempPath();
+            var trxFilePath = Path.Combine(resultsDir, trxFileName);
             arguments = string.Concat(arguments, $" /logger:\"trx;LogFileName={trxFileName}\"");
             arguments = string.Concat(arguments, $" /ResultsDirectory:{resultsDir}");
 
             // Delete if already exists
-            var dir = new DirectoryInfo(resultsDir);
-            foreach (var file in dir.EnumerateFiles(trxFileNamePattern))
-            {
-                file.Delete();
-            }
+            File.Delete(trxFilePath);
 
             this.InvokeVsTest(arguments);
 
-            Assert.IsTrue(Directory.EnumerateFiles(resultsDir, trxFileNamePattern).Any(), $"Expected Trx file with pattern: {trxFileNamePattern} not created in results directory");
+            Assert.IsTrue(File.Exists(trxFilePath), $"Expected Trx file: {trxFilePath} not created in results directory");
         }
 
         [TestMethod]
@@ -44,10 +39,10 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
             var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
             var trxFileName = "TestResults.trx";
-            var trxFileNamePattern = "TestResults*.trx";
             var relativeDirectory = @"relative\directory";
             var resultsDirectory = Path.Combine(Directory.GetCurrentDirectory(), relativeDirectory);
 
+            var trxFilePath = Path.Combine(resultsDirectory , trxFileName);
             arguments = string.Concat(arguments, $" /logger:\"trx;LogFileName={trxFileName}\"");
             arguments = string.Concat(arguments, $" /ResultsDirectory:{relativeDirectory}");
 
@@ -58,7 +53,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
             this.InvokeVsTest(arguments);
 
-            Assert.IsTrue(Directory.EnumerateFiles(resultsDirectory, trxFileNamePattern).Any(), $"Expected Trx file with pattern: { trxFileNamePattern} not created in results directory");
+            Assert.IsTrue(File.Exists(trxFilePath), $"Expected Trx file: {trxFilePath} not created in results directory");
         }
     }
 }

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -637,12 +637,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
         {
             this.MakeTestRunComplete();
 
-            string expectedFileNameWithoutTimestamp = Path.Combine(TrxLoggerTests.DefaultTestRunDirectory, TrxLoggerTests.DefaultLogFileNameParameterValue);
-            string fileName = Path.GetFileNameWithoutExtension(this.testableTrxLogger.trxFile);
-            string actualFileNameWithoutTimestamp = this.testableTrxLogger.trxFile.Replace(fileName, fileName.Split('_')[0]);
-
-            Assert.AreNotEqual(expectedFileNameWithoutTimestamp, this.testableTrxLogger.trxFile, "Expected time stamp to appear in file name");
-            Assert.AreEqual(expectedFileNameWithoutTimestamp, actualFileNameWithoutTimestamp, "Trx file name should construct from log file parameter");
+            Assert.AreEqual(Path.Combine(TrxLoggerTests.DefaultTestRunDirectory, TrxLoggerTests.DefaultLogFileNameParameterValue), this.testableTrxLogger.trxFile, "Wrong Trx file name");
         }
 
         /// <summary>


### PR DESCRIPTION
Revert "Fix - dotnet test on a multi-target projects logs only the last target (#1877)"

This reverts commit 37696768786ef1018f0b4499eab9ca27af141057.

## Description
Reverting the above fix because it came out as a breaking change for a lot of customers.
We will be revisiting this soon with a proper fix and RFCs

This will be a take back for https://github.com/Microsoft/vstest/issues/1603
(Timestamp is appended to trx filename with millisecond precision. Thus for multi-target projects, trx for both targets will be stored.)
