### PR TITLE
TestRunRequestEventsRegistrar null in run specific tests

### DIFF
--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -435,7 +435,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
             if (!string.IsNullOrEmpty(incompatibleSettingWarning))
             {
                 EqtTrace.Warning(incompatibleSettingWarning);
-                registrar.LogWarning(incompatibleSettingWarning);
+                registrar?.LogWarning(incompatibleSettingWarning);
             }
 
             // Log compatible sources

--- a/test/Microsoft.TestPlatform.AcceptanceTests/FrameworkTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/FrameworkTests.cs
@@ -50,5 +50,29 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 this.StdErrorContains("Test Run Aborted.");
             }
         }
+
+        [TestMethod]
+        [NetFullTargetFrameworkDataSource]
+        [NetCoreTargetFrameworkDataSource]
+        public void RunSpecificTestsShouldWorkWithFrameworkInCompatibleWarning(RunnerInfo runnerInfo)
+        {
+            AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+
+            var arguments = PrepareArguments(GetSampleTestAssembly(), string.Empty, string.Empty, this.FrameworkArgValue);
+            arguments = string.Concat(arguments, " ", "/tests:PassingTest");
+            arguments = string.Concat(arguments, " ", "/Framework:Framework40");
+
+            this.InvokeVsTest(arguments);
+
+            if (runnerInfo.TargetFramework.Contains("netcore"))
+            {
+                this.StdOutputContains("No test is available");
+            }
+            else
+            {
+                this.StdOutputContains("Following DLL(s) do not match framework/platform settings. ");
+                this.ValidateSummaryStatus(1, 0, 0);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description
Test run events registrar is null in case of run selected scenario causing the following error:
```
Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object.
Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers.TestRequestManager.CheckSourcesForCompatibility(Framework chosenFramework, Architecture chosenPlatform, IDictionary`2 sourcePlatforms, IDictionary`2 sourceFrameworks, IBaseTestEventsRegistrar registrar)
Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers.TestRequestManager.UpdateRunSettingsIfRequired(String runsettingsXml, List`1 sources, IBaseTestEventsRegistrar registrar, String& updatedRunSettingsXml)
Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers.TestRequestManager.RunTests(TestRunRequestPayload testRunRequestPayload, ITestHostLauncher testHostLauncher, ITestRunEventsRegistrar testRunEventsRegistrar, ProtocolConfig protocolConfig)
Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.RunSpecificTestsArgumentExecutor.ExecuteSelectedTests()
Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.RunSpecificTestsArgumentExecutor.Execute()
Microsoft.VisualStudio.TestPlatform.CommandLine.Executor.ExecuteArgumentProcessor(IArgumentProcessor processor, Int32& exitCode)
Microsoft.VisualStudio.TestPlatform.CommandLine.Executor.Execute(String[] args)
Microsoft.VisualStudio.TestPlatform.CommandLine.Program.Main(String[] args)
```
