### PR TITLE
Allow sources to be parallelized across processes and controlled by adapters

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
@@ -102,8 +102,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine
         /// </returns>
         public IProxyExecutionManager GetExecutionManager(IRequestData requestData, ITestRuntimeProvider testHostManager, TestRunCriteria testRunCriteria)
         {
-            var distinctSources = GetDistinctNumberOfSources(testRunCriteria);
-            var parallelLevel = this.VerifyParallelSettingAndCalculateParallelLevel(distinctSources, testRunCriteria.TestRunSettings);
+            var bucketCount = GetDistinctNumberOfBuckets(testRunCriteria);
+            var parallelLevel = this.VerifyParallelSettingAndCalculateParallelLevel(bucketCount, testRunCriteria.TestRunSettings);
 
             // Collecting IsParallel Enabled
             requestData.MetricsCollection.Add(TelemetryDataConstants.ParallelEnabledDuringExecution, parallelLevel > 1 ? "True" : "False");
@@ -172,14 +172,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine
 
         #endregion
 
-        private static int GetDistinctNumberOfSources(TestRunCriteria testRunCriteria)
+        private static int GetDistinctNumberOfBuckets(TestRunCriteria testRunCriteria)
         {
             // No point in creating more processes if number of sources is less than what user configured for
             int numSources = 1;
             if (testRunCriteria.HasSpecificTests)
             {
                 numSources = new System.Collections.Generic.HashSet<string>(
-                    testRunCriteria.Tests.Select((testCase) => testCase.Source)).Count;
+                    testRunCriteria.Tests.Select((testCase) => $"{testCase.Source}:{testCase.GetPropertyValue(TestCaseProperties.Bucket, 0)}")).Count;
             }
             else
             {

--- a/src/Microsoft.TestPlatform.ObjectModel/TestCase.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TestCase.cs
@@ -325,6 +325,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         private const string SourceLabel = "Source";
         private const string FilePathLabel = "File Path";
         private const string LineNumberLabel = "Line Number";
+        private const string BucketLabel = "Bucket";
 
         #endregion
 
@@ -348,6 +349,9 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         public static readonly TestProperty LineNumber = TestProperty.Register("TestCase.LineNumber", LineNumberLabel, typeof(int), TestPropertyAttributes.Hidden, typeof(TestCase));
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+        public static readonly TestProperty Bucket = TestProperty.Register("TestCase.Bucket", BucketLabel, typeof(int), TestPropertyAttributes.Hidden, typeof(TestCase));
 
         internal static TestProperty[] Properties { get; } =
         {

--- a/src/vstest.console/Processors/RunBucketizedTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunBucketizedTestsArgumentProcessor.cs
@@ -1,0 +1,39 @@
+﻿// <copyright file="RunBucketizedTestsArgumentProcessor.cs" company="Microsoft Corporation">
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// </copyright>
+
+namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
+{
+    using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
+    using Microsoft.VisualStudio.TestPlatform.Common;
+    using Microsoft.VisualStudio.TestPlatform.Utilities;
+    using System;
+
+
+    internal class RunBucketizedTestsArgumentProcessor : IArgumentProcessor
+    {
+        public const string CommandName = "/Bucketize";
+
+        public Lazy<IArgumentProcessorCapabilities> Metadata { get; } =
+            new Lazy<IArgumentProcessorCapabilities>(() => new RunBucketizedTestsrgumentProcessorCapabilities());
+
+        public Lazy<IArgumentExecutor> Executor { get; set; } =
+            new Lazy<IArgumentExecutor>(() => new RunSpecificTestsArgumentExecutor(
+                CommandLineOptions.Instance,
+                RunSettingsManager.Instance,
+                TestRequestManager.Instance,
+                ConsoleOutput.Instance,
+                enableBucketization: true));
+    }
+
+    internal class RunBucketizedTestsrgumentProcessorCapabilities : BaseArgumentProcessorCapabilities
+    {
+        public override string CommandName => RunBucketizedTestsArgumentProcessor.CommandName;
+
+        public override bool IsAction => true;
+
+        public override bool AllowMultiple => false;
+
+        public override ArgumentProcessorPriority Priority => ArgumentProcessorPriority.Normal;
+    }
+}

--- a/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
+++ b/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
@@ -219,6 +219,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
                 new ListTestsArgumentProcessor(),
                 new RunTestsArgumentProcessor(),
                 new RunSpecificTestsArgumentProcessor(),
+                new RunBucketizedTestsArgumentProcessor(),
                 new TestAdapterPathArgumentProcessor(),
                 new TestCaseFilterArgumentProcessor(),
                 new ParentProcessIdArgumentProcessor(),


### PR DESCRIPTION
Wanted to get feedback on the general idea. I can clean up and add unit tests if this is something vstest is open to.

## Description
Add Bucketize command to allow adapters to bucketize tests within a source and parallelize across buckets.

## Related issue
Add support for #2138
