### PR TITLE
Change the error message to display name instead of version

### DIFF
--- a/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
@@ -629,7 +629,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
                     string incompatiblityMessage;
                     var onlyFileName = Path.GetFileName(source);
                     // Add message for incompatible sources.
-                    incompatiblityMessage = string.Format(CultureInfo.CurrentCulture, OMResources.SourceIncompatible, onlyFileName, actualFramework.Version, actualPlatform);
+                    incompatiblityMessage = string.Format(CultureInfo.CurrentCulture, OMResources.SourceIncompatible, onlyFileName, actualFramework.Name, actualPlatform);
 
                     warnings.AppendLine(incompatiblityMessage);
                     incompatiblityFound = true;


### PR DESCRIPTION
The current incompatible message uses the version number as an error message. So it could give a confusing message like:
ProjectA is built for framework 2.1 and platform Any CPU. But the project could be built for .NET Core 2.1.

This message is quite confusing since it uses the word 'framework' so the user may think it is a strange version of .NET Framework