### PR TITLE
Redirect procdump process output to diag files

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DefaultDataCollectionLauncher.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DefaultDataCollectionLauncher.cs
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
             }
 
             var argumentsString = string.Join(" ", commandLineArguments);
-            var dataCollectorProcess = this.processHelper.LaunchProcess(dataCollectorProcessPath, argumentsString, Directory.GetCurrentDirectory(), environmentVariables, this.ErrorReceivedCallback, this.ExitCallBack);
+            var dataCollectorProcess = this.processHelper.LaunchProcess(dataCollectorProcessPath, argumentsString, Directory.GetCurrentDirectory(), environmentVariables, this.ErrorReceivedCallback, this.ExitCallBack, null) ;
             this.DataCollectorProcessId = this.processHelper.GetProcessId(dataCollectorProcess);
             return this.DataCollectorProcessId;
         }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DotnetDataCollectionLauncher.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DotnetDataCollectionLauncher.cs
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
 
             var cliArgs = string.Join(" ", commandLineArguments);
             var argumentsString = string.Format("{0} \"{1}\" {2} ", args, dataCollectorAssemblyPath, cliArgs);
-            var dataCollectorProcess = this.processHelper.LaunchProcess(currentProcessFileName, argumentsString, Directory.GetCurrentDirectory(), environmentVariables, this.ErrorReceivedCallback, this.ExitCallBack);
+            var dataCollectorProcess = this.processHelper.LaunchProcess(currentProcessFileName, argumentsString, Directory.GetCurrentDirectory(), environmentVariables, this.ErrorReceivedCallback, this.ExitCallBack, null);
             this.DataCollectorProcessId = this.processHelper.GetProcessId(dataCollectorProcess);
             return this.DataCollectorProcessId;
         }

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcessDumpUtility.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcessDumpUtility.cs
@@ -42,6 +42,16 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
             this.nativeMethodsHelper = nativeMethodsHelper;
         }
 
+        protected Action<object, string> OutputReceivedCallback => (process, data) =>
+        {
+            // Log all standard output message of procdump in diag files.
+            // Otherwise they end up coming on console in pipleine.
+            if (EqtTrace.IsInfoEnabled)
+            {
+                EqtTrace.Info("ProcessDumpUtility.OutputReceivedCallback: Output received from procdump process: " + data);
+            }
+        };
+
         /// <inheritdoc/>
         public string GetDumpFile()
         {
@@ -101,7 +111,9 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                                             testResultsDirectory,
                                             null,
                                             null,
-                                            null) as Process;
+                                            null,
+                                            null,
+                                            this.OutputReceivedCallback) as Process;
         }
 
         /// <inheritdoc/>
@@ -126,7 +138,9 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                                             testResultsDirectory,
                                             null,
                                             null,
-                                            null) as Process;
+                                            null,
+                                            null,
+                                            this.OutputReceivedCallback) as Process;
         }
 
         /// <inheritdoc/>
@@ -171,8 +185,8 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                 }
                 else
                 {
-                     filename = this.nativeMethodsHelper.Is64Bit(this.processHelper.GetProcessHandle(processId)) ?
-                     Constants.Procdump64Process : Constants.ProcdumpProcess;
+                    filename = this.nativeMethodsHelper.Is64Bit(this.processHelper.GetProcessHandle(processId)) ?
+                    Constants.Procdump64Process : Constants.ProcdumpProcess;
                 }
 
                 var procDumpExe = Path.Combine(procdumpPath, filename);

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcessDumpUtility.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcessDumpUtility.cs
@@ -112,7 +112,6 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                                             null,
                                             null,
                                             null,
-                                            null,
                                             this.OutputReceivedCallback) as Process;
         }
 
@@ -136,7 +135,6 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                                             this.GetProcDumpExecutable(processId),
                                             procDumpArgs,
                                             testResultsDirectory,
-                                            null,
                                             null,
                                             null,
                                             null,

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/IProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/IProcessHelper.cs
@@ -20,8 +20,9 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces
         /// <param name="environmentVariables">Environment variables to set while bootstrapping the process.</param>
         /// <param name="errorCallback">Call back for to read error stream data</param>
         /// <param name="exitCallBack">Call back for on process exit</param>
+        /// <param name="outputCallback">Call back for on process output</param>
         /// <returns>The process created.</returns>
