### PR TITLE
Fixed incorrect timeout message when test host crashes/exits

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.cs.xlf
@@ -79,8 +79,7 @@
       <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Proces testovacího hostitele se chybově ukončil.</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.de.xlf
@@ -79,8 +79,7 @@
       <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Der Testhostprozess ist abgestürzt.</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.es.xlf
@@ -79,8 +79,7 @@
       <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Proceso de host de pruebas bloqueado</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.fr.xlf
@@ -79,8 +79,7 @@
       <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Plantage du processus hôte de test</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.it.xlf
@@ -79,8 +79,7 @@
       <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Arresto anomalo del processo host di test</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ja.xlf
@@ -79,8 +79,7 @@
       <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">テストのホスト プロセスがクラッシュしました</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ko.xlf
@@ -79,8 +79,7 @@
       <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">테스트 호스트 프로세스 작동이 중단됨</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pl.xlf
@@ -79,8 +79,7 @@
       <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Wystąpiła awaria procesu hosta testu</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pt-BR.xlf
@@ -79,8 +79,7 @@
       <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Falha no processo do host de teste</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ru.xlf
@@ -79,8 +79,7 @@
       <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Сбой хост-процесса теста</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.tr.xlf
@@ -79,8 +79,7 @@
       <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Test ana işlemi kilitlendi</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hans.xlf
@@ -79,8 +79,7 @@
       <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">测试主机进程崩溃</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hant.xlf
@@ -79,8 +79,7 @@
       <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">測試主機處理序當機</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -160,8 +160,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                 if (!this.testHostLaunched ||
                     !this.RequestSender.WaitForRequestHandlerConnection(connTimeout * 1000, this.CancellationTokenSource.Token))
                 {
+                    // Throw a test platform exception with the appropriate message if user requested cancellation
                     this.CancellationTokenSource.Token.ThrowTestPlatformExceptionIfCancellationRequested();
+
+                    // Throw a test platform exception along with the error messages from the test if the test host exited unexpectedly
+                    // before communication was established
                     this.ThrowOnTestHostExited(this.testHostExited.IsSet);
+
+                    // Throw a test platform exception stating the connection to test could not be established even after waiting
+                    // for the configure timeout period
                     this.ThrowExceptionOnConnectionFailure(connTimeout);
                 }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -161,6 +161,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                     !this.RequestSender.WaitForRequestHandlerConnection(connTimeout * 1000, this.CancellationTokenSource.Token))
                 {
                     this.CancellationTokenSource.Token.ThrowTestPlatformExceptionIfCancellationRequested();
+                    this.ThrowOnTestHostExited(this.testHostExited.IsSet);
                     this.ThrowExceptionOnConnectionFailure(connTimeout);
                 }
 
@@ -304,6 +305,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             this.RequestSender.OnClientProcessExit(this.testHostProcessStdError);
 
             this.testHostExited.Set();
+        }
+
+        private void ThrowOnTestHostExited(bool testHostExited)
+        {
+            if (testHostExited)
+            {
+                throw new TestPlatformException(Resources.Resources.TestHostExited);
+            }
         }
 
         private void ThrowExceptionOnConnectionFailure(int connTimeout)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -311,7 +311,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         {
             if (testHostExited)
             {
-                throw new TestPlatformException(Resources.Resources.TestHostExited);
+                throw new TestPlatformException(string.Format(CrossPlatEngineResources.TestHostExitedWithError, this.testHostProcessStdError));
             }
         }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
