### PR TITLE
Package Shim with testplatform to allow verifiable instrumentation via Coverage

### DIFF
--- a/scripts/verify-nupkgs.ps1
+++ b/scripts/verify-nupkgs.ps1
@@ -14,7 +14,7 @@ function Verify-Nuget-Packages($packageDirectory)
     Write-Log "Starting Verify-Nuget-Packages."
     $expectedNumOfFiles = @{"Microsoft.CodeCoverage" = 29;
                      "Microsoft.NET.Test.Sdk" = 13;
-                     "Microsoft.TestPlatform" = 421;
+                     "Microsoft.TestPlatform" = 422;
                      "Microsoft.TestPlatform.Build" = 19;
                      "Microsoft.TestPlatform.CLI" = 302;
                      "Microsoft.TestPlatform.Extensions.TrxLogger" = 33;

--- a/src/package/nuspec/Microsoft.TestPlatform.nuspec
+++ b/src/package/nuspec/Microsoft.TestPlatform.nuspec
@@ -405,6 +405,7 @@
     <file src="Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\msdia140.dll"	target="tools\net451\Team Tools\Dynamic Code Coverage Tools\amd64\msdia140.dll" />
     <file src="Intellitrace\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.Telemetry.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.Telemetry.dll" />
     <file src="Intellitrace\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.Utilities.Internal.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.Utilities.Internal.dll" />
+    <file src="Microsoft.CodeCoverage\Shim\net45\Microsoft.VisualStudio.CodeCoverage.Shim.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.CodeCoverage.Shim.dll" />
 
     <!-- CUIT -->
     <file src="net451\$Runtime$\Interop.UIAutomationClient.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Interop.UIAutomationClient.dll" />


### PR DESCRIPTION
## Description
Allow verifiable instrumentation, during code coverage, this allows coverage from code under [SecurityCritical] attributes, which otherwise cause System.Security.VerificationException

## Related issue
Fixes https://github.com/Microsoft/vstest/issues/1950. 