-        object LaunchProcess(string processPath, string arguments, string workingDirectory, IDictionary<string, string> environmentVariables, Action<object, string> errorCallback, Action<object> exitCallBack);
+        object LaunchProcess(string processPath, string arguments, string workingDirectory, IDictionary<string, string> environmentVariables, Action<object, string> errorCallback, Action<object> exitCallBack, Action<object, string> outputCallback);
 
         /// <summary>
         /// Gets the current process file path.

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -30,7 +30,6 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
                 process.StartInfo.FileName = processPath;
                 process.StartInfo.Arguments = arguments;
                 process.StartInfo.RedirectStandardError = true;
-                process.StartInfo.RedirectStandardOutput = true;
 
                 process.EnableRaisingEvents = true;
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -8,7 +8,6 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
     using System.Diagnostics;
     using System.IO;
     using System.Reflection;
-
     using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
 
     /// <summary>
@@ -19,7 +18,7 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         private static readonly string ARM = "arm";
 
         /// <inheritdoc/>
-        public object LaunchProcess(string processPath, string arguments, string workingDirectory, IDictionary<string, string> envVariables, Action<object, string> errorCallback, Action<object> exitCallBack)
+        public object LaunchProcess(string processPath, string arguments, string workingDirectory, IDictionary<string, string> envVariables, Action<object, string> errorCallback, Action<object> exitCallBack, Action<object, string> outputCallBack)
         {
             var process = new Process();
             try
@@ -31,6 +30,8 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
                 process.StartInfo.FileName = processPath;
                 process.StartInfo.Arguments = arguments;
                 process.StartInfo.RedirectStandardError = true;
+                process.StartInfo.RedirectStandardOutput = true;
+
                 process.EnableRaisingEvents = true;
 
                 if (envVariables != null)
@@ -39,6 +40,12 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
                     {
                         process.StartInfo.AddEnvironmentVariable(kvp.Key, kvp.Value);
                     }
+                }
+
+                if (outputCallBack != null)
+                {
+                    process.StartInfo.RedirectStandardOutput = true;
+                    process.OutputDataReceived += (sender, args) => outputCallBack(sender as Process, args.Data);
                 }
 
                 if (errorCallback != null)
@@ -72,6 +79,11 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
                 if (errorCallback != null)
                 {
                     process.BeginErrorReadLine();
+                }
+
+                if (outputCallBack != null)
+                {
+                    process.BeginOutputReadLine();
                 }
             }
             catch (Exception)

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/System/ProcessHelper.cs
@@ -19,7 +19,8 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
             string workingDirectory,
             IDictionary<string, string> environmentVariables,
             Action<object, string> errorCallback,
-            Action<object> exitCallBack)
+            Action<object> exitCallBack,
+            Action<object, string> ouputCallBack)
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/ProcessHelper.cs
@@ -20,7 +20,8 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
             string workingDirectory,
             IDictionary<string, string> environmentVariables,
             Action<object, string> errorCallback,
-            Action<object> exitCallBack)
+            Action<object> exitCallBack,
+            Action<object, string> outputCallback)
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -370,7 +370,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
                 EqtTrace.Verbose("DefaultTestHostManager: Starting process '{0}' with command line '{1}'", testHostStartInfo.FileName, testHostStartInfo.Arguments);
 
                 cancellationToken.ThrowIfCancellationRequested();
-                this.testHostProcess = this.processHelper.LaunchProcess(testHostStartInfo.FileName, testHostStartInfo.Arguments, testHostStartInfo.WorkingDirectory, testHostStartInfo.EnvironmentVariables, this.ErrorReceivedCallback, this.ExitCallBack) as Process;
+                this.testHostProcess = this.processHelper.LaunchProcess(testHostStartInfo.FileName, testHostStartInfo.Arguments, testHostStartInfo.WorkingDirectory, testHostStartInfo.EnvironmentVariables, this.ErrorReceivedCallback, this.ExitCallBack, null) as Process;
             }
             else
             {

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -346,7 +346,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
                 EqtTrace.Verbose("DotnetTestHostManager: Starting process '{0}' with command line '{1}'", testHostStartInfo.FileName, testHostStartInfo.Arguments);
 
                 cancellationToken.ThrowIfCancellationRequested();
-                this.testHostProcess = this.processHelper.LaunchProcess(testHostStartInfo.FileName, testHostStartInfo.Arguments, testHostStartInfo.WorkingDirectory, testHostStartInfo.EnvironmentVariables, this.ErrorReceivedCallback, this.ExitCallBack) as Process;
+                this.testHostProcess = this.processHelper.LaunchProcess(testHostStartInfo.FileName, testHostStartInfo.Arguments, testHostStartInfo.WorkingDirectory, testHostStartInfo.EnvironmentVariables, this.ErrorReceivedCallback, this.ExitCallBack, null) as Process;
             }
             else
             {

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
@@ -493,8 +493,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
                             It.IsAny<Action<object, string>>(),
                             It.IsAny<Action<object>>(),
                             It.IsAny<Action<object, string>>()))
