### PR TITLE
Cleaning the remaining set of dependencies for source build.

### DIFF
--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -24,5 +24,12 @@
     <MoqVersion>4.7.63</MoqVersion>
     <TestPlatformExternalsVersion>16.0.0-preview-2148743</TestPlatformExternalsVersion>
 
+    <MicrosoftBuildPackageVersion>16.0.461</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
+    <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>3.0.0-preview4-27615-11</MicrosoftExtensionsDependencyModelPackageVersion>
   </PropertyGroup>
+
+  <Import Project="$(DotNetPackageVersionPropsPath)" Condition="'$(DotNetPackageVersionPropsPath)' != ''" />
+
 </Project>

--- a/scripts/build/TestPlatform.targets
+++ b/scripts/build/TestPlatform.targets
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <!-- Static analysis dependencies -->
-  <ItemGroup Condition="$(EnableCodeAnalysis) == 'true'">
+  <ItemGroup Condition="$(EnableCodeAnalysis) == 'true' AND '$(DotNetBuildFromSource)' != 'true'" >
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.0.1</Version>
       <PrivateAssets>All</PrivateAssets>

--- a/scripts/verify-nupkgs.ps1
+++ b/scripts/verify-nupkgs.ps1
@@ -19,7 +19,7 @@ function Verify-Nuget-Packages($packageDirectory)
                      "Microsoft.TestPlatform.CLI" = 303;
                      "Microsoft.TestPlatform.Extensions.TrxLogger" = 33;
                      "Microsoft.TestPlatform.ObjectModel" = 65;
-                     "Microsoft.TestPlatform.Portable" = 470;
+                     "Microsoft.TestPlatform.Portable" = 472;
                      "Microsoft.TestPlatform.TestHost" = 140;
                      "Microsoft.TestPlatform.TranslationLayer" = 121}
 

--- a/scripts/verify-nupkgs.ps1
+++ b/scripts/verify-nupkgs.ps1
@@ -14,12 +14,12 @@ function Verify-Nuget-Packages($packageDirectory)
     Write-Log "Starting Verify-Nuget-Packages."
     $expectedNumOfFiles = @{"Microsoft.CodeCoverage" = 29;
                      "Microsoft.NET.Test.Sdk" = 13;
-                     "Microsoft.TestPlatform" = 422;
+                     "Microsoft.TestPlatform" = 421;
                      "Microsoft.TestPlatform.Build" = 19;
-                     "Microsoft.TestPlatform.CLI" = 302;
+                     "Microsoft.TestPlatform.CLI" = 303;
                      "Microsoft.TestPlatform.Extensions.TrxLogger" = 33;
                      "Microsoft.TestPlatform.ObjectModel" = 65;
-                     "Microsoft.TestPlatform.Portable" = 472;
+                     "Microsoft.TestPlatform.Portable" = 470;
                      "Microsoft.TestPlatform.TestHost" = 140;
                      "Microsoft.TestPlatform.TranslationLayer" = 121}
 

--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.csproj
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.csproj
@@ -5,8 +5,9 @@
   </PropertyGroup>
   <Import Project="$(TestPlatformRoot)scripts/build/TestPlatform.Settings.targets" />
   <PropertyGroup>
+    <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
     <AssemblyName>Microsoft.TestPlatform.Build</AssemblyName>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.csproj
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.csproj
@@ -32,10 +32,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework">
-      <Version>15.1.548</Version>
+      <Version>16.0.461</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Utilities.Core">
-      <Version>15.1.548</Version>
+      <Version>16.0.461</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(TestPlatformRoot)scripts\build\TestPlatform.targets" />

--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.csproj
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.csproj
@@ -32,12 +32,8 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework">
-      <Version>16.0.461</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Build.Utilities.Core">
-      <Version>16.0.461</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
   </ItemGroup>
   <Import Project="$(TestPlatformRoot)scripts\build\TestPlatform.targets" />
 </Project>

--- a/src/Microsoft.TestPlatform.CoreUtilities/Microsoft.TestPlatform.CoreUtilities.csproj
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Microsoft.TestPlatform.CoreUtilities.csproj
@@ -13,9 +13,6 @@
     <EmbeddedResource Include="Resources\Resources.resx" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <PackageReference Include="Microsoft.Internal.Dia.Interop">
