### PR TITLE
Do not show TPv2 vsix in Extensions and Updates.

### DIFF
--- a/src/package/VSIXProject/source.extension.vsixmanifest
+++ b/src/package/VSIXProject/source.extension.vsixmanifest
@@ -7,7 +7,7 @@
     <License>License.rtf</License>
     <PackageId>Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI</PackageId>
   </Metadata>
-  <Installation AllUsers="true">
+  <Installation AllUsers="true" SystemComponent="true">
     <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Community" />
     <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
     <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />


### PR DESCRIPTION
## Description
Making the TPv2 vsix a system component so that it cannot be disabled by the user.

## Issue
https://developercommunity.visualstudio.com/content/problem/531135/test-explorer-fails-with-exception.html