### PR TITLE
for #2120 DisableProgress when environment CI true

### DIFF
--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -131,46 +131,61 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
         [TestMethod]
         public void InitializeWithParametersShouldSetNoProgress()
         {
-            var parameters = new Dictionary<string, string>();
+            try
+            {
+                var parameters = new Dictionary<string, string>();
 
-            Assert.IsFalse(ConsoleLogger.DisableProgress);
+                Assert.IsFalse(ConsoleLogger.DisableProgress);
 
-            parameters.Add("noprogress", "true");
-            this.consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, parameters);
+                parameters.Add("noprogress", "true");
+                this.consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, parameters);
 
-            Assert.IsTrue(ConsoleLogger.DisableProgress);
-
-            ConsoleLogger.DisableProgress = false;
+                Assert.IsTrue(ConsoleLogger.DisableProgress);
+            }
+            finally
+            {
+                ConsoleLogger.DisableProgress = false;
+            }
         }
 
         [TestMethod]
         public void InitializeWithParametersShouldSetDisableProgressWhenCI()
         {
-            Environment.SetEnvironmentVariable("CI", "true");
+            try
+            {
+                Environment.SetEnvironmentVariable("CI", "true");
 
-            var parameters = new Dictionary<string, string>();
-            parameters.Add("fakeparam", "false");
+                var parameters = new Dictionary<string, string>();
+                parameters.Add("fakeparam", "false");
 
-            this.consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, parameters);
+                this.consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, parameters);
 
-            Assert.IsTrue(ConsoleLogger.DisableProgress);
-
-            ConsoleLogger.DisableProgress = false;
+                Assert.IsTrue(ConsoleLogger.DisableProgress);
+            }
+            finally
+            {
+                ConsoleLogger.DisableProgress = false;
+            }
         }
 
         [TestMethod]
         public void InitializeWithParametersShouldSetDisableProgressFalseOverrideCI()
         {
-            Environment.SetEnvironmentVariable("CI", "true");
+            try
+            {
+                Environment.SetEnvironmentVariable("CI", "true");
 
-            var parameters = new Dictionary<string, string>();
-            parameters.Add("noprogress", "false");
+                var parameters = new Dictionary<string, string>();
+                parameters.Add("noprogress", "false");
 
-            this.consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, parameters);
+                this.consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, parameters);
 
-            Assert.IsFalse(ConsoleLogger.DisableProgress);
-
-            ConsoleLogger.DisableProgress = false;
+                Assert.IsFalse(ConsoleLogger.DisableProgress);
+            }
+            finally
+            {
+                ConsoleLogger.DisableProgress = false;
+            }
         }
 
 

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -149,6 +149,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
             Environment.SetEnvironmentVariable("CI", "true");
 
             var parameters = new Dictionary<string, string>();
+            parameters.Add("fakeparam", "false");
 
             this.consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, parameters);
 

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -144,6 +144,36 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
         }
 
         [TestMethod]
+        public void InitializeWithParametersShouldSetDisableProgressWhenCI()
+        {
+            Environment.SetEnvironmentVariable("CI", "true");
+
+            var parameters = new Dictionary<string, string>();
+
+            this.consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, parameters);
+
+            Assert.IsTrue(ConsoleLogger.DisableProgress);
+
+            ConsoleLogger.DisableProgress = false;
+        }
+
+        [TestMethod]
+        public void InitializeWithParametersShouldSetDisableProgressFalseOverrideCI()
+        {
+            Environment.SetEnvironmentVariable("CI", "true");
+
+            var parameters = new Dictionary<string, string>();
+            parameters.Add("noprogress", "false");
+
+            this.consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, parameters);
+
+            Assert.IsFalse(ConsoleLogger.DisableProgress);
+
+            ConsoleLogger.DisableProgress = false;
+        }
+
+
+        [TestMethod]
         public void TestMessageHandlerShouldThrowExceptionIfEventArgsIsNull()
         {
             var loggerEvents = new InternalTestLoggerEvents(TestSessionMessageLogger.Instance);
@@ -977,7 +1007,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
             this.consoleLogger.Initialize(loggerEvents, parameters);
 
             var testresults = this.GetTestResultObject(TestOutcome.Passed);
-            testresults[0].Messages.Add(new TestResultMessage (TestResultMessage.StandardOutCategory, "Hello"));
+            testresults[0].Messages.Add(new TestResultMessage(TestResultMessage.StandardOutCategory, "Hello"));
 
             foreach (var testResult in testresults)
             {
@@ -1096,7 +1126,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
             return testresultList;
         }
 
-        
+
 
 
         private List<ObjectModel.TestResult> GetTestResultObject(TestOutcome outcome)


### PR DESCRIPTION
## Description
Disable the progress when CI environment variable is true to mitigate performance issue when running tests on detached hosts and verbosity normal or greater.

## Related issue
Fixes #2120 , #2106  
