### PR TITLE
Add timers to the TestResult, and update the TRX logger to output the timer information

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
@@ -10,7 +10,6 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.Utility
     using System.Globalization;
     using System.IO;
     using System.Linq;
-    using System.Runtime.CompilerServices;
     using System.Text;
     using Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -113,12 +112,17 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.Utility
             if (rockSteadyTestResult.Duration != null)
                 testResult.Duration = rockSteadyTestResult.Duration;
 
-            // Clear exsting messages and store rocksteady result messages.
+            // Clear existing messages and store rocksteady result messages.
             testResult.TextMessages = null;
             UpdateResultMessages(testResult, rockSteadyTestResult);
 
             // Save result attachments to target location.
             UpdateTestResultAttachments(rockSteadyTestResult, testResult, testRun, trxFileDirectory, true);
+
+            if (rockSteadyTestResult.Timers != null)
+            {
+                testResult.AddTimerEntries(rockSteadyTestResult.Timers);
+            }
 
             return testResult;
         }

--- a/src/Microsoft.TestPlatform.ObjectModel/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Resources/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -663,15 +663,6 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Resources {
         internal static string TestResultTextMessagesFormat {
             get {
                 return ResourceManager.GetString("TestResultTextMessagesFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to   {0} : {1} : {2}.
-        /// </summary>
-        internal static string TestResultTimerFormat {
-            get {
-                return ResourceManager.GetString("TestResultTimerFormat", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TestPlatform.ObjectModel/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Resources/Resources.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Resources {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -20,7 +19,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -32,7 +31,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Resources {
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Resources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -40,7 +39,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.VisualStudio.TestPlatform.ObjectModel.Resources.Resources", typeof(Resources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.VisualStudio.TestPlatform.ObjectModel.Resources.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -278,6 +277,33 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to Create msdia Session COM HResult &apos;{0}&apos;..
+        /// </summary>
+        internal static string FailedToCreateDiaSession {
+            get {
+                return ResourceManager.GetString("FailedToCreateDiaSession", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to load msdia.
+        /// </summary>
+        internal static string FailedToLoadMsDia {
+            get {
+                return ResourceManager.GetString("FailedToLoadMsDia", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid URI in data collector settings &apos;{0}&apos;..
+        /// </summary>
+        internal static string InvalidDataCollectorUriInSettings {
+            get {
+                return ResourceManager.GetString("InvalidDataCollectorUriInSettings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The root node of the run settings must be named &apos;RunSettings&apos;..
         /// </summary>
         internal static string InvalidRunSettingsRootNode {
@@ -312,29 +338,16 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Resources {
                 return ResourceManager.GetString("InvalidSettingsXmlElement", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Invalid URI in data collector settings &apos;{0}&apos;..
-        /// </summary>
-        internal static string InvalidDataCollectorUriInSettings
-        {
-            get
-            {
-                return ResourceManager.GetString("InvalidDataCollectorUriInSettings", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Invalid URI &apos;{0}&apos; in settings &apos;{1}&apos;..
         /// </summary>
-        internal static string InvalidUriInSettings
-        {
-            get
-            {
+        internal static string InvalidUriInSettings {
+            get {
                 return ResourceManager.GetString("InvalidUriInSettings", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Invalid data collector settings. Expected attribute &apos;{0}&apos; is missing.  A typical data collector setting would look like &lt;DataCollector uri=&quot;dataCollector://Samples/SampleCollector/1.0&quot; assemblyQualifiedName=&quot;Samples.SampleCollector.SampleDataCollector, SampleCollectors, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1111111111111111&quot; friendlyName=&quot;sampleCollector&quot;&gt;..
         /// </summary>
@@ -343,18 +356,16 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Resources {
                 return ResourceManager.GetString("MissingDataCollectorAttributes", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Invalid settings &apos;{0}&apos;. Expected atleast one of the XmlAttribute among friendlyName, uri and assemblyQualifiedName..
         /// </summary>
-        internal static string MissingLoggerAttributes
-        {
-            get
-            {
+        internal static string MissingLoggerAttributes {
+            get {
                 return ResourceManager.GetString("MissingLoggerAttributes", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Cannot specify TestCaseFilter for specific tests run. FilterCriteria is only for run with sources..
         /// </summary>
@@ -397,6 +408,15 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Resources {
         internal static string SolutionDirectoryNotExists {
             get {
                 return ResourceManager.GetString("SolutionDirectoryNotExists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Filter string &apos;{0}&apos; includes unrecognized escape sequence..
+        /// </summary>
+        internal static string TestCaseFilterEscapeException {
+            get {
+                return ResourceManager.GetString("TestCaseFilterEscapeException", resourceCulture);
             }
         }
         
@@ -647,44 +667,30 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to   {0} : {1} : {2}.
+        /// </summary>
+        internal static string TestResultTimerFormat {
+            get {
+                return ResourceManager.GetString("TestResultTimerFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to   Test Timers:
+        ///{0}.
+        /// </summary>
+        internal static string TestResultTimerMessagesFormat {
+            get {
+                return ResourceManager.GetString("TestResultTimerMessagesFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The test property type &apos;{0}&apos; of property &apos;{1}&apos; is not supported. Use one of the supported property type (primitive types, uri, string, string[]) and try again. .
         /// </summary>
         internal static string UnexpectedTypeOfProperty {
             get {
                 return ResourceManager.GetString("UnexpectedTypeOfProperty", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The test property type &apos;{0}&apos; of property &apos;{1}&apos; is not supported. Use one of the supported property type (primitive types, uri, string, string[]) and try again. .
-        /// </summary>
-        internal static string FailedToLoadMsDia
-        {
-            get
-            {
-                return ResourceManager.GetString("FailedToLoadMsDia", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The test property type &apos;{0}&apos; of property &apos;{1}&apos; is not supported. Use one of the supported property type (primitive types, uri, string, string[]) and try again. .
-        /// </summary>
-        internal static string FailedToCreateDiaSession
-        {
-            get
-            {
-                return ResourceManager.GetString("FailedToCreateDiaSession", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Filter string &apos;{0}&apos; includes unrecognized escape sequence..
-        /// </summary>
-        internal static string TestCaseFilterEscapeException
-        {
-            get
-            {
-                return ResourceManager.GetString("TestCaseFilterEscapeException", resourceCulture);
             }
         }
     }

--- a/src/Microsoft.TestPlatform.ObjectModel/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.ObjectModel/Resources/Resources.resx
@@ -286,10 +286,6 @@
     <value>  {0}:
 {1}</value>
   </data>
-  <data name="TestResultTimerFormat" xml:space="preserve">
-    <value>  {0} : {1} : {2}</value>
-    <comment>Timer name, start-time, and duration</comment>
-  </data>
   <data name="TestResultPropertyComputerNameLabel" xml:space="preserve">
     <value>Computer Name</value>
     <comment>The label of the test property ComputerName for test result.</comment>

--- a/src/Microsoft.TestPlatform.ObjectModel/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.ObjectModel/Resources/Resources.resx
@@ -286,6 +286,10 @@
     <value>  {0}:
 {1}</value>
   </data>
+  <data name="TestResultTimerFormat" xml:space="preserve">
+    <value>  {0} : {1} : {2}</value>
+    <comment>Timer name, start-time, and duration</comment>
+  </data>
   <data name="TestResultPropertyComputerNameLabel" xml:space="preserve">
     <value>Computer Name</value>
     <comment>The label of the test property ComputerName for test result.</comment>
@@ -324,6 +328,10 @@
   </data>
   <data name="TestResultTextMessagesFormat" xml:space="preserve">
     <value>  Test Messages:
+{0}</value>
+  </data>
+  <data name="TestResultTimerMessagesFormat" xml:space="preserve">
+    <value>  Test Timers:
 {0}</value>
   </data>
   <data name="UnexpectedTypeOfProperty" xml:space="preserve">

--- a/src/Microsoft.TestPlatform.ObjectModel/TestResult.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TestResult.cs
@@ -87,6 +87,9 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         [DataMember]
         public Collection<TestResultMessage> Messages { get; private set; }
 
+        /// <summary>
+        /// Gets the named timers for TestResult, if any.
+        /// </summary>
         [DataMember]
         public Collection<TimerResult> Timers { get; private set; }
 
@@ -184,12 +187,14 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 
             if (this.Timers.Any())
             {
+                // Timer name, start-time, and duration
+                const string testResultTimerFormat = "  {0} : {1} : {2}";
                 var timerMessages = new StringBuilder();
                 foreach (var timer in this.Timers)
                 {
                     timerMessages.AppendFormat(
                         CultureInfo.CurrentUICulture,
-                        Resources.Resources.TestResultTimerFormat,
+                        testResultTimerFormat,
                         timer.Name,
                         timer.StartTime.ToString("O"),
                         timer.Duration.ToString("c"));
@@ -332,13 +337,30 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         }
     }
 
+    /// <summary>
+    /// Named timer within the Timers collection of a TestResult.
+    /// </summary>
+    /// <remarks>
+    /// Class is immutable.
+    /// </remarks>
     [DataContract]
     public class TimerResult
     {
+        /// <summary>
+        /// Gets the name of the timer.
+        /// </summary>
         [DataMember]
         public string Name { get; }
+
+        /// <summary>
+        /// Gets the time the timer was started.
+        /// </summary>
         [DataMember]
         public DateTimeOffset StartTime { get; }
+
+        /// <summary>
+        /// Gets the duration of the timer.
+        /// </summary>
         [DataMember]
         public TimeSpan Duration { get; }
 

--- a/src/Microsoft.TestPlatform.ObjectModel/TestResult.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TestResult.cs
@@ -33,6 +33,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
             this.TestCase = testCase;
             this.Messages = new Collection<TestResultMessage>();
             this.Attachments = new Collection<AttachmentSet>();
+            this.Timers = new Collection<TimerResult>();
 
             // Default start and end time values for a test result are initialized to current timestamp
             // to maintain compatibility.
@@ -85,6 +86,9 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         /// </summary>
         [DataMember]
         public Collection<TestResultMessage> Messages { get; private set; }
+
+        [DataMember]
+        public Collection<TimerResult> Timers { get; private set; }
 
         /// <summary>
         /// Gets or sets test result ComputerName.
@@ -176,6 +180,25 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
                     CultureInfo.CurrentUICulture,
                     Resources.Resources.TestResultTextMessagesFormat,
                     testMessages.ToString());
+            }
+
+            if (this.Timers.Any())
+            {
+                var timerMessages = new StringBuilder();
+                foreach (var timer in this.Timers)
+                {
+                    timerMessages.AppendFormat(
+                        CultureInfo.CurrentUICulture,
+                        Resources.Resources.TestResultTimerFormat,
+                        timer.Name,
+                        timer.StartTime.ToString("O"),
+                        timer.Duration.ToString("c"));
+                }
+
+                result.AppendLine();
+                result.AppendFormat(CultureInfo.CurrentUICulture,
+                    Resources.Resources.TestResultTimerMessagesFormat,
+                    timerMessages);
             }
 
             return result.ToString();
@@ -306,6 +329,26 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         {
             get;
             private set;
+        }
+    }
+
+    [DataContract]
+    public class TimerResult
+    {
+        [DataMember]
+        public string Name { get; }
+        [DataMember]
+        public DateTimeOffset StartTime { get; }
+        [DataMember]
+        public TimeSpan Duration { get; }
+
+        public TimerResult(string name,
+            DateTimeOffset startTime,
+            TimeSpan duration)
+        {
+            this.Name = name;
+            this.StartTime = startTime;
+            this.Duration = duration;
         }
     }
 

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/Serialization/TestResultSerializationTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/Serialization/TestResultSerializationTests.cs
@@ -218,7 +218,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization
             result.StartTime = default(DateTimeOffset);
             result.EndTime = default(DateTimeOffset);
             result.Attachments.Add(new AttachmentSet(new Uri("http://dummyUri"), "sampleAttachment"));
-            var expectedJson = "{\"TestCase\":{\"Id\":\"28e7a7ed-8fb9-05b7-5e90-4a8c52f32b5b\",\"FullyQualifiedName\":\"sampleTestClass.sampleTestCase\",\"DisplayName\":\"sampleTestClass.sampleTestCase\",\"ExecutorUri\":\"executor://sampleTestExecutor\",\"Source\":\"sampleTest.dll\",\"CodeFilePath\":null,\"LineNumber\":-1,\"Properties\":[]},\"Attachments\":[{\"Uri\":\"http://dummyUri\",\"DisplayName\":\"sampleAttachment\",\"Attachments\":[]}],\"Outcome\":0,\"ErrorMessage\":null,\"ErrorStackTrace\":null,\"DisplayName\":null,\"Messages\":[],\"ComputerName\":null,\"Duration\":\"00:00:00\",\"StartTime\":\"0001-01-01T00:00:00+00:00\",\"EndTime\":\"0001-01-01T00:00:00+00:00\",\"Properties\":[]}";
+            var expectedJson = "{\"TestCase\":{\"Id\":\"28e7a7ed-8fb9-05b7-5e90-4a8c52f32b5b\",\"FullyQualifiedName\":\"sampleTestClass.sampleTestCase\",\"DisplayName\":\"sampleTestClass.sampleTestCase\",\"ExecutorUri\":\"executor://sampleTestExecutor\",\"Source\":\"sampleTest.dll\",\"CodeFilePath\":null,\"LineNumber\":-1,\"Properties\":[]},\"Attachments\":[{\"Uri\":\"http://dummyUri\",\"DisplayName\":\"sampleAttachment\",\"Attachments\":[]}],\"Outcome\":0,\"ErrorMessage\":null,\"ErrorStackTrace\":null,\"DisplayName\":null,\"Messages\":[],\"Timers\":[],\"ComputerName\":null,\"Duration\":\"00:00:00\",\"StartTime\":\"0001-01-01T00:00:00+00:00\",\"EndTime\":\"0001-01-01T00:00:00+00:00\",\"Properties\":[]}";
 
             var json = Serialize(result, 2);
 


### PR DESCRIPTION
Add timers to the TestResult, and update the TRX logger output the timer 
information to the TRX file if any timers are in the collection, as per 
the XML schema of the TRX from
%VSINSTALLDIR%\xml\Schemas\vstst.xsd

It looks almost like an oversight that the TestResult did not previously include
the named timers.

## Related issues
- The primary motivation for this connects back to [testfx#504](https://github.com/microsoft/testfx/issues/504)
- To support testfx#504, the TRX logger has to be updated, as per #2196.
