### PR TITLE
Made first chance exception configurable

### DIFF
--- a/open.bat
+++ b/open.bat
@@ -1,2 +1,7 @@
+REM #############################################################
+REM ## This is used to open the sln file (with default program ##
+REM ## associated with sln files) with PATH overidden to point ##
+REM ## to the dotnet installation in the tools folder.         ##
+REM #############################################################
 set PATH=%cd%\tools\dotnet;%PATH%
 TestPlatform.sln

--- a/open.bat
+++ b/open.bat
@@ -1,0 +1,2 @@
+set PATH=%cd%\tools\dotnet;%PATH%
+TestPlatform.sln

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
@@ -34,6 +34,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
         private bool collectDumpAlways;
         private bool processFullDumpEnabled;
         private string attachmentGuid;
+        private bool includeFirstChanceExceptions = true;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BlameCollector"/> class.
@@ -107,6 +108,8 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                 {
                     this.ValidateAndAddProcessDumpParameters(collectDumpNode);
                 }
+
+                var includeFirstChanceExceptions = this.configurationElement[Constants.IncludeFirstChanceExceptionsKey];
             }
 
             this.attachmentGuid = Guid.NewGuid().ToString().Replace("-", string.Empty);
@@ -136,6 +139,21 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                     else
                     {
                         this.logger.LogWarning(this.context.SessionDataCollectionContext, string.Format(CultureInfo.CurrentUICulture, Resources.Resources.BlameParameterValueIncorrect, attribute.Name, Constants.FullConfigurationValue, Constants.MiniConfigurationValue));
+                    }
+                }
+                else if (string.Equals(attribute.Name, Constants.IncludeFirstChanceExceptionsKey, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (string.Equals(attribute.Value, "true", StringComparison.OrdinalIgnoreCase))
+                    {
+                        this.includeFirstChanceExceptions = true;
+                    }
+                    else if (string.Equals(attribute.Value, "false", StringComparison.OrdinalIgnoreCase))
+                    {
+                        this.includeFirstChanceExceptions = false;
+                    }
+                    else
+                    {
+                        this.logger.LogWarning(this.context.SessionDataCollectionContext, string.Format(CultureInfo.CurrentUICulture, Resources.Resources.BlameParameterValueIncorrect, attribute.Name, "true", "false"));
                     }
                 }
                 else
@@ -268,7 +286,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
 
             try
             {
-                this.processDumpUtility.StartProcessDump(args.TestHostProcessId, this.attachmentGuid, this.GetResultsDirectory(), this.processFullDumpEnabled);
+                this.processDumpUtility.StartProcessDump(args.TestHostProcessId, this.attachmentGuid, this.GetResultsDirectory(), this.includeFirstChanceExceptions, this.processFullDumpEnabled);
             }
             catch (TestPlatformException e)
             {

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
@@ -284,7 +284,13 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
 
             try
             {
-                this.processDumpUtility.StartProcessDump(args.TestHostProcessId, this.attachmentGuid, this.GetResultsDirectory(), this.includeFirstChanceExceptions, this.processFullDumpEnabled);
+                this.processDumpUtility.StartProcessDump(
+                    new ProcDumpConfig(
+                        args.TestHostProcessId,
+                        this.attachmentGuid,
+                        this.GetResultsDirectory(),
+                        this.includeFirstChanceExceptions,
+                        this.processFullDumpEnabled));
             }
             catch (TestPlatformException e)
             {
@@ -302,7 +308,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                     EqtTrace.Warning("BlameCollector.TestHostLaunched_Handler: Could not start process dump. {0}", e);
                 }
 
-                this.logger.LogWarning(args.Context, string.Format(CultureInfo.CurrentUICulture, Resources.Resources.ProcDumpCouldNotStart, e.ToString()));
+                this.logger.LogWarning(args.Context, string.Format(Resources.Resources.ProcDumpCouldNotStart, e.Message));
             }
         }
 

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
@@ -108,8 +108,6 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                 {
                     this.ValidateAndAddProcessDumpParameters(collectDumpNode);
                 }
-
-                var includeFirstChanceExceptions = this.configurationElement[Constants.IncludeFirstChanceExceptionsKey];
             }
 
             this.attachmentGuid = Guid.NewGuid().ToString().Replace("-", string.Empty);

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Constants.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Constants.cs
@@ -63,10 +63,15 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
         /// </summary>
         public const string Procdump64Process = "procdump64.exe";
 