@@ -260,16 +260,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The testhost process exited unexpectedly. Please check the diagnostic logs for more information..
-        /// </summary>
-        internal static string TestHostExited {
-            get {
-                return ResourceManager.GetString("TestHostExited", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Testhost process exited with error: {0}.
+        ///   Looks up a localized string similar to Testhost process exited with error: {0}. Please check the diagnostic logs for more information..
         /// </summary>
         internal static string TestHostExitedWithError {
             get {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
@@ -260,6 +260,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The testhost process exited unexpectedly. Please check the diagnostic logs for more information..
+        /// </summary>
+        internal static string TestHostExited {
+            get {
+                return ResourceManager.GetString("TestHostExited", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Testhost process exited with error: {0}.
         /// </summary>
         internal static string TestHostExitedWithError {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
@@ -195,4 +195,7 @@
   <data name="NoTestsAvailableForGivenTestCaseFilter" xml:space="preserve">
     <value>No test matches the given testcase filter `{0}` in {1}</value>
   </data>
+  <data name="TestHostExited" xml:space="preserve">
+    <value>The testhost process exited unexpectedly. Please check the diagnostic logs for more information.</value>
+  </data>
 </root>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
@@ -169,7 +169,7 @@
     <value>Logging TestHost Diagnostics in file: {0}</value>
   </data>
   <data name="TestHostExitedWithError" xml:space="preserve">
-    <value>Testhost process exited with error: {0}</value>
+    <value>Testhost process exited with error: {0}. Please check the diagnostic logs for more information.</value>
   </data>
   <data name="TestRunFailed_NoDiscovererFound_NoTestsAreAvailableInTheSources" xml:space="preserve">
     <value>No test is available in {0}. Make sure that test discoverer &amp; executors are registered and platform &amp; framework version settings are appropriate and try again.</value>
@@ -194,8 +194,5 @@
   </data>
   <data name="NoTestsAvailableForGivenTestCaseFilter" xml:space="preserve">
     <value>No test matches the given testcase filter `{0}` in {1}</value>
-  </data>
-  <data name="TestHostExited" xml:space="preserve">
-    <value>The testhost process exited unexpectedly. Please check the diagnostic logs for more information.</value>
   </data>
 </root>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.cs.xlf
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestHostExitedWithError">
-        <source>Testhost process exited with error: {0}</source>
-        <target state="translated">Proces hostitele testu se ukončil s chybou: {0}</target>
-        <note />
+        <source>Testhost process exited with error: {0}. Please check the diagnostic logs for more information.</source>
+        <target state="new">Proces hostitele testu se ukončil s chybou: {0}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="DataCollectorDebuggerWarning">
         <source>DataCollector debugging is enabled. Please attach debugger to datacollector process to continue.</source>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.de.xlf
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestHostExitedWithError">
-        <source>Testhost process exited with error: {0}</source>
-        <target state="translated">Der Testhostprozess wurde mit dem Fehler {0} beendet.</target>
-        <note />
+        <source>Testhost process exited with error: {0}. Please check the diagnostic logs for more information.</source>
+        <target state="new">Der Testhostprozess wurde mit dem Fehler {0} beendet.</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="DataCollectorDebuggerWarning">
         <source>DataCollector debugging is enabled. Please attach debugger to datacollector process to continue.</source>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.es.xlf
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestHostExitedWithError">
-        <source>Testhost process exited with error: {0}</source>
-        <target state="translated">El proceso del host de pruebas se cerró con el error {0}</target>
-        <note />
+        <source>Testhost process exited with error: {0}. Please check the diagnostic logs for more information.</source>
+        <target state="new">El proceso del host de pruebas se cerró con el error {0}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="DataCollectorDebuggerWarning">
         <source>DataCollector debugging is enabled. Please attach debugger to datacollector process to continue.</source>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.fr.xlf
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestHostExitedWithError">
-        <source>Testhost process exited with error: {0}</source>
-        <target state="translated">Le processus testhost s'est arrêté avec l'erreur : {0}.</target>
-        <note />
+        <source>Testhost process exited with error: {0}. Please check the diagnostic logs for more information.</source>
+        <target state="new">Le processus testhost s'est arrêté avec l'erreur : {0}.</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="DataCollectorDebuggerWarning">
         <source>DataCollector debugging is enabled. Please attach debugger to datacollector process to continue.</source>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.it.xlf
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestHostExitedWithError">
-        <source>Testhost process exited with error: {0}</source>
-        <target state="translated">Il processo host dei test è terminato con l'errore {0}</target>
-        <note />
+        <source>Testhost process exited with error: {0}. Please check the diagnostic logs for more information.</source>
+        <target state="new">Il processo host dei test è terminato con l'errore {0}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="DataCollectorDebuggerWarning">
         <source>DataCollector debugging is enabled. Please attach debugger to datacollector process to continue.</source>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ja.xlf
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestHostExitedWithError">
-        <source>Testhost process exited with error: {0}</source>
-        <target state="translated">Testhost プロセスが次のエラーにより終了しました: {0}</target>
-        <note />
+        <source>Testhost process exited with error: {0}. Please check the diagnostic logs for more information.</source>
+        <target state="new">Testhost プロセスが次のエラーにより終了しました: {0}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="DataCollectorDebuggerWarning">
         <source>DataCollector debugging is enabled. Please attach debugger to datacollector process to continue.</source>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ko.xlf
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestHostExitedWithError">
-        <source>Testhost process exited with error: {0}</source>
-        <target state="translated">Testhost 프로세스가 종료되었습니다(오류: {0}).</target>
-        <note />
+        <source>Testhost process exited with error: {0}. Please check the diagnostic logs for more information.</source>
+        <target state="new">Testhost 프로세스가 종료되었습니다(오류: {0}).</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="DataCollectorDebuggerWarning">
         <source>DataCollector debugging is enabled. Please attach debugger to datacollector process to continue.</source>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pl.xlf
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestHostExitedWithError">
-        <source>Testhost process exited with error: {0}</source>
-        <target state="translated">Proces testhost zakończył się z błędem: {0}</target>
-        <note />
+        <source>Testhost process exited with error: {0}. Please check the diagnostic logs for more information.</source>
+        <target state="new">Proces testhost zakończył się z błędem: {0}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="DataCollectorDebuggerWarning">
         <source>DataCollector debugging is enabled. Please attach debugger to datacollector process to continue.</source>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pt-BR.xlf
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestHostExitedWithError">
-        <source>Testhost process exited with error: {0}</source>
-        <target state="translated">Processo de testhood encerrado com erro: {0}</target>
-        <note />
+        <source>Testhost process exited with error: {0}. Please check the diagnostic logs for more information.</source>
+        <target state="new">Processo de testhood encerrado com erro: {0}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="DataCollectorDebuggerWarning">
         <source>DataCollector debugging is enabled. Please attach debugger to datacollector process to continue.</source>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ru.xlf
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestHostExitedWithError">
-        <source>Testhost process exited with error: {0}</source>
-        <target state="translated">Процесс testhost завершен с ошибкой {0}</target>
-        <note />
+        <source>Testhost process exited with error: {0}. Please check the diagnostic logs for more information.</source>
+        <target state="new">Процесс testhost завершен с ошибкой {0}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="DataCollectorDebuggerWarning">
         <source>DataCollector debugging is enabled. Please attach debugger to datacollector process to continue.</source>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.tr.xlf
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestHostExitedWithError">
-        <source>Testhost process exited with error: {0}</source>
-        <target state="translated">Testhost işleminden hata ile çıkıldı: {0}</target>
-        <note />
+        <source>Testhost process exited with error: {0}. Please check the diagnostic logs for more information.</source>
+        <target state="new">Testhost işleminden hata ile çıkıldı: {0}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="DataCollectorDebuggerWarning">
         <source>DataCollector debugging is enabled. Please attach debugger to datacollector process to continue.</source>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf
@@ -64,7 +64,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="TestHostExitedWithError">
-        <source>Testhost process exited with error: {0}</source>
+        <source>Testhost process exited with error: {0}. Please check the diagnostic logs for more information.</source>
         <target state="new">Testhost process exited with error: {0}</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hans.xlf
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestHostExitedWithError">
-        <source>Testhost process exited with error: {0}</source>
-        <target state="translated">Testhost 进程已退出，并显示错误: {0}。</target>
-        <note />
+        <source>Testhost process exited with error: {0}. Please check the diagnostic logs for more information.</source>
+        <target state="new">Testhost 进程已退出，并显示错误: {0}。</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="DataCollectorDebuggerWarning">
         <source>DataCollector debugging is enabled. Please attach debugger to datacollector process to continue.</source>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hant.xlf
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestHostExitedWithError">
-        <source>Testhost process exited with error: {0}</source>
-        <target state="translated">Testhost 處理序已結束。錯誤: {0}</target>
-        <note />
+        <source>Testhost process exited with error: {0}. Please check the diagnostic logs for more information.</source>
+        <target state="new">Testhost 處理序已結束。錯誤: {0}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="DataCollectorDebuggerWarning">
         <source>DataCollector debugging is enabled. Please attach debugger to datacollector process to continue.</source>

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.cs.xlf
@@ -59,8 +59,7 @@
       <trans-unit id="InvalidFilePath">
         <source>File {0} does not exists</source>
         <target state="translated">Soubor {0} neexistuje.</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.de.xlf
@@ -59,8 +59,7 @@
       <trans-unit id="InvalidFilePath">
         <source>File {0} does not exists</source>
         <target state="translated">Die Datei "{0}" ist nicht vorhanden.</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.es.xlf
@@ -59,8 +59,7 @@
       <trans-unit id="InvalidFilePath">
         <source>File {0} does not exists</source>
         <target state="translated">El archivo {0} no existe</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.fr.xlf
@@ -59,8 +59,7 @@
       <trans-unit id="InvalidFilePath">
         <source>File {0} does not exists</source>
         <target state="translated">Le fichier {0} n'existe pas</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.it.xlf
@@ -59,8 +59,7 @@
       <trans-unit id="InvalidFilePath">
         <source>File {0} does not exists</source>
         <target state="translated">Il file {0} non esiste</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.ja.xlf
@@ -59,8 +59,7 @@
       <trans-unit id="InvalidFilePath">
         <source>File {0} does not exists</source>
         <target state="translated">ファイル {0} が存在しません</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.ko.xlf
@@ -59,8 +59,7 @@
       <trans-unit id="InvalidFilePath">
         <source>File {0} does not exists</source>
         <target state="translated">{0} 파일이 없습니다.</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.pl.xlf
@@ -59,8 +59,7 @@
       <trans-unit id="InvalidFilePath">
         <source>File {0} does not exists</source>
         <target state="translated">Plik {0} nie istnieje</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.pt-BR.xlf
@@ -59,8 +59,7 @@
       <trans-unit id="InvalidFilePath">
         <source>File {0} does not exists</source>
         <target state="translated">O arquivo {0} não existe</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.ru.xlf
@@ -59,8 +59,7 @@
       <trans-unit id="InvalidFilePath">
         <source>File {0} does not exists</source>
         <target state="translated">Файл {0} не существует.</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.tr.xlf
@@ -59,8 +59,7 @@
       <trans-unit id="InvalidFilePath">
         <source>File {0} does not exists</source>
         <target state="translated">{0} dosyası yok</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.zh-Hans.xlf
@@ -59,8 +59,7 @@
       <trans-unit id="InvalidFilePath">
         <source>File {0} does not exists</source>
         <target state="translated">文件 {0} 不存在</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Resources/xlf/Resources.zh-Hant.xlf
@@ -59,8 +59,7 @@
       <trans-unit id="InvalidFilePath">
         <source>File {0} does not exists</source>
         <target state="translated">檔案 {0} 不存在</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.cs.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.cs.xlf
@@ -1214,8 +1214,7 @@
       <trans-unit id="ExecutionTimeFormatString">
         <source> Total time: {0:0.0000} {1}</source>
         <target state="translated"> Celkový čas: {0:0.0000} {1}</target>
-        <note>
-        </note>
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Testen der Ausführungszeit: {0:0.0000} {1}</target>
         </alt-trans>
@@ -1533,8 +1532,7 @@
       <trans-unit id="TestRunSummaryForCanceledOrAbortedRun">
         <source>Total tests: Unknown</source>
         <target state="translated">Celkový počet testů: neznámý</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="StringFormatToJoinTwoStrings">
         <source>{0} {1}</source>
@@ -1628,38 +1626,32 @@
       <trans-unit id="Framework35NotSupported">
         <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="translated">Rozhraní Framework35 není podporováno. Pro projekty, které cílí na rozhraní .Net Framework 3.5, bude test spuštěn v „režimu kompatibility“ CLR 4.0.</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="ProgressIndicatorString">
         <source>Test run in progress</source>
         <target state="translated">Probíhá testovací běh</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryTotalTests">
         <source>Total tests: {0}</source>
         <target state="translated">Celkový počet testů: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryFailedTests">
         <source>     Failed: {0}</source>
         <target state="translated">     Neúspěšné: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryPassedTests">
         <source>     Passed: {0}</source>
         <target state="translated">     Úspěšné: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummarySkippedTests">
         <source>    Skipped: {0}</source>
         <target state="translated">    Přeskočené: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.de.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.de.xlf
@@ -1214,8 +1214,7 @@
       <trans-unit id="ExecutionTimeFormatString">
         <source> Total time: {0:0.0000} {1}</source>
         <target state="translated"> Gesamtzeit: {0:0.0000} {1}</target>
-        <note>
-        </note>
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Testen der Ausführungszeit: {0:0.0000} {1}</target>
         </alt-trans>
@@ -1533,8 +1532,7 @@
       <trans-unit id="TestRunSummaryForCanceledOrAbortedRun">
         <source>Total tests: Unknown</source>
         <target state="translated">Gesamtzahl Tests: unbekannt</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="StringFormatToJoinTwoStrings">
         <source>{0} {1}</source>
@@ -1628,38 +1626,32 @@
       <trans-unit id="Framework35NotSupported">
         <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="translated">Framework35 wird nicht unterstützt. Bei Projekten für Zielversion .NET Framework 3.5 wird der Test im CLR 4.0-Kompatibilitätsmodus ausgeführt.</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="ProgressIndicatorString">
         <source>Test run in progress</source>
         <target state="translated">Testlauf wird ausgeführt.</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryTotalTests">
         <source>Total tests: {0}</source>
         <target state="translated">Gesamtzahl Tests: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryFailedTests">
         <source>     Failed: {0}</source>
         <target state="translated">     Nicht bestanden: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryPassedTests">
         <source>     Passed: {0}</source>
         <target state="translated">     Bestanden: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummarySkippedTests">
         <source>    Skipped: {0}</source>
         <target state="translated">    Übersprungen: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.es.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.es.xlf
@@ -1216,8 +1216,7 @@
       <trans-unit id="ExecutionTimeFormatString">
         <source> Total time: {0:0.0000} {1}</source>
         <target state="translated"> Tiempo total: {0:0.0000} {1}</target>
-        <note>
-        </note>
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Testen der Ausführungszeit: {0:0.0000} {1}</target>
         </alt-trans>
@@ -1535,8 +1534,7 @@
       <trans-unit id="TestRunSummaryForCanceledOrAbortedRun">
         <source>Total tests: Unknown</source>
         <target state="translated">Pruebas totales: desconocido</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="StringFormatToJoinTwoStrings">
         <source>{0} {1}</source>
@@ -1630,38 +1628,32 @@
       <trans-unit id="Framework35NotSupported">
         <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="translated">No se admite Framework35. Para los proyectos que tienen como destino .NET Framework 3.5, la prueba se ejecutará en el "modo de compatibilidad" de CLR 4.0.</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="ProgressIndicatorString">
         <source>Test run in progress</source>
         <target state="translated">Serie de pruebas en curso</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryTotalTests">
         <source>Total tests: {0}</source>
         <target state="translated">Pruebas totales: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryFailedTests">
         <source>     Failed: {0}</source>
         <target state="translated">     Incorrecto: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryPassedTests">
         <source>     Passed: {0}</source>
         <target state="translated">     Correcto: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummarySkippedTests">
         <source>    Skipped: {0}</source>
         <target state="translated">    Omitido: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.fr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.fr.xlf
@@ -1214,8 +1214,7 @@
       <trans-unit id="ExecutionTimeFormatString">
         <source> Total time: {0:0.0000} {1}</source>
         <target state="translated"> Durée totale : {0:0.0000} {1}</target>
-        <note>
-        </note>
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Testen der Ausführungszeit: {0:0.0000} {1}</target>
         </alt-trans>
@@ -1533,8 +1532,7 @@
       <trans-unit id="TestRunSummaryForCanceledOrAbortedRun">
         <source>Total tests: Unknown</source>
         <target state="translated">Nombre total de tests : inconnu</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="StringFormatToJoinTwoStrings">
         <source>{0} {1}</source>
@@ -1628,38 +1626,32 @@
       <trans-unit id="Framework35NotSupported">
         <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="translated">Framework35 n'est pas pris en charge. Pour les projets ciblant .NET Framework 3.5, le test s'exécutera dans CLR 4.0 en « mode de compatibilité ».</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="ProgressIndicatorString">
         <source>Test run in progress</source>
         <target state="translated">Série de tests en cours</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryTotalTests">
         <source>Total tests: {0}</source>
         <target state="translated">Nombre total de tests : {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryFailedTests">
         <source>     Failed: {0}</source>
         <target state="translated">     Non réussi(s) : {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryPassedTests">
         <source>     Passed: {0}</source>
         <target state="translated">     Réussi(s) : {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummarySkippedTests">
         <source>    Skipped: {0}</source>
         <target state="translated">    Ignoré(s) : {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.it.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.it.xlf
@@ -1214,8 +1214,7 @@
       <trans-unit id="ExecutionTimeFormatString">
         <source> Total time: {0:0.0000} {1}</source>
         <target state="translated"> Tempo totale: {0:0.0000} {1}</target>
-        <note>
-        </note>
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Testen der Ausführungszeit: {0:0.0000} {1}</target>
         </alt-trans>
@@ -1533,8 +1532,7 @@
       <trans-unit id="TestRunSummaryForCanceledOrAbortedRun">
         <source>Total tests: Unknown</source>
         <target state="translated">Totale test: sconosciuto</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="StringFormatToJoinTwoStrings">
         <source>{0} {1}</source>
@@ -1628,38 +1626,32 @@
       <trans-unit id="Framework35NotSupported">
         <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="translated">Framework35 non è supportato. Per i progetti destinati a .NET Framework 3.5, i test verranno eseguiti nella modalità di compatibilità di CLR 4.0.</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="ProgressIndicatorString">
         <source>Test run in progress</source>
         <target state="translated">Esecuzione dei test in corso</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryTotalTests">
         <source>Total tests: {0}</source>
         <target state="translated">Totale test: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryFailedTests">
         <source>     Failed: {0}</source>
         <target state="translated">     Non superati: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryPassedTests">
         <source>     Passed: {0}</source>
         <target state="translated">     Superati: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummarySkippedTests">
         <source>    Skipped: {0}</source>
         <target state="translated">    Ignorati: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.ja.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ja.xlf
@@ -1214,8 +1214,7 @@
       <trans-unit id="ExecutionTimeFormatString">
         <source> Total time: {0:0.0000} {1}</source>
         <target state="translated">合計時間: {0:0.0000} {1}</target>
-        <note>
-        </note>
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Testen der Ausführungszeit: {0:0.0000} {1}</target>
         </alt-trans>
@@ -1533,8 +1532,7 @@
       <trans-unit id="TestRunSummaryForCanceledOrAbortedRun">
         <source>Total tests: Unknown</source>
         <target state="translated">テストの合計数: 不明</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="StringFormatToJoinTwoStrings">
         <source>{0} {1}</source>
@@ -1628,38 +1626,32 @@
       <trans-unit id="Framework35NotSupported">
         <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="translated">Framework35 はサポートされていません。.Net Framework 3.5 を対象にしたプロジェクトでは、CLR 4.0 の「互換モード」でテストが実行されます。</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="ProgressIndicatorString">
         <source>Test run in progress</source>
         <target state="translated">テストの実行が処理中</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryTotalTests">
         <source>Total tests: {0}</source>
         <target state="translated">テストの合計数: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryFailedTests">
         <source>     Failed: {0}</source>
         <target state="translated">     失敗: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryPassedTests">
         <source>     Passed: {0}</source>
         <target state="translated">     成功: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummarySkippedTests">
         <source>    Skipped: {0}</source>
         <target state="translated">    スキップ: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.ko.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ko.xlf
@@ -1214,8 +1214,7 @@
       <trans-unit id="ExecutionTimeFormatString">
         <source> Total time: {0:0.0000} {1}</source>
         <target state="translated"> 총 시간: {0:0.0000} {1}</target>
-        <note>
-        </note>
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Testen der Ausführungszeit: {0:0.0000} {1}</target>
         </alt-trans>
@@ -1533,8 +1532,7 @@
       <trans-unit id="TestRunSummaryForCanceledOrAbortedRun">
         <source>Total tests: Unknown</source>
         <target state="translated">총 테스트 수: 알 수 없음</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="StringFormatToJoinTwoStrings">
         <source>{0} {1}</source>
@@ -1628,38 +1626,32 @@
       <trans-unit id="Framework35NotSupported">
         <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="translated">Framework35가 지원되지 않습니다. .NET Framework 3.5를 대상으로 하는 프로젝트의 경우 테스트가 CLR 4.0 "호환 모드"에서 실행됩니다.</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="ProgressIndicatorString">
         <source>Test run in progress</source>
         <target state="translated">테스트 실행 중</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryTotalTests">
         <source>Total tests: {0}</source>
         <target state="translated">총 테스트 수: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryFailedTests">
         <source>     Failed: {0}</source>
         <target state="translated">     실패: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryPassedTests">
         <source>     Passed: {0}</source>
         <target state="translated">     통과: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummarySkippedTests">
         <source>    Skipped: {0}</source>
         <target state="translated">    건너뜀: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.pl.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pl.xlf
@@ -1214,8 +1214,7 @@
       <trans-unit id="ExecutionTimeFormatString">
         <source> Total time: {0:0.0000} {1}</source>
         <target state="translated"> Łączny czas: {0:0.0000} {1}</target>
-        <note>
-        </note>
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Testen der Ausführungszeit: {0:0.0000} {1}</target>
         </alt-trans>
@@ -1533,8 +1532,7 @@
       <trans-unit id="TestRunSummaryForCanceledOrAbortedRun">
         <source>Total tests: Unknown</source>
         <target state="translated">Łączna liczba testów: nieznana</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="StringFormatToJoinTwoStrings">
         <source>{0} {1}</source>
@@ -1628,38 +1626,32 @@
       <trans-unit id="Framework35NotSupported">
         <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="translated">Program Framework35 nie jest obsługiwany. W przypadku projektów przeznaczonych dla programu .Net Framework 3.5 testy zostaną uruchomione w aparacie CLR 4.0 w trybie zgodności.</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="ProgressIndicatorString">
         <source>Test run in progress</source>
         <target state="translated">Uruchomienie testu w toku</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryTotalTests">
         <source>Total tests: {0}</source>
         <target state="translated">Łączna liczba testów: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryFailedTests">
         <source>     Failed: {0}</source>
         <target state="translated">     Zakończone niepowodzeniem: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryPassedTests">
         <source>     Passed: {0}</source>
         <target state="translated">     Zakończone pomyślnie: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummarySkippedTests">
         <source>    Skipped: {0}</source>
         <target state="translated">    Pominięte: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
@@ -1214,8 +1214,7 @@ Altere o prefixo de nível de diagnóstico do agente de console, como mostrado a
       <trans-unit id="ExecutionTimeFormatString">
         <source> Total time: {0:0.0000} {1}</source>
         <target state="translated">Tempo total: {0:0.0000} {1}</target>
-        <note>
-        </note>
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Testen der Ausführungszeit: {0:0.0000} {1}</target>
         </alt-trans>
@@ -1533,8 +1532,7 @@ Alterar o nível de rastreamento dos logs, como mostrado abaixo
       <trans-unit id="TestRunSummaryForCanceledOrAbortedRun">
         <source>Total tests: Unknown</source>
         <target state="translated">Total de testes: desconhecido</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="StringFormatToJoinTwoStrings">
         <source>{0} {1}</source>
@@ -1628,38 +1626,32 @@ Altere o prefixo de nível de diagnóstico do agente de console, como mostrado a
       <trans-unit id="Framework35NotSupported">
         <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="translated">Não há suporte para Framework35. Para projetos destinados ao .Net Framework 3.5, o teste será executado no "modo de compatibilidade" do CLR 4.0.</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="ProgressIndicatorString">
         <source>Test run in progress</source>
         <target state="translated">Execução de teste em andamento</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryTotalTests">
         <source>Total tests: {0}</source>
         <target state="translated">Total de testes: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryFailedTests">
         <source>     Failed: {0}</source>
         <target state="translated">     Com falha: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryPassedTests">
         <source>     Passed: {0}</source>
         <target state="translated">     Aprovados: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummarySkippedTests">
         <source>    Skipped: {0}</source>
         <target state="translated">    Ignorados: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.ru.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ru.xlf
@@ -1214,8 +1214,7 @@
       <trans-unit id="ExecutionTimeFormatString">
         <source> Total time: {0:0.0000} {1}</source>
         <target state="translated"> Общее время: {0:0.0000} {1}</target>
-        <note>
-        </note>
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Testen der Ausführungszeit: {0:0.0000} {1}</target>
         </alt-trans>
@@ -1533,8 +1532,7 @@
       <trans-unit id="TestRunSummaryForCanceledOrAbortedRun">
         <source>Total tests: Unknown</source>
         <target state="translated">Всего тестов: неизвестно</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="StringFormatToJoinTwoStrings">
         <source>{0} {1}</source>
@@ -1628,38 +1626,32 @@
       <trans-unit id="Framework35NotSupported">
         <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="translated">Framework35 не поддерживается. Для проектов, предназначенных для .NET Framework 3.5, тест будет выполняться в среде CLR 4.0 в "режиме совместимости".</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="ProgressIndicatorString">
         <source>Test run in progress</source>
         <target state="translated">Выполняется тестовый запуск</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryTotalTests">
         <source>Total tests: {0}</source>
         <target state="translated">Всего тестов: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryFailedTests">
         <source>     Failed: {0}</source>
         <target state="translated">     Не пройдено: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryPassedTests">
         <source>     Passed: {0}</source>
         <target state="translated">     Пройдено: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummarySkippedTests">
         <source>    Skipped: {0}</source>
         <target state="translated">    Пропущено: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.tr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.tr.xlf
@@ -1214,8 +1214,7 @@
       <trans-unit id="ExecutionTimeFormatString">
         <source> Total time: {0:0.0000} {1}</source>
         <target state="translated"> Toplam süre: {0:0.0000} {1}</target>
-        <note>
-        </note>
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Testen der Ausführungszeit: {0:0.0000} {1}</target>
         </alt-trans>
@@ -1533,8 +1532,7 @@ Günlükler için izleme düzeyini aşağıda gösterildiği gibi değiştirin
       <trans-unit id="TestRunSummaryForCanceledOrAbortedRun">
         <source>Total tests: Unknown</source>
         <target state="translated">Toplam test sayısı: Bilinmiyor</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="StringFormatToJoinTwoStrings">
         <source>{0} {1}</source>
@@ -1628,38 +1626,32 @@ Günlükler için izleme düzeyini aşağıda gösterildiği gibi değiştirin
       <trans-unit id="Framework35NotSupported">
         <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="translated">Framework35 desteklenmiyor. İçin hedefleme .net Framework 3.5, test CLR 4.0 "uyumluluk moduna" çalışacak.</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="ProgressIndicatorString">
         <source>Test run in progress</source>
         <target state="translated">Test çalıştırması devam ediyor</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryTotalTests">
         <source>Total tests: {0}</source>
         <target state="translated">Toplam test sayısı: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryFailedTests">
         <source>     Failed: {0}</source>
         <target state="translated">     Başarısız: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryPassedTests">
         <source>     Passed: {0}</source>
         <target state="translated">     Geçti: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummarySkippedTests">
         <source>    Skipped: {0}</source>
         <target state="translated">    Atlandı: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
@@ -1213,8 +1213,7 @@
       <trans-unit id="ExecutionTimeFormatString">
         <source> Total time: {0:0.0000} {1}</source>
         <target state="translated">总时间: {0:0.0000} {1}</target>
-        <note>
-        </note>
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Testen der Ausführungszeit: {0:0.0000} {1}</target>
         </alt-trans>
@@ -1532,8 +1531,7 @@
       <trans-unit id="TestRunSummaryForCanceledOrAbortedRun">
         <source>Total tests: Unknown</source>
         <target state="translated">测试总数: 未知</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="StringFormatToJoinTwoStrings">
         <source>{0} {1}</source>
@@ -1627,38 +1625,32 @@
       <trans-unit id="Framework35NotSupported">
         <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="translated">不支持 Framework35。对于面向 .Net Framework 3.5 的项目，将在 CLR 4.0“兼容性模式”中运行测试。</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="ProgressIndicatorString">
         <source>Test run in progress</source>
         <target state="translated">正在运行测试</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryTotalTests">
         <source>Total tests: {0}</source>
         <target state="translated">测试总数: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryFailedTests">
         <source>     Failed: {0}</source>
         <target state="translated">     失败数: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryPassedTests">
         <source>     Passed: {0}</source>
         <target state="translated">     通过数: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummarySkippedTests">
         <source>    Skipped: {0}</source>
         <target state="translated">    跳过数: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
@@ -1215,8 +1215,7 @@
       <trans-unit id="ExecutionTimeFormatString">
         <source> Total time: {0:0.0000} {1}</source>
         <target state="translated"> 時間總計: {0:0.0000} {1}</target>
-        <note>
-        </note>
+        <note></note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="mt-suggestion">Testen der Ausführungszeit: {0:0.0000} {1}</target>
         </alt-trans>
@@ -1534,8 +1533,7 @@
       <trans-unit id="TestRunSummaryForCanceledOrAbortedRun">
         <source>Total tests: Unknown</source>
         <target state="translated">測試數總計: 未知</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="StringFormatToJoinTwoStrings">
         <source>{0} {1}</source>
@@ -1629,38 +1627,32 @@
       <trans-unit id="Framework35NotSupported">
         <source>Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".</source>
         <target state="translated">不支援 Framework35。若是目標為 .Net Framework 3.5 的專案，就會在 CLR 4.0「相容模式」中執行測試。</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="ProgressIndicatorString">
         <source>Test run in progress</source>
         <target state="translated">測試回合正在進行中</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryTotalTests">
         <source>Total tests: {0}</source>
         <target state="translated">測試數總計: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryFailedTests">
         <source>     Failed: {0}</source>
         <target state="translated">     失敗: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummaryPassedTests">
         <source>     Passed: {0}</source>
         <target state="translated">     通過: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
       <trans-unit id="TestRunSummarySkippedTests">
         <source>    Skipped: {0}</source>
         <target state="translated">    跳過: {0}</target>
-        <note>
-        </note>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
@@ -346,7 +346,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
             this.mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
             this.mockTestHostManager.Setup(tmh => tmh.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(true)).Callback(() => { this.mockTestHostManager.Raise(t => t.HostExited += null, new HostProviderEventArgs("I crashed!")); });
 
-            Assert.AreEqual(string.Format(CrossPlatEngineResources.Resources.TestHostExitedWithError, "I crashed!"), Assert.ThrowsException<TestPlatformException>(() => this.testExecutionManager.SetupChannel(new List<string> { "source.dll" })));
+            Assert.AreEqual(string.Format(CrossPlatEngineResources.Resources.TestHostExitedWithError, "I crashed!"), Assert.ThrowsException<TestPlatformException>(() => this.testExecutionManager.SetupChannel(new List<string> { "source.dll" })).Message);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
@@ -346,14 +346,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
             this.mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
             this.mockTestHostManager.Setup(tmh => tmh.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(true)).Callback(() => { this.mockTestHostManager.Raise(t => t.HostExited += null, new HostProviderEventArgs("I crashed!")); });
 
-            try
-            {
-                this.testExecutionManager.SetupChannel(new List<string> { "source.dll" });
-            }
-            catch (TestPlatformException tpe)
-            {
-                Assert.AreEqual(string.Format(CrossPlatEngineResources.Resources.TestHostExitedWithError, "I crashed!"), tpe.Message);
-            }
+            Assert.AreEqual(string.Format(CrossPlatEngineResources.Resources.TestHostExitedWithError, "I crashed!"), Assert.ThrowsException<TestPlatformException>(() => this.testExecutionManager.SetupChannel(new List<string> { "source.dll" })));
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixed incorrect timeout message when test host crashes/exits

Related issue
#2022