### PR TITLE
Bug fix multiple vstest.console processes

### DIFF
--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
@@ -107,7 +107,6 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
             EqtTrace.Verbose("VsTestCommandLineWrapper: Process Start Info {0} {1}", info.FileName, info.Arguments);
 
             this.process = Process.Start(info);
-            this.process.Start();
 
             lock (syncObject)
             {


### PR DESCRIPTION
## Description
`Process.Start(info)` starts the process already. Documentation [here](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.start?view=netframework-4.8)
`this.process.Start()` results in creating one other vstest.console process which is not killed and is lying around. 
## Related issue
[https://github.com/microsoft/vstest/issues/2034](https://github.com/microsoft/vstest/issues/2034)
