### PR TITLE
Fix RuntimeInformation min version dependency

### DIFF
--- a/src/package/nuspec/TestPlatform.ObjectModel.nuspec
+++ b/src/package/nuspec/TestPlatform.ObjectModel.nuspec
@@ -15,7 +15,7 @@
     <tags>vstest visual-studio unittest testplatform mstest microsoft test testing</tags>
     <dependencies>
       <group targetFramework="net451">
-        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="[4.1.0, )" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="[4.0.0, )" />
         <dependency id="System.Reflection.Metadata" version="[1.3.0, )" />
       </group>
       <group targetFramework="netstandard1.5">


### PR DESCRIPTION
## Description
No package exists for `System.Runtime.InteropServices.RuntimeInformation` with version `4.1.0`. Downgrading the version to fix the nuget restore error.

## Related issue
```
C:\git\corefx\src\System.Windows.Extensions\tests\System.Windows.Extensions.Tests.csproj : error NU1603: Microsoft.TestPlatform.ObjectModel 16.1.1 depends on System.Runtime.InteropServices.RuntimeInformation (>= 4.1.0) but System.Runtime.InteropServices.RuntimeInformation 4.1.0 was not found. An approximate best match of System.Runtime.InteropServices.RuntimeInformation 4.3.0 was resolved. [C:\git\corefx\src\tests.proj]
```