-        ///<summary>
+        /// <summary>
         /// Configuration key name for collect dump always
         /// </summary>
         public const string CollectDumpAlwaysKey = "CollectAlways";
+
+        /// <summary>
+        /// Configuration key name for proc dump to collect dumps on first chance exceptions
+        /// </summary>
+        public const string IncludeFirstChanceExceptionsKey = "IncludeFirstChanceExceptions";
 
         /// <summary>
         /// Configuration key name for dump type

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Interfaces/IProcessDumpUtility.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Interfaces/IProcessDumpUtility.cs
@@ -16,22 +16,10 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
         /// <summary>
         /// Launch procdump process
         /// </summary>
-        /// <param name="processId">
-        /// Process ID of test host
+        /// <param name="procDumpConfig">
+        /// Configurations for proc dump
         /// </param>
-        /// <param name="dumpFileGuid">
-        /// Guid as postfix for dump file, testhost.exe_&lt;guid&gt;.dmp
-        /// </param>
-        /// <param name="testResultsDirectory">
-        /// Path to TestResults directory
-        /// </param>
-        /// <param name="includeFirstChanceExceptions">
-        /// Indicates whether proc dump should be configured to capture dumps on first chance exceptions.
-        /// </param>
-        /// <param name="isFullDump">
-        /// Is full dump enabled
-        /// </param>
-        void StartProcessDump(int processId, string dumpFileGuid, string testResultsDirectory, bool includeFirstChanceExceptions, bool isFullDump = false);
+        void StartProcessDump(ProcDumpConfig procDumpConfig);
 
         /// <summary>
         /// Terminate the proc dump process

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Interfaces/IProcessDumpUtility.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Interfaces/IProcessDumpUtility.cs
@@ -25,10 +25,13 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
         /// <param name="testResultsDirectory">
         /// Path to TestResults directory
         /// </param>
+        /// <param name="includeFirstChanceExceptions">
+        /// Indicates whether proc dump should be configured to capture dumps on first chance exceptions.
+        /// </param>
         /// <param name="isFullDump">
         /// Is full dump enabled
         /// </param>
-        void StartProcessDump(int processId, string dumpFileGuid, string testResultsDirectory, bool isFullDump = false);
+        void StartProcessDump(int processId, string dumpFileGuid, string testResultsDirectory, bool includeFirstChanceExceptions, bool isFullDump = false);
 
         /// <summary>
         /// Terminate the proc dump process

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcDumpConfig.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcDumpConfig.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
+{
+    /// <summary>
+    /// Wrapper class for configs related to proc dump
+    /// </summary>
+    public class ProcDumpConfig
+    {
+        public ProcDumpConfig(int processId, string dumpFileGuid, string dumpFileSaveLocation, bool includeFirstChanceExceptions = true, bool isFullDump = false)
+        {
+            this.ProcessId = processId;
+            this.DumpFileGuid = dumpFileGuid;
+            this.DumpFileSaveLocation = dumpFileSaveLocation;
+            this.IncludeFirstChanceExceptions = includeFirstChanceExceptions;
+            this.IsFullDump = isFullDump;
+        }
+
+        /// <summary>
+        /// Gets a value indicating process ID of test host
+        /// </summary>
+        public int ProcessId { get; }
+
+        /// <summary>
+        /// Gets a value indicating postfix for dump file, testhost.exe_&lt;guid&gt;.dmp
+        /// </summary>
+        public string DumpFileGuid { get; }
+
+        /// <summary>
+        /// Gets a value indicating path to where the dump should be written
+        /// </summary>
+        public string DumpFileSaveLocation { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether proc dump should be configured to capture dumps on first chance exceptions.
+        /// </summary>
+        public bool IncludeFirstChanceExceptions { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether full dump capture enabled
+        /// </summary>
+        public bool IsFullDump { get; }
+    }
+}

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameCollectorTests.cs
@@ -321,7 +321,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockDataColectionEvents.Raise(x => x.TestHostLaunched += null, new TestHostLaunchedEventArgs(this.dataCollectionContext, 1234));
 
             // Verify StartProcessDumpCall
-            this.mockProcessDumpUtility.Verify(x => x.StartProcessDump(1234, It.IsAny<string>(), It.IsAny<string>(), false));
+            this.mockProcessDumpUtility.Verify(x => x.StartProcessDump(1234, It.IsAny<string>(), It.IsAny<string>(), true, false));
         }
 
         /// <summary>
@@ -342,7 +342,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockDataColectionEvents.Raise(x => x.TestHostLaunched += null, new TestHostLaunchedEventArgs(this.dataCollectionContext, 1234));
 
             // Verify StartProcessDumpCall
-            this.mockProcessDumpUtility.Verify(x => x.StartProcessDump(1234, It.IsAny<string>(), It.IsAny<string>(), true));
+            this.mockProcessDumpUtility.Verify(x => x.StartProcessDump(1234, It.IsAny<string>(), It.IsAny<string>(), true, true));
         }
 
         /// <summary>
