### PR TITLE
Incompatible framework message fix

### DIFF
--- a/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
@@ -629,7 +629,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
                     string incompatiblityMessage;
                     var onlyFileName = Path.GetFileName(source);
                     // Add message for incompatible sources.
-                    incompatiblityMessage = string.Format(CultureInfo.CurrentCulture, OMResources.SourceIncompatible, onlyFileName, actualFramework.Version, actualPlatform);
+                    incompatiblityMessage = string.Format(CultureInfo.CurrentCulture, OMResources.SourceIncompatible, onlyFileName, actualFramework.Name, actualPlatform);
 
                     warnings.AppendLine(incompatiblityMessage);
                     incompatiblityFound = true;

--- a/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
@@ -217,7 +217,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void IncompatibleSourcesWarningShouldBeDisplayedInTheConsole(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
-            var expectedWarningContains = @"Following DLL(s) do not match framework/platform settings. SimpleTestProject3.dll is built for Framework 4.5.1 and Platform X64";
+            var expectedWarningContains = @"Following DLL(s) do not match framework/platform settings. SimpleTestProject3.dll is built for Framework .NETFramework,Version=v4.5.1 and Platform X64";
             var assemblyPaths =
                 this.BuildMultipleAssemblyPath("SimpleTestProject3.dll", "SimpleTestProjectx86.dll").Trim('\"');
             var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/InferRunSettingsHelperTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/InferRunSettingsHelperTests.cs
@@ -736,7 +736,7 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
 
         private string GetSourceIncompatibleMessage(string source)
         {
-            return string.Format(CultureInfo.CurrentCulture, OMResources.SourceIncompatible, source, sourceFrameworks[source].Version, sourceArchitectures[source]);
+            return string.Format(CultureInfo.CurrentCulture, OMResources.SourceIncompatible, source, sourceFrameworks[source].Name, sourceArchitectures[source]);
         }
 
         private XmlDocument GetXmlDocument(string settingsXml)


### PR DESCRIPTION
## Description
Fix the error reported for incompatible framework to give complete framework name.

Actual:
```
Test run will use DLL(s) built for framework .NETFramework,Version=v4.5 and platform X86. Following DLL(s) do not match framework/platform settings.
temp.dll is built for Framework 3.0 and Platform AnyCPU.
```
Expected
```
Test run will use DLL(s) built for framework .NETFramework,Version=v4.5 and platform X86. Following DLL(s) do not match framework/platform settings.
temp.dll is built for Framework .NETCoreApp,Version=v3.0 and Platform AnyCPU.
```


