### PR TITLE
Manifest folder

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -812,8 +812,12 @@ function Update-VsixVersion($vsixProjectDir)
 
 function Generate-Manifest
 {
+    Write-Log "Generate-Manifest: Started."
+
     $sdkTaskPath = Join-Path $env:TP_ROOT_DIR "eng\common\sdk-task.ps1"
-    & $sdkTaskPath -restore -task GenerateBuildManifest /p:PackagesToPublishPattern=$TPB_PackageOutDir\*.nupkg /p:AssetManifestFilePath=$TPB_PackageOutDir\manifest.xml /p:ManifestBuildData="Location=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" /p:BUILD_BUILDNUMBER=$BuildNumber
+    & $sdkTaskPath -restore -task GenerateBuildManifest /p:PackagesToPublishPattern=$TPB_PackageOutDir\*.nupkg /p:AssetManifestFilePath=$TPB_PackageOutDir\manifest\manifest.xml /p:ManifestBuildData="Location=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" /p:BUILD_BUILDNUMBER=$BuildNumber
+
+    Write-Log "Generate-Manifest: Completed."
 }
 
 function Build-SpecificProjects


### PR DESCRIPTION
Creating a clean folder for the manifest file. This is required because file publishing we need to give the directory path, and path contains non-xml files, which makes the publish code throw an exception.
