### PR TITLE
Add netstandard20 dependencies to the TestHost pkg

### DIFF
--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -28,7 +28,7 @@
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <!-- .NetStandardLibrary1.6.0 brings in dependencies which are supported in UWP,
          any higher version will bring in dependencies which are not supported by current UWP version -->
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition="'$(OverrideImplicitNSVersion)' != 'true'">1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj
+++ b/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj
@@ -1,13 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OverrideImplicitNSVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">true</OverrideImplicitNSVersion>
     <TestPlatformRoot Condition="$(TestPlatformRoot) == ''">..\..\</TestPlatformRoot>
   </PropertyGroup>
   <Import Project="$(TestPlatformRoot)scripts/build/TestPlatform.Settings.targets" />
   <PropertyGroup>
     <AssemblyName>Microsoft.VisualStudio.TestPlatform.ObjectModel</AssemblyName>
-    <TargetFrameworks>net451;netstandard1.4</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">netstandard1.4</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard1.4;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.TestPlatform.ObjectModel</PackageId>
   </PropertyGroup>
   <ItemGroup>
@@ -31,11 +32,13 @@
     <ProjectReference Include="..\Microsoft.TestPlatform.CoreUtilities\Microsoft.TestPlatform.CoreUtilities.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation">
-      <Version>4.0.0</Version>
-    </PackageReference>
     <PackageReference Include="System.Reflection.Metadata">
       <Version>1.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation">
+      <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
@@ -80,9 +83,6 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <RootNamespace>Microsoft.VisualStudio.TestPlatform.ObjectModel</RootNamespace>

--- a/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
@@ -209,13 +209,14 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
             var dataCollectorsNode = doc.CreateElement(Constants.DataCollectorsSettingName);
             dataCollectionRunSettingsNode.AppendChild(dataCollectorsNode);
 
-#if NET451
+#if NET451 || NETSTANDARD2_0
             return doc;
 #else
             // Xmldocument doesn't inherit from XmlDocument for netcoreapp2.0
             var ret = doc as IXPathNavigable;
             if (ret == null)
             {
+                
                 return doc.ToXPathNavigable();
             }
 

--- a/src/package/nuspec/TestPlatform.TestHost.nuspec
+++ b/src/package/nuspec/TestPlatform.TestHost.nuspec
@@ -17,7 +17,7 @@
       <group targetFramework="netcoreapp1.0">
         <dependency id="Microsoft.TestPlatform.ObjectModel" version="$Version$"/>
         <dependency id="Newtonsoft.Json" version="$JsonNetVersion$"/>
-        <dependency id="Microsoft.Extensions.DependencyModel" version="1.0.3"/>
+        <dependency id="Microsoft.Extensions.DependencyModel" version="3.0.0-preview5-27626-15"/>
       </group>
 
       <group targetFramework="uap10.0">


### PR DESCRIPTION
## Description
To reduce the dependency graph when restoring with .NET Core >= 2.0, add a .NET Standard 2.0 configuration to `Microsoft.TestPlatform.ObjectModel` and reference a newer package (prerelease but considered as stable) of `Microsoft.Extensions.DependencyModel` with a .NET Standard 2.0 configuration.

CoreFx currently can't use the Microsoft.NET.Test.Sdk because of dependencies that are copied to the output directory. All framework references that come from netstandard < 2.0 are creating conflicts with the live built framework assets in corefx. We really want to enable Test Explorer integration in CoreFx + simple F5 debugging.

## Related issue
Fixes https://github.com/microsoft/vstest/issues/2027
