### PR TITLE
Fix testhost exe config to be used during ngen.

### DIFF
--- a/src/package/VSIXProject/TestPlatform.csproj
+++ b/src/package/VSIXProject/TestPlatform.csproj
@@ -30,6 +30,7 @@
     <VsixInputFileLocation>$(TestPlatformRoot)artifacts\$(Configuration)\net451\win7-x64</VsixInputFileLocation>
     <OutputPath>$(TestPlatformRoot)artifacts\$(Configuration)\VSIX</OutputPath>
     <ExtensionInstallationFolder>TestPlatform</ExtensionInstallationFolder>
+    <ExtensionInstallationRelativeToVS>Common7\IDE\Extensions\TestPlatform</ExtensionInstallationRelativeToVS>
 
     <!-- Disable warning that there are no source files. It is intentional. -->
     <NoWarn>$(NoWarn);2008</NoWarn>
@@ -235,8 +236,8 @@
 
     <VsixSourceItem Include="$(VsixInputFileLocation)\*.*" Exclude="$(VsixInputFileLocation)\*.pdb" />
 
-    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.exe" Ngen="true" NgenArchitecture="X64" NgenPriority="1" NgenApplication="$(VsixInputFileLocation)\testhost.exe" /> 
-    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="1" NgenApplication="$(VsixInputFileLocation)\testhost.x86.exe" />
+    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.exe" Ngen="true" NgenArchitecture="X64" NgenPriority="1" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.exe" /> 
+    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="1" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.x86.exe" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="License.rtf">


### PR DESCRIPTION
Ngen: https://docs.microsoft.com/en-us/visualstudio/extensibility/ngen-support?view=vs-2019#how-to-enable-ngen

Bug: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/957154/