### PR TITLE
DataCollector check with only Uri in Runsettings

### DIFF
--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
@@ -438,7 +438,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
 
                 if (!IsUriValid(dataCollectorUri) && !this.TryGetUriFromFriendlyName(dataCollectorSettings.FriendlyName, out dataCollectorUri))
                 {
-                    this.LogWarning(string.Format(CultureInfo.CurrentUICulture, Resources.Resources.CannotFetchByFriendlyName, dataCollectorSettings.FriendlyName));
+                    this.LogWarning(string.Format(CultureInfo.CurrentUICulture, Resources.Resources.UnableToFetchUriString, dataCollectorSettings.FriendlyName));
                 }
 
                 DataCollector dataCollector = null;

--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
@@ -425,7 +425,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
 
                 if (!this.TryGetUriFromFriendlyName(dataCollectorSettings.FriendlyName, out dataCollectorUri))
                 {
-                    dataCollectorUri = dataCollectorSettings.Uri.ToString();
+                    this.LogWarning(string.Format(CultureInfo.CurrentUICulture, Resources.Resources.CannotFetchByFriendlyName, dataCollectorSettings.FriendlyName));
+                    dataCollectorUri = dataCollectorSettings.Uri?.ToString();
                 }
 
                 DataCollector dataCollector = null;

--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
@@ -422,7 +422,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
                 // Look up the extension and initialize it if one is found.
                 var extensionManager = this.DataCollectorExtensionManager;
                 var dataCollectorUri = string.Empty;
-                this.TryGetUriFromFriendlyName(dataCollectorSettings.FriendlyName, out dataCollectorUri);
+
+                if (!this.TryGetUriFromFriendlyName(dataCollectorSettings.FriendlyName, out dataCollectorUri))
+                {
+                    dataCollectorUri = dataCollectorSettings.Uri.ToString();
+                }
 
                 DataCollector dataCollector = null;
                 if (!string.IsNullOrWhiteSpace(dataCollectorUri))

