### PR TITLE
Test run parameter added as part of CLI runsettings args

### DIFF
--- a/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
         {
             var attrName = $"(?<{Constants.AttributeNameString}>\\w+)";
             var attrValue = $"(?<{Constants.AttributeValueString}>.+)";
-            Regex regex = new Regex($"{Constants.TestRunParametersString}.{Constants.ParameterString}\\(name=\\s*\"{attrName}\"\\s*,value=\\s*\"{attrValue}\"\\s*\\)");
+            Regex regex = new Regex($"{Constants.TestRunParametersString}.{Constants.ParameterString}\\(name\\s*=\\s*\"{attrName}\"\\s*,value\\s*=\\s*\"{attrValue}\"\\)");
             Match match = regex.Match(node);
             return match;
         }

--- a/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
             var attrName = match.Groups[AttributeNameString].Value;
             var attrValue = match.Groups[AttributeValueString].Value;
 
-            if (!TryOverRideAttributeValue(testRunParameterNode, attrName, attrValue))
+            if (!TryOverrideAttributeValue(testRunParameterNode, attrName, attrValue))
             {
                 XmlElement element = xmlDocument.CreateElement(ParameterString);
                 element.SetAttribute(NameString, attrName);
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
             runSettingsProvider.UpdateRunSettings(xmlDocument.OuterXml);
         }
 