@@ -371,7 +371,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockDataColectionEvents.Raise(x => x.TestHostLaunched += null, new TestHostLaunchedEventArgs(this.dataCollectionContext, 1234));
 
             // Verify StartProcessDumpCall
-            this.mockProcessDumpUtility.Verify(x => x.StartProcessDump(1234, It.IsAny<string>(), It.IsAny<string>(), true));
+            this.mockProcessDumpUtility.Verify(x => x.StartProcessDump(1234, It.IsAny<string>(), It.IsAny<string>(), true, true));
         }
 
         /// <summary>
@@ -468,7 +468,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             // Make StartProcessDump throw exception
             var tpex = new TestPlatformException("env var exception");
-            this.mockProcessDumpUtility.Setup(x => x.StartProcessDump(1234, It.IsAny<string>(), It.IsAny<string>(), false))
+            this.mockProcessDumpUtility.Setup(x => x.StartProcessDump(1234, It.IsAny<string>(), It.IsAny<string>(), true, false))
                                        .Throws(tpex);
 
             // Raise TestHostLaunched
@@ -494,7 +494,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             // Make StartProcessDump throw exception
             var ex = new Exception("start process failed");
-            this.mockProcessDumpUtility.Setup(x => x.StartProcessDump(1234, It.IsAny<string>(), It.IsAny<string>(), false))
+            this.mockProcessDumpUtility.Setup(x => x.StartProcessDump(1234, It.IsAny<string>(), It.IsAny<string>(), true, false))
                                        .Throws(ex);
 
             // Raise TestHostLaunched

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameCollectorTests.cs
@@ -321,7 +321,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockDataColectionEvents.Raise(x => x.TestHostLaunched += null, new TestHostLaunchedEventArgs(this.dataCollectionContext, 1234));
 
             // Verify StartProcessDumpCall
-            this.mockProcessDumpUtility.Verify(x => x.StartProcessDump(1234, It.IsAny<string>(), It.IsAny<string>(), true, false));
+            this.mockProcessDumpUtility.Verify(x => x.StartProcessDump(It.Is<ProcDumpConfig>(y => y.ProcessId == 1234 && y.IncludeFirstChanceExceptions == true && y.IsFullDump == false)));
         }
 
         /// <summary>
@@ -342,7 +342,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockDataColectionEvents.Raise(x => x.TestHostLaunched += null, new TestHostLaunchedEventArgs(this.dataCollectionContext, 1234));
 
             // Verify StartProcessDumpCall
-            this.mockProcessDumpUtility.Verify(x => x.StartProcessDump(1234, It.IsAny<string>(), It.IsAny<string>(), true, true));
+            this.mockProcessDumpUtility.Verify(x => x.StartProcessDump(It.Is<ProcDumpConfig>(y => y.ProcessId == 1234 && y.IncludeFirstChanceExceptions == true && y.IsFullDump == true)));
         }
 
         /// <summary>
@@ -371,7 +371,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockDataColectionEvents.Raise(x => x.TestHostLaunched += null, new TestHostLaunchedEventArgs(this.dataCollectionContext, 1234));
 
             // Verify StartProcessDumpCall
-            this.mockProcessDumpUtility.Verify(x => x.StartProcessDump(1234, It.IsAny<string>(), It.IsAny<string>(), true, true));
+            this.mockProcessDumpUtility.Verify(x => x.StartProcessDump(It.Is<ProcDumpConfig>(y => y.ProcessId == 1234 && y.IncludeFirstChanceExceptions == true && y.IsFullDump == true)));
         }
 
         /// <summary>
@@ -468,7 +468,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             // Make StartProcessDump throw exception
             var tpex = new TestPlatformException("env var exception");
