### PR TITLE
[Draft] [Design mode] Invoking vstest.console with environment variables

### DIFF
--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/ConsoleParameters.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/ConsoleParameters.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
 {
     using System;
-    using System.Collections.Specialized;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
 
@@ -44,7 +44,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         /// TODO: Remove the #if when project is targeted to netstandard2.0
         /// Environment variables to be set for the process
         /// </summary>
-        public StringDictionary EnvironmentVariables { get; set; } = new StringDictionary();
+        public Dictionary<string, string> EnvironmentVariables { get; set; }
 
 #endif
 

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/ConsoleParameters.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/ConsoleParameters.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
 {
     using System;
+    using System.Collections.Specialized;
     using System.Diagnostics;
     using System.IO;
 
@@ -36,6 +37,16 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         {
             this.fileHelper = fileHelper;
         }
+
+#if NET451
+
+        /// <summary>
+        /// TODO: Remove the #if when project is targeted to netstandard2.0
+        /// Environment variables to be set for the process
+        /// </summary>
+        public StringDictionary EnvironmentVariables { get; set; } = new StringDictionary();
+
+#endif
 
         /// <summary>
         /// Trace level for logs.

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
@@ -108,10 +108,16 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
             EqtTrace.Verbose("VsTestCommandLineWrapper: Process Start Info {0} {1}", info.FileName, info.Arguments);
 
 #if NET451
-            info.EnvironmentVariables.Clear();
-            foreach (DictionaryEntry envVariable in consoleParameters.EnvironmentVariables)
+            if (consoleParameters.EnvironmentVariables != null)
             {
-                info.EnvironmentVariables.Add(envVariable.Key.ToString(), envVariable.Value.ToString());
+                info.EnvironmentVariables.Clear();
+                foreach (var envVariable in consoleParameters.EnvironmentVariables)
+                {
+                    if (envVariable.Key != null)
+                    {
+                        info.EnvironmentVariables.Add(envVariable.Key.ToString(), envVariable.Value?.ToString());
+                    }
+                }
             }
 #endif
             this.process = Process.Start(info);

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
@@ -9,6 +9,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
     using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
     using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Globalization;
@@ -106,6 +107,13 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
 
             EqtTrace.Verbose("VsTestCommandLineWrapper: Process Start Info {0} {1}", info.FileName, info.Arguments);
 
+#if NET451
+            info.EnvironmentVariables.Clear();
+            foreach (DictionaryEntry envVariable in consoleParameters.EnvironmentVariables)
+            {
+                info.EnvironmentVariables.Add(envVariable.Key.ToString(), envVariable.Value.ToString());
+            }
+#endif
             this.process = Process.Start(info);
             this.process.Start();
 


### PR DESCRIPTION
## Description
Changes to allow clients to provide environment variable while initializing VsTestConsoleWrapper