### PR TITLE
Test Console fails if path contains forward slash

### DIFF
--- a/src/vstest.console/Processors/ResultsDirectoryArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ResultsDirectoryArgumentProcessor.cs
@@ -139,20 +139,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
 
             try
             {
-                // to check valid directory path
-                if (!string.IsNullOrEmpty(argument) && !IsValidPath(argument) )
-                {
-                    throw new ArgumentException("Illegal characters in path.");
-                }
-
-                var di = new DirectoryInfo(argument);
-
                 if (!Path.IsPathRooted(argument))
                 {
                     argument = Path.GetFullPath(argument);
                 }
+
+                var di = Directory.CreateDirectory(argument);
             }
-            catch (Exception ex) when( ex is NotSupportedException || ex is SecurityException || ex is ArgumentException || ex is PathTooLongException)
+            catch (Exception ex) when( ex is NotSupportedException || ex is SecurityException || ex is ArgumentException || ex is PathTooLongException || ex is IOException)
             {
                 throw new CommandLineException(string.Format(CommandLineResources.InvalidResultsDirectoryPathCommand, argument, ex.Message));
             }
@@ -169,34 +163,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
         {
             // Nothing to do since we updated the parameter during initialize parameter
             return ArgumentProcessorResult.Success;
-        }
-
-        /// <summary>
-        /// Checks if a given path is valid
-        /// </summary>
-        /// <returns> Is valid path </returns>
-        private bool IsValidPath(string argument)
-        {
-            if (argument.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
-            {
-                return false;
-            }
-
-            if (Path.IsPathRooted(argument))
-            {
-                argument = argument.Substring(argument.IndexOf(Path.DirectorySeparatorChar) + 1);
-            }
-            var folders = argument.Split(new char[] { Path.DirectorySeparatorChar });
-
-            foreach (var folder in folders)
-            {
-                if(folder.IndexOfAny(Path.GetInvalidFileNameChars())>=0)
-                {
-                    return false;
-                }
-            }
-
-            return true;
         }
 
         #endregion

--- a/test/vstest.console.UnitTests/Processors/ResultsDirectoryArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ResultsDirectoryArgumentProcessorTests.cs
@@ -87,10 +87,19 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         public void InitializeShouldThrowIfGivenPathisIllegal()
         {
             var folder = @"c:\som>\illegal\path\";
-            var message = string.Format(
+            string message;
+
+            message = string.Format(
+                @"The path '{0}' specified in the 'ResultsDirectory' is invalid. Error: {1}",
+                folder,
+                "The filename, directory name, or volume label syntax is incorrect : \'c:\\som>\\illegal\\path\\\'");
+
+#if NET451
+            message = string.Format(
                 @"The path '{0}' specified in the 'ResultsDirectory' is invalid. Error: {1}",
                 folder,
                 "Illegal characters in path.");
+#endif
             this.InitializeExceptionTestTemplate(folder, message);
         }
 
@@ -99,11 +108,17 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         {
 
             var folder = @"c:\path\to\in:valid";
-
-            var message = string.Format(
+            string message;
+            message = string.Format(
                 @"The path '{0}' specified in the 'ResultsDirectory' is invalid. Error: {1}",
                 folder,
-                "Illegal characters in path.");
+                "The directory name is invalid : \'c:\\path\\to\\in:valid\'");
+#if NET451
+            message = string.Format(
+                @"The path '{0}' specified in the 'ResultsDirectory' is invalid. Error: {1}",
+                folder,
+                "The given path's format is not supported.");
+#endif
             this.InitializeExceptionTestTemplate(folder, message);
         }
 
@@ -138,7 +153,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         [TestMethod]
         public void InitializeShouldSetCommandLineOptionsAndRunSettingsForAbsolutePathValue()
         {
-            var absolutePath = @"c:\Users\someone\testresults";
+            var absolutePath = @"c:\random\someone\testresults";
             this.executor.Initialize(absolutePath);
             Assert.AreEqual(absolutePath, CommandLineOptions.Instance.ResultsDirectory);
             Assert.AreEqual(absolutePath, this.runSettingsProvider.QueryRunSettingsNode(ResultsDirectoryArgumentExecutor.RunSettingsPath));


### PR DESCRIPTION
## Description
Removing pre validation checks for results directory.
Instead, creating the results directory if possible.

## Related issue
#2126 