-                .Callback<string, string, string, IDictionary<string, string>, Action<object, string>, Action<object>>(
-                    (var1, var2, var3, dictionary, errorCallback, exitCallback) =>
+                .Callback<string, string, string, IDictionary<string, string>, Action<object, string>, Action<object>, Action<object, string>>(
+                    (var1, var2, var3, dictionary, errorCallback, exitCallback, outputCallback) =>
                         {
                             var process = Process.GetCurrentProcess();
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
@@ -491,7 +491,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
                             It.IsAny<string>(),
                             It.IsAny<IDictionary<string, string>>(),
                             It.IsAny<Action<object, string>>(),
-                            It.IsAny<Action<object>>()))
+                            It.IsAny<Action<object>>(),
+                            It.IsAny<Action<object, string>>()))
                 .Callback<string, string, string, IDictionary<string, string>, Action<object, string>, Action<object>>(
                     (var1, var2, var3, dictionary, errorCallback, exitCallback) =>
                         {

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/DotnetDataCollectionLauncherTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/DotnetDataCollectionLauncherTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.TestPlatform.CrossPlatEngine.UnitTests.DataCollection
             List<string> arguments = new List<string>();
             this.dataCollectionLauncher.LaunchDataCollector(null, arguments);
 
-            this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<Action<object, string>>(), It.IsAny<Action<Object>>()), Times.Once());
+            this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<Action<object, string>>(), It.IsAny<Action<Object>>(), It.IsAny<Action<object, string>>()), Times.Once());
         }
 
         [TestMethod]
@@ -55,7 +55,7 @@ namespace Microsoft.TestPlatform.CrossPlatEngine.UnitTests.DataCollection
             List<string> arguments = new List<string>();
             this.dataCollectionLauncher.LaunchDataCollector(null, arguments);
 
-            this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), string.Format("{0} \"{1}\" {2} ", "exec", dataCollectorAssemblyPath, string.Join(" ", arguments)), It.IsAny<string>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<Action<object, string>>(), It.IsAny<Action<Object>>()), Times.Once());
+            this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), string.Format("{0} \"{1}\" {2} ", "exec", dataCollectorAssemblyPath, string.Join(" ", arguments)), It.IsAny<string>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<Action<object, string>>(), It.IsAny<Action<Object>>(), It.IsAny<Action<object, string>>()), Times.Once());
         }
 
         [TestMethod]
@@ -66,7 +66,7 @@ namespace Microsoft.TestPlatform.CrossPlatEngine.UnitTests.DataCollection
 
             string currentWorkingDirectory = Directory.GetCurrentDirectory();
 
-            this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), currentWorkingDirectory, It.IsAny<IDictionary<string, string>>(), It.IsAny<Action<object, string>>(), It.IsAny<Action<Object>>()), Times.Once());
+            this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), currentWorkingDirectory, It.IsAny<IDictionary<string, string>>(), It.IsAny<Action<object, string>>(), It.IsAny<Action<Object>>(), It.IsAny<Action<object, string>>()), Times.Once());
         }
     }
 }

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/ProcessDumpUtilityTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/ProcessDumpUtilityTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 .Returns(new string[] { });
             this.mockProcessHelper.Setup(x => x.GetProcessName(processId))
                 .Returns(process);
