### PR TITLE
remove redundant blank line before test run outcome

### DIFF
--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -597,7 +597,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
                         Output.Information(false, attachmentOutput);
                     }
                 }
-                Output.WriteLine(String.Empty, OutputLevel.Information);
             }
 
             if (e.IsCanceled)


### PR DESCRIPTION
## Description

The blank line before the test outcome bloats the line count (especially when many test runs are performed in a single build) and has little value.

### Before

```
Starting test execution, please wait...

Test Run Successful.
Total tests: 63
     Passed: 63
 Total time: 1.6310 Seconds
```

### After

```
Starting test execution, please wait...
Test Run Successful.
Total tests: 63
     Passed: 63
 Total time: 1.6310 Seconds
```