-        private static bool TryOverRideAttributeValue(XmlNode xmlNode, string attrName, string attrValue)
+        private static bool TryOverrideAttributeValue(XmlNode xmlNode, string attrName, string attrValue)
         {
             foreach (XmlNode node in xmlNode.ChildNodes)
             {

--- a/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
@@ -25,32 +25,32 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
         /// <summary>
         /// Pattern used to find test run parameter node.
         /// </summary>
-        private const string TestRunParameters = "TestRunParameters";
+        private const string TestRunParametersString = "TestRunParameters";
 
         /// <summary>
         /// Pattern used to find parameter node.
         /// </summary>
-        private const string Parameter = "Parameter";
+        private const string ParameterString = "Parameter";
 
         /// <summary>
         /// Pattern that indicates Attribute name.
         /// </summary>
-        private const string AttributeName = "AttrName";
+        private const string AttributeNameString = "AttrName";
 
         /// <summary>
         /// Pattern that indicates  Attribute value.
         /// </summary>
-        private const string AttributeValue = "AttrValue";
+        private const string AttributeValueString = "AttrValue";
 
         /// <summary>
         /// Attribute name key for test run parameter node
         /// </summary>
-        private const string Name = "name";
+        private const string NameString = "name";
 
         /// <summary>
         /// Attribute value key for test run parameter node
         /// </summary>
-        private const string Value = "value";
+        private const string ValueString = "value";
 
         public static void UpdateRunSettings(this IRunSettingsProvider runSettingsProvider, string runsettingsXml)
         {
@@ -102,9 +102,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
         /// <returns></returns>
         public static Match GetTestRunParameterNodeMatch(this IRunSettingsProvider runSettingsProvider, string node)
         {
-            var attrName = $"(?<{AttributeName}>\\w+)";
-            var attrValue = $"(?<{AttributeValue}>.+)";
-            Regex regex = new Regex($"{TestRunParameters}.{Parameter}\\(name={attrName},value={attrValue}\\)");
+            var attrName = $"(?<{AttributeNameString}>\\w+)";
+            var attrValue = $"(?<{AttributeValueString}>.+)";
+            Regex regex = new Regex($"{TestRunParametersString}.{ParameterString}\\(name={attrName},value={attrValue}\\)");
             Match match = regex.Match(node);
             return match;
         }
@@ -119,14 +119,15 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
             ValidateArg.NotNull(runSettingsProvider, nameof(runSettingsProvider));
 
             var xmlDocument = runSettingsProvider.GetRunSettingXmlDocument();
-            XmlNode testRunParameterNode = GetXmlNode(xmlDocument, TestRunParameters) ?? xmlDocument.CreateElement(TestRunParameters);
-            var attrName = match.Groups[AttributeName].Value;
-            var attrValue = match.Groups[AttributeValue].Value;
+            XmlNode testRunParameterNode = GetXmlNode(xmlDocument, TestRunParametersString) ?? xmlDocument.CreateElement(TestRunParametersString);
+            var attrName = match.Groups[AttributeNameString].Value;
+            var attrValue = match.Groups[AttributeValueString].Value;
+
             if (!TryOverRideAttributeName(testRunParameterNode, attrName, attrValue))
             {
-                XmlElement element = xmlDocument.CreateElement(Parameter);
-                element.SetAttribute(Name, attrName);
-                element.SetAttribute(Value, attrValue);
+                XmlElement element = xmlDocument.CreateElement(ParameterString);
+                element.SetAttribute(NameString, attrName);
+                element.SetAttribute(ValueString, attrValue);
                 testRunParameterNode.AppendChild(element);
                 xmlDocument.DocumentElement.AppendChild(testRunParameterNode);
             }
@@ -138,9 +139,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
         {
             foreach (XmlNode node in xmlNode.ChildNodes)
             {
-                if (string.Compare(node.Attributes[Name].Value, attrName) == 0)
+                if (string.Compare(node.Attributes[NameString].Value, attrName) == 0)
                 {
-                    node.Attributes[Value].Value = attrValue;
+                    node.Attributes[ValueString].Value = attrValue;
                     return true;
                 }
             }

--- a/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
@@ -22,36 +22,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
     {
         public const string EmptyRunSettings = @"<RunSettings><RunConfiguration></RunConfiguration></RunSettings>";
 
-        /// <summary>
-        /// Pattern used to find test run parameter node.
-        /// </summary>
-        private const string TestRunParametersString = "TestRunParameters";
-
-        /// <summary>
-        /// Pattern used to find parameter node.
-        /// </summary>
-        private const string ParameterString = "Parameter";
-
-        /// <summary>
-        /// Pattern that indicates Attribute name.
-        /// </summary>
-        private const string AttributeNameString = "AttrName";
-
-        /// <summary>
-        /// Pattern that indicates  Attribute value.
-        /// </summary>
-        private const string AttributeValueString = "AttrValue";
-
-        /// <summary>
-        /// Attribute name key for test run parameter node
-        /// </summary>
-        private const string NameString = "name";
-
-        /// <summary>
-        /// Attribute value key for test run parameter node
-        /// </summary>
-        private const string ValueString = "value";
-
         public static void UpdateRunSettings(this IRunSettingsProvider runSettingsProvider, string runsettingsXml)
         {
             ValidateArg.NotNull(runSettingsProvider, nameof(runSettingsProvider));
@@ -102,9 +72,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
         /// <returns></returns>
         public static Match GetTestRunParameterNodeMatch(this IRunSettingsProvider runSettingsProvider, string node)
         {
-            var attrName = $"(?<{AttributeNameString}>\\w+)";
-            var attrValue = $"(?<{AttributeValueString}>.+)";
-            Regex regex = new Regex($"{TestRunParametersString}.{ParameterString}\\(name={attrName},value={attrValue}\\)");
+            var attrName = $"(?<{Constants.AttributeNameString}>\\w+)";
+            var attrValue = $"(?<{Constants.AttributeValueString}>.+)";
+            Regex regex = new Regex($"{Constants.TestRunParametersString}.{Constants.ParameterString}\\(name=\\s*\"{attrName}\"\\s*,value=\\s*\"{attrValue}\"\\s*\\)");
             Match match = regex.Match(node);
             return match;
         }
@@ -119,15 +89,15 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
             ValidateArg.NotNull(runSettingsProvider, nameof(runSettingsProvider));
 
             var xmlDocument = runSettingsProvider.GetRunSettingXmlDocument();
-            XmlNode testRunParameterNode = GetXmlNode(xmlDocument, TestRunParametersString) ?? xmlDocument.CreateElement(TestRunParametersString);
-            var attrName = match.Groups[AttributeNameString].Value;
-            var attrValue = match.Groups[AttributeValueString].Value;
+            XmlNode testRunParameterNode = GetXmlNode(xmlDocument, Constants.TestRunParametersString) ?? xmlDocument.CreateElement(Constants.TestRunParametersString);
+            var attrName = match.Groups[Constants.AttributeNameString].Value;
+            var attrValue = match.Groups[Constants.AttributeValueString].Value;
 
             if (!TryOverRideAttributeName(testRunParameterNode, attrName, attrValue))
             {
-                XmlElement element = xmlDocument.CreateElement(ParameterString);
-                element.SetAttribute(NameString, attrName);
-                element.SetAttribute(ValueString, attrValue);
+                XmlElement element = xmlDocument.CreateElement(Constants.ParameterString);
+                element.SetAttribute(Constants.NameString, attrName);
+                element.SetAttribute(Constants.ValueString, attrValue);
                 testRunParameterNode.AppendChild(element);
                 xmlDocument.DocumentElement.AppendChild(testRunParameterNode);
             }
@@ -139,9 +109,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
         {
             foreach (XmlNode node in xmlNode.ChildNodes)
             {
-                if (string.Compare(node.Attributes[NameString].Value, attrName) == 0)
+                if (string.Compare(node.Attributes[Constants.NameString].Value, attrName) == 0)
                 {
-                    node.Attributes[ValueString].Value = attrValue;
+                    node.Attributes[Constants.ValueString].Value = attrValue;
                     return true;
                 }
             }

--- a/src/Microsoft.TestPlatform.ObjectModel/Constants.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Constants.cs
@@ -124,32 +124,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         /// <summary>
         /// Pattern used to find test run parameter node.
         /// </summary>
-        public const string TestRunParametersString = "TestRunParameters";
-
-        /// <summary>
-        /// Pattern used to find parameter node.
-        /// </summary>
-        public const string ParameterString = "Parameter";
-
-        /// <summary>
-        /// Pattern that indicates Attribute name.
-        /// </summary>
-        public const string AttributeNameString = "AttrName";
-
-        /// <summary>
-        /// Pattern that indicates  Attribute value.
-        /// </summary>
-        public const string AttributeValueString = "AttrValue";
-
-        /// <summary>
-        /// Attribute name key for test run parameter node
-        /// </summary>
-        public const string NameString = "name";
-
-        /// <summary>
-        /// Attribute value key for test run parameter node
-        /// </summary>
-        public const string ValueString = "value";
+        public const string TestRunParametersName = "TestRunParameters";
 
         /// <summary>
         /// Type of the unit test extension. (Extension author will use this name while authoring their Vsix)

--- a/src/Microsoft.TestPlatform.ObjectModel/Constants.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Constants.cs
@@ -121,7 +121,35 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 
         public const string DataCollectorSettingName = "DataCollector";
 
-        public const string TestRunParametersName = "TestRunParameters";
+        /// <summary>
+        /// Pattern used to find test run parameter node.
+        /// </summary>
+        public const string TestRunParametersString = "TestRunParameters";
+
+        /// <summary>
+        /// Pattern used to find parameter node.
+        /// </summary>
+        public const string ParameterString = "Parameter";
+
+        /// <summary>
+        /// Pattern that indicates Attribute name.
+        /// </summary>
+        public const string AttributeNameString = "AttrName";
+
+        /// <summary>
+        /// Pattern that indicates  Attribute value.
+        /// </summary>
+        public const string AttributeValueString = "AttrValue";
+
+        /// <summary>
+        /// Attribute name key for test run parameter node
+        /// </summary>
+        public const string NameString = "name";
+
+        /// <summary>
+        /// Attribute value key for test run parameter node
+        /// </summary>
+        public const string ValueString = "value";
 
         /// <summary>
         /// Type of the unit test extension. (Extension author will use this name while authoring their Vsix)

--- a/src/Microsoft.TestPlatform.ObjectModel/RunSettings/TestRunParameters.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RunSettings/TestRunParameters.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
                                 string.Format(
                                     CultureInfo.CurrentCulture,
                                     Resources.Resources.InvalidSettingsXmlElement,
-                                    Constants.TestRunParametersName,
+                                    Constants.TestRunParametersString,
                                     reader.Name));
                     }
 

--- a/src/Microsoft.TestPlatform.ObjectModel/RunSettings/TestRunParameters.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RunSettings/TestRunParameters.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
                                 string.Format(
                                     CultureInfo.CurrentCulture,
                                     Resources.Resources.InvalidSettingsXmlElement,
-                                    Constants.TestRunParametersString,
+                                    Constants.TestRunParametersName,
                                     reader.Name));
                     }
 

--- a/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
@@ -168,7 +168,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
         /// <remarks>If there is no test run parameters section defined in the settings xml a blank dictionary is returned.</remarks>
         public static Dictionary<string, object> GetTestRunParameters(string settingsXml)
         {
-            var nodeValue = GetNodeValue<Dictionary<string, object>>(settingsXml, Constants.TestRunParametersString, TestRunParameters.FromXml);
+            var nodeValue = GetNodeValue<Dictionary<string, object>>(settingsXml, Constants.TestRunParametersName, TestRunParameters.FromXml);
             if (nodeValue == default(Dictionary<string, object>))
             {
                 // Return default.

--- a/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Utilities/XmlRunSettingsUtilities.cs
@@ -168,7 +168,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
         /// <remarks>If there is no test run parameters section defined in the settings xml a blank dictionary is returned.</remarks>
         public static Dictionary<string, object> GetTestRunParameters(string settingsXml)
         {
-            var nodeValue = GetNodeValue<Dictionary<string, object>>(settingsXml, Constants.TestRunParametersName, TestRunParameters.FromXml);
+            var nodeValue = GetNodeValue<Dictionary<string, object>>(settingsXml, Constants.TestRunParametersString, TestRunParameters.FromXml);
             if (nodeValue == default(Dictionary<string, object>))
             {
                 // Return default.

--- a/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
@@ -148,10 +148,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
                 }
 
                 var indexOfSeparator = arg.IndexOf("=");
+
                 if (indexOfSeparator <= 0 || indexOfSeparator >= arg.Length - 1)
                 {
                     continue;
                 }
+
                 var key = arg.Substring(0, indexOfSeparator).Trim();
                 var value = arg.Substring(indexOfSeparator + 1);
 

--- a/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
@@ -171,7 +171,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
         {
             var match = runSettingsProvider.GetTestRunParameterNodeMatch(node);
 
-            if (!node.Contains("TestRunParameters"))
+            if (!node.Contains(Constants.TestRunParametersString))
             {
                 return false;
             }

--- a/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
@@ -170,12 +170,20 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
         private bool TryUpdateTestRunParameterNode(IRunSettingsProvider runSettingsProvider, string node)
         {
             var match = runSettingsProvider.GetTestRunParameterNodeMatch(node);
+
+            if (!node.Contains("TestRunParameters"))
+            {
+                return false;
+            }
+
             if (string.Compare(match.Value, node) == 0)
             {
                 runSettingsProvider.UpdateTestRunParameterSettingsNode(match);
                 return true;
             }
-            return false;
+
+            var exceptionMessage = string.Format(CommandLineResources.InvalidTestRunParameterArgument, node);
+            throw new CommandLineException(exceptionMessage);
         }
 
         private void UpdateFrameworkAndPlatform(string key, string value)

--- a/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             {
                 var arg = args[index];
 
-                if (TryUpdateTestRunParameterNode(runSettingsProvider, arg))
+                if (UpdateTestRunParameterNode(runSettingsProvider, arg))
                 {
                     continue;
                 }
@@ -169,14 +169,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             }
         }
 
-        private bool TryUpdateTestRunParameterNode(IRunSettingsProvider runSettingsProvider, string node)
+        private bool UpdateTestRunParameterNode(IRunSettingsProvider runSettingsProvider, string node)
         {
-            var match = runSettingsProvider.GetTestRunParameterNodeMatch(node);
-
-            if (!node.Contains(Constants.TestRunParametersString))
+            if (!node.Contains(Constants.TestRunParametersName))
             {
                 return false;
             }
+
+            var match = runSettingsProvider.GetTestRunParameterNodeMatch(node);
 
             if (string.Compare(match.Value, node) == 0)
             {

--- a/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
@@ -140,6 +140,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             for (int index = 0; index < length; index++)
             {
                 var keyValuePair = args[index];
+                if (IsTestRunParameterUpadated(runSettingsProvider, keyValuePair))
+                {
+                    return;
+                }
+
                 var indexOfSeparator = keyValuePair.IndexOf("=");
                 if (indexOfSeparator <= 0 || indexOfSeparator >= keyValuePair.Length - 1)
                 {
@@ -152,12 +157,22 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
                 {
                     continue;
                 }
-
+              
                 // To determine whether to infer framework and platform.
                 UpdateFrameworkAndPlatform(key, value);
 
                 runSettingsProvider.UpdateRunSettingsNode(key, value);
             }
+        }
+
+        private bool IsTestRunParameterUpadated(IRunSettingsProvider runSettingsProvider, string key)
+        {
+            if (key.Contains("TestRunParameters.Parameter"))
+            {
+                runSettingsProvider.UpdateTestRunParmeterSettingsNode(key);
+                return true;
+            }
+            return false;
         }
 
         private void UpdateFrameworkAndPlatform(string key, string value)

--- a/src/vstest.console/Resources/Resources.Designer.cs
+++ b/src/vstest.console/Resources/Resources.Designer.cs
@@ -827,7 +827,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources
         
         /// <summary>
         ///   Looks up a localized string similar to The test run parameter argument &apos;{0}&apos; is invalid. Please use the format below.
-        ///Format : TestRunParameters.Parameter(name=&quot;&lt;name&gt;&quot;, value=&quot;&lt;value&gt;&quot;).
+        ///     Format: TestRunParameters.Parameter(name=&quot;&lt;name&gt;&quot;, value=&quot;&lt;value&gt;&quot;).
         /// </summary>
         internal static string InvalidTestRunParameterArgument {
             get {

--- a/src/vstest.console/Resources/Resources.Designer.cs
+++ b/src/vstest.console/Resources/Resources.Designer.cs
@@ -827,6 +827,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The {0} argument is invalid..
+        /// </summary>
+        internal static string InvalidTestRunParameterArgument {
+            get {
+                return ResourceManager.GetString("InvalidTestRunParameterArgument", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Argument {0} is not expected in the &apos;UseVsixExtensions&apos; command. Specify the command indicating whether the vsix extensions should be used or skipped (Example: vstest.console.exe myTests.dll /UseVsixExtensions:true) and try again..
         /// </summary>
         internal static string InvalidUseVsixExtensionsCommand {

--- a/src/vstest.console/Resources/Resources.Designer.cs
+++ b/src/vstest.console/Resources/Resources.Designer.cs
@@ -827,7 +827,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources
         
         /// <summary>
         ///   Looks up a localized string similar to The test run parameter argument &apos;{0}&apos; is invalid. Please use the format below.
-        ///     Format: TestRunParameters.Parameter(name=&quot;&lt;name&gt;&quot;, value=&quot;&lt;value&gt;&quot;).
+        ///     Format: TestRunParameters.Parameter(name=\&quot;&lt;name&gt;\&quot;, value=\&quot;&lt;value&gt;\&quot;).
         /// </summary>
         internal static string InvalidTestRunParameterArgument {
             get {

--- a/src/vstest.console/Resources/Resources.Designer.cs
+++ b/src/vstest.console/Resources/Resources.Designer.cs
@@ -13,7 +13,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources
     using System;
     using System.Reflection;
 
-
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -827,7 +826,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The {0} argument is invalid..
+        ///   Looks up a localized string similar to The test run parameter argument &apos;{0}&apos; is invalid. Please use the format below.
+        ///Format : TestRunParameters.Parameter(name=&quot;&lt;name&gt;&quot;, value=&quot;&lt;value&gt;&quot;).
         /// </summary>
         internal static string InvalidTestRunParameterArgument {
             get {

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -736,6 +736,6 @@
   </data>
   <data name="InvalidTestRunParameterArgument" xml:space="preserve">
     <value>The test run parameter argument '{0}' is invalid. Please use the format below.
-     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</value>
+     Format: TestRunParameters.Parameter(name=\"&lt;name&gt;\", value=\"&lt;value&gt;\")</value>
   </data>
 </root>

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -736,6 +736,6 @@
   </data>
   <data name="InvalidTestRunParameterArgument" xml:space="preserve">
     <value>The test run parameter argument '{0}' is invalid. Please use the format below.
-Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</value>
+     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</value>
   </data>
 </root>

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -735,6 +735,7 @@
     <value>A total of {0} test files matched the specified pattern.</value>
   </data>
   <data name="InvalidTestRunParameterArgument" xml:space="preserve">
-    <value>The {0} argument is invalid.</value>
+    <value>The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</value>
   </data>
 </root>

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -734,4 +734,7 @@
   <data name="TestSourcesDiscovered" xml:space="preserve">
     <value>A total of {0} test files matched the specified pattern.</value>
   </data>
+  <data name="InvalidTestRunParameterArgument" xml:space="preserve">
+    <value>The {0} argument is invalid.</value>
+  </data>
 </root>

--- a/src/vstest.console/Resources/xlf/Resources.cs.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.cs.xlf
@@ -1656,6 +1656,13 @@
         <target state="translated">Celkový počet testovacích souborů, které odpovídají zadanému vzoru: {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InvalidTestRunParameterArgument">
+        <source>The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+        <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.cs.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.cs.xlf
@@ -1658,7 +1658,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.cs.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.cs.xlf
@@ -1658,7 +1658,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name=\"&lt;name&gt;\", value=\"&lt;value&gt;\")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.de.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.de.xlf
@@ -1658,7 +1658,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.de.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.de.xlf
@@ -1658,7 +1658,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name=\"&lt;name&gt;\", value=\"&lt;value&gt;\")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.de.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.de.xlf
@@ -1656,6 +1656,13 @@
         <target state="translated">Insgesamt {0} Testdateien stimmten mit dem angegebenen Muster überein.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InvalidTestRunParameterArgument">
+        <source>The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+        <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.es.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.es.xlf
@@ -1661,7 +1661,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.es.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.es.xlf
@@ -1659,6 +1659,13 @@
         <target state="translated">{0} archivos de prueba en total coincidieron con el patrón especificado.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InvalidTestRunParameterArgument">
+        <source>The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+        <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.es.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.es.xlf
@@ -1661,7 +1661,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name=\"&lt;name&gt;\", value=\"&lt;value&gt;\")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.fr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.fr.xlf
@@ -1656,6 +1656,13 @@
         <target state="translated">Au total, {0} fichiers de test ont correspondu au modèle spécifié.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InvalidTestRunParameterArgument">
+        <source>The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+        <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.fr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.fr.xlf
@@ -1658,7 +1658,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.fr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.fr.xlf
@@ -1658,7 +1658,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name=\"&lt;name&gt;\", value=\"&lt;value&gt;\")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.it.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.it.xlf
@@ -1656,6 +1656,13 @@
         <target state="translated">Un totale di {0} file di test corrisponde al criterio specificato.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InvalidTestRunParameterArgument">
+        <source>The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+        <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.it.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.it.xlf
@@ -1658,7 +1658,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.it.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.it.xlf
@@ -1658,7 +1658,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name=\"&lt;name&gt;\", value=\"&lt;value&gt;\")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.ja.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ja.xlf
@@ -1658,7 +1658,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.ja.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ja.xlf
@@ -1656,6 +1656,13 @@
         <target state="translated">合計 {0} 個のテスト ファイルが指定されたパターンと一致しました。</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InvalidTestRunParameterArgument">
+        <source>The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+        <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.ja.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ja.xlf
@@ -1658,7 +1658,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name=\"&lt;name&gt;\", value=\"&lt;value&gt;\")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.ko.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ko.xlf
@@ -1658,7 +1658,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.ko.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ko.xlf
@@ -1656,6 +1656,13 @@
         <target state="translated">지정된 패턴과 일치한 총 테스트 파일 수는 {0}개입니다.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InvalidTestRunParameterArgument">
+        <source>The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+        <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.ko.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ko.xlf
@@ -1658,7 +1658,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name=\"&lt;name&gt;\", value=\"&lt;value&gt;\")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.pl.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pl.xlf
@@ -1656,6 +1656,13 @@
         <target state="translated">Łączna liczba plików testowych dopasowanych do określonego wzorca: {0}.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InvalidTestRunParameterArgument">
+        <source>The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+        <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.pl.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pl.xlf
@@ -1658,7 +1658,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.pl.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pl.xlf
@@ -1658,7 +1658,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name=\"&lt;name&gt;\", value=\"&lt;value&gt;\")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
@@ -1658,7 +1658,7 @@ Altere o prefixo de nível de diagnóstico do agente de console, como mostrado a
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
@@ -1656,6 +1656,13 @@ Altere o prefixo de nível de diagnóstico do agente de console, como mostrado a
         <target state="translated">{0} arquivos de teste no total corresponderam ao padrão especificado.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InvalidTestRunParameterArgument">
+        <source>The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+        <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
@@ -1658,7 +1658,7 @@ Altere o prefixo de nível de diagnóstico do agente de console, como mostrado a
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name=\"&lt;name&gt;\", value=\"&lt;value&gt;\")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.ru.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ru.xlf
@@ -1656,6 +1656,13 @@
         <target state="translated">Общее количество тестовых файлов ({0}), соответствующих указанному шаблону.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InvalidTestRunParameterArgument">
+        <source>The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+        <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.ru.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ru.xlf
@@ -1658,7 +1658,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.ru.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ru.xlf
@@ -1658,7 +1658,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name=\"&lt;name&gt;\", value=\"&lt;value&gt;\")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.tr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.tr.xlf
@@ -1656,6 +1656,13 @@ Günlükler için izleme düzeyini aşağıda gösterildiği gibi değiştirin
         <target state="translated">Toplam {0} test dosyası belirtilen desenle eşleşti.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InvalidTestRunParameterArgument">
+        <source>The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+        <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.tr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.tr.xlf
@@ -1658,7 +1658,7 @@ Günlükler için izleme düzeyini aşağıda gösterildiği gibi değiştirin
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name=\"&lt;name&gt;\", value=\"&lt;value&gt;\")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.tr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.tr.xlf
@@ -1658,7 +1658,7 @@ Günlükler için izleme düzeyini aşağıda gösterildiği gibi değiştirin
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.xlf
@@ -849,7 +849,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name=\"&lt;name&gt;\", value=\"&lt;value&gt;\")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.xlf
@@ -847,6 +847,13 @@
         <target state="new">A total of {0} test source files are discovered.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InvalidTestRunParameterArgument">
+        <source>The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+        <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.xlf
@@ -849,7 +849,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
@@ -1657,7 +1657,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
@@ -1657,7 +1657,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name=\"&lt;name&gt;\", value=\"&lt;value&gt;\")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
@@ -1655,6 +1655,13 @@
         <target state="translated">总共 {0} 个测试文件与指定模式相匹配。</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InvalidTestRunParameterArgument">
+        <source>The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+        <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
@@ -1659,7 +1659,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
@@ -1657,6 +1657,13 @@
         <target state="translated">總共有 {0} 個測試檔案與指定的模式相符。</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InvalidTestRunParameterArgument">
+        <source>The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+        <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
+Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
@@ -1659,7 +1659,7 @@
       </trans-unit>
       <trans-unit id="InvalidTestRunParameterArgument">
         <source>The test run parameter argument '{0}' is invalid. Please use the format below.
-     Format: TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</source>
+     Format: TestRunParameters.Parameter(name=\"&lt;name&gt;\", value=\"&lt;value&gt;\")</source>
         <target state="new">The test run parameter argument '{0}' is invalid. Please use the format below.
 Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")</target>
         <note></note>

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/RunSettingsProviderExtensionsTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/RunSettingsProviderExtensionsTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors.U
         [TestMethod]
         public void UpdateTestRunParameterSettingsNodeShouldAddNewKeyIfNotPresent()
         {
-            var match = this.runSettingsProvider.GetTestRunParameterNodeMatch("TestRunParameters.Parameter(name=weburl,value=http://localhost//abc)");
+            var match = this.runSettingsProvider.GetTestRunParameterNodeMatch("TestRunParameters.Parameter(name=\"weburl\",value=\"http://localhost//abc\")");
             var runSettingsWithTestRunParameters = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>";
 
             this.runSettingsProvider.UpdateRunSettings("<RunSettings>\r\n  </RunSettings>");
@@ -151,7 +151,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors.U
             var runSettingsWithTestRunParametersOverRode = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//def\" />\r\n  </TestRunParameters>\r\n</RunSettings>";
 
             this.runSettingsProvider.UpdateRunSettings(runSettingsWithTestRunParameters);
-            var match = this.runSettingsProvider.GetTestRunParameterNodeMatch("TestRunParameters.Parameter(name=weburl,value=http://localhost//def)");
+            var match = this.runSettingsProvider.GetTestRunParameterNodeMatch("TestRunParameters.Parameter(name=\"weburl\",value=\"http://localhost//def\")");
             this.runSettingsProvider.UpdateTestRunParameterSettingsNode(match);
 
             Assert.AreEqual(runSettingsWithTestRunParametersOverRode, this.runSettingsProvider.ActiveRunSettings.SettingsXml);

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/RunSettingsProviderExtensionsTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/RunSettingsProviderExtensionsTests.cs
@@ -141,7 +141,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors.U
             this.runSettingsProvider.UpdateTestRunParameterSettingsNode(match);
 
             Assert.AreEqual(runSettingsWithTestRunParameters, this.runSettingsProvider.ActiveRunSettings.SettingsXml);
-
         }
 
         [TestMethod]
@@ -155,7 +154,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors.U
             this.runSettingsProvider.UpdateTestRunParameterSettingsNode(match);
 
             Assert.AreEqual(runSettingsWithTestRunParametersOverRode, this.runSettingsProvider.ActiveRunSettings.SettingsXml);
-
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/RunSettingsProviderExtensionsTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/RunSettingsProviderExtensionsTests.cs
@@ -4,13 +4,14 @@
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors.Utilities
 {
     using System;
-    
+
     using Microsoft.VisualStudio.TestPlatform.Common;
     using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
+    using System.Text.RegularExpressions;
 
     [TestClass]
     public class RunSettingsProviderExtensionsTests
@@ -24,7 +25,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors.U
         {
             runSettingsProvider = new TestableRunSettingsProvider();
         }
-        
+
         [TestMethod]
         public void UpdateRunSettingsShouldUpdateGivenSettingsXml()
         {
@@ -131,6 +132,33 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors.U
         }
 
         [TestMethod]
+        public void UpdateTetsRunParameterSettingsNodeShouldAddNewKeyIfNotPresent()
+        {
+            var match = this.runSettingsProvider.GetTestRunParameterNodeMatch("TestRunParameters.Parameter(name=weburl,value=http://localhost//abc)");
+            var runSettingsWithTestRunParameters = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>";
+
+            this.runSettingsProvider.UpdateRunSettings("<RunSettings>\r\n  </RunSettings>");
+            this.runSettingsProvider.UpdateTestRunParameterSettingsNode(match);
+
+            Assert.AreEqual(runSettingsWithTestRunParameters, this.runSettingsProvider.ActiveRunSettings.SettingsXml);
+
+        }
+
+        [TestMethod]
+        public void UpdateTetsRunParameterSettingsNodeShouldOverrideValueIfKeyIsAlreadyPresent()
+        {
+            var runSettingsWithTestRunParameters = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>";
+            var runSettingsWithTestRunParametersOverRode = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//def\" />\r\n  </TestRunParameters>\r\n</RunSettings>";
+
+            this.runSettingsProvider.UpdateRunSettings(runSettingsWithTestRunParameters);
+            var match = this.runSettingsProvider.GetTestRunParameterNodeMatch("TestRunParameters.Parameter(name=weburl,value=http://localhost//def)");
+            this.runSettingsProvider.UpdateTestRunParameterSettingsNode(match);
+
+            Assert.AreEqual(runSettingsWithTestRunParametersOverRode, this.runSettingsProvider.ActiveRunSettings.SettingsXml);
+
+        }
+
+        [TestMethod]
         public void UpdateRunSettingsNodeShouldUpdateKeyIfAlreadyPresent()
         {
             this.runSettingsProvider.UpdateRunSettings("<RunSettings>  <RunConfiguration> <MaxCpuCount>1</MaxCpuCount></RunConfiguration>  </RunSettings>");
@@ -203,7 +231,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors.U
             this.runSettingsProvider.UpdateRunSettings("<RunSettings>  <RunConfiguration> <TargetPlatform>x86</TargetPlatform></RunConfiguration>  </RunSettings>");
             Assert.AreEqual("x86", this.runSettingsProvider.QueryRunSettingsNode("RunConfiguration.TargetPlatform"));
         }
-        
+
         private class TestableRunSettingsProvider : IRunSettingsProvider
         {
             public RunSettings ActiveRunSettings
@@ -211,7 +239,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors.U
                 get;
                 set;
             }
-
             public void SetActiveRunSettings(RunSettings runSettings)
             {
                 this.ActiveRunSettings = runSettings;

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/RunSettingsProviderExtensionsTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/RunSettingsProviderExtensionsTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors.U
         }
 
         [TestMethod]
-        public void UpdateTetsRunParameterSettingsNodeShouldAddNewKeyIfNotPresent()
+        public void UpdateTestRunParameterSettingsNodeShouldAddNewKeyIfNotPresent()
         {
             var match = this.runSettingsProvider.GetTestRunParameterNodeMatch("TestRunParameters.Parameter(name=weburl,value=http://localhost//abc)");
             var runSettingsWithTestRunParameters = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>";

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/RunSettingsProviderExtensionsTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/RunSettingsProviderExtensionsTests.cs
@@ -147,13 +147,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors.U
         public void UpdateTetsRunParameterSettingsNodeShouldOverrideValueIfKeyIsAlreadyPresent()
         {
             var runSettingsWithTestRunParameters = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>";
-            var runSettingsWithTestRunParametersOverRode = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//def\" />\r\n  </TestRunParameters>\r\n</RunSettings>";
+            var runSettingsWithTestRunParametersOverrode = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//def\" />\r\n  </TestRunParameters>\r\n</RunSettings>";
 
             this.runSettingsProvider.UpdateRunSettings(runSettingsWithTestRunParameters);
             var match = this.runSettingsProvider.GetTestRunParameterNodeMatch("TestRunParameters.Parameter(name=\"weburl\",value=\"http://localhost//def\")");
             this.runSettingsProvider.UpdateTestRunParameterSettingsNode(match);
 
-            Assert.AreEqual(runSettingsWithTestRunParametersOverRode, this.runSettingsProvider.ActiveRunSettings.SettingsXml);
+            Assert.AreEqual(runSettingsWithTestRunParametersOverrode, this.runSettingsProvider.ActiveRunSettings.SettingsXml);
         }
 
         [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
@@ -210,11 +210,14 @@ namespace vstest.console.UnitTests.Processors
 
         private static readonly List<object[]> validTestCases = new List<object[]>
         {
+            new object[] { "TestRunParameters.Parameter(name=\"weburl\",value=\"&><\")" ,
+             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"&amp;&gt;&lt;\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
+            },
             new object[] { "TestRunParameters.Parameter(name=\"weburl\",value=\"http://localhost//abc\")" ,
              "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
             },
-            new object[] { "TestRunParameters.Parameter(name= \"asf123\",value= \"2324346a!@#$%^*()_+-=':;.,/?{}[]|\")" ,
-             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"asf123\" value=\"2324346a!@#$%^*()_+-=':;.,/?{}[]|\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
+            new object[] { "TestRunParameters.Parameter(name= \"a_sf123_12\",value= \"2324346a!@#$%^*()_+-=':;.,/?{}[]|\")" ,
+             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"a_sf123_12\" value=\"2324346a!@#$%^*()_+-=':;.,/?{}[]|\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
             },
             new object[] { "TestRunParameters.Parameter(name = \"weburl\",value = \"http://localhost//abc\")" ,
              "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>"

--- a/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
@@ -298,52 +298,56 @@ namespace vstest.console.UnitTests.Processors
 
         public static IEnumerable<object[]> TestRunParameterArgInvalidTestCases()
         {
-            return new List<object[]>
-            {
-                new object[] { "TestRunParameters.Parameter(name=asf,value=rgq)" },
-                new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq\" )"},
-                new object[] { "TestRunParameters.Parameter( name=\"asf\",value=\"rgq\")" },
-                new object[] { "TestRunParametersParameter(name=\"asf\",value=\"rgq\")" },
-                new object[] { "TestRunParameters.Paramete(name=\"asf\",value=\"rgq\")" },
-                new object[] { "TestRunParameters.Parametername=\"asf\",value=\"rgq\")" },
-                new object[] { "TestRunParameters.Parameter(ame=\"asf\",value=\"rgq\")" },
-                new object[] { "TestRunParameters.Parameter(name\"asf\",value=\"rgq\")" },
-                new object[] { "TestRunParameters.Parameter(name=\"asf\" value=\"rgq\")" },
-                new object[] { "TestRunParameters.Parameter(name=\"asf\",alue=\"rgq\")" },
-                new object[] { "TestRunParameters.Parameter(name=\"asf\",value\"rgq\")" },
-                new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq\"" },
-                new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq\")wfds" },
-                new object[] { "TestRunParameters.Parameter(name=\"\",value=\"rgq\")" },
-                new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"\")" },
-                new object[] { "TestRunParameters.Parameter(name=asf\",value=\"rgq\")" },
-                new object[] { "TestRunParameters.Parameter(name=\"asf,value=\"rgq\")" },
-                new object[] { "TestRunParameters.Parameter(name=\"asf\",value=rgq\")" },
-                new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq)" },
-                new object[] { "TestRunParameters.Parameter(name=\"asf@#!\",value=\"rgq\")" },
-                new object[] { "TestRunParameters.Parameter(name=\"\",value=\"fgf\")" },
-                new object[] { "TestRunParameters.Parameter(name=\"gag\",value=\"\")" },
-                new object[] { "TestRunParameters.Parameter(name=\"gag\")" }
-            };
+            return invalidTestCases;
         }
+
+        private static readonly List<object[]> invalidTestCases = new List<object[]>
+        {
+            new object[] { "TestRunParameters.Parameter(name=asf,value=rgq)" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq\" )"},
+            new object[] { "TestRunParameters.Parameter( name=\"asf\",value=\"rgq\")" },
+            new object[] { "TestRunParametersParameter(name=\"asf\",value=\"rgq\")" },
+            new object[] { "TestRunParameters.Paramete(name=\"asf\",value=\"rgq\")" },
+            new object[] { "TestRunParameters.Parametername=\"asf\",value=\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(ame=\"asf\",value=\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name\"asf\",value=\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf\" value=\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf\",alue=\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf\",value\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq\"" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq\")wfds" },
+            new object[] { "TestRunParameters.Parameter(name=\"\",value=\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"\")" },
+            new object[] { "TestRunParameters.Parameter(name=asf\",value=\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf,value=\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq)" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf@#!\",value=\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"\",value=\"fgf\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"gag\",value=\"\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"gag\")" }
+        };
 
         public static IEnumerable<object[]> TestRunParameterArgValidTestCases()
         {
-            return new List<object[]> {
-                new object[] { "TestRunParameters.Parameter(name=\"weburl\",value=\"&><\")" ,
-                    "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"&amp;&gt;&lt;\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
-                },
-                new object[] { "TestRunParameters.Parameter(name=\"weburl\",value=\"http://localhost//abc\")" ,
-                    "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
-                },
-                new object[] { "TestRunParameters.Parameter(name= \"a_sf123_12\",value= \"2324346a!@#$%^*()_+-=':;.,/?{}[]|\")" ,
-                    "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"a_sf123_12\" value=\"2324346a!@#$%^*()_+-=':;.,/?{}[]|\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
-                },
-                new object[] { "TestRunParameters.Parameter(name = \"weburl\" , value = \"http://localhost//abc\")" ,
-                    "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
-                },
-            };
+            return validTestCases;
         }
 
+        private static readonly List<object[]> validTestCases = new List<object[]>
+        {
+            new object[] { "TestRunParameters.Parameter(name=\"weburl\",value=\"&><\")" ,
+             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"&amp;&gt;&lt;\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
+            },
+            new object[] { "TestRunParameters.Parameter(name=\"weburl\",value=\"http://localhost//abc\")" ,
+             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
+            },
+            new object[] { "TestRunParameters.Parameter(name= \"a_sf123_12\",value= \"2324346a!@#$%^*()_+-=':;.,/?{}[]|\")" ,
+             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"a_sf123_12\" value=\"2324346a!@#$%^*()_+-=':;.,/?{}[]|\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
+            },
+            new object[] { "TestRunParameters.Parameter(name = \"weburl\" , value = \"http://localhost//abc\")" ,
+             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
+            },
+        };
         #endregion
     }
 }

--- a/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
@@ -24,6 +24,7 @@ namespace vstest.console.UnitTests.Processors
         private const string DefaultRunSettings = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n</RunSettings>";
         private const string RunSettingsWithDeploymentDisabled = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <MSTest>\r\n    <DeploymentEnabled>False</DeploymentEnabled>\r\n  </MSTest>\r\n</RunSettings>";
         private const string RunSettingsWithDeploymentEnabled = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <MSTest>\r\n    <DeploymentEnabled>True</DeploymentEnabled>\r\n  </MSTest>\r\n</RunSettings>";
+        private const string RunSettingsWithTestRunParameters = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>";
 
         [TestInitialize]
         public void Init()
@@ -131,6 +132,17 @@ namespace vstest.console.UnitTests.Processors
 
             Assert.IsNotNull(this.settingsProvider.ActiveRunSettings);
             Assert.AreEqual(RunSettingsWithDeploymentDisabled, settingsProvider.ActiveRunSettings.SettingsXml);
+        }
+
+        [TestMethod]
+        public void InitializeShouldValidateTestRunParameter()
+        {
+            var args = new string[] { "TestRunParameters.Parameter(name=weburl,value=http://localhost//abc)" };
+
+            this.executor.Initialize(args);
+
+            Assert.IsNotNull(this.settingsProvider.ActiveRunSettings);
+            Assert.AreEqual(RunSettingsWithTestRunParameters, settingsProvider.ActiveRunSettings.SettingsXml);
         }
 
         [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
@@ -24,7 +24,6 @@ namespace vstest.console.UnitTests.Processors
         private const string DefaultRunSettings = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n</RunSettings>";
         private const string RunSettingsWithDeploymentDisabled = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <MSTest>\r\n    <DeploymentEnabled>False</DeploymentEnabled>\r\n  </MSTest>\r\n</RunSettings>";
         private const string RunSettingsWithDeploymentEnabled = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <MSTest>\r\n    <DeploymentEnabled>True</DeploymentEnabled>\r\n  </MSTest>\r\n</RunSettings>";
-        private const string RunSettingsWithTestRunParameters = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>";
 
         [TestInitialize]
         public void Init()
@@ -140,9 +139,10 @@ namespace vstest.console.UnitTests.Processors
             var args = new string[] { "TestRunParameters.Parameter(name=weburl,value=http://localhost//abc)" };
 
             this.executor.Initialize(args);
+            var runSettingsWithTestRunParameters = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>";
 
             Assert.IsNotNull(this.settingsProvider.ActiveRunSettings);
-            Assert.AreEqual(RunSettingsWithTestRunParameters, settingsProvider.ActiveRunSettings.SettingsXml);
+            Assert.AreEqual(runSettingsWithTestRunParameters, settingsProvider.ActiveRunSettings.SettingsXml);
         }
 
         [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
@@ -123,6 +123,19 @@ namespace vstest.console.UnitTests.Processors
             Assert.AreEqual(RunSettingsWithDeploymentDisabled, settingsProvider.ActiveRunSettings.SettingsXml);
         }
 
+        [DataRow("Testameter.Parameter(name=\"asf\",value=\"rgq\")")]
+        [DataRow("TestRunParameter.Parameter(name=\"asf\",value=\"rgq\")")]
+        [TestMethod]
+        public void InitializeShouldThrowErrorIfArgumentIsInValid(string arg)
+        {
+            var args = new string[] { arg };
+            var str = string.Format(CommandLineResources.MalformedRunSettingsKey);
+
+            CommandLineException ex = Assert.ThrowsException<CommandLineException>(() => this.executor.Initialize(args));
+
+            Assert.AreEqual(str, ex.Message);
+        }
+
         [TestMethod]
         public void InitializeShouldIgnoreWhiteSpaceInBeginningOrEndOfKey()
         {
@@ -133,96 +146,6 @@ namespace vstest.console.UnitTests.Processors
             Assert.IsNotNull(this.settingsProvider.ActiveRunSettings);
             Assert.AreEqual(RunSettingsWithDeploymentDisabled, settingsProvider.ActiveRunSettings.SettingsXml);
         }
-
-        [DynamicData(nameof(ValidTestCases), DynamicDataSourceType.Method)]
-        [DataTestMethod]
-        public void InitializeShouldValidateTestRunParameter(string arg, string runSettingsWithTestRunParameters)
-        {
-            var args = new string[] { arg };
-
-            this.executor.Initialize(args);
-
-            Assert.IsNotNull(this.settingsProvider.ActiveRunSettings);
-            Assert.AreEqual(runSettingsWithTestRunParameters, settingsProvider.ActiveRunSettings.SettingsXml);
-        }
-
-        [DynamicData(nameof(InvalidTestCases), DynamicDataSourceType.Method)]
-        [DataTestMethod]
-        public void InitializeShouldThrowErrorIfTestRunParameterNodeIsInValid(string arg)
-        {
-            var args = new string[] { arg };
-            var str = string.Format(CommandLineResources.InvalidTestRunParameterArgument, arg);
-
-            CommandLineException ex = Assert.ThrowsException<CommandLineException>(() => this.executor.Initialize(args));
-
-            Assert.AreEqual(str, ex.Message);
-        }
-
-        [DataRow("Testameter.Parameter(name=\"asf\",value=\"rgq\")")]
-        [DataRow("TestRunParameter.Parameter(name=\"asf\",value=\"rgq\")")]
-        [TestMethod]
-        public void InitializeShouldThrowErrorIfTestRunParameterNodeNameIsInValid(string arg)
-        {
-            var args = new string[] { arg };
-            var str = string.Format(CommandLineResources.MalformedRunSettingsKey);
-
-            CommandLineException ex = Assert.ThrowsException<CommandLineException>(() => this.executor.Initialize(args));
-
-            Assert.AreEqual(str, ex.Message);
-        }
-
-        public static IEnumerable<object[]> InvalidTestCases()
-        {
-            return invalidTestCases;
-        }
-
-        private static readonly List<object[]> invalidTestCases = new List<object[]>
-        {
-            new object[] { "TestRunParameters.Parameter(name=asf,value=rgq)" },
-            new object[] {  "TestRunParameters.Parameter(name=\"asf\",value=\"rgq\" )"},
-            new object[] { "TestRunParameters.Parameter( name=\"asf\",value=\"rgq\")" },
-            new object[] { "TestRunParametersParameter(name=\"asf\",value=\"rgq\")" },
-            new object[] { "TestRunParameters.Paramete(name=\"asf\",value=\"rgq\")" },
-            new object[] { "TestRunParameters.Parametername=\"asf\",value=\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(ame=\"asf\",value=\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name\"asf\",value=\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf\" value=\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf\",alue=\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf\",value\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq\"" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq\")wfds" },
-            new object[] { "TestRunParameters.Parameter(name=\"\",value=\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"\")" },
-            new object[] { "TestRunParameters.Parameter(name=asf\",value=\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf,value=\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq)" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf@#!\",value=\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"\",value=\"fgf\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"gag\",value=\"\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"gag\")" }
-        };
-
-        public static IEnumerable<object[]> ValidTestCases()
-        {
-            return validTestCases;
-        }
-
-        private static readonly List<object[]> validTestCases = new List<object[]>
-        {
-            new object[] { "TestRunParameters.Parameter(name=\"weburl\",value=\"&><\")" ,
-             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"&amp;&gt;&lt;\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
-            },
-            new object[] { "TestRunParameters.Parameter(name=\"weburl\",value=\"http://localhost//abc\")" ,
-             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
-            },
-            new object[] { "TestRunParameters.Parameter(name= \"a_sf123_12\",value= \"2324346a!@#$%^*()_+-=':;.,/?{}[]|\")" ,
-             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"a_sf123_12\" value=\"2324346a!@#$%^*()_+-=':;.,/?{}[]|\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
-            },
-            new object[] { "TestRunParameters.Parameter(name = \"weburl\",value = \"http://localhost//abc\")" ,
-             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
-            },
-        };
 
         [TestMethod]
         public void InitializeShouldIgnoreThrowExceptionIfKeyHasWhiteSpace()
@@ -349,6 +272,82 @@ namespace vstest.console.UnitTests.Processors
             Assert.IsFalse(this.commandLineOptions.FrameworkVersionSpecified);
         }
 
+        [DynamicData(nameof(TestRunParameterArgValidTestCases), DynamicDataSourceType.Method)]
+        [DataTestMethod]
+        public void InitializeShouldValidateTestRunParameter(string arg, string runSettingsWithTestRunParameters)
+        {
+            var args = new string[] { arg };
+
+            this.executor.Initialize(args);
+
+            Assert.IsNotNull(this.settingsProvider.ActiveRunSettings);
+            Assert.AreEqual(runSettingsWithTestRunParameters, settingsProvider.ActiveRunSettings.SettingsXml);
+        }
+
+        [DynamicData(nameof(TestRunParameterArgInvalidTestCases), DynamicDataSourceType.Method)]
+        [DataTestMethod]
+        public void InitializeShouldThrowErrorIfTestRunParameterNodeIsInValid(string arg)
+        {
+            var args = new string[] { arg };
+            var str = string.Format(CommandLineResources.InvalidTestRunParameterArgument, arg);
+
+            CommandLineException ex = Assert.ThrowsException<CommandLineException>(() => this.executor.Initialize(args));
+
+            Assert.AreEqual(str, ex.Message);
+        }
+
+        public static IEnumerable<object[]> TestRunParameterArgInvalidTestCases()
+        {
+            return invalidTestCases;
+        }
+
+        private static readonly List<object[]> invalidTestCases = new List<object[]>
+        {
+            new object[] { "TestRunParameters.Parameter(name=asf,value=rgq)" },
+            new object[] {  "TestRunParameters.Parameter(name=\"asf\",value=\"rgq\" )"},
+            new object[] { "TestRunParameters.Parameter( name=\"asf\",value=\"rgq\")" },
+            new object[] { "TestRunParametersParameter(name=\"asf\",value=\"rgq\")" },
+            new object[] { "TestRunParameters.Paramete(name=\"asf\",value=\"rgq\")" },
+            new object[] { "TestRunParameters.Parametername=\"asf\",value=\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(ame=\"asf\",value=\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name\"asf\",value=\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf\" value=\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf\",alue=\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf\",value\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq\"" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq\")wfds" },
+            new object[] { "TestRunParameters.Parameter(name=\"\",value=\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"\")" },
+            new object[] { "TestRunParameters.Parameter(name=asf\",value=\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf,value=\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq)" },
+            new object[] { "TestRunParameters.Parameter(name=\"asf@#!\",value=\"rgq\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"\",value=\"fgf\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"gag\",value=\"\")" },
+            new object[] { "TestRunParameters.Parameter(name=\"gag\")" }
+        };
+
+        public static IEnumerable<object[]> TestRunParameterArgValidTestCases()
+        {
+            return validTestCases;
+        }
+
+        private static readonly List<object[]> validTestCases = new List<object[]>
+        {
+            new object[] { "TestRunParameters.Parameter(name=\"weburl\",value=\"&><\")" ,
+             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"&amp;&gt;&lt;\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
+            },
+            new object[] { "TestRunParameters.Parameter(name=\"weburl\",value=\"http://localhost//abc\")" ,
+             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
+            },
+            new object[] { "TestRunParameters.Parameter(name= \"a_sf123_12\",value= \"2324346a!@#$%^*()_+-=':;.,/?{}[]|\")" ,
+             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"a_sf123_12\" value=\"2324346a!@#$%^*()_+-=':;.,/?{}[]|\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
+            },
+            new object[] { "TestRunParameters.Parameter(name = \"weburl\" , value = \"http://localhost//abc\")" ,
+             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
+            },
+        };
         #endregion
     }
 }

--- a/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
@@ -134,10 +134,12 @@ namespace vstest.console.UnitTests.Processors
             Assert.AreEqual(RunSettingsWithDeploymentDisabled, settingsProvider.ActiveRunSettings.SettingsXml);
         }
 
+        [DataRow("TestRunParameters.Parameter(name= \"weburl\",value= \"http://localhost//abc\")")]
+        [DataRow("TestRunParameters.Parameter(name= weburl ,value= http://localhost//abc)" )]
         [TestMethod]
-        public void InitializeShouldValidateTestRunParameter()
+        public void InitializeShouldValidateTestRunParameter(string arg)
         {
-            var args = new string[] { "TestRunParameters.Parameter(name=weburl,value=http://localhost//abc)" };
+            var args = new string[] {arg };
 
             this.executor.Initialize(args);
             var runSettingsWithTestRunParameters = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>";
@@ -154,7 +156,6 @@ namespace vstest.console.UnitTests.Processors
 
             CommandLineException ex = Assert.ThrowsException<CommandLineException>(() => this.executor.Initialize(args));
             Assert.AreEqual(str, ex.Message);
-
         }
 
         [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
@@ -14,6 +14,7 @@ namespace vstest.console.UnitTests.Processors
     using Microsoft.VisualStudio.TestPlatform.Common;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;
 
     [TestClass]
     public class CLIRunSettingsArgumentProcessorTests
@@ -143,6 +144,17 @@ namespace vstest.console.UnitTests.Processors
 
             Assert.IsNotNull(this.settingsProvider.ActiveRunSettings);
             Assert.AreEqual(runSettingsWithTestRunParameters, settingsProvider.ActiveRunSettings.SettingsXml);
+        }
+
+        [TestMethod]
+        public void InitializeShouldThrowErrorIfTestRunParameterNodeIsInValid()
+        {
+            var args = new string[] { "TestRunParameters.Parameter(foo=bar)" };
+            var str = string.Format(CommandLineResources.InvalidTestRunParameterArgument, args[0]);
+
+            CommandLineException ex = Assert.ThrowsException<CommandLineException>(() => this.executor.Initialize(args));
+            Assert.AreEqual(str, ex.Message);
+
         }
 
         [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
@@ -298,56 +298,52 @@ namespace vstest.console.UnitTests.Processors
 
         public static IEnumerable<object[]> TestRunParameterArgInvalidTestCases()
         {
-            return invalidTestCases;
+            return new List<object[]>
+            {
+                new object[] { "TestRunParameters.Parameter(name=asf,value=rgq)" },
+                new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq\" )"},
+                new object[] { "TestRunParameters.Parameter( name=\"asf\",value=\"rgq\")" },
+                new object[] { "TestRunParametersParameter(name=\"asf\",value=\"rgq\")" },
+                new object[] { "TestRunParameters.Paramete(name=\"asf\",value=\"rgq\")" },
+                new object[] { "TestRunParameters.Parametername=\"asf\",value=\"rgq\")" },
+                new object[] { "TestRunParameters.Parameter(ame=\"asf\",value=\"rgq\")" },
+                new object[] { "TestRunParameters.Parameter(name\"asf\",value=\"rgq\")" },
+                new object[] { "TestRunParameters.Parameter(name=\"asf\" value=\"rgq\")" },
+                new object[] { "TestRunParameters.Parameter(name=\"asf\",alue=\"rgq\")" },
+                new object[] { "TestRunParameters.Parameter(name=\"asf\",value\"rgq\")" },
+                new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq\"" },
+                new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq\")wfds" },
+                new object[] { "TestRunParameters.Parameter(name=\"\",value=\"rgq\")" },
+                new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"\")" },
+                new object[] { "TestRunParameters.Parameter(name=asf\",value=\"rgq\")" },
+                new object[] { "TestRunParameters.Parameter(name=\"asf,value=\"rgq\")" },
+                new object[] { "TestRunParameters.Parameter(name=\"asf\",value=rgq\")" },
+                new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq)" },
+                new object[] { "TestRunParameters.Parameter(name=\"asf@#!\",value=\"rgq\")" },
+                new object[] { "TestRunParameters.Parameter(name=\"\",value=\"fgf\")" },
+                new object[] { "TestRunParameters.Parameter(name=\"gag\",value=\"\")" },
+                new object[] { "TestRunParameters.Parameter(name=\"gag\")" }
+            };
         }
-
-        private static readonly List<object[]> invalidTestCases = new List<object[]>
-        {
-            new object[] { "TestRunParameters.Parameter(name=asf,value=rgq)" },
-            new object[] {  "TestRunParameters.Parameter(name=\"asf\",value=\"rgq\" )"},
-            new object[] { "TestRunParameters.Parameter( name=\"asf\",value=\"rgq\")" },
-            new object[] { "TestRunParametersParameter(name=\"asf\",value=\"rgq\")" },
-            new object[] { "TestRunParameters.Paramete(name=\"asf\",value=\"rgq\")" },
-            new object[] { "TestRunParameters.Parametername=\"asf\",value=\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(ame=\"asf\",value=\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name\"asf\",value=\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf\" value=\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf\",alue=\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf\",value\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq\"" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq\")wfds" },
-            new object[] { "TestRunParameters.Parameter(name=\"\",value=\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"\")" },
-            new object[] { "TestRunParameters.Parameter(name=asf\",value=\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf,value=\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf\",value=\"rgq)" },
-            new object[] { "TestRunParameters.Parameter(name=\"asf@#!\",value=\"rgq\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"\",value=\"fgf\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"gag\",value=\"\")" },
-            new object[] { "TestRunParameters.Parameter(name=\"gag\")" }
-        };
 
         public static IEnumerable<object[]> TestRunParameterArgValidTestCases()
         {
-            return validTestCases;
+            return new List<object[]> {
+                new object[] { "TestRunParameters.Parameter(name=\"weburl\",value=\"&><\")" ,
+                    "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"&amp;&gt;&lt;\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
+                },
+                new object[] { "TestRunParameters.Parameter(name=\"weburl\",value=\"http://localhost//abc\")" ,
+                    "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
+                },
+                new object[] { "TestRunParameters.Parameter(name= \"a_sf123_12\",value= \"2324346a!@#$%^*()_+-=':;.,/?{}[]|\")" ,
+                    "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"a_sf123_12\" value=\"2324346a!@#$%^*()_+-=':;.,/?{}[]|\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
+                },
+                new object[] { "TestRunParameters.Parameter(name = \"weburl\" , value = \"http://localhost//abc\")" ,
+                    "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
+                },
+            };
         }
 
-        private static readonly List<object[]> validTestCases = new List<object[]>
-        {
-            new object[] { "TestRunParameters.Parameter(name=\"weburl\",value=\"&><\")" ,
-             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"&amp;&gt;&lt;\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
-            },
-            new object[] { "TestRunParameters.Parameter(name=\"weburl\",value=\"http://localhost//abc\")" ,
-             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
-            },
-            new object[] { "TestRunParameters.Parameter(name= \"a_sf123_12\",value= \"2324346a!@#$%^*()_+-=':;.,/?{}[]|\")" ,
-             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"a_sf123_12\" value=\"2324346a!@#$%^*()_+-=':;.,/?{}[]|\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
-            },
-            new object[] { "TestRunParameters.Parameter(name = \"weburl\" , value = \"http://localhost//abc\")" ,
-             "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"weburl\" value=\"http://localhost//abc\" />\r\n  </TestRunParameters>\r\n</RunSettings>"
-            },
-        };
         #endregion
     }
 }


### PR DESCRIPTION
The following error is shown when TestRunParameter Argument is invalid.
![testrunparameter](https://user-images.githubusercontent.com/39301309/69848210-6877c080-129f-11ea-9e3e-52f0629d4900.PNG)
