### PR TITLE
Fixed the fqdn mapping for the method name in the trx file

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestMethod.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestMethod.cs
@@ -24,7 +24,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         {
             Debug.Assert(!string.IsNullOrEmpty(name), "name is null");
             Debug.Assert(!string.IsNullOrEmpty(className), "className is null");
-            this.name = name;
+            this.name = name.StartsWith($"{ClassName}.") ? name.Remove(0, $"{ClassName}.".Length) : name;
             this.className = className;
         }
 

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
@@ -684,7 +684,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.Utility
             {
                 var codeBase = source;
                 var className = GetTestClassName(name, fullyQualifiedName, source);
-                var testMethod = new TestMethod(name, className);
+                var testMethod = new TestMethod(fullyQualifiedName, className);
 
                 testElement = new UnitTestElement(testId, name, adapter, testMethod);
                 (testElement as UnitTestElement).CodeBase = codeBase;


### PR DESCRIPTION
## Description
Fixed the method name field in the UnitTestDefinition node of the trx to contain the FQDN instead of the display name of the method