### PR TITLE
Only send Coverlet in proc datacollector dll to testhost

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -37,6 +37,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         private bool skipDefaultAdapters;
         private readonly IFileHelper fileHelper;
 
+        // Only send coverlet inproc datacollector dll to be initialized via testhost, 
+        // ideally this should get initialized via InProcessDC Node in runsettings, but 
+        // somehow it is failing, hence putting this ugly HACK, to fix issues like
+        // https://developercommunity.visualstudio.com/content/problem/738856/could-not-load-file-or-assembly-microsoftintellitr.html
+        private const string CoverletDataCollector = "coverlet.collector.dll";
+
         /// <inheritdoc/>
         public bool IsInitialized { get; private set; } = false;
 
@@ -261,7 +267,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         private void InitializeExtensions(IEnumerable<string> sources)
         {
             var extensions = TestPluginCache.Instance.GetExtensionPaths(TestPlatformConstants.TestAdapterEndsWithPattern, this.skipDefaultAdapters);
-            extensions = extensions.Concat(TestPluginCache.Instance.GetExtensionPaths(TestPlatformConstants.DataCollectorEndsWithPattern, true)).ToList();
+            
+            // remove this line once we figure out why coverlet inrpoc DC is not initialized via runsetting inproc node.
+            extensions = extensions.Concat(TestPluginCache.Instance.GetExtensionPaths(ProxyExecutionManager.CoverletDataCollector, true)).ToList();
 
             // Filter out non existing extensions
             var nonExistingExtensions = extensions.Where(extension => !this.fileHelper.Exists(extension));

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -268,7 +268,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         {
             var extensions = TestPluginCache.Instance.GetExtensionPaths(TestPlatformConstants.TestAdapterEndsWithPattern, this.skipDefaultAdapters);
             
-            // remove this line once we figure out why coverlet inrpoc DC is not initialized via runsetting inproc node.
+            // remove this line once we figure out why coverlet inproc DC is not initialized via runsetting inproc node.
             extensions = extensions.Concat(TestPluginCache.Instance.GetExtensionPaths(ProxyExecutionManager.CoverletDataCollector, true)).ToList();
 
             // Filter out non existing extensions

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
@@ -303,11 +303,11 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
         }
 
         [TestMethod]
-        public void StartTestRunShouldInitializeExtensionsWithExistingDataCOllectorExtensions()
+        public void StartTestRunShouldInitializeExtensionsOnlyWithCoverletDataCollectorExtensions()
         {
             TestPluginCache.Instance = null;
-            TestPluginCache.Instance.UpdateExtensions(new List<string> { "abc.TestAdapter.dll", "def.TestAdapter.dll", "xyz.TestAdapter.dll", "abc.DataCollector.dll" }, false);
-            var expectedOutputPaths = new[] { "abc.TestAdapter.dll", "xyz.TestAdapter.dll", "abc.DataCollector.dll" };
+            TestPluginCache.Instance.UpdateExtensions(new List<string> { "abc.TestAdapter.dll", "def.TestAdapter.dll", "xyz.TestAdapter.dll", "abc.DataCollector.dll", "xyz.coverlet.collector.dll" }, false);
+            var expectedOutputPaths = new[] { "abc.TestAdapter.dll", "xyz.TestAdapter.dll", "xyz.coverlet.collector.dll" };
 
             this.mockTestHostManager.SetupGet(th => th.Shared).Returns(false);
             this.mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(true);
@@ -324,6 +324,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client
             this.mockFileHelper.Setup(fh => fh.Exists("abc.TestAdapter.dll")).Returns(true);
             this.mockFileHelper.Setup(fh => fh.Exists("xyz.TestAdapter.dll")).Returns(true);
             this.mockFileHelper.Setup(fh => fh.Exists("abc.DataCollector.dll")).Returns(true);
+            this.mockFileHelper.Setup(fh => fh.Exists("xyz.coverlet.collector.dll")).Returns(true); 
 
             var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
             this.testExecutionManager.StartTestRun(this.mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);


### PR DESCRIPTION
Bug: https://developercommunity.visualstudio.com/content/problem/738856/could-not-load-file-or-assembly-microsoftintellitr.html

RC: Earlier we were loading all datacollector dll's in testhost process. In case of netcore test where dotnet is launched, we started loading FullCLR dlls inside testhost process. Now loading dlls was okay, but the moment user did 

`AppDomain.CurrentDomain.GetAssemblies().First(asm => asm.DefinedTypes.Any(t => t.FullName == "foo"))` it would fail

This was because the above line would cause dependent dll of FullCLR dll's to be loaded, which if not found would throw FileNotFoundException, & user code/test code would start failing.

We are white-listing coverlet inproc dll to be loaded in testhost process. Please see code comments to understand why, & how it should be fixed