### PR TITLE
Corrected name of method  as per the functionality

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestSender.cs
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
         }
 
         /// <inheritdoc/>
-        public Collection<AttachmentSet> SendAfterTestRunStartAndGetResult(ITestMessageEventHandler runEventsHandler, bool isCancelled)
+        public Collection<AttachmentSet> SendAfterTestRunEndAndGetResult(ITestMessageEventHandler runEventsHandler, bool isCancelled)
         {
             var isDataCollectionComplete = false;
             Collection<AttachmentSet> attachmentSets = null;

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/IDataCollectionRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/IDataCollectionRequestSender.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
         BeforeTestRunStartResult SendBeforeTestRunStartAndGetResult(string settingXml, IEnumerable<string> sources, ITestMessageEventHandler runEventsHandler);
 
         /// <summary>
-        /// Sends the AfterTestRunStart event and waits for result
+        /// Sends the AfterTestRunEnd event and waits for result
         /// </summary>
         /// <param name="runEventsHandler">
         /// Test message event handler for handling messages.
@@ -71,6 +71,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
         /// <returns>
         /// DataCollector attachments
         /// </returns>
-        Collection<AttachmentSet> SendAfterTestRunStartAndGetResult(ITestMessageEventHandler runEventsHandler, bool isCancelled);
+        Collection<AttachmentSet> SendAfterTestRunEndAndGetResult(ITestMessageEventHandler runEventsHandler, bool isCancelled);
     }
 }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
            () =>
            {
                EqtTrace.Info("ProxyDataCollectionManager.AfterTestRunEnd: Get attachment set for datacollector processId: {0} port: {1}", dataCollectionProcessId, dataCollectionPort);
-               attachmentSet = this.dataCollectionRequestSender.SendAfterTestRunStartAndGetResult(runEventsHandler, isCanceled);
+               attachmentSet = this.dataCollectionRequestSender.SendAfterTestRunEndAndGetResult(runEventsHandler, isCanceled);
            },
                 runEventsHandler);
             return attachmentSet;

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/DataCollectionRequestSenderTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/DataCollectionRequestSenderTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
         }
 
         [TestMethod]
-        public void SendAfterTestRunStartAndGetResultShouldReturnAttachments()
+        public void SendAfterTestRunEndAndGetResultShouldReturnAttachments()
         {
             var datacollectorUri = new Uri("my://custom/datacollector");
             var attachmentUri = new Uri("my://filename.txt");
@@ -43,7 +43,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
             this.mockDataSerializer.Setup(x => x.DeserializePayload<Collection<AttachmentSet>>(It.IsAny<Message>())).Returns(new Collection<AttachmentSet>() { attachment });
             this.mockCommunicationManager.Setup(x => x.ReceiveMessage()).Returns(new Message() { MessageType = MessageType.AfterTestRunEndResult, Payload = null });
 
-            var attachmentSets = this.requestSender.SendAfterTestRunStartAndGetResult(null, false);
+            var attachmentSets = this.requestSender.SendAfterTestRunEndAndGetResult(null, false);
 
             Assert.IsNotNull(attachmentSets);
             Assert.AreEqual(attachmentSets.Count, 1);
@@ -54,9 +54,9 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
         }
 
         [TestMethod]
-        public void SendAfterTestRunStartAndGetResultShouldNotReturnAttachmentsWhenRequestCancelled()
+        public void SendAfterTestRunEndAndGetResultShouldNotReturnAttachmentsWhenRequestCancelled()
         {
-            var attachmentSets = this.requestSender.SendAfterTestRunStartAndGetResult(null, true);
+            var attachmentSets = this.requestSender.SendAfterTestRunEndAndGetResult(null, true);
 
             Assert.IsNull(attachmentSets);
         }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
@@ -229,7 +229,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
             var attachmentSet = new AttachmentSet(uri, dispName);
             attachments.Add(attachmentSet);
 
-            this.mockDataCollectionRequestSender.Setup(x => x.SendAfterTestRunStartAndGetResult(It.IsAny<ITestRunEventsHandler>(), It.IsAny<bool>())).Returns(attachments);
+            this.mockDataCollectionRequestSender.Setup(x => x.SendAfterTestRunEndAndGetResult(It.IsAny<ITestRunEventsHandler>(), It.IsAny<bool>())).Returns(attachments);
 
             var result = this.proxyDataCollectionManager.AfterTestRunEnd(false, null);
 
@@ -245,7 +245,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
         {
             var mockRunEventsHandler = new Mock<ITestMessageEventHandler>();
             this.mockDataCollectionRequestSender.Setup(
-                    x => x.SendAfterTestRunStartAndGetResult(It.IsAny<ITestMessageEventHandler>(), It.IsAny<bool>()))
+                    x => x.SendAfterTestRunEndAndGetResult(It.IsAny<ITestMessageEventHandler>(), It.IsAny<bool>()))
                 .Throws<Exception>();
 
             var result = this.proxyDataCollectionManager.AfterTestRunEnd(false, mockRunEventsHandler.Object);


### PR DESCRIPTION
## Description
Renamed IDataCollectionRequestSender.SendAfterTestRunStartAndGetResult to IDataCollectionRequestSender.SendAfterTestRunEndAndGetResult. This because `AfterTestRunEnd` event is sent to `DataCollector` process in this method.

## Related issue
N/A
