### PR TITLE
Pdb Lock Issue

### DIFF
--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleRequestSender.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleRequestSender.cs
@@ -417,13 +417,9 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
             catch (Exception exception)
             {
                 EqtTrace.Error("Aborting Test Discovery Operation: {0}", exception);
-
                 eventHandler.HandleLogMessage(TestMessageLevel.Error, TranslationLayerResources.AbortedTestsDiscovery);
-
                 var discoveryCompleteEventArgs = new DiscoveryCompleteEventArgs(-1, true);
                 eventHandler.HandleDiscoveryComplete(discoveryCompleteEventArgs, null);
-
-                CleanupCommunicationIfProcessExit();
             }
 
             this.testPlatformEventSource.TranslationLayerDiscoveryStop();
@@ -482,8 +478,6 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
 
                 var discoveryCompleteEventArgs = new DiscoveryCompleteEventArgs(-1, true);
                 eventHandler.HandleDiscoveryComplete(discoveryCompleteEventArgs, null);
-
-                CleanupCommunicationIfProcessExit();
             }
 
             this.testPlatformEventSource.TranslationLayerDiscoveryStop();
@@ -537,7 +531,6 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
                 eventHandler.HandleLogMessage(TestMessageLevel.Error, TranslationLayerResources.AbortedTestsRun);
                 var completeArgs = new TestRunCompleteEventArgs(null, false, true, exception, null, TimeSpan.Zero);
                 eventHandler.HandleTestRunComplete(completeArgs, null, null, null);
-                this.CleanupCommunicationIfProcessExit();
             }
 
             this.testPlatformEventSource.TranslationLayerExecutionStop();
@@ -591,19 +584,9 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
                 eventHandler.HandleLogMessage(TestMessageLevel.Error, TranslationLayerResources.AbortedTestsRun);
                 var completeArgs = new TestRunCompleteEventArgs(null, false, true, exception, null, TimeSpan.Zero);
                 eventHandler.HandleTestRunComplete(completeArgs, null, null, null);
-                this.CleanupCommunicationIfProcessExit();
             }
 
             this.testPlatformEventSource.TranslationLayerExecutionStop();
-        }
-
-        private void CleanupCommunicationIfProcessExit()
-        {
-            if (this.processExitCancellationTokenSource != null
-                && this.processExitCancellationTokenSource.IsCancellationRequested)
-            {
-                this.communicationManager.StopServer();
-            }
         }
 
         private Message TryReceiveMessage()

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleRequestSender.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleRequestSender.cs
@@ -420,6 +420,11 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
                 eventHandler.HandleLogMessage(TestMessageLevel.Error, TranslationLayerResources.AbortedTestsDiscovery);
                 var discoveryCompleteEventArgs = new DiscoveryCompleteEventArgs(-1, true);
                 eventHandler.HandleDiscoveryComplete(discoveryCompleteEventArgs, null);
+
+                // Earlier we were closing the connection with vstest.console in case of exceptions
+                // Removing that code because vstest.console might be in a healthy state and letting the client
+                // know of the error, so that the TL can wait for the next instruction from the client itself.
+                // Also, connection termination might not kill the process which could result in files being locked by testhost.
             }
 
             this.testPlatformEventSource.TranslationLayerDiscoveryStop();
@@ -478,6 +483,11 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
 
                 var discoveryCompleteEventArgs = new DiscoveryCompleteEventArgs(-1, true);
                 eventHandler.HandleDiscoveryComplete(discoveryCompleteEventArgs, null);
+
+                // Earlier we were closing the connection with vstest.console in case of exceptions
+                // Removing that code because vstest.console might be in a healthy state and letting the client
+                // know of the error, so that the TL can wait for the next instruction from the client itself.
+                // Also, connection termination might not kill the process which could result in files being locked by testhost.
             }
 
             this.testPlatformEventSource.TranslationLayerDiscoveryStop();
@@ -531,6 +541,11 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
                 eventHandler.HandleLogMessage(TestMessageLevel.Error, TranslationLayerResources.AbortedTestsRun);
                 var completeArgs = new TestRunCompleteEventArgs(null, false, true, exception, null, TimeSpan.Zero);
                 eventHandler.HandleTestRunComplete(completeArgs, null, null, null);
