### PR TITLE
Readme: Correct name and link for RFC 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ There are many ways to contribute to VSTest
 - [Packaging](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0014-Packaging.md)
 - [Telemetry](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0015-Telemetry.md)
 - [Loggers Information From RunSettings](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0016-Loggers-Information-From-RunSettings.md)
-- [TestCase FullyQualifiedName](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0017-TestCase-FullyQualifiedName.md)
+- [Properties for TestCases in Managed Code](https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md)
 - [Skip Default Adapters](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0018-Skip-Default-Adapters.md)
 - [Disable Appdomain While Running Tests](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0019-Disable-Appdomain-While-Running-Tests.md)
 - [Improving Logic To Pass Sources To Adapters](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0020-Improving-Logic-To-Pass-Sources-To-Adapters.md)


### PR DESCRIPTION
The file "TestCase FullyQualifiedName" was renamed to "Properties for TestCases in Managed Code" as part of [vstest-docs PR133](https://github.com/microsoft/vstest-docs/pull/133).  This change updates the link text to match the new document name, and corrects the link URL to the new document path.