--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
@@ -393,6 +393,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
 
         protected virtual bool IsUriValid(string uri)
         {
+            if (string.IsNullOrEmpty(uri))
+            {
+                return false;
+            }
+
             var extensionManager = this.dataCollectorExtensionManager;
             foreach (var extension in extensionManager.TestExtensions)
             {

--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
@@ -391,6 +391,19 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
             return false;
         }
 
+        protected virtual bool IsUriValid(string uri)
+        {
+            var extensionManager = this.dataCollectorExtensionManager;
+            foreach (var extension in extensionManager.TestExtensions)
+            {
+                if (string.Compare(uri, extension.Metadata.ExtensionUri, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         /// <summary>
         /// Gets the extension using uri.
         /// </summary>
@@ -421,12 +434,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
             {
                 // Look up the extension and initialize it if one is found.
                 var extensionManager = this.DataCollectorExtensionManager;
-                var dataCollectorUri = string.Empty;
+                var dataCollectorUri = dataCollectorSettings.Uri?.ToString();
 
-                if (!this.TryGetUriFromFriendlyName(dataCollectorSettings.FriendlyName, out dataCollectorUri))
+                if (!IsUriValid(dataCollectorUri) && !this.TryGetUriFromFriendlyName(dataCollectorSettings.FriendlyName, out dataCollectorUri))
                 {
                     this.LogWarning(string.Format(CultureInfo.CurrentUICulture, Resources.Resources.CannotFetchByFriendlyName, dataCollectorSettings.FriendlyName));
-                    dataCollectorUri = dataCollectorSettings.Uri?.ToString();
                 }
 
                 DataCollector dataCollector = null;

--- a/src/Microsoft.TestPlatform.Common/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.Common/Resources/Resources.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace Microsoft.VisualStudio.TestPlatform.Common.Resources {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -20,7 +19,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -40,7 +39,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.VisualStudio.TestPlatform.Common.Resources.Resources", typeof(Resources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.VisualStudio.TestPlatform.Common.Resources.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -67,6 +66,15 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Resources {
         internal static string CancellationRequested {
             get {
                 return ResourceManager.GetString("CancellationRequested", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot Fetch Uri with {0}..
+        /// </summary>
+        internal static string CannotFetchByFriendlyName {
+            get {
+                return ResourceManager.GetString("CannotFetchByFriendlyName", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TestPlatform.Common/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.Common/Resources/Resources.Designer.cs
@@ -70,15 +70,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot Fetch Uri with {0}..
-        /// </summary>
-        internal static string CannotFetchByFriendlyName {
-            get {
-                return ResourceManager.GetString("CannotFetchByFriendlyName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Data collection : {0}.
         /// </summary>
         internal static string DataCollectionMessageFormat {
@@ -345,6 +336,15 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Resources {
         internal static string TestCaseFilterFormatException {
             get {
                 return ResourceManager.GetString("TestCaseFilterFormatException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to find a datacollector with friendly name &apos;[0}&apos;..
+        /// </summary>
+        internal static string UnableToFetchUriString {
+            get {
+                return ResourceManager.GetString("UnableToFetchUriString", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TestPlatform.Common/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.Common/Resources/Resources.resx
@@ -120,6 +120,9 @@
   <data name="CancellationRequested" xml:space="preserve">
     <value>Cancelling the operation as requested.</value>
   </data>
+  <data name="CannotFetchByFriendlyName" xml:space="preserve">
+    <value>Cannot Fetch Uri with {0}.</value>
+  </data>
   <data name="DataCollectionMessageFormat" xml:space="preserve">
     <value>Data collection : {0}</value>
   </data>

--- a/src/Microsoft.TestPlatform.Common/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.Common/Resources/Resources.resx
@@ -120,9 +120,6 @@
   <data name="CancellationRequested" xml:space="preserve">
     <value>Cancelling the operation as requested.</value>
   </data>
-  <data name="CannotFetchByFriendlyName" xml:space="preserve">
-    <value>Cannot Fetch Uri with {0}.</value>
-  </data>
   <data name="DataCollectionMessageFormat" xml:space="preserve">
     <value>Data collection : {0}</value>
   </data>
@@ -212,6 +209,9 @@
   </data>
   <data name="TestCaseFilterFormatException" xml:space="preserve">
     <value>Incorrect format for TestCaseFilter {0}. Specify the correct format and try again. Note that the incorrect format can lead to no test getting executed.</value>
+  </data>
+  <data name="UnableToFetchUriString" xml:space="preserve">
+    <value>Unable to find a datacollector with friendly name '[0}'.</value>
   </data>
   <data name="VSInstallationNotFound" xml:space="preserve">
     <value>This option works only with vstest.console.exe installed as part of Visual Studio.</value>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.cs.xlf
@@ -269,6 +269,11 @@
         <target state="translated">Operace se ruší na základě žádosti.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotFetchByFriendlyName">
+        <source>Cannot Fetch Uri with {0}.</source>
+        <target state="new">Cannot Fetch Uri with {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.cs.xlf
@@ -272,6 +272,8 @@
       <trans-unit id="UnableToFetchUriString">
         <source>Unable to find a datacollector with friendly name '[0}'.</source>
         <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
+        <note></note>
+      </trans-unit>
       <trans-unit id="FailedToLoadAdapaterFile">
         <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
         <target state="new">TestPluginDiscoverer: Failed to load extensions from file '{0}'. Please use /diag for more information.</target>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.cs.xlf
@@ -269,9 +269,9 @@
         <target state="translated">Operace se ruší na základě žádosti.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotFetchByFriendlyName">
-        <source>Cannot Fetch Uri with {0}.</source>
-        <target state="new">Cannot Fetch Uri with {0}.</target>
+      <trans-unit id="UnableToFetchUriString">
+        <source>Unable to find a datacollector with friendly name '[0}'.</source>
+        <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.de.xlf
@@ -272,6 +272,8 @@
       <trans-unit id="UnableToFetchUriString">
         <source>Unable to find a datacollector with friendly name '[0}'.</source>
         <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
+        <note></note>
+      </trans-unit>
       <trans-unit id="FailedToLoadAdapaterFile">
         <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
         <target state="new">TestPluginDiscoverer: Failed to load extensions from file '{0}'. Please use /diag for more information.</target>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.de.xlf
@@ -269,9 +269,9 @@
         <target state="translated">Der Vorgang wird gemäß Anforderung abgebrochen.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotFetchByFriendlyName">
-        <source>Cannot Fetch Uri with {0}.</source>
-        <target state="new">Cannot Fetch Uri with {0}.</target>
+      <trans-unit id="UnableToFetchUriString">
+        <source>Unable to find a datacollector with friendly name '[0}'.</source>
+        <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.de.xlf
@@ -269,6 +269,11 @@
         <target state="translated">Der Vorgang wird gemäß Anforderung abgebrochen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotFetchByFriendlyName">
+        <source>Cannot Fetch Uri with {0}.</source>
+        <target state="new">Cannot Fetch Uri with {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.es.xlf
@@ -272,6 +272,8 @@
       <trans-unit id="UnableToFetchUriString">
         <source>Unable to find a datacollector with friendly name '[0}'.</source>
         <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
+        <note></note>
+      </trans-unit>
       <trans-unit id="FailedToLoadAdapaterFile">
         <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
         <target state="new">TestPluginDiscoverer: Failed to load extensions from file '{0}'. Please use /diag for more information.</target>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.es.xlf
@@ -269,9 +269,9 @@
         <target state="translated">La operación se cancelará como se ha solicitado.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotFetchByFriendlyName">
-        <source>Cannot Fetch Uri with {0}.</source>
-        <target state="new">Cannot Fetch Uri with {0}.</target>
+      <trans-unit id="UnableToFetchUriString">
+        <source>Unable to find a datacollector with friendly name '[0}'.</source>
+        <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.es.xlf
@@ -269,6 +269,11 @@
         <target state="translated">La operación se cancelará como se ha solicitado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotFetchByFriendlyName">
+        <source>Cannot Fetch Uri with {0}.</source>
+        <target state="new">Cannot Fetch Uri with {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.fr.xlf
@@ -272,6 +272,8 @@
       <trans-unit id="UnableToFetchUriString">
         <source>Unable to find a datacollector with friendly name '[0}'.</source>
         <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
+        <note></note>
+      </trans-unit>
       <trans-unit id="FailedToLoadAdapaterFile">
         <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
         <target state="new">TestPluginDiscoverer: Failed to load extensions from file '{0}'. Please use /diag for more information.</target>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.fr.xlf
@@ -269,6 +269,11 @@
         <target state="translated">Annulation de l'opération, comme demandé.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotFetchByFriendlyName">
+        <source>Cannot Fetch Uri with {0}.</source>
+        <target state="new">Cannot Fetch Uri with {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.fr.xlf
@@ -269,9 +269,9 @@
         <target state="translated">Annulation de l'opération, comme demandé.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotFetchByFriendlyName">
-        <source>Cannot Fetch Uri with {0}.</source>
-        <target state="new">Cannot Fetch Uri with {0}.</target>
+      <trans-unit id="UnableToFetchUriString">
+        <source>Unable to find a datacollector with friendly name '[0}'.</source>
+        <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.it.xlf
@@ -269,6 +269,11 @@
         <target state="translated">L'operazione verrà annullata come richiesto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotFetchByFriendlyName">
+        <source>Cannot Fetch Uri with {0}.</source>
+        <target state="new">Cannot Fetch Uri with {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.it.xlf
@@ -272,6 +272,8 @@
       <trans-unit id="UnableToFetchUriString">
         <source>Unable to find a datacollector with friendly name '[0}'.</source>
         <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
+        <note></note>
+      </trans-unit>
       <trans-unit id="FailedToLoadAdapaterFile">
         <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
         <target state="new">TestPluginDiscoverer: Failed to load extensions from file '{0}'. Please use /diag for more information.</target>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.it.xlf
@@ -269,9 +269,9 @@
         <target state="translated">L'operazione verrà annullata come richiesto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotFetchByFriendlyName">
-        <source>Cannot Fetch Uri with {0}.</source>
-        <target state="new">Cannot Fetch Uri with {0}.</target>
+      <trans-unit id="UnableToFetchUriString">
+        <source>Unable to find a datacollector with friendly name '[0}'.</source>
+        <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ja.xlf
@@ -272,6 +272,8 @@
       <trans-unit id="UnableToFetchUriString">
         <source>Unable to find a datacollector with friendly name '[0}'.</source>
         <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
+        <note></note>
+      </trans-unit>
       <trans-unit id="FailedToLoadAdapaterFile">
         <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
         <target state="new">TestPluginDiscoverer: Failed to load extensions from file '{0}'. Please use /diag for more information.</target>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ja.xlf
@@ -269,9 +269,9 @@
         <target state="translated">操作のキャンセルが要求されたため、キャンセルしています。</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotFetchByFriendlyName">
-        <source>Cannot Fetch Uri with {0}.</source>
-        <target state="new">Cannot Fetch Uri with {0}.</target>
+      <trans-unit id="UnableToFetchUriString">
+        <source>Unable to find a datacollector with friendly name '[0}'.</source>
+        <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ja.xlf
@@ -269,6 +269,11 @@
         <target state="translated">操作のキャンセルが要求されたため、キャンセルしています。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotFetchByFriendlyName">
+        <source>Cannot Fetch Uri with {0}.</source>
+        <target state="new">Cannot Fetch Uri with {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ko.xlf
@@ -272,6 +272,8 @@
       <trans-unit id="UnableToFetchUriString">
         <source>Unable to find a datacollector with friendly name '[0}'.</source>
         <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
+        <note></note>
+      </trans-unit>
       <trans-unit id="FailedToLoadAdapaterFile">
         <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
         <target state="new">TestPluginDiscoverer: Failed to load extensions from file '{0}'. Please use /diag for more information.</target>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ko.xlf
@@ -269,9 +269,9 @@
         <target state="translated">요청한 대로 작업을 취소하는 중입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotFetchByFriendlyName">
-        <source>Cannot Fetch Uri with {0}.</source>
-        <target state="new">Cannot Fetch Uri with {0}.</target>
+      <trans-unit id="UnableToFetchUriString">
+        <source>Unable to find a datacollector with friendly name '[0}'.</source>
+        <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ko.xlf
@@ -269,6 +269,11 @@
         <target state="translated">요청한 대로 작업을 취소하는 중입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotFetchByFriendlyName">
+        <source>Cannot Fetch Uri with {0}.</source>
+        <target state="new">Cannot Fetch Uri with {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pl.xlf
@@ -272,6 +272,8 @@
       <trans-unit id="UnableToFetchUriString">
         <source>Unable to find a datacollector with friendly name '[0}'.</source>
         <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
+        <note></note>
+      </trans-unit>
       <trans-unit id="FailedToLoadAdapaterFile">
         <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
         <target state="new">TestPluginDiscoverer: Failed to load extensions from file '{0}'. Please use /diag for more information.</target>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pl.xlf
@@ -269,6 +269,11 @@
         <target state="translated">Anulowanie operacji zgodnie z żądaniem.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotFetchByFriendlyName">
+        <source>Cannot Fetch Uri with {0}.</source>
+        <target state="new">Cannot Fetch Uri with {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pl.xlf
@@ -269,9 +269,9 @@
         <target state="translated">Anulowanie operacji zgodnie z żądaniem.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotFetchByFriendlyName">
-        <source>Cannot Fetch Uri with {0}.</source>
-        <target state="new">Cannot Fetch Uri with {0}.</target>
+      <trans-unit id="UnableToFetchUriString">
+        <source>Unable to find a datacollector with friendly name '[0}'.</source>
+        <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pt-BR.xlf
@@ -272,6 +272,8 @@
       <trans-unit id="UnableToFetchUriString">
         <source>Unable to find a datacollector with friendly name '[0}'.</source>
         <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
+        <note></note>
+      </trans-unit>
       <trans-unit id="FailedToLoadAdapaterFile">
         <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
         <target state="new">TestPluginDiscoverer: Failed to load extensions from file '{0}'. Please use /diag for more information.</target>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pt-BR.xlf
@@ -269,6 +269,11 @@
         <target state="translated">Cancelando a operação conforme solicitado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotFetchByFriendlyName">
+        <source>Cannot Fetch Uri with {0}.</source>
+        <target state="new">Cannot Fetch Uri with {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pt-BR.xlf
@@ -269,9 +269,9 @@
         <target state="translated">Cancelando a operação conforme solicitado.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotFetchByFriendlyName">
-        <source>Cannot Fetch Uri with {0}.</source>
-        <target state="new">Cannot Fetch Uri with {0}.</target>
+      <trans-unit id="UnableToFetchUriString">
+        <source>Unable to find a datacollector with friendly name '[0}'.</source>
+        <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ru.xlf
@@ -269,9 +269,9 @@
         <target state="translated">Операция отменяется в соответствии с запросом.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotFetchByFriendlyName">
-        <source>Cannot Fetch Uri with {0}.</source>
-        <target state="new">Cannot Fetch Uri with {0}.</target>
+      <trans-unit id="UnableToFetchUriString">
+        <source>Unable to find a datacollector with friendly name '[0}'.</source>
+        <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ru.xlf
@@ -272,6 +272,8 @@
       <trans-unit id="UnableToFetchUriString">
         <source>Unable to find a datacollector with friendly name '[0}'.</source>
         <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
+        <note></note>
+      </trans-unit>
       <trans-unit id="FailedToLoadAdapaterFile">
         <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
         <target state="new">TestPluginDiscoverer: Failed to load extensions from file '{0}'. Please use /diag for more information.</target>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ru.xlf
@@ -269,6 +269,11 @@
         <target state="translated">Операция отменяется в соответствии с запросом.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotFetchByFriendlyName">
+        <source>Cannot Fetch Uri with {0}.</source>
+        <target state="new">Cannot Fetch Uri with {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.tr.xlf
@@ -272,6 +272,8 @@
       <trans-unit id="UnableToFetchUriString">
         <source>Unable to find a datacollector with friendly name '[0}'.</source>
         <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
+        <note></note>
+      </trans-unit>
       <trans-unit id="FailedToLoadAdapaterFile">
         <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
         <target state="new">TestPluginDiscoverer: Failed to load extensions from file '{0}'. Please use /diag for more information.</target>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.tr.xlf
@@ -269,9 +269,9 @@
         <target state="translated">İşlem istek üzerine iptal ediliyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotFetchByFriendlyName">
-        <source>Cannot Fetch Uri with {0}.</source>
-        <target state="new">Cannot Fetch Uri with {0}.</target>
+      <trans-unit id="UnableToFetchUriString">
+        <source>Unable to find a datacollector with friendly name '[0}'.</source>
+        <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.tr.xlf
@@ -269,6 +269,11 @@
         <target state="translated">İşlem istek üzerine iptal ediliyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotFetchByFriendlyName">
+        <source>Cannot Fetch Uri with {0}.</source>
+        <target state="new">Cannot Fetch Uri with {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.xlf
@@ -146,6 +146,11 @@
         <target state="new">Cancelling the operation as requested.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CannotFetchByFriendlyName">
+        <source>Cannot Fetch Uri with {0}.</source>
+        <target state="new">Cannot Fetch Uri with {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.xlf
@@ -149,6 +149,8 @@
       <trans-unit id="UnableToFetchUriString">
         <source>Unable to find a datacollector with friendly name '[0}'.</source>
         <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
+        <note></note>
+      </trans-unit>
       <trans-unit id="FailedToLoadAdapaterFile">
         <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
         <target state="new">TestPluginDiscoverer: Failed to load extensions from file '{0}'. Please use /diag for more information.</target>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.xlf
@@ -146,9 +146,9 @@
         <target state="new">Cancelling the operation as requested.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="CannotFetchByFriendlyName">
-        <source>Cannot Fetch Uri with {0}.</source>
-        <target state="new">Cannot Fetch Uri with {0}.</target>
+      <trans-unit id="UnableToFetchUriString">
+        <source>Unable to find a datacollector with friendly name '[0}'.</source>
+        <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hans.xlf
@@ -272,6 +272,8 @@
       <trans-unit id="UnableToFetchUriString">
         <source>Unable to find a datacollector with friendly name '[0}'.</source>
         <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
+        <note></note>
+      </trans-unit>
       <trans-unit id="FailedToLoadAdapaterFile">
         <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
         <target state="new">TestPluginDiscoverer: Failed to load extensions from file '{0}'. Please use /diag for more information.</target>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hans.xlf
@@ -269,6 +269,11 @@
         <target state="translated">按要求取消该操作。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotFetchByFriendlyName">
+        <source>Cannot Fetch Uri with {0}.</source>
+        <target state="new">Cannot Fetch Uri with {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hans.xlf
@@ -269,9 +269,9 @@
         <target state="translated">按要求取消该操作。</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotFetchByFriendlyName">
-        <source>Cannot Fetch Uri with {0}.</source>
-        <target state="new">Cannot Fetch Uri with {0}.</target>
+      <trans-unit id="UnableToFetchUriString">
+        <source>Unable to find a datacollector with friendly name '[0}'.</source>
+        <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hant.xlf
@@ -269,6 +269,11 @@
         <target state="translated">正在應要求取消作業。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CannotFetchByFriendlyName">
+        <source>Cannot Fetch Uri with {0}.</source>
+        <target state="new">Cannot Fetch Uri with {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hant.xlf
@@ -272,6 +272,8 @@
       <trans-unit id="UnableToFetchUriString">
         <source>Unable to find a datacollector with friendly name '[0}'.</source>
         <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
+        <note></note>
+      </trans-unit>
       <trans-unit id="FailedToLoadAdapaterFile">
         <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
         <target state="new">TestPluginDiscoverer: Failed to load extensions from file '{0}'. Please use /diag for more information.</target>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hant.xlf
@@ -269,9 +269,9 @@
         <target state="translated">正在應要求取消作業。</target>
         <note />
       </trans-unit>
-      <trans-unit id="CannotFetchByFriendlyName">
-        <source>Cannot Fetch Uri with {0}.</source>
-        <target state="new">Cannot Fetch Uri with {0}.</target>
+      <trans-unit id="UnableToFetchUriString">
+        <source>Unable to find a datacollector with friendly name '[0}'.</source>
+        <target state="new">Unable to find a datacollector with friendly name '[0}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionLauncherFactory.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionLauncherFactory.cs
@@ -28,11 +28,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
                 var dataCollectionRunSettings = XmlRunSettingsUtilities.GetDataCollectionRunSettings(settingsXml);
                 foreach (var dataCollectorSettings in dataCollectionRunSettings.DataCollectorSettingsList)
                 {
-                    if (dataCollectorSettings.FriendlyName!=null && dataCollectorSettings.FriendlyName.ToLower().Equals("event log"))
-                    {
-                        return new DefaultDataCollectionLauncher();
-                    }
-                    if(dataCollectorSettings.Uri!=null && dataCollectorSettings.Uri.ToString().ToLower().Equals(@"datacollector://Microsoft/EventLog/2.0"))
+                    if (string.Equals(dataCollectorSettings.FriendlyName, "event Log", StringComparison.OrdinalIgnoreCase) || string.Equals(dataCollectorSettings.Uri?.ToString(), @"datacollector://Microsoft/EventLog/2.0", StringComparison.OrdinalIgnoreCase))
                     {
                         return new DefaultDataCollectionLauncher();
                     }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionLauncherFactory.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionLauncherFactory.cs
@@ -28,7 +28,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
                 var dataCollectionRunSettings = XmlRunSettingsUtilities.GetDataCollectionRunSettings(settingsXml);
                 foreach (var dataCollectorSettings in dataCollectionRunSettings.DataCollectorSettingsList)
                 {
-                    if (dataCollectorSettings.FriendlyName.ToLower().Equals("event log"))
+                    if (dataCollectorSettings.FriendlyName!=null && dataCollectorSettings.FriendlyName.ToLower().Equals("event log"))
+                    {
+                        return new DefaultDataCollectionLauncher();
+                    }
+                    if(dataCollectorSettings.Uri!=null && dataCollectorSettings.Uri.ToString().ToLower().Equals(@"datacollector://Microsoft/EventLog/2.0"))
                     {
                         return new DefaultDataCollectionLauncher();
                     }

--- a/src/Microsoft.TestPlatform.ObjectModel/DataCollector/DataCollectorSettings.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/DataCollector/DataCollectorSettings.cs
@@ -201,12 +201,6 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 
             }
 
-            if (string.IsNullOrWhiteSpace(settings.FriendlyName))
-            {
-                throw new SettingsException(
-                    String.Format(CultureInfo.CurrentCulture, Resources.Resources.MissingDataCollectorAttributes, "FriendlyName"));
-            }
-
             reader.Read();
             if (!empty)
             {

--- a/test/datacollector.UnitTests/DataCollectionManagerTests.cs
+++ b/test/datacollector.UnitTests/DataCollectionManagerTests.cs
@@ -24,8 +24,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
         private string defaultRunSettings = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors >{0}</DataCollectors>\r\n  </DataCollectionRunSettings>\r\n</RunSettings>";
         private string defaultDataCollectionSettings = "<DataCollector friendlyName=\"{0}\" uri=\"{1}\" assemblyQualifiedName=\"{2}\" codebase=\"{3}\" {4} />";
         private string dataCollectorSettings;
-
-        private string dataCollectorSettingsWithWrongFriendlyName, dataCollectorSettingsWithWrongFriendlyNameAndWrongUri, dataCollectorSettingsWithoutFriendlyName, dataCollectorSettingsEnabled, dataCollectorSettingsDisabled, dataCollectorSettingsWithWrongUri;
+        private string dataCollectorSettingsWithWrongFriendlyName, dataCollectorSettingsWithWrongFriendlyNameAndWrongUri, dataCollectorSettingsWithNullFriendlyName, dataCollectorSettingsWithEmptyFriendlyName,
+                       dataCollectorSettingsEnabled, dataCollectorSettingsDisabled, dataCollectorSettingsWithWrongUri, dataCollectorSettingsWithNullUri, dataCollectorSettingsWithEmptyUri;
 
         private Mock<IMessageSink> mockMessageSink;
         private Mock<DataCollector2> mockDataCollector;
@@ -44,8 +44,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
             this.dataCollectorSettings = string.Format(this.defaultRunSettings, string.Format(this.defaultDataCollectionSettings, friendlyName, uri, this.mockDataCollector.Object.GetType().AssemblyQualifiedName, typeof(DataCollectionManagerTests).GetTypeInfo().Assembly.Location, string.Empty));
             this.dataCollectorSettingsWithWrongFriendlyName = string.Format(this.defaultRunSettings, string.Format(this.defaultDataCollectionSettings, "anyFriendlyName", uri, this.mockDataCollector.Object.GetType().AssemblyQualifiedName, typeof(DataCollectionManagerTests).GetTypeInfo().Assembly.Location, string.Empty));
             this.dataCollectorSettingsWithWrongUri = string.Format(this.defaultRunSettings, string.Format(this.defaultDataCollectionSettings, friendlyName, "my://custom/WrongDatacollector", this.mockDataCollector.Object.GetType().AssemblyQualifiedName, typeof(DataCollectionManagerTests).GetTypeInfo().Assembly.Location, string.Empty));
+            this.dataCollectorSettingsWithEmptyFriendlyName = string.Format(this.defaultRunSettings, string.Format(this.defaultDataCollectionSettings, friendlyName, string.Empty, this.mockDataCollector.Object.GetType().AssemblyQualifiedName, typeof(DataCollectionManagerTests).GetTypeInfo().Assembly.Location, string.Empty));
+            this.dataCollectorSettingsWithEmptyUri = string.Format(this.defaultRunSettings, string.Format(this.defaultDataCollectionSettings, friendlyName, string.Empty, this.mockDataCollector.Object.GetType().AssemblyQualifiedName, typeof(DataCollectionManagerTests).GetTypeInfo().Assembly.Location, string.Empty));
             this.dataCollectorSettingsWithWrongFriendlyNameAndWrongUri = string.Format(this.defaultRunSettings, string.Format(this.defaultDataCollectionSettings, "anyFriendlyName", "datacollector://data", this.mockDataCollector.Object.GetType().AssemblyQualifiedName, typeof(DataCollectionManagerTests).GetTypeInfo().Assembly.Location, string.Empty));
-            this.dataCollectorSettingsWithoutFriendlyName = string.Format(this.defaultRunSettings, string.Format(this.defaultDataCollectionSettings, string.Empty, uri, this.mockDataCollector.Object.GetType().AssemblyQualifiedName, typeof(DataCollectionManagerTests).GetTypeInfo().Assembly.Location, string.Empty).Replace("friendlyName=\"\"", string.Empty));
+            this.dataCollectorSettingsWithNullFriendlyName = string.Format(this.defaultRunSettings, string.Format(this.defaultDataCollectionSettings, string.Empty, uri, this.mockDataCollector.Object.GetType().AssemblyQualifiedName, typeof(DataCollectionManagerTests).GetTypeInfo().Assembly.Location, string.Empty).Replace("friendlyName=\"\"", string.Empty));
+            this.dataCollectorSettingsWithNullUri = string.Format(this.defaultRunSettings, string.Format(this.defaultDataCollectionSettings, friendlyName, string.Empty, this.mockDataCollector.Object.GetType().AssemblyQualifiedName, typeof(DataCollectionManagerTests).GetTypeInfo().Assembly.Location, string.Empty).Replace("uri=\"\"", string.Empty));
             this.dataCollectorSettingsEnabled = string.Format(this.defaultRunSettings, string.Format(this.defaultDataCollectionSettings, friendlyName, uri, this.mockDataCollector.Object.GetType().AssemblyQualifiedName, typeof(DataCollectionManagerTests).GetTypeInfo().Assembly.Location, "enabled=\"true\""));
             this.dataCollectorSettingsDisabled = string.Format(this.defaultRunSettings, string.Format(this.defaultDataCollectionSettings, friendlyName, uri, this.mockDataCollector.Object.GetType().AssemblyQualifiedName, typeof(DataCollectionManagerTests).GetTypeInfo().Assembly.Location, "enabled=\"false\""));
             this.mockMessageSink = new Mock<IMessageSink>();
@@ -110,6 +113,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
             this.mockDataCollector.Verify(x => x.Initialize(It.IsAny<XmlElement>(), It.IsAny<DataCollectionEvents>(), It.IsAny<DataCollectionSink>(), It.IsAny<DataCollectionLogger>(), It.IsAny<DataCollectionEnvironmentContext>()), Times.Once);
         }
 
+
         [TestMethod]
         public void InitializeDataCollectorsShouldLoadDataCollectorIfFriendlyNameIsCorrectAndUriIsNotCorrect()
         {
@@ -117,6 +121,36 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
 
             Assert.AreEqual(1, this.dataCollectionManager.RunDataCollectors.Count);
             this.mockDataCollector.Verify(x => x.Initialize(It.IsAny<XmlElement>(), It.IsAny<DataCollectionEvents>(), It.IsAny<DataCollectionSink>(), It.IsAny<DataCollectionLogger>(), It.IsAny<DataCollectionEnvironmentContext>()), Times.Once);
+        }
+
+        [TestMethod]
+        public void InitializeDataCollectorsShouldLoadDataCollectorIfFriendlyNameIsCorrectAndUriIsNull()
+        {
+            this.dataCollectionManager.InitializeDataCollectors(this.dataCollectorSettingsWithNullUri);
+
+            Assert.AreEqual(0, this.dataCollectionManager.RunDataCollectors.Count);
+            this.mockDataCollector.Verify(x => x.Initialize(It.IsAny<XmlElement>(), It.IsAny<DataCollectionEvents>(), It.IsAny<DataCollectionSink>(), It.IsAny<DataCollectionLogger>(), It.IsAny<DataCollectionEnvironmentContext>()), Times.Never);
+        }
+
+        [TestMethod]
+        public void InitializeDataCollectorsShouldLoadDataCollectorIfFriendlyNameIsNullAndUriIsCorrect()
+        {
+            this.dataCollectionManager.InitializeDataCollectors(this.dataCollectorSettingsWithNullFriendlyName);
+
+            Assert.AreEqual(1, this.dataCollectionManager.RunDataCollectors.Count);
+            this.mockDataCollector.Verify(x => x.Initialize(It.IsAny<XmlElement>(), It.IsAny<DataCollectionEvents>(), It.IsAny<DataCollectionSink>(), It.IsAny<DataCollectionLogger>(), It.IsAny<DataCollectionEnvironmentContext>()), Times.Once);
+        }
+
+        [TestMethod]
+        public void InitializeDataCollectorsShouldLoadDataCollectorIfFriendlyNameIsCorrectAndUriIsEmpty()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => this.dataCollectionManager.InitializeDataCollectors(this.dataCollectorSettingsWithEmptyUri));
+        }
+
+        [TestMethod]
+        public void InitializeDataCollectorsShouldLoadDataCollectorIfFriendlyNameIsEmptyAndUriIsCorrect()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => this.dataCollectionManager.InitializeDataCollectors(this.dataCollectorSettingsWithEmptyFriendlyName));
         }
 
         [TestMethod]

--- a/test/datacollector.UnitTests/DataCollectionManagerTests.cs
+++ b/test/datacollector.UnitTests/DataCollectionManagerTests.cs
@@ -38,6 +38,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
             this.envVarList = new List<KeyValuePair<string, string>>();
             this.mockDataCollector = new Mock<DataCollector2>();
             this.mockDataCollector.As<ITestExecutionEnvironmentSpecifier>().Setup(x => x.GetTestExecutionEnvironmentVariables()).Returns(this.envVarList);
+            this.dataCollectorSettings = string.Format(this.defaultRunSettings, string.Format(this.defaultDataCollectionSettings, this.friendlyName, this.uri, this.mockDataCollector.Object.GetType().AssemblyQualifiedName, typeof(DataCollectionManagerTests).GetTypeInfo().Assembly.Location, string.Empty));
             this.mockMessageSink = new Mock<IMessageSink>();
             this.mockDataCollectionAttachmentManager = new Mock<IDataCollectionAttachmentManager>();
             this.mockDataCollectionAttachmentManager.SetReturnsDefault<List<AttachmentSet>>(new List<AttachmentSet>());
@@ -93,7 +94,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
             this.mockDataCollector.Verify(x => x.Initialize(It.IsAny<XmlElement>(), It.IsAny<DataCollectionEvents>(), It.IsAny<DataCollectionSink>(), It.IsAny<DataCollectionLogger>(), It.IsAny<DataCollectionEnvironmentContext>()), Times.Once);
         }
 
-
         [TestMethod]
         public void InitializeDataCollectorsShouldLoadDataCollectorIfFriendlyNameIsNotCorrectAndUriIsCorrect()
         {
@@ -103,7 +103,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
             Assert.AreEqual(1, this.dataCollectionManager.RunDataCollectors.Count);
             this.mockDataCollector.Verify(x => x.Initialize(It.IsAny<XmlElement>(), It.IsAny<DataCollectionEvents>(), It.IsAny<DataCollectionSink>(), It.IsAny<DataCollectionLogger>(), It.IsAny<DataCollectionEnvironmentContext>()), Times.Once);
         }
-
 
         [TestMethod]
         public void InitializeDataCollectorsShouldLoadDataCollectorIfFriendlyNameIsCorrectAndUriIsNotCorrect()
@@ -159,7 +158,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
             this.mockDataCollector.Verify(x => x.Initialize(It.IsAny<XmlElement>(), It.IsAny<DataCollectionEvents>(), It.IsAny<DataCollectionSink>(), It.IsAny<DataCollectionLogger>(), It.IsAny<DataCollectionEnvironmentContext>()), Times.Never);
         }
 
-
         [TestMethod]
         public void InitializeDataCollectorsShouldNotAddSameDataCollectorMoreThanOnce()
         {
@@ -171,7 +169,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
             Assert.IsTrue(this.dataCollectionManager.RunDataCollectors.ContainsKey(this.mockDataCollector.Object.GetType()));
             this.mockDataCollector.Verify(x => x.Initialize(It.IsAny<XmlElement>(), It.IsAny<DataCollectionEvents>(), It.IsAny<DataCollectionSink>(), It.IsAny<DataCollectionLogger>(), It.IsAny<DataCollectionEnvironmentContext>()), Times.Once);
         }
-
 
         [TestMethod]
         public void InitializeDataCollectorsShouldLoadDataCollectorAndReturnEnvironmentVariables()


### PR DESCRIPTION
## Description
removing friendly name check when only Uri is given in run settings
If Uri is correct it proceeds with Uri otherwise if friendly name is correct we get the first uri with that friendly name and proceeds with it. In rest of the cases it shows error.

## Related issue
#1952 

## Behavior
| Friendly name  |   Uri | Result | 
|---------|-------|--------|
|correct |  null  |  Find URI using friendly name |
|correct |  empty/invalid |  Invalid URI Exception |
|correct |  wrong uri  |   Find URI using friendly name  |
|null |  correct|  Use this URI |
|empty |  correct  |   Invalid Friendly Name Exception |
|wrong  |  correct |  Use the URI |
|correct |  correct |  Use the URI directly |
|wrong |  wrong |  Invalid data collector warning |