-      <Version>14.0.0</Version>
-    </PackageReference>
     <Reference Include="System.Configuration" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.TestPlatform.CoreUtilities/Microsoft.TestPlatform.CoreUtilities.csproj
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Microsoft.TestPlatform.CoreUtilities.csproj
@@ -13,6 +13,9 @@
     <EmbeddedResource Include="Resources\Resources.resx" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+    <PackageReference Include="Microsoft.Internal.Dia.Interop">
+      <Version>14.0.0</Version>
+    </PackageReference>
     <Reference Include="System.Configuration" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Microsoft.TestPlatform.PlatformAbstractions.csproj
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Microsoft.TestPlatform.PlatformAbstractions.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <TestPlatformRoot Condition="$(TestPlatformRoot) == ''">..\..\</TestPlatformRoot>
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.TestPlatform.PlatformAbstractions</AssemblyName>
     <TargetFrameworks>netstandard1.0;netcoreapp1.0;net451;uap10.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">netstandard1.0;netcoreapp1.0;net451</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">netstandard1.0;netcoreapp1.0</TargetFrameworks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableCodeAnalysis>true</EnableCodeAnalysis>
   </PropertyGroup>
@@ -59,9 +59,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Compile Include="net451\**\*.cs" />
     <Compile Include="common\**\*.cs" />
-    <PackageReference Include="Microsoft.Internal.Dia.Interop">
-      <Version>14.0.0</Version>
-    </PackageReference>
     <Reference Include="System.Configuration" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Microsoft.TestPlatform.PlatformAbstractions.csproj
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Microsoft.TestPlatform.PlatformAbstractions.csproj
@@ -59,6 +59,9 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Compile Include="net451\**\*.cs" />
     <Compile Include="common\**\*.cs" />
+    <PackageReference Include="Microsoft.Internal.Dia.Interop">
+      <Version>14.0.0</Version>
+    </PackageReference>
     <Reference Include="System.Configuration" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.TestPlatform.TestHostProvider/Microsoft.TestPlatform.TestHostProvider.csproj
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Microsoft.TestPlatform.TestHostProvider.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyModel">
-      <Version>1.0.3</Version>
+      <Version>3.0.0-preview4-27615-11</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">

--- a/src/Microsoft.TestPlatform.TestHostProvider/Microsoft.TestPlatform.TestHostProvider.csproj
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Microsoft.TestPlatform.TestHostProvider.csproj
@@ -21,9 +21,7 @@
     <EmbeddedResource Include="Resources\Resources.resx" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyModel">
-      <Version>3.0.0-preview4-27615-11</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
     <PackageReference Include="System.Diagnostics.Process">

--- a/src/package/external/external.csproj
+++ b/src/package/external/external.csproj
@@ -81,15 +81,15 @@
       <Version>15.6.815-master284DF69C</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-      <!-- Required for resolution of desktop dependencies in non windows environment.
+    <!-- Required for resolution of desktop dependencies in non windows environment.
          We've to set to net46 since the net451 and other packages have assemblies in wrong case.
          E.g. System.XML instead of System.Xml. -->
-   <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.6">
+    <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.6">
       <Version>1.0.1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/package/nuspec/Microsoft.TestPlatform.Portable.nuspec
+++ b/src/package/nuspec/Microsoft.TestPlatform.Portable.nuspec
@@ -223,6 +223,8 @@
     <file src="netcoreapp2.0\datacollector.dll.config"	target="tools\netcoreapp2.0\datacollector.dll.config" />
     <file src="netcoreapp2.0\datacollector.runtimeconfig.json"	target="tools\netcoreapp2.0\datacollector.runtimeconfig.json" />
     <file src="netcoreapp2.0\Microsoft.Extensions.DependencyModel.dll"	target="tools\netcoreapp2.0\Microsoft.Extensions.DependencyModel.dll" />
