### PR TITLE
VsTestConsoleWrapper endsession should shut down vstest console process

### DIFF
--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
@@ -150,7 +150,8 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         {
             // Ideally process should die by itself
             if(!processExitedEvent.WaitOne(ENDSESSIONTIMEOUT) && IsProcessInitialized())
-            { 
+            {
+                EqtTrace.Info($"VsTestConsoleProcessManager.ShutDownProcess : Terminating vstest.console process after waiting for {ENDSESSIONTIMEOUT} milliseconds.");
                 vstestConsoleExited = true;
                 this.process.OutputDataReceived -= Process_OutputDataReceived;
                 this.process.ErrorDataReceived -= Process_ErrorDataReceived;
@@ -180,9 +181,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
             lock (syncObject)
             {
                 processExitedEvent.Set();
-
-                ShutdownProcess();
-
+                vstestConsoleExited = true;
                 this.ProcessExited?.Invoke(sender, e);
             }
         }

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
@@ -9,10 +9,10 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
     using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
     using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Globalization;
+    using System.Threading;
     using Resources = Microsoft.VisualStudio.TestPlatform.VsTestConsole.TranslationLayer.Resources.Resources;
 
     /// <summary>
@@ -39,6 +39,11 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         /// </summary>
         private const string DIAG_ARGUMENT = "/diag:{0};tracelevel={1}";
 
+        /// <summary>
+        /// EndSession timeout
+        /// </summary>
+        private const int ENDSESSIONTIMEOUT = 1000;
+
         private string vstestConsolePath;
         private object syncObject = new object();
         private bool vstestConsoleStarted = false;
@@ -46,6 +51,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         private readonly bool isNetCoreRunner;
         private string dotnetExePath;
         private Process process;
+        private ManualResetEvent processExitedEvent = new ManualResetEvent(false);
 
         internal IFileHelper FileHelper { get; set; }
 
@@ -143,15 +149,15 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         public void ShutdownProcess()
         {
             // Ideally process should die by itself
-            if (IsProcessInitialized())
-            {
+            if(!processExitedEvent.WaitOne(ENDSESSIONTIMEOUT) && IsProcessInitialized())
+            { 
                 vstestConsoleExited = true;
                 this.process.OutputDataReceived -= Process_OutputDataReceived;
                 this.process.ErrorDataReceived -= Process_ErrorDataReceived;
                 SafelyTerminateProcess();
                 this.process.Dispose();
                 this.process = null;
-            }
+            }            
         }
 
         private void SafelyTerminateProcess()
@@ -173,6 +179,8 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         {
             lock (syncObject)
             {
+                processExitedEvent.Set();
+
                 ShutdownProcess();
 
                 this.ProcessExited?.Invoke(sender, e);

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
@@ -259,6 +259,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
             this.requestSender.EndSession();
             this.requestSender.Close();
             this.sessionStarted = false;
+            this.vstestConsoleProcessManager.ShutdownProcess();
         }
 
         #endregion

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
@@ -255,10 +255,12 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
 
         /// <inheritdoc/>
         public void EndSession()
-        {
+        {            
             this.requestSender.EndSession();
             this.requestSender.Close();
             this.sessionStarted = false;
+
+            EqtTrace.Info("VsTestConsoleWrapper.EndSession: Terminating vstest.cosole process");
             this.vstestConsoleProcessManager.ShutdownProcess();
         }
 

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
@@ -36,8 +36,6 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
 
         private bool sessionStarted;
 
-        private const int ENDSESSIONTIMEOUT = 5000;
-
         /// <summary>
         /// Path to additional extensions to reinitialize vstest.console
         /// </summary>
@@ -257,16 +255,9 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
 
         /// <inheritdoc/>
         public void EndSession()
-        {            
+        {
             this.requestSender.EndSession();
             this.requestSender.Close();
-            
-            // Wait fot vstest.console to die by itself
-            // This ensures that we return from here only when the vstest.cosole process has actually died
-            Stopwatch watch = new Stopwatch();
-            watch.Start();
-            do { } while (this.vstestConsoleProcessManager.IsProcessInitialized() && watch.ElapsedMilliseconds < ENDSESSIONTIMEOUT);
-            watch.Stop();
 
             // If vstest.console is still hanging around, it should be explicitly killed.
             this.vstestConsoleProcessManager.ShutdownProcess();

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/RunTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/RunTests.cs
@@ -11,6 +11,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
     using VisualStudio.TestPlatform.ObjectModel.Logging;
 
@@ -50,6 +51,25 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
             Assert.AreEqual(2, this.runEventHandler.TestResults.Count(t => t.Outcome == TestOutcome.Passed));
             Assert.AreEqual(2, this.runEventHandler.TestResults.Count(t => t.Outcome == TestOutcome.Failed));
             Assert.AreEqual(2, this.runEventHandler.TestResults.Count(t => t.Outcome == TestOutcome.Skipped));
+        }
+
+        [TestMethod]
+        [NetFullTargetFrameworkDataSource]
+        [NetCoreTargetFrameworkDataSource]
+        public void EndSessionShouldEnsureVstestConsoleProcessDies(RunnerInfo runnerInfo)
+        {
+            var numOfProcesses = Process.GetProcessesByName("vstest.console").Length;
+
+            AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            this.Setup();
+            
+            this.vstestConsoleWrapper.RunTests(this.GetTestAssemblies(), this.GetDefaultRunSettings(), this.runEventHandler);
+            this.vstestConsoleWrapper?.EndSession();
+
+            // Assert
+            Assert.AreEqual(numOfProcesses, Process.GetProcessesByName("vstest.console").Length);
+
+            this.vstestConsoleWrapper = null;
         }
 
         [TestMethod]

--- a/test/TranslationLayer.UnitTests/VsTestConsoleWrapperTests.cs
+++ b/test/TranslationLayer.UnitTests/VsTestConsoleWrapperTests.cs
@@ -310,6 +310,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
 
             this.mockRequestSender.Verify(rs => rs.EndSession(), Times.Once);
             this.mockRequestSender.Verify(rs => rs.Close(), Times.Once);
+            this.mockProcessManager.Verify(x => x.ShutdownProcess(), Times.Once);
         }
     }
 }


### PR DESCRIPTION
Related issue: #2026 