-            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null, null))
+            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null, It.IsAny<Action<object, string>>()))
                 .Returns(this.mockProcDumpProcess.Object);
 
             var processDumpUtility = new ProcessDumpUtility(
@@ -84,7 +84,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             var processId = 12345;
             var testResultsDirectory = "D:\\TestResults";
 
-            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null, null))
+            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null, It.IsAny<Action<object, string>>()))
                 .Throws(new Exception());
             this.mockProcessHelper.Setup(x => x.GetProcessName(processId))
                 .Returns(process);
@@ -114,7 +114,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 .Returns(new string[] { "dump.dmp" });
             this.mockProcessHelper.Setup(x => x.GetProcessName(processId))
                 .Returns(process);
-            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null, null))
+            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null, It.IsAny<Action<object, string>>()))
                 .Returns(this.mockProcDumpProcess.Object);
 
             var processDumpUtility = new ProcessDumpUtility(
@@ -142,7 +142,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             var args = $"-accepteula -e 1 -g -t -f STACK_OVERFLOW -f ACCESS_VIOLATION {processId} {filename}";
             var testResultsDirectory = "D:\\TestResults";
 
-            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null, null))
+            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null, It.IsAny<Action<object, string>>()))
                 .Returns(this.mockProcDumpProcess.Object);
             this.mockProcessHelper.Setup(x => x.GetProcessName(processId))
                 .Returns(process);
@@ -158,7 +158,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             processDumpUtility.StartTriggerBasedProcessDump(processId, guid, testResultsDirectory);
 
-            this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), args, It.IsAny<string>(), null, null, null, null), Times.Once);
+            this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), args, It.IsAny<string>(), null, null, null, It.IsAny<Action<object, string>>()), Times.Once);
             Assert.AreEqual(Path.Combine(testResultsDirectory, filename), processDumpUtility.GetDumpFile());
         }
 
@@ -175,7 +175,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             var args = $"-accepteula -e 1 -g -t -ma -f STACK_OVERFLOW -f ACCESS_VIOLATION {processId} {filename}";
             var testResultsDirectory = "D:\\TestResults";
 
-            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null, null))
+            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null, It.IsAny<Action<object, string>>()))
                 .Returns(this.mockProcDumpProcess.Object);
             this.mockProcessHelper.Setup(x => x.GetProcessName(processId))
                 .Returns(process);
@@ -190,7 +190,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             processDumpUtility.StartTriggerBasedProcessDump(processId, guid, testResultsDirectory, isFullDump: true);
 
-            this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), args, It.IsAny<string>(), null, null, null, null), Times.Once);
+            this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), args, It.IsAny<string>(), null, null, null, It.IsAny<Action<object, string>>()), Times.Once);
             Assert.AreEqual(Path.Combine(testResultsDirectory, filename), processDumpUtility.GetDumpFile());
         }
 
@@ -207,7 +207,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             var args = $"-accepteula -n 1 -ma {processId} {filename}";
             var testResultsDirectory = "D:\\TestResults";
 
-            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null, null))
+            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null, It.IsAny<Action<object, string>>()))
                 .Returns(this.mockProcDumpProcess.Object);
             this.mockProcessHelper.Setup(x => x.GetProcessName(processId))
                 .Returns(process);
@@ -222,7 +222,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             processDumpUtility.StartHangBasedProcessDump(processId, guid, testResultsDirectory, isFullDump: true);
 
-            this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), args, It.IsAny<string>(), null, null, null, null), Times.Once);
+            this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), args, It.IsAny<string>(), null, null, null, It.IsAny<Action<object, string>>()), Times.Once);
             Assert.AreEqual(Path.Combine(testResultsDirectory, filename), processDumpUtility.GetDumpFile());
         }
 
@@ -268,7 +268,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             processDumpUtility.StartTriggerBasedProcessDump(processId, guid, testResultsDirectory);
 
-            this.mockProcessHelper.Verify(x => x.LaunchProcess(Path.Combine("D:\\procdump", "procdump.exe"), It.IsAny<string>(), It.IsAny<string>(), null, null, null, null));
+            this.mockProcessHelper.Verify(x => x.LaunchProcess(Path.Combine("D:\\procdump", "procdump.exe"), It.IsAny<string>(), It.IsAny<string>(), null, null, null, It.IsAny<Action<object, string>>()));
         }
 
         /// <summary>
@@ -294,7 +294,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             processDumpUtility.StartTriggerBasedProcessDump(processId, "guid", "D:\\");
 
