### PR TITLE
Update the hand shake message payload.

### DIFF
--- a/samples/Microsoft.TestPlatform.Protocol/Program.cs
+++ b/samples/Microsoft.TestPlatform.Protocol/Program.cs
@@ -142,13 +142,13 @@ namespace Microsoft.TestPlatform.Protocol
             if (message.MessageType == MessageType.SessionConnected)
             {
                 // Version Check
-                communicationManager.SendMessage(MessageType.VersionCheck);
+                communicationManager.SendMessage(MessageType.VersionCheck, 1);
                 message = communicationManager.ReceiveMessage();
 
                 if (message.MessageType == MessageType.VersionCheck)
                 {
                     var version = JsonDataSerializer.Instance.DeserializePayload<int>(message);
-                    
+
                     var success = version == 1;
                     Console.WriteLine("Version Success: {0}", success);
                 }


### PR DESCRIPTION
The payload of Version Operation message must not be null, otherwise, the test host process won't reply message.