### PR TITLE
Fixing the verify sign script

### DIFF
--- a/scripts/verify-sign.ps1
+++ b/scripts/verify-sign.ps1
@@ -54,8 +54,12 @@ function Verify-Assemblies
                     elseif ($signature.SignerCertificate.Thumbprint -eq "5EAD300DC7E4D637948ECB0ED829A072BD152E17") {
                         Write-Log "Valid (Prod Signed): $($_.FullName)."
                     }
-					# For some dlls e.g. "Interop.UIAutomationClient.dll", sign certificate is different signature. Skip such binaries.
+		    # For some dlls e.g. "Interop.UIAutomationClient.dll", sign certificate is different signature. Skip such binaries.
                     elseif ($signature.SignerCertificate.Thumbprint -eq "67B1757863E3EFF760EA9EBB02849AF07D3A8080") {
+                        Write-Log "Valid (Prod Signed): $($_.FullName)."
+                    }
+		    # For some dlls e.g. "Microsoft.VisualStudio.ArchitectureTools.PEReader.dll", sign certificate is different signature. Skip such binaries.
+                    elseif ($signature.SignerCertificate.Thumbprint -eq "9DC17888B5CFAD98B3CB35C1994E96227F061675") {
                         Write-Log "Valid (Prod Signed): $($_.FullName)."
                     }
                     else {


### PR DESCRIPTION
## Description
CI build is failing because the certificates have changed. The dlls like *PEReader*dll and msdia*dll are signed with older certificate, changing the script to accommodate the change in the certificate for signing.