-            this.mockProcessHelper.Verify(x => x.LaunchProcess(Path.Combine("D:\\procdump", "procdump64.exe"), It.IsAny<string>(), It.IsAny<string>(), null, null, null, null));
+            this.mockProcessHelper.Verify(x => x.LaunchProcess(Path.Combine("D:\\procdump", "procdump64.exe"), It.IsAny<string>(), It.IsAny<string>(), null, null, null, It.IsAny<Action<object, string>>()));
         }
 
         /// <summary>
@@ -320,7 +320,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             processDumpUtility.StartTriggerBasedProcessDump(processId, "guid", "D:\\");
 
-            this.mockProcessHelper.Verify(x => x.LaunchProcess(Path.Combine("D:\\procdump", "procdump.exe"), It.IsAny<string>(), It.IsAny<string>(), null, null, null, null));
+            this.mockProcessHelper.Verify(x => x.LaunchProcess(Path.Combine("D:\\procdump", "procdump.exe"), It.IsAny<string>(), It.IsAny<string>(), null, null, null, It.IsAny<Action<object, string>>()));
         }
 
         /// <summary>

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/ProcessDumpUtilityTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/ProcessDumpUtilityTests.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
 
@@ -57,7 +58,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 .Returns(new string[] { });
             this.mockProcessHelper.Setup(x => x.GetProcessName(processId))
                 .Returns(process);
-            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null))
+            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null, null))
                 .Returns(this.mockProcDumpProcess.Object);
 
             var processDumpUtility = new ProcessDumpUtility(
@@ -83,7 +84,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             var processId = 12345;
             var testResultsDirectory = "D:\\TestResults";
 
-            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null))
+            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null, null))
                 .Throws(new Exception());
             this.mockProcessHelper.Setup(x => x.GetProcessName(processId))
                 .Returns(process);
@@ -113,7 +114,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 .Returns(new string[] { "dump.dmp" });
             this.mockProcessHelper.Setup(x => x.GetProcessName(processId))
                 .Returns(process);
-            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null))
+            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null, null))
                 .Returns(this.mockProcDumpProcess.Object);
 
             var processDumpUtility = new ProcessDumpUtility(
@@ -141,7 +142,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             var args = $"-accepteula -e 1 -g -t -f STACK_OVERFLOW -f ACCESS_VIOLATION {processId} {filename}";
             var testResultsDirectory = "D:\\TestResults";
 
-            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null))
+            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null, null))
                 .Returns(this.mockProcDumpProcess.Object);
             this.mockProcessHelper.Setup(x => x.GetProcessName(processId))
                 .Returns(process);
@@ -157,7 +158,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             processDumpUtility.StartTriggerBasedProcessDump(processId, guid, testResultsDirectory);
 
-            this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), args, It.IsAny<string>(), null, null, null), Times.Once);
+            this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), args, It.IsAny<string>(), null, null, null, null), Times.Once);
             Assert.AreEqual(Path.Combine(testResultsDirectory, filename), processDumpUtility.GetDumpFile());
         }
 
@@ -174,7 +175,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             var args = $"-accepteula -e 1 -g -t -ma -f STACK_OVERFLOW -f ACCESS_VIOLATION {processId} {filename}";
             var testResultsDirectory = "D:\\TestResults";
 
-            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null))
+            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null, null))
                 .Returns(this.mockProcDumpProcess.Object);
             this.mockProcessHelper.Setup(x => x.GetProcessName(processId))
                 .Returns(process);
@@ -189,7 +190,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             processDumpUtility.StartTriggerBasedProcessDump(processId, guid, testResultsDirectory, isFullDump: true);
 
-            this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), args, It.IsAny<string>(), null, null, null), Times.Once);
+            this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), args, It.IsAny<string>(), null, null, null, null), Times.Once);
             Assert.AreEqual(Path.Combine(testResultsDirectory, filename), processDumpUtility.GetDumpFile());
         }
 
@@ -206,7 +207,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             var args = $"-accepteula -n 1 -ma {processId} {filename}";
             var testResultsDirectory = "D:\\TestResults";
 
-            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null))
+            this.mockProcessHelper.Setup(x => x.LaunchProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, null, null, null))
                 .Returns(this.mockProcDumpProcess.Object);
             this.mockProcessHelper.Setup(x => x.GetProcessName(processId))
                 .Returns(process);