+
+                // Earlier we were closing the connection with vstest.console in case of exceptions
+                // Removing that code because vstest.console might be in a healthy state and letting the client
+                // know of the error, so that the TL can wait for the next instruction from the client itself.
+                // Also, connection termination might not kill the process which could result in files being locked by testhost.
             }
 
             this.testPlatformEventSource.TranslationLayerExecutionStop();
@@ -584,6 +599,11 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
                 eventHandler.HandleLogMessage(TestMessageLevel.Error, TranslationLayerResources.AbortedTestsRun);
                 var completeArgs = new TestRunCompleteEventArgs(null, false, true, exception, null, TimeSpan.Zero);
                 eventHandler.HandleTestRunComplete(completeArgs, null, null, null);
+
+                // Earlier we were closing the connection with vstest.console in case of exceptions
+                // Removing that code because vstest.console might be in a healthy state and letting the client
+                // know of the error, so that the TL can wait for the next instruction from the client itself.
+                // Also, connection termination might not kill the process which could result in files being locked by testhost.
             }
 
             this.testPlatformEventSource.TranslationLayerExecutionStop();

--- a/test/TranslationLayer.UnitTests/VsTestConsoleRequestSenderTests.cs
+++ b/test/TranslationLayer.UnitTests/VsTestConsoleRequestSenderTests.cs
@@ -673,7 +673,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
         }
 
         [TestMethod]
-        public void DiscoverTestsShouldAbortWhenProcessExited()
+        public void DiscoverTestsShouldLogErrorWhenProcessExited()
         {
             var mockHandler = new Mock<ITestDiscoveryEventsHandler2>();
             var sources = new List<string> { "1.dll" };
@@ -698,11 +698,10 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
 
             manualEvent.WaitOne();
             mockHandler.Verify(mh => mh.HandleLogMessage(TestMessageLevel.Error, It.IsAny<string>()), Times.Once);
-            this.mockCommunicationManager.Verify(cm => cm.StopServer(), Times.Once);
         }
 
         [TestMethod]
-        public async Task DiscoverTestsAsyncShouldAbortWhenProcessExited()
+        public async Task DiscoverTestsAsyncShouldLogErrorWhenProcessExited()
         {
             var mockHandler = new Mock<ITestDiscoveryEventsHandler2>();
             var sources = new List<string> { "1.dll" };
@@ -723,7 +722,6 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
             await this.requestSenderAsync.DiscoverTestsAsync(sources, null, new TestPlatformOptions(), mockHandler.Object);
 
             mockHandler.Verify(mh => mh.HandleLogMessage(TestMessageLevel.Error, It.IsAny<string>()), Times.Once);
-            this.mockCommunicationManager.Verify(cm => cm.StopServer(), Times.Once);
         }
 
         #endregion
@@ -1840,7 +1838,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
         }
 
         [TestMethod]
-        public void StartTestRunShouldAbortOnProcessExited()
+        public void StartTestRunShouldLogErrorOnProcessExited()
         {
             var mockHandler = new Mock<ITestRunEventsHandler>();
             var manualEvent = new ManualResetEvent(false);
@@ -1869,11 +1867,10 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
 
             manualEvent.WaitOne();
             mockHandler.Verify(mh => mh.HandleLogMessage(TestMessageLevel.Error, It.IsAny<string>()), Times.Once);
-            this.mockCommunicationManager.Verify(cm => cm.StopServer(), Times.Once);
         }
 
         [TestMethod]
-        public async Task StartTestRunAsyncShouldAbortOnProcessExited()
+        public async Task StartTestRunAsyncShouldLogErrorOnProcessExited()
         {
             var mockHandler = new Mock<ITestRunEventsHandler>();
             var sources = new List<string> { "1.dll" };
@@ -1898,7 +1895,6 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
             await this.requestSenderAsync.StartTestRunAsync(sources, null, null, mockHandler.Object);
 
             mockHandler.Verify(mh => mh.HandleLogMessage(TestMessageLevel.Error, It.IsAny<string>()), Times.Once);
-            this.mockCommunicationManager.Verify(cm => cm.StopServer(), Times.Once);
         }
 
         #endregion


### PR DESCRIPTION
## Description
The lifetime of testhost process isn't directly controlled by the IDE. It basically depends on the lifetime of a discovery/execution operation and exits as vstest.console dictates at the end of these operations. What is happening here is that because there was an unhandled exception as part of the execution workflow in the translation layer, it tries to perform cleanup which terminates connection with vstest.console which doesn't ensure test host being cleaned up.

## Related issue
Associated bug: [here](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/895180)
