### PR TITLE
Add netstandard2 target to object model and lower

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -607,7 +607,7 @@ function Create-NugetPackages
         }
 
         Write-Verbose "$nugetExe pack $stagingDir\$file -OutputDirectory $packageOutputDir -Version $TPB_Version -Properties Version=$TPB_Version $additionalArgs"
-        & $nugetExe pack $stagingDir\$file -OutputDirectory $packageOutputDir -Version $TPB_Version -Properties Version=$TPB_Version`;JsonNetVersion=$JsonNetVersion`;Runtime=$TPB_TargetRuntime`;NetCoreTargetFramework=$TPB_TargetFrameworkCore20 $additionalArgs
+        & $nugetExe pack $stagingDir\$file -OutputDirectory $packageOutputDir -Version $TPB_Version -Properties Version=$TPB_Version`;JsonNetVersion=$JsonNetVersion`;Runtime=$TPB_TargetRuntime`;NetCoreTargetFramework20=$TPB_TargetFrameworkCore20`;NetCoreTargetFramework=$TPB_TargetFrameworkCore $additionalArgs
 
         Set-ScriptFailedOnError
     }

--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -28,7 +28,7 @@
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <!-- .NetStandardLibrary1.6.0 brings in dependencies which are supported in UWP,
          any higher version will bring in dependencies which are not supported by current UWP version -->
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' != 'netstandard2.0' ">1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -28,7 +28,7 @@
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <!-- .NetStandardLibrary1.6.0 brings in dependencies which are supported in UWP,
          any higher version will bring in dependencies which are not supported by current UWP version -->
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' != 'netstandard2.0' ">1.6.0</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' != 'netstandard2.0' or '$(TargetFramework)' != 'netcoreapp2.0' or '$(TargetFramework)' != 'netcoreapp2.1' ">1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -26,9 +26,6 @@
     <!-- Disable default inclusion of .resx file. We generate files in the Resources directory only
          if localization is enabled, default inclusion ends up including the generated files by default. -->
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <!-- .NetStandardLibrary1.6.0 brings in dependencies which are supported in UWP,
-         any higher version will bring in dependencies which are not supported by current UWP version -->
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' != 'netstandard2.0' or '$(TargetFramework)' != 'netcoreapp2.0' or '$(TargetFramework)' != 'netcoreapp2.1' ">1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/scripts/verify-nupkgs.ps1
+++ b/scripts/verify-nupkgs.ps1
@@ -16,7 +16,7 @@ function Verify-Nuget-Packages($packageDirectory)
                      "Microsoft.NET.Test.Sdk" = 13;
                      "Microsoft.TestPlatform" = 421;
                      "Microsoft.TestPlatform.Build" = 19;
-                     "Microsoft.TestPlatform.CLI" = 303;
+                     "Microsoft.TestPlatform.CLI" = 305;
                      "Microsoft.TestPlatform.Extensions.TrxLogger" = 33;
                      "Microsoft.TestPlatform.ObjectModel" = 65;
                      "Microsoft.TestPlatform.Portable" = 472;

--- a/src/Microsoft.TestPlatform.CoreUtilities/Microsoft.TestPlatform.CoreUtilities.csproj
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Microsoft.TestPlatform.CoreUtilities.csproj
@@ -6,7 +6,7 @@
   <Import Project="$(TestPlatformRoot)scripts/build/TestPlatform.Settings.targets" />
   <PropertyGroup>
     <AssemblyName>Microsoft.TestPlatform.CoreUtilities</AssemblyName>
-    <TargetFrameworks>netstandard1.4;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.4;net451;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">netstandard1.4</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.TestPlatform.CoreUtilities/Microsoft.TestPlatform.CoreUtilities.csproj
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Microsoft.TestPlatform.CoreUtilities.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
     <PackageReference Include="System.Diagnostics.FileVersionInfo">
-      <Version>4.0.0</Version>
+      <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.TestPlatform.CoreUtilities/Tracing/EqtTrace.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Tracing/EqtTrace.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 
 #endif
 
-#if NETSTANDARD1_4
+#if NETSTANDARD1_4 || NETSTANDARD2_0
         public static PlatformTraceLevel TraceLevel
         {
             get

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Microsoft.TestPlatform.Extensions.TrxLogger.csproj
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Microsoft.TestPlatform.Extensions.TrxLogger.csproj
@@ -25,13 +25,13 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
     <PackageReference Include="System.Collections.NonGeneric">
-      <Version>4.0.1</Version>
+      <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Security.Principal.Windows">
-      <Version>4.0.0</Version>
+      <Version>4.5.1</Version>
     </PackageReference>
     <PackageReference Include="System.Collections.Specialized">
-      <Version>4.0.1</Version>
+      <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj
+++ b/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Reflection.Metadata">
-      <Version>1.3.0</Version>
+      <Version>1.6.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">

--- a/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj
+++ b/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj
@@ -6,7 +6,7 @@
   <Import Project="$(TestPlatformRoot)scripts/build/TestPlatform.Settings.targets" />
   <PropertyGroup>
     <AssemblyName>Microsoft.VisualStudio.TestPlatform.ObjectModel</AssemblyName>
-    <TargetFrameworks>net451;netstandard1.4</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard1.4;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">netstandard1.4</TargetFrameworks>
     <PackageId>Microsoft.TestPlatform.ObjectModel</PackageId>
   </PropertyGroup>
@@ -57,7 +57,12 @@
     <PackageReference Include="System.Reflection.TypeExtensions">
       <Version>4.1.0</Version>
     </PackageReference>
-  </ItemGroup>
+  </ItemGroup>  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Xml.XPath.XmlDocument">
+      <Version>4.3.0</Version>
+    </PackageReference>
+  </ItemGroup>  
   <ItemGroup>
     <Compile Update="Resources\CommonResources.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj
+++ b/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj
@@ -31,7 +31,6 @@
     <ProjectReference Include="..\Microsoft.TestPlatform.CoreUtilities\Microsoft.TestPlatform.CoreUtilities.csproj" />
   </ItemGroup>
   <ItemGroup>
-
     <PackageReference Include="System.Reflection.Metadata">
       <Version>1.3.0</Version>
     </PackageReference>

--- a/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj
+++ b/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj
@@ -31,9 +31,7 @@
     <ProjectReference Include="..\Microsoft.TestPlatform.CoreUtilities\Microsoft.TestPlatform.CoreUtilities.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation">
-      <Version>4.0.0</Version>
-    </PackageReference>
+
     <PackageReference Include="System.Reflection.Metadata">
       <Version>1.3.0</Version>
     </PackageReference>

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Microsoft.TestPlatform.PlatformAbstractions.csproj
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Microsoft.TestPlatform.PlatformAbstractions.csproj
@@ -6,7 +6,7 @@
   <Import Project="$(TestPlatformRoot)scripts/build/TestPlatform.Settings.targets" />
   <PropertyGroup>
     <AssemblyName>Microsoft.TestPlatform.PlatformAbstractions</AssemblyName>
-    <TargetFrameworks>netstandard1.0;netcoreapp1.0;net451;uap10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netcoreapp1.0;net451;uap10.0;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">netstandard1.0;netcoreapp1.0</TargetFrameworks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableCodeAnalysis>true</EnableCodeAnalysis>
@@ -31,7 +31,7 @@
     <Compile Include="Interfaces\**\*.cs" />
     <Compile Include="Properties\**\*.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' or '$(TargetFramework)' == 'netstandard2.0' ">
     <Compile Include="netstandard1.0\**\*.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.csproj
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.csproj
@@ -26,12 +26,6 @@
     <PackageReference Include="System.Runtime.Serialization.Primitives">
       <Version>4.1.1</Version>
     </PackageReference>
-    <PackageReference Include="System.Xml.XPath.XmlDocument">
-      <Version>4.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="System.Runtime.InteropServices">
-      <Version>4.1.0</Version>
-    </PackageReference>
     <PackageReference Include="System.ComponentModel.TypeConverter">
       <Version>4.1.0</Version>
     </PackageReference>

--- a/src/datacollector/datacollector.csproj
+++ b/src/datacollector/datacollector.csproj
@@ -28,14 +28,9 @@
       <FromP2P>true</FromP2P>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">
-    <PackageReference Include="System.Runtime.Loader">
-      <Version>4.0.0</Version>
-    </PackageReference>
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Reflection">
-      <Version>4.1.0</Version>
+      <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/package/nuspec/Microsoft.TestPlatform.Portable.nuspec
+++ b/src/package/nuspec/Microsoft.TestPlatform.Portable.nuspec
@@ -369,7 +369,6 @@
     <file src="netcoreapp2.0\TestHost\Newtonsoft.Json.dll"	target="tools\netcoreapp2.0\TestHost\Newtonsoft.Json.dll" />
     <file src="netcoreapp2.0\TestHost\System.Collections.Immutable.dll"	target="tools\netcoreapp2.0\TestHost\System.Collections.Immutable.dll" />
     <file src="netcoreapp2.0\TestHost\System.Reflection.Metadata.dll"	target="tools\netcoreapp2.0\TestHost\System.Reflection.Metadata.dll" />
-    <file src="netcoreapp2.0\TestHost\System.Runtime.InteropServices.RuntimeInformation.dll"	target="tools\netcoreapp2.0\TestHost\System.Runtime.InteropServices.RuntimeInformation.dll" />
     <file src="netcoreapp2.0\TestHost\testhost.exe"	target="tools\netcoreapp2.0\TestHost\testhost.exe" />
     <file src="netcoreapp2.0\TestHost\testhost.exe.config"	target="tools\netcoreapp2.0\TestHost\testhost.exe.config" />
     <file src="netcoreapp2.0\TestHost\testhost.x86.exe"	target="tools\netcoreapp2.0\TestHost\testhost.x86.exe" />

--- a/src/package/nuspec/TestPlatform.ObjectModel.nuspec
+++ b/src/package/nuspec/TestPlatform.ObjectModel.nuspec
@@ -15,30 +15,17 @@
     <tags>vstest visual-studio unittest testplatform mstest microsoft test testing</tags>
     <dependencies>
       <group targetFramework="net451">
-        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="[4.0.0, )" />
         <dependency id="System.Reflection.Metadata" version="[1.3.0, )" />
       </group>
       <group targetFramework="netstandard1.5">
-        <dependency id="NETStandard.Library" version="[1.6.0, )" />
-        <dependency id="System.ComponentModel.EventBasedAsync" version="[4.0.11, )" />
-        <dependency id="System.ComponentModel.TypeConverter" version="[4.1.0, )" />
-        <dependency id="System.Reflection.TypeExtensions" version="[4.1.0, )" />
-        <dependency id="System.Reflection.Metadata" version="[1.3.0, )" />
-        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="[4.0.0, )" />
-        <dependency id="System.Runtime.Loader" version="[4.0.0, )" />
-        <dependency id="System.Runtime.Serialization.Primitives" version="[4.1.1, )" />
-        <dependency id="System.Runtime.Serialization.Json" version="[4.0.2, )" />
-        <dependency id="System.Xml.XPath.XmlDocument" version="[4.0.1, )" />
-
-        <!-- Dependencies for core utilities -->
-        <dependency id="System.Diagnostics.Process" version="[4.1.0, )" />
-        <dependency id="System.Diagnostics.TextWriterTraceListener" version="[4.0.0, )" />
-        <dependency id="System.Diagnostics.TraceSource" version="[4.0.0, )" />
-        <dependency id="System.Threading.Thread" version="[4.0.0, )" />
+        <dependency id="NETStandard.Library" version="[1.6.1, )" />
+        <dependency id="System.Xml.XPath.XmlDocument" version="[4.3.0, )" />
       </group>
       <group targetFramework="netstandard1.4">
-        <dependency id="System.ComponentModel.TypeConverter" version="[4.1.0, )" />
-        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="[4.0.0, )" />
+        <dependency id="System.Diagnostics.FileVersionInfo" version="[4.3.0, )" />
+      </group>
+      <group targetFramework="netstandard2.0">
+        <dependency id="System.Xml.XPath.XmlDocument" version="[4.3.0, )" />
       </group>
     </dependencies>
     <frameworkAssemblies>
@@ -60,6 +47,10 @@
     <file src="$NetCoreTargetFramework$\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" target="lib\netstandard1.5\" />
     <file src="$NetCoreTargetFramework$\Microsoft.TestPlatform.CoreUtilities.dll" target="lib\netstandard1.5\" />
     <file src="$NetCoreTargetFramework$\Microsoft.TestPlatform.PlatformAbstractions.dll" target="lib\netstandard1.5\" />
+    
+    <file src="$NetCoreTargetFramework20$\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" target="lib\netstandard1.5\" />
+    <file src="$NetCoreTargetFramework20$\Microsoft.TestPlatform.CoreUtilities.dll" target="lib\netstandard1.5\" />
+    <file src="$NetCoreTargetFramework20$\Microsoft.TestPlatform.PlatformAbstractions.dll" target="lib\netstandard1.5\" />    
 
     <file src="Microsoft.TestPlatform.TestHost\netstandard1.4\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" target="lib\netstandard1.4\" />
     <file src="Microsoft.TestPlatform.TestHost\netstandard1.4\Microsoft.TestPlatform.CoreUtilities.dll" target="lib\netstandard1.4\" />
@@ -121,6 +112,35 @@
     <file src="$NetCoreTargetFramework$\tr\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\netstandard1.5\tr" />
     <file src="$NetCoreTargetFramework$\zh-Hans\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\netstandard1.5\zh-Hans" />
     <file src="$NetCoreTargetFramework$\zh-Hant\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\netstandard1.5\zh-Hant" />
+
+    <file src="$NetCoreTargetFramework20$\cs\Microsoft.VisualStudio.TestPlatform.ObjectModel.*resources.dll" target="lib\netstandard2.0\cs" />
+    <file src="$NetCoreTargetFramework20$\de\Microsoft.VisualStudio.TestPlatform.ObjectModel.*resources.dll" target="lib\netstandard2.0\de" />
+    <file src="$NetCoreTargetFramework20$\es\Microsoft.VisualStudio.TestPlatform.ObjectModel.*resources.dll" target="lib\netstandard2.0\es" />
+    <file src="$NetCoreTargetFramework20$\fr\Microsoft.VisualStudio.TestPlatform.ObjectModel.*resources.dll" target="lib\netstandard2.0\fr" />
+    <file src="$NetCoreTargetFramework20$\it\Microsoft.VisualStudio.TestPlatform.ObjectModel.*resources.dll" target="lib\netstandard2.0\it" />
+    <file src="$NetCoreTargetFramework20$\ja\Microsoft.VisualStudio.TestPlatform.ObjectModel.*resources.dll" target="lib\netstandard2.0\ja" />
+    <file src="$NetCoreTargetFramework20$\ko\Microsoft.VisualStudio.TestPlatform.ObjectModel.*resources.dll" target="lib\netstandard2.0\ko" />
+    <file src="$NetCoreTargetFramework20$\pl\Microsoft.VisualStudio.TestPlatform.ObjectModel.*resources.dll" target="lib\netstandard2.0\pl" />
+    <file src="$NetCoreTargetFramework20$\pt-BR\Microsoft.VisualStudio.TestPlatform.ObjectModel.*resources.dll" target="lib\netstandard2.0\pt-BR" />
+    <file src="$NetCoreTargetFramework20$\ru\Microsoft.VisualStudio.TestPlatform.ObjectModel.*resources.dll" target="lib\netstandard2.0\ru" />
+    <file src="$NetCoreTargetFramework20$\tr\Microsoft.VisualStudio.TestPlatform.ObjectModel.*resources.dll" target="lib\netstandard2.0\tr" />
+    <file src="$NetCoreTargetFramework20$\zh-Hans\Microsoft.VisualStudio.TestPlatform.ObjectModel.*resources.dll" target="lib\netstandard2.0\zh-Hans" />
+    <file src="$NetCoreTargetFramework20$\zh-Hant\Microsoft.VisualStudio.TestPlatform.ObjectModel.*resources.dll" target="lib\netstandard2.0\zh-Hant" />
+
+    <file src="$NetCoreTargetFramework20$\cs\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\netstandard2.0\cs" />
+    <file src="$NetCoreTargetFramework20$\de\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\netstandard2.0\de" />
+    <file src="$NetCoreTargetFramework20$\es\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\netstandard2.0\es" />
+    <file src="$NetCoreTargetFramework20$\fr\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\netstandard2.0\fr" />
+    <file src="$NetCoreTargetFramework20$\it\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\netstandard2.0\it" />
+    <file src="$NetCoreTargetFramework20$\ja\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\netstandard2.0\ja" />
+    <file src="$NetCoreTargetFramework20$\ko\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\netstandard2.0\ko" />
+    <file src="$NetCoreTargetFramework20$\pl\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\netstandard2.0\pl" />
+    <file src="$NetCoreTargetFramework20$\pt-BR\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\netstandard2.0\pt-BR" />
+    <file src="$NetCoreTargetFramework20$\ru\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\netstandard2.0\ru" />
+    <file src="$NetCoreTargetFramework20$\tr\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\netstandard2.0\tr" />
+    <file src="$NetCoreTargetFramework20$\zh-Hans\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\netstandard2.0\zh-Hans" />
+    <file src="$NetCoreTargetFramework20$\zh-Hant\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\netstandard2.0\zh-Hant" />
+
 
   </files>
 </package>

--- a/src/package/nuspec/TestPlatform.ObjectModel.nuspec
+++ b/src/package/nuspec/TestPlatform.ObjectModel.nuspec
@@ -15,7 +15,7 @@
     <tags>vstest visual-studio unittest testplatform mstest microsoft test testing</tags>
     <dependencies>
       <group targetFramework="net451">
-        <dependency id="System.Reflection.Metadata" version="[1.3.0, )" />
+        <dependency id="System.Reflection.Metadata" version="[1.6.0, )" />
       </group>
       <group targetFramework="netstandard1.5">
         <dependency id="NETStandard.Library" version="[1.6.1, )" />

--- a/src/vstest.console/vstest.console.csproj
+++ b/src/vstest.console/vstest.console.csproj
@@ -41,9 +41,6 @@
     <PackageReference Include="System.Diagnostics.Contracts">
       <Version>4.0.1</Version>
     </PackageReference>
-    <PackageReference Include="System.Xml.XPath">
-      <Version>4.0.1</Version>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />

--- a/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Microsoft.TestPlatform.CoreUtilities.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Microsoft.TestPlatform.CoreUtilities.UnitTests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
   <Import Project="$(TestPlatformRoot)scripts/build/TestPlatform.Settings.targets" />
   <PropertyGroup>
-    <OutputType Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.0;net451</TargetFrameworks>
+    <OutputType Condition=" '$(TargetFramework)' == 'netcoreapp1.0' or '$(TargetFramework)' == 'netcoreapp2.1' ">Exe</OutputType>
+    <TargetFrameworks>netcoreapp1.0;net451;netcoreapp2.1</TargetFrameworks>
     <AssemblyName>Microsoft.TestPlatform.CoreUtilities.UnitTests</AssemblyName>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">

--- a/test/Microsoft.TestPlatform.ObjectModel.PlatformTests/Microsoft.TestPlatform.ObjectModel.PlatformTests.csproj
+++ b/test/Microsoft.TestPlatform.ObjectModel.PlatformTests/Microsoft.TestPlatform.ObjectModel.PlatformTests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
   <Import Project="$(TestPlatformRoot)scripts/build/TestPlatform.Settings.targets" />
   <PropertyGroup>
-    <OutputType Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.0;net451</TargetFrameworks>
+    <OutputType Condition=" '$(TargetFramework)' == 'netcoreapp1.0' or '$(TargetFramework)' == 'netcoreapp2.1'">Exe</OutputType>
+    <TargetFrameworks>netcoreapp1.0;net451;netcoreapp2.1</TargetFrameworks>
     <AssemblyName>Microsoft.TestPlatform.ObjectModel.PlatformTests</AssemblyName>
   </PropertyGroup>
   <ItemGroup>

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Microsoft.TestPlatform.ObjectModel.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Microsoft.TestPlatform.ObjectModel.UnitTests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
   <Import Project="$(TestPlatformRoot)scripts/build/TestPlatform.Settings.targets" />
   <PropertyGroup>
-    <OutputType Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.0;net451</TargetFrameworks>
+    <OutputType Condition=" '$(TargetFramework)' == 'netcoreapp1.0' or '$(TargetFramework)' == 'netcoreapp2.1' ">Exe</OutputType>
+    <TargetFrameworks>netcoreapp1.0;net451;netcoreapp2.1</TargetFrameworks>
     <AssemblyName>Microsoft.TestPlatform.ObjectModel.UnitTests</AssemblyName>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description
This adds a .NET Standard 2.0 build target to ObjectModel, CoreUtilities and PlatformAbstractions. This is necessary to prevent package downgrade warnings when using them on newer platforms.

## Related issue
Fixes #2073