+    <file src="netcoreapp2.0\System.Memory.dll"	  target="tools\netcoreapp2.0\System.Memory.dll" />
+    <file src="netcoreapp2.0\System.Runtime.CompilerServices.Unsafe.dll"   target="tools\netcoreapp2.0\System.Runtime.CompilerServices.Unsafe.dll" />
     <file src="netcoreapp2.0\Microsoft.TestPlatform.CommunicationUtilities.dll"	target="tools\netcoreapp2.0\Microsoft.TestPlatform.CommunicationUtilities.dll" />
     <file src="netcoreapp2.0\Microsoft.TestPlatform.CoreUtilities.dll"	target="tools\netcoreapp2.0\Microsoft.TestPlatform.CoreUtilities.dll" />
     <file src="netcoreapp2.0\Microsoft.TestPlatform.CrossPlatEngine.dll"	target="tools\netcoreapp2.0\Microsoft.TestPlatform.CrossPlatEngine.dll" />

--- a/src/package/nuspec/Microsoft.TestPlatform.Portable.nuspec
+++ b/src/package/nuspec/Microsoft.TestPlatform.Portable.nuspec
@@ -21,7 +21,6 @@
     <!-- net451 -->
     <file src="net451\$Runtime$\datacollector.exe"	target="tools\net451\datacollector.exe" />
     <file src="net451\$Runtime$\datacollector.exe.config"	target="tools\net451\datacollector.exe.config" />
-    <file src="net451\$Runtime$\Microsoft.DotNet.PlatformAbstractions.dll"	target="tools\net451\Microsoft.DotNet.PlatformAbstractions.dll" />
     <file src="net451\$Runtime$\Microsoft.Extensions.DependencyModel.dll"	target="tools\net451\Microsoft.Extensions.DependencyModel.dll" />
     <file src="net451\$Runtime$\Microsoft.TestPlatform.CommunicationUtilities.dll"	target="tools\net451\Microsoft.TestPlatform.CommunicationUtilities.dll" />
     <file src="net451\$Runtime$\Microsoft.TestPlatform.CoreUtilities.dll"	target="tools\net451\Microsoft.TestPlatform.CoreUtilities.dll" />
@@ -223,7 +222,6 @@
     <file src="netcoreapp2.0\datacollector.dll"	target="tools\netcoreapp2.0\datacollector.dll" />
     <file src="netcoreapp2.0\datacollector.dll.config"	target="tools\netcoreapp2.0\datacollector.dll.config" />
     <file src="netcoreapp2.0\datacollector.runtimeconfig.json"	target="tools\netcoreapp2.0\datacollector.runtimeconfig.json" />
-    <file src="netcoreapp2.0\Microsoft.DotNet.PlatformAbstractions.dll"	target="tools\netcoreapp2.0\Microsoft.DotNet.PlatformAbstractions.dll" />
     <file src="netcoreapp2.0\Microsoft.Extensions.DependencyModel.dll"	target="tools\netcoreapp2.0\Microsoft.Extensions.DependencyModel.dll" />
     <file src="netcoreapp2.0\Microsoft.TestPlatform.CommunicationUtilities.dll"	target="tools\netcoreapp2.0\Microsoft.TestPlatform.CommunicationUtilities.dll" />
     <file src="netcoreapp2.0\Microsoft.TestPlatform.CoreUtilities.dll"	target="tools\netcoreapp2.0\Microsoft.TestPlatform.CoreUtilities.dll" />

--- a/src/package/nuspec/Microsoft.TestPlatform.nuspec
+++ b/src/package/nuspec/Microsoft.TestPlatform.nuspec
@@ -96,7 +96,6 @@
     <file src="net451\$Runtime$\LegacyTypes.testtype"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\LegacyTypes.testtype" />
     <file src="net451\$Runtime$\ManualTests.testtype"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\ManualTests.testtype" />
     <file src="net451\$Runtime$\Microsoft.DiaSymReader.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Microsoft.DiaSymReader.dll" />
-    <file src="net451\$Runtime$\Microsoft.DotNet.PlatformAbstractions.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Microsoft.DotNet.PlatformAbstractions.dll" />
     <file src="net451\$Runtime$\Microsoft.Extensions.DependencyModel.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Microsoft.Extensions.DependencyModel.dll" />
     <file src="net451\$Runtime$\Microsoft.IntelliTrace.Core.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Microsoft.IntelliTrace.Core.dll" />
     <file src="net451\$Runtime$\Microsoft.TestPlatform.CommunicationUtilities.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Microsoft.TestPlatform.CommunicationUtilities.dll" />

