### PR TITLE
DataCollector search in output directory

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
@@ -7,7 +7,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
     using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
-    using System.Linq;
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
@@ -246,14 +245,21 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
             try
             {
                 var customTestAdaptersPaths = RunSettingsUtilities.GetTestAdaptersPaths(payload.SettingsXml);
-                customTestAdaptersPaths = customTestAdaptersPaths.Concat(payload.Sources.Select(x => Path.GetDirectoryName(x)).Distinct());
-                if (customTestAdaptersPaths != null)
+                var datacollectorSearchPaths = new List<string>();
+                foreach (var source in payload.Sources)
+                {
+                    datacollectorSearchPaths.Add(Path.GetDirectoryName(source));
+                }
+
+                datacollectorSearchPaths.AddRange(customTestAdaptersPaths);
+
+                if (datacollectorSearchPaths != null)
                 {
                     List<string> extensionAssemblies = new List<string>();
-                    foreach (var customTestAdaptersPath in customTestAdaptersPaths)
+                    foreach (var datacollectorSearchPath in datacollectorSearchPaths)
                     {
                         var adapterPath =
-                            Path.GetFullPath(Environment.ExpandEnvironmentVariables(customTestAdaptersPath));
+                            Path.GetFullPath(Environment.ExpandEnvironmentVariables(datacollectorSearchPath));
                         if (!this.fileHelper.DirectoryExists(adapterPath))
                         {
                             EqtTrace.Warning(string.Format("AdapterPath Not Found:", adapterPath));

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
@@ -245,7 +245,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
         {
             try
             {
-                IEnumerable<string> customTestAdaptersPaths = RunSettingsUtilities.GetTestAdaptersPaths(payload.SettingsXml);
+                var customTestAdaptersPaths = RunSettingsUtilities.GetTestAdaptersPaths(payload.SettingsXml);
                 customTestAdaptersPaths = customTestAdaptersPaths.Concat(payload.Sources.Select(x => Path.GetDirectoryName(x)).Distinct());
                 if (customTestAdaptersPaths != null)
                 {

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Microsoft.TestPlatform.CommunicationUtilities.csproj
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Microsoft.TestPlatform.CommunicationUtilities.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="System.Runtime.Serialization.Primitives">
       <Version>4.1.1</Version>
     </PackageReference>
+    <Reference Include="System.Runtime" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Microsoft.TestPlatform.CommunicationUtilities.csproj
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Microsoft.TestPlatform.CommunicationUtilities.csproj
@@ -17,9 +17,6 @@
     <ProjectReference Include="..\Microsoft.TestPlatform.CoreUtilities\Microsoft.TestPlatform.CoreUtilities.csproj" />
     <ProjectReference Include="..\Microsoft.TestPlatform.ObjectModel\Microsoft.TestPlatform.ObjectModel.csproj" />
     <ProjectReference Include="..\Microsoft.TestPlatform.Common\Microsoft.TestPlatform.Common.csproj" />
-    <PackageReference Include="System.Runtime">
-      <Version>4.1.0</Version>
-    </PackageReference>
 
     <PackageReference Include="Newtonsoft.Json">
       <Version>$(JsonNetVersion)</Version>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Microsoft.TestPlatform.CommunicationUtilities.csproj
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Microsoft.TestPlatform.CommunicationUtilities.csproj
@@ -17,6 +17,9 @@
     <ProjectReference Include="..\Microsoft.TestPlatform.CoreUtilities\Microsoft.TestPlatform.CoreUtilities.csproj" />
     <ProjectReference Include="..\Microsoft.TestPlatform.ObjectModel\Microsoft.TestPlatform.ObjectModel.csproj" />
     <ProjectReference Include="..\Microsoft.TestPlatform.Common\Microsoft.TestPlatform.Common.csproj" />
+    <PackageReference Include="System.Runtime">
+      <Version>4.1.0</Version>
+    </PackageReference>
 
     <PackageReference Include="Newtonsoft.Json">
       <Version>$(JsonNetVersion)</Version>
@@ -26,7 +29,6 @@
     <PackageReference Include="System.Runtime.Serialization.Primitives">
       <Version>4.1.1</Version>
     </PackageReference>
-    <Reference Include="System.Runtime" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestDoubles/TestableDataCollectionRequestHandler.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestDoubles/TestableDataCollectionRequestHandler.cs
@@ -8,6 +8,9 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.TestDoubles
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 
+    /// <summary>
+    /// Testable class for DataCollectionRequestHandler since all constructors of DataCollectionRequestHandler are protected.
+    /// </summary>
     internal class TestableDataCollectionRequestHandler : DataCollectionRequestHandler
     {
         public TestableDataCollectionRequestHandler(ICommunicationManager communicationManager, IMessageSink messageSink, IDataCollectionManager dataCollectionManager, IDataCollectionTestCaseEventHandler dataCollectionTestCaseEventHandler, IDataSerializer dataSerializer, IFileHelper fIleHelper)

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestDoubles/TestableDataCollectionRequestHandler.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestDoubles/TestableDataCollectionRequestHandler.cs
@@ -6,11 +6,12 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.TestDoubles
     using Microsoft.VisualStudio.TestPlatform.Common.DataCollector.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollection;
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
+    using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 
     internal class TestableDataCollectionRequestHandler : DataCollectionRequestHandler
     {
-        public TestableDataCollectionRequestHandler(ICommunicationManager communicationManager, IMessageSink messageSink, IDataCollectionManager dataCollectionManager, IDataCollectionTestCaseEventHandler dataCollectionTestCaseEventHandler, IDataSerializer dataSerializer)
-            : base(communicationManager, messageSink, dataCollectionManager, dataCollectionTestCaseEventHandler, dataSerializer)
+        public TestableDataCollectionRequestHandler(ICommunicationManager communicationManager, IMessageSink messageSink, IDataCollectionManager dataCollectionManager, IDataCollectionTestCaseEventHandler dataCollectionTestCaseEventHandler, IDataSerializer dataSerializer, IFileHelper fIleHelper)
+            : base(communicationManager, messageSink, dataCollectionManager, dataCollectionTestCaseEventHandler, dataSerializer, fIleHelper)
         {
         }
     }


### PR DESCRIPTION
Modifying the search directories to pick up datacollector from directory from where the test dll is picked up. This is needed because  `dotnet vstest` does not work with with code coverage as the datacollector is not picked up from the output/bin (publish directory in case of code coverage).
