### PR TITLE
Add noprogress parameter to disable progress indicator

### DIFF
--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -56,6 +56,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
         internal static bool AppendPrefix;
 
         /// <summary>
+        /// Bool to decide whether progress indicator should be disabled.
+        /// </summary>
+        internal static bool DisableProgress;
+
+        /// <summary>
         /// Uri used to uniquely identify the console logger.
         /// </summary>
         public const string ExtensionUri = "logger://Microsoft/TestPlatform/ConsoleLogger/v1";
@@ -74,6 +79,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
         /// Parameter for log message prefix
         /// </summary>
         public const string PrefixParam = "prefix";
+
+        /// <summary>
+        /// Parameter for disabling progress
+        /// </summary>
+        public const string NoProgressParam = "noprogress";
 
         #endregion
 
@@ -166,7 +176,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
                 ConsoleLogger.Output = ConsoleOutput.Instance;
             }
 
-            if (this.progressIndicator == null && !Console.IsOutputRedirected)
+            if (this.progressIndicator == null && !Console.IsOutputRedirected && !DisableProgress)
             {
                 // Progress indicator needs to be displayed only for cli experience.
                 this.progressIndicator = new ProgressIndicator(Output, new ConsoleHelper());
@@ -206,6 +216,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
             if (prefixExists)
             {
                 bool.TryParse(prefix, out AppendPrefix);
+            }
+
+            var noprogressExists = parameters.TryGetValue(ConsoleLogger.NoProgressParam, out string noprogress);
+            if (noprogressExists)
+            {
+                bool.TryParse(noprogress, out DisableProgress);
             }
 
             Initialize(events, String.Empty);

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -126,6 +126,21 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
         }
 
         [TestMethod]
+        public void InitializeWithParametersShouldSetNoProgress()
+        {
+            var parameters = new Dictionary<string, string>();
+
+            Assert.IsFalse(ConsoleLogger.DisableProgress);
+
+            parameters.Add("noprogress", "true");
+            this.consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, parameters);
+
+            Assert.IsTrue(ConsoleLogger.DisableProgress);
+
+            ConsoleLogger.DisableProgress = false;
+        }
+
+        [TestMethod]
         public void TestMessageHandlerShouldThrowExceptionIfEventArgsIsNull()
         {
             var loggerEvents = new InternalTestLoggerEvents(TestSessionMessageLogger.Instance);


### PR DESCRIPTION
## Description
Console progress indicator might have issues in certain terminals or terminal emulators (e.g. mintty, travis CI). This PR adds option to disable progress indicator.
