### PR TITLE
VsTestConsoleWrapper endsession should shut down vstest console process

### DIFF
--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
@@ -259,6 +259,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
             this.requestSender.EndSession();
             this.requestSender.Close();
             this.sessionStarted = false;
+            this.vstestConsoleProcessManager.ShutdownProcess();
         }
 
         #endregion

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
@@ -255,10 +255,12 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
 
         /// <inheritdoc/>
         public void EndSession()
-        {
+        {            
             this.requestSender.EndSession();
             this.requestSender.Close();
             this.sessionStarted = false;
+
+            EqtTrace.Info("VsTestConsoleWrapper.EndSession: Terminating vstest.cosole process");
             this.vstestConsoleProcessManager.ShutdownProcess();
         }
 

--- a/test/TranslationLayer.UnitTests/VsTestConsoleWrapperTests.cs
+++ b/test/TranslationLayer.UnitTests/VsTestConsoleWrapperTests.cs
@@ -310,6 +310,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
 
             this.mockRequestSender.Verify(rs => rs.EndSession(), Times.Once);
             this.mockRequestSender.Verify(rs => rs.Close(), Times.Once);
+            this.mockProcessManager.Verify(x => x.ShutdownProcess(), Times.Once);
         }
     }
 }


### PR DESCRIPTION
Related issue: https://github.com/microsoft/vstest/issues/2026