### PR TITLE
Trx ClassName fix

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
@@ -606,7 +606,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.Utility
 
             // In case, fullyQualifiedName ends with testName, className is checked within remaining value of fullyQualifiedName.
             // Example: In case, testName = TestMethod1(2, 3, 4.0d) and fullyQualifiedName = TestProject1.Class1.TestMethod1(2, 3, 4.0d), className will be checked within 'TestProject1.Class1.' only
-            var nameToCheck = fullyQualifiedName.EndsWith(testName) ?
+            var nameToCheck = !fullyQualifiedName.Equals(testName, StringComparison.OrdinalIgnoreCase) && fullyQualifiedName.EndsWith(testName) ?
                 fullyQualifiedName.Substring(0, fullyQualifiedName.Length - testName.Length) :
                 fullyQualifiedName;
 

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/Utility/ConverterTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/Utility/ConverterTests.cs
@@ -100,6 +100,16 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests.Utility
         }
 
         [TestMethod]
+        public void ToTestElementShouldContainExpectedTestMethodPropertiesIfFqnIsSameAsTestName()
+        {
+            var expectedClassName = "TestProject1.Class1";
+            var fullyQualifiedName = expectedClassName + "." + "TestMethod1";
+            var testName = "TestProject1.Class1.TestMethod1";
+
+            ValidateTestMethodProperties(testName, fullyQualifiedName, expectedClassName);
+        }
+
+        [TestMethod]
         public void ToTestElementShouldContainExpectedTestMethodPropertiesIfFqnEndsWithTestName()
         {
             var expectedClassName = "TestProject1.Class1";


### PR DESCRIPTION
## Description
Fix for the trx classname being wrongly stamped when testname and fullyqualifiedname are same.

## Related issue
https://github.com/microsoft/vstest/issues/1992