@@ -221,7 +222,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             processDumpUtility.StartHangBasedProcessDump(processId, guid, testResultsDirectory, isFullDump: true);
 
-            this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), args, It.IsAny<string>(), null, null, null), Times.Once);
+            this.mockProcessHelper.Verify(x => x.LaunchProcess(It.IsAny<string>(), args, It.IsAny<string>(), null, null, null, null), Times.Once);
             Assert.AreEqual(Path.Combine(testResultsDirectory, filename), processDumpUtility.GetDumpFile());
         }
 
@@ -267,7 +268,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             processDumpUtility.StartTriggerBasedProcessDump(processId, guid, testResultsDirectory);
 
-            this.mockProcessHelper.Verify(x => x.LaunchProcess(Path.Combine("D:\\procdump", "procdump.exe"), It.IsAny<string>(), It.IsAny<string>(), null, null, null));
+            this.mockProcessHelper.Verify(x => x.LaunchProcess(Path.Combine("D:\\procdump", "procdump.exe"), It.IsAny<string>(), It.IsAny<string>(), null, null, null, null));
         }
 
         /// <summary>
@@ -293,7 +294,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             processDumpUtility.StartTriggerBasedProcessDump(processId, "guid", "D:\\");
 
-            this.mockProcessHelper.Verify(x => x.LaunchProcess(Path.Combine("D:\\procdump", "procdump64.exe"), It.IsAny<string>(), It.IsAny<string>(), null, null, null));
+            this.mockProcessHelper.Verify(x => x.LaunchProcess(Path.Combine("D:\\procdump", "procdump64.exe"), It.IsAny<string>(), It.IsAny<string>(), null, null, null, null));
         }
 
         /// <summary>
@@ -319,7 +320,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             processDumpUtility.StartTriggerBasedProcessDump(processId, "guid", "D:\\");
 
-            this.mockProcessHelper.Verify(x => x.LaunchProcess(Path.Combine("D:\\procdump", "procdump.exe"), It.IsAny<string>(), It.IsAny<string>(), null, null, null));
+            this.mockProcessHelper.Verify(x => x.LaunchProcess(Path.Combine("D:\\procdump", "procdump.exe"), It.IsAny<string>(), It.IsAny<string>(), null, null, null, null));
         }
 
         /// <summary>

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -320,7 +320,8 @@ namespace TestPlatform.TestHostProvider.Hosting.UnitTests
                         It.IsAny<string>(),
                         It.IsAny<IDictionary<string, string>>(),
                         It.IsAny<Action<object, string>>(),
-                        It.IsAny<Action<object>>())).Returns(Process.GetCurrentProcess());
+                        It.IsAny<Action<object>>(),
+                         It.IsAny<Action<object, string>>())).Returns(Process.GetCurrentProcess());
 
             this.testHostManager.Initialize(this.mockMessageLogger.Object, $"<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings> <RunConfiguration> <TargetPlatform>{Architecture.X64}</TargetPlatform> <TargetFrameworkVersion>{Framework.DefaultFramework}</TargetFrameworkVersion> <DisableAppDomain>{false}</DisableAppDomain> </RunConfiguration> </RunSettings>");
             var startInfo = this.testHostManager.GetTestHostProcessStartInfo(Enumerable.Empty<string>(), null, default(TestRunnerConnectionInfo));
@@ -524,7 +525,8 @@ namespace TestPlatform.TestHostProvider.Hosting.UnitTests
                             It.IsAny<string>(),
                             It.IsAny<IDictionary<string, string>>(),
                             It.IsAny<Action<object, string>>(),
-                            It.IsAny<Action<object>>()))
+                            It.IsAny<Action<object>>(),
+                            It.IsAny<Action<object, string>>()))
                 .Callback<string, string, string, IDictionary<string, string>, Action<object, string>, Action<object>>(
                     (var1, var2, var3, dictionary, errorCallback, exitCallback) =>
                     {
@@ -556,7 +558,8 @@ namespace TestPlatform.TestHostProvider.Hosting.UnitTests
                             It.IsAny<string>(),
                             It.IsAny<IDictionary<string, string>>(),
                             It.IsAny<Action<object, string>>(),
-                            It.IsAny<Action<object>>()))
+                            It.IsAny<Action<object>>(),
+                            It.IsAny<Action<object, string>>()))
                 .Callback<string, string, string, IDictionary<string, string>, Action<object, string>, Action<object>>(
                     (var1, var2, var3, dictionary, errorCallback, exitCallback) =>
                     {

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -527,8 +527,8 @@ namespace TestPlatform.TestHostProvider.Hosting.UnitTests
                             It.IsAny<Action<object, string>>(),
                             It.IsAny<Action<object>>(),
                             It.IsAny<Action<object, string>>()))