-            this.mockProcessDumpUtility.Setup(x => x.StartProcessDump(1234, It.IsAny<string>(), It.IsAny<string>(), true, false))
+            this.mockProcessDumpUtility.Setup(x => x.StartProcessDump(It.Is<ProcDumpConfig>(y => y.ProcessId == 1234 && y.IncludeFirstChanceExceptions == true && y.IsFullDump == false)))
                                        .Throws(tpex);
 
             // Raise TestHostLaunched
@@ -494,14 +494,14 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             // Make StartProcessDump throw exception
             var ex = new Exception("start process failed");
-            this.mockProcessDumpUtility.Setup(x => x.StartProcessDump(1234, It.IsAny<string>(), It.IsAny<string>(), true, false))
+            this.mockProcessDumpUtility.Setup(x => x.StartProcessDump(It.Is<ProcDumpConfig>(y => y.ProcessId == 1234 && y.IncludeFirstChanceExceptions == true && y.IsFullDump == false)))
                                        .Throws(ex);
 
             // Raise TestHostLaunched
             this.mockDataColectionEvents.Raise(x => x.TestHostLaunched += null, new TestHostLaunchedEventArgs(this.dataCollectionContext, 1234));
 
             // Verify
-            this.mockLogger.Verify(x => x.LogWarning(It.IsAny<DataCollectionContext>(), It.Is<string>(str => str == string.Format(CultureInfo.CurrentUICulture, Resources.Resources.ProcDumpCouldNotStart, ex.ToString()))), Times.Once);
+            this.mockLogger.Verify(x => x.LogWarning(It.IsAny<DataCollectionContext>(), It.Is<string>(str => str == string.Format(CultureInfo.CurrentUICulture, Resources.Resources.ProcDumpCouldNotStart, ex.Message))), Times.Once);
         }
 
         [TestCleanup]

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TestPlatformRoot Condition="$(TestPlatformRoot) == ''">..\..\</TestPlatformRoot>

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/ProcessDumpUtilityTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/ProcessDumpUtilityTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 this.mockPlatformEnvironment.Object,
                 this.mockNativeMethodsHelper.Object);
 
-            processDumpUtility.StartProcessDump(processId, guid, testResultsDirectory);
+            processDumpUtility.StartProcessDump(processId, guid, testResultsDirectory, true);
 
             var ex = Assert.ThrowsException<FileNotFoundException>(() => processDumpUtility.GetDumpFile());
             Assert.AreEqual(ex.Message, Resources.Resources.DumpFileNotGeneratedErrorMessage);
@@ -95,7 +95,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                  this.mockPlatformEnvironment.Object,
                  this.mockNativeMethodsHelper.Object);
 
-            Assert.ThrowsException<Exception>(() => processDumpUtility.StartProcessDump(processId, guid, testResultsDirectory));
+            Assert.ThrowsException<Exception>(() => processDumpUtility.StartProcessDump(processId, guid, testResultsDirectory, true));
             Assert.AreEqual(string.Empty, processDumpUtility.GetDumpFile());
         }
 
@@ -123,7 +123,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 this.mockPlatformEnvironment.Object,
                 this.mockNativeMethodsHelper.Object);
 
-            processDumpUtility.StartProcessDump(processId, guid, testResultsDirectory);
+            processDumpUtility.StartProcessDump(processId, guid, testResultsDirectory, true);
             processDumpUtility.GetDumpFile();
 
             this.mockProcessHelper.Verify(x => x.WaitForProcessExit(It.IsAny<Process>()), Times.Once);
@@ -156,7 +156,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 this.mockPlatformEnvironment.Object,
                 this.mockNativeMethodsHelper.Object);
 
-            processDumpUtility.StartProcessDump(processId, guid, testResultsDirectory);
+            processDumpUtility.StartProcessDump(processId, guid, testResultsDirectory, true);
 
             this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), args, It.IsAny<string>(), null, null, null), Times.Once);
             Assert.AreEqual(Path.Combine(testResultsDirectory, filename), processDumpUtility.GetDumpFile());
@@ -189,7 +189,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 this.mockPlatformEnvironment.Object,
                 this.mockNativeMethodsHelper.Object);
 
-            processDumpUtility.StartProcessDump(processId, guid, testResultsDirectory, isFullDump: true);
+            processDumpUtility.StartProcessDump(processId, guid, testResultsDirectory, true, isFullDump: true);
 
             this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), args, It.IsAny<string>(), null, null, null), Times.Once);
             Assert.AreEqual(Path.Combine(testResultsDirectory, filename), processDumpUtility.GetDumpFile());
@@ -209,7 +209,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 this.mockPlatformEnvironment.Object,
                 this.mockNativeMethodsHelper.Object);
 
-            var ex = Assert.ThrowsException<TestPlatformException>(() => processDumpUtility.StartProcessDump(1234, "guid", "D:\\"));
+            var ex = Assert.ThrowsException<TestPlatformException>(() => processDumpUtility.StartProcessDump(1234, "guid", "D:\\", true));
             Assert.AreEqual(ex.Message, Resources.Resources.ProcDumpEnvVarEmpty);
         }
 
@@ -235,7 +235,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 this.mockPlatformEnvironment.Object,
                 this.mockNativeMethodsHelper.Object);
 
-            processDumpUtility.StartProcessDump(processId, guid, testResultsDirectory);
+            processDumpUtility.StartProcessDump(processId, guid, testResultsDirectory, true);
 
             this.mockProcessHelper.Verify(x => x.LaunchProcess(Path.Combine("D:\\procdump", "procdump.exe"), It.IsAny<string>(), It.IsAny<string>(), null, null, null));
         }
@@ -261,7 +261,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockPlatformEnvironment.Object,
             this.mockNativeMethodsHelper.Object);
 
-            processDumpUtility.StartProcessDump(processId, "guid", "D:\\");
+            processDumpUtility.StartProcessDump(processId, "guid", "D:\\", true);
 
             this.mockProcessHelper.Verify(x => x.LaunchProcess(Path.Combine("D:\\procdump", "procdump64.exe"), It.IsAny<string>(), It.IsAny<string>(), null, null, null));
         }
@@ -287,7 +287,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockPlatformEnvironment.Object,
             this.mockNativeMethodsHelper.Object);
 
-            processDumpUtility.StartProcessDump(processId, "guid", "D:\\");
+            processDumpUtility.StartProcessDump(processId, "guid", "D:\\", true);
 
             this.mockProcessHelper.Verify(x => x.LaunchProcess(Path.Combine("D:\\procdump", "procdump.exe"), It.IsAny<string>(), It.IsAny<string>(), null, null, null));
         }

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/ProcessDumpUtilityTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/ProcessDumpUtilityTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 this.mockPlatformEnvironment.Object,
                 this.mockNativeMethodsHelper.Object);
 
-            processDumpUtility.StartProcessDump(processId, guid, testResultsDirectory, true);
+            processDumpUtility.StartProcessDump(new ProcDumpConfig(processId, guid, testResultsDirectory, true));
 
             var ex = Assert.ThrowsException<FileNotFoundException>(() => processDumpUtility.GetDumpFile());
             Assert.AreEqual(ex.Message, Resources.Resources.DumpFileNotGeneratedErrorMessage);
@@ -95,7 +95,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                  this.mockPlatformEnvironment.Object,
                  this.mockNativeMethodsHelper.Object);
 
-            Assert.ThrowsException<Exception>(() => processDumpUtility.StartProcessDump(processId, guid, testResultsDirectory, true));
+            Assert.ThrowsException<Exception>(() => processDumpUtility.StartProcessDump(new ProcDumpConfig(processId, guid, testResultsDirectory, true)));
             Assert.AreEqual(string.Empty, processDumpUtility.GetDumpFile());
         }
 
@@ -123,7 +123,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 this.mockPlatformEnvironment.Object,
                 this.mockNativeMethodsHelper.Object);
 
-            processDumpUtility.StartProcessDump(processId, guid, testResultsDirectory, true);
+            processDumpUtility.StartProcessDump(new ProcDumpConfig(processId, guid, testResultsDirectory, true));
             processDumpUtility.GetDumpFile();
 
             this.mockProcessHelper.Verify(x => x.WaitForProcessExit(It.IsAny<Process>()), Times.Once);
@@ -139,7 +139,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             var process = "process";
             var processId = 12345;
             var filename = $"{process}_{processId}_{guid}.dmp";
-            var args = $"-accepteula -e 1 -g -t -f STACK_OVERFLOW -f ACCESS_VIOLATION {processId} {filename}";
+            var args = $"-accepteula -g -t -e 1 -f STACK_OVERFLOW -f ACCESS_VIOLATION {processId} {filename}";
             var testResultsDirectory = "D:\\TestResults";
 
             this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null))
@@ -156,7 +156,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 this.mockPlatformEnvironment.Object,
                 this.mockNativeMethodsHelper.Object);
 
-            processDumpUtility.StartProcessDump(processId, guid, testResultsDirectory, true);
+            processDumpUtility.StartProcessDump(new ProcDumpConfig(processId, guid, testResultsDirectory, true));
 
             this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), args, It.IsAny<string>(), null, null, null), Times.Once);
             Assert.AreEqual(Path.Combine(testResultsDirectory, filename), processDumpUtility.GetDumpFile());
@@ -172,7 +172,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             var process = "process";
             var processId = 12345;
             var filename = $"{process}_{processId}_{guid}.dmp";
-            var args = $"-accepteula -e 1 -g -t -ma -f STACK_OVERFLOW -f ACCESS_VIOLATION {processId} {filename}";
+            var args = $"-accepteula -g -t -e 1 -ma -f STACK_OVERFLOW -f ACCESS_VIOLATION {processId} {filename}";
             var testResultsDirectory = "D:\\TestResults";
 
             this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null))
@@ -189,7 +189,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 this.mockPlatformEnvironment.Object,
                 this.mockNativeMethodsHelper.Object);
 
-            processDumpUtility.StartProcessDump(processId, guid, testResultsDirectory, true, isFullDump: true);
+            processDumpUtility.StartProcessDump(new ProcDumpConfig(processId, guid, testResultsDirectory, true, isFullDump: true));
 
             this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), args, It.IsAny<string>(), null, null, null), Times.Once);
             Assert.AreEqual(Path.Combine(testResultsDirectory, filename), processDumpUtility.GetDumpFile());
@@ -209,7 +209,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 this.mockPlatformEnvironment.Object,
                 this.mockNativeMethodsHelper.Object);
 
-            var ex = Assert.ThrowsException<TestPlatformException>(() => processDumpUtility.StartProcessDump(1234, "guid", "D:\\", true));
+            var ex = Assert.ThrowsException<TestPlatformException>(() => processDumpUtility.StartProcessDump(new ProcDumpConfig(1234, "guid", "D:\\", true)));
             Assert.AreEqual(ex.Message, Resources.Resources.ProcDumpEnvVarEmpty);
         }
 
@@ -235,7 +235,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 this.mockPlatformEnvironment.Object,
                 this.mockNativeMethodsHelper.Object);
 
-            processDumpUtility.StartProcessDump(processId, guid, testResultsDirectory, true);
+            processDumpUtility.StartProcessDump(new ProcDumpConfig(processId, guid, testResultsDirectory, true));
 
             this.mockProcessHelper.Verify(x => x.LaunchProcess(Path.Combine("D:\\procdump", "procdump.exe"), It.IsAny<string>(), It.IsAny<string>(), null, null, null));
         }
@@ -261,7 +261,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockPlatformEnvironment.Object,
             this.mockNativeMethodsHelper.Object);
 
-            processDumpUtility.StartProcessDump(processId, "guid", "D:\\", true);
+            processDumpUtility.StartProcessDump(new ProcDumpConfig(processId, "guid", "D:\\", true));
 
             this.mockProcessHelper.Verify(x => x.LaunchProcess(Path.Combine("D:\\procdump", "procdump64.exe"), It.IsAny<string>(), It.IsAny<string>(), null, null, null));
         }
@@ -287,7 +287,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockPlatformEnvironment.Object,
             this.mockNativeMethodsHelper.Object);
 
-            processDumpUtility.StartProcessDump(processId, "guid", "D:\\", true);
+            processDumpUtility.StartProcessDump(new ProcDumpConfig(processId, "guid", "D:\\", true));
 
             this.mockProcessHelper.Verify(x => x.LaunchProcess(Path.Combine("D:\\procdump", "procdump.exe"), It.IsAny<string>(), It.IsAny<string>(), null, null, null));
         }


### PR DESCRIPTION
## Description
Made first chance exception in blame data collector configurable

Sample runsettings to turn it off
```
<RunSettings>
    <LoggerRunSettings>
        <Loggers>
            <Logger friendlyName="blame" enabled="True" />
        </Loggers>
    </LoggerRunSettings>
    <DataCollectionRunSettings>
        <DataCollectors>
            <DataCollector friendlyName="blame" enabled="True">
                <Configuration>
                    <ResultsDirectory>C:\TestResults</ResultsDirectory>
                    <CollectDump CollectAlways="true" DumpType="mini" IncludeFirstChanceExceptions="false"/>
                </Configuration>
            </DataCollector>
        </DataCollectors>
    </DataCollectionRunSettings>
</RunSettings>
```