--- a/src/package/nuspec/TestPlatform.Build.nuspec
+++ b/src/package/nuspec/TestPlatform.Build.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0"?>
 <package >
   <metadata>
     <id>Microsoft.TestPlatform.Build</id>
@@ -15,10 +15,10 @@
     <tags>vstest visual-studio unittest testplatform mstest microsoft test testing</tags>
   </metadata>
   <files>
-    <file src="Microsoft.TestPlatform.Build\netstandard1.3\Microsoft.TestPlatform.targets" target="runtimes\any\native" />
+    <file src="Microsoft.TestPlatform.Build\netstandard2.0\Microsoft.TestPlatform.targets" target="runtimes\any\native" />
 
     <!-- Add localized resources -->
-    <file src="Microsoft.TestPlatform.Build\netstandard1.3\**\*.dll" target="lib\netstandard1.3" />
+    <file src="Microsoft.TestPlatform.Build\netstandard2.0\**\*.dll" target="lib\netstandard2.0" />
 
   </files>
 </package>

--- a/src/package/nuspec/TestPlatform.TestHost.nuspec
+++ b/src/package/nuspec/TestPlatform.TestHost.nuspec
@@ -17,7 +17,7 @@
       <group targetFramework="netcoreapp1.0">
         <dependency id="Microsoft.TestPlatform.ObjectModel" version="$Version$"/>
         <dependency id="Newtonsoft.Json" version="$JsonNetVersion$"/>
-        <dependency id="Microsoft.Extensions.DependencyModel" version="1.0.3"/>
+        <dependency id="Microsoft.Extensions.DependencyModel" version="3.0.0-preview4-27615-11"/>
       </group>
 
       <group targetFramework="uap10.0">

--- a/src/package/nuspec/TestPlatform.TestHost.nuspec
+++ b/src/package/nuspec/TestPlatform.TestHost.nuspec
@@ -17,7 +17,6 @@
       <group targetFramework="netcoreapp1.0">
         <dependency id="Microsoft.TestPlatform.ObjectModel" version="$Version$"/>
         <dependency id="Newtonsoft.Json" version="$JsonNetVersion$"/>
-        <dependency id="Microsoft.Extensions.DependencyModel" version="3.0.0-preview4-27615-11"/>
       </group>
 
       <group targetFramework="uap10.0">

--- a/test/Microsoft.TestPlatform.Build.UnitTests/Microsoft.TestPlatform.Build.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/Microsoft.TestPlatform.Build.UnitTests.csproj
@@ -18,12 +18,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework">
-      <Version>16.0.461</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Build.Utilities.Core">
-      <Version>16.0.461</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
   </ItemGroup>
   <Import Project="$(TestPlatformRoot)scripts\build\TestPlatform.targets" />
 </Project>

--- a/test/Microsoft.TestPlatform.Build.UnitTests/Microsoft.TestPlatform.Build.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/Microsoft.TestPlatform.Build.UnitTests.csproj
@@ -7,7 +7,7 @@
   <Import Project="$(TestPlatformRoot)scripts/build/TestPlatform.Settings.targets" />
   <PropertyGroup>
     <OutputType Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <AssemblyName>Microsoft.TestPlatform.Build.UnitTests</AssemblyName>
     <WarningsAsErrors>true</WarningsAsErrors>
     <EnableCodeAnalysis>true</EnableCodeAnalysis>

--- a/test/Microsoft.TestPlatform.Build.UnitTests/Microsoft.TestPlatform.Build.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/Microsoft.TestPlatform.Build.UnitTests.csproj
@@ -19,10 +19,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework">
-      <Version>15.1.548</Version>
+      <Version>16.0.461</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Utilities.Core">
-      <Version>15.1.548</Version>
+      <Version>16.0.461</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(TestPlatformRoot)scripts\build\TestPlatform.targets" />


### PR DESCRIPTION
a. Microsoft.Build.Framework and Microsoft.Build.Utilities.Core to source built version: 16.0.461
b. Microsoft.Extensions.DependencyModel to source built version: 3.0.0-preview4-27615-11
c. Removed the redundant reference to Microsoft.Internal.Dia.Interop
d. Adding check for source build for StyleCop.Analyzers

## Related issue
https://github.com/dotnet/source-build/issues/896