-                .Callback<string, string, string, IDictionary<string, string>, Action<object, string>, Action<object>>(
-                    (var1, var2, var3, dictionary, errorCallback, exitCallback) =>
+                .Callback<string, string, string, IDictionary<string, string>, Action<object, string>, Action<object>, Action<object, string>>(
+                    (var1, var2, var3, dictionary, errorCallback, exitCallback, outputCallback) =>
                     {
                         var process = Process.GetCurrentProcess();
 
@@ -560,8 +560,8 @@ namespace TestPlatform.TestHostProvider.Hosting.UnitTests
                             It.IsAny<Action<object, string>>(),
                             It.IsAny<Action<object>>(),
                             It.IsAny<Action<object, string>>()))
-                .Callback<string, string, string, IDictionary<string, string>, Action<object, string>, Action<object>>(
-                    (var1, var2, var3, dictionary, errorCallback, exitCallback) =>
+                .Callback<string, string, string, IDictionary<string, string>, Action<object, string>, Action<object>, Action<object, string>>(
+                    (var1, var2, var3, dictionary, errorCallback, exitCallback, outputCallback) =>
                     {
                         var process = Process.GetCurrentProcess();
                         exitCallback(process);

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -801,8 +801,8 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
                             It.IsAny<Action<object, string>>(),
                             It.IsAny<Action<object>>(),
                             It.IsAny<Action<object, string>>()))
-                .Callback<string, string, string, IDictionary<string, string>, Action<object, string>, Action<object>>(
-                    (var1, var2, var3, dictionary, errorCallback, exitCallback) =>
+                .Callback<string, string, string, IDictionary<string, string>, Action<object, string>, Action<object>, Action<object, string>>(
+                    (var1, var2, var3, dictionary, errorCallback, exitCallback, outputCallback) =>
                     {
                         var process = Process.GetCurrentProcess();
 
@@ -825,8 +825,8 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
                             It.IsAny<Action<object, string>>(),
                             It.IsAny<Action<object>>(),
                             It.IsAny<Action<object, string>>()))
-                .Callback<string, string, string, IDictionary<string, string>, Action<object, string>, Action<object>>(
-                    (var1, var2, var3, dictionary, errorCallback, exitCallback) =>
+                .Callback<string, string, string, IDictionary<string, string>, Action<object, string>, Action<object>, Action<object, string>>(
+                    (var1, var2, var3, dictionary, errorCallback, exitCallback, outputCallback) =>
                     {
                         var process = Process.GetCurrentProcess();
                         exitCallback(process);

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -799,7 +799,8 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
                             It.IsAny<string>(),
                             It.IsAny<IDictionary<string, string>>(),
                             It.IsAny<Action<object, string>>(),
-                            It.IsAny<Action<object>>()))
+                            It.IsAny<Action<object>>(),
+                            It.IsAny<Action<object, string>>()))
                 .Callback<string, string, string, IDictionary<string, string>, Action<object, string>, Action<object>>(
                     (var1, var2, var3, dictionary, errorCallback, exitCallback) =>
                     {
@@ -822,7 +823,8 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
                             It.IsAny<string>(),
                             It.IsAny<IDictionary<string, string>>(),
                             It.IsAny<Action<object, string>>(),
-                            It.IsAny<Action<object>>()))
+                            It.IsAny<Action<object>>(),
+                            It.IsAny<Action<object, string>>()))
                 .Callback<string, string, string, IDictionary<string, string>, Action<object, string>, Action<object>>(
                     (var1, var2, var3, dictionary, errorCallback, exitCallback) =>
                     {


### PR DESCRIPTION
The procdump process std output is written to console in vstesttask. 
Redirecting the std output to diag files.