### PR TITLE
Trx changes for fqdn mapping in test method name

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestMethod.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestMethod.cs
@@ -24,8 +24,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         {
             Debug.Assert(!string.IsNullOrEmpty(name), "name is null");
             Debug.Assert(!string.IsNullOrEmpty(className), "className is null");
-            this.name = name.StartsWith(className) ? name.Remove(0, $"{className}.".Length) : name;
-
+            this.name = name;
             this.className = className;
         }
 

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestMethod.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestMethod.cs
@@ -24,7 +24,8 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         {
             Debug.Assert(!string.IsNullOrEmpty(name), "name is null");
             Debug.Assert(!string.IsNullOrEmpty(className), "className is null");
-            this.name = name;
+            this.name = name.StartsWith(className) ? name.Remove(0, $"{className}.".Length) : name;
+
             this.className = className;
         }
 

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
@@ -684,7 +684,8 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.Utility
             {
                 var codeBase = source;
                 var className = GetTestClassName(name, fullyQualifiedName, source);
-                var testMethod = new TestMethod(fullyQualifiedName, className);
+                var testMethodName = fullyQualifiedName.StartsWith(className) ? fullyQualifiedName.Remove(0, $"{className}.".Length) : fullyQualifiedName;
+                var testMethod = new TestMethod(testMethodName, className);
 
                 testElement = new UnitTestElement(testId, name, adapter, testMethod);
                 (testElement as UnitTestElement).CodeBase = codeBase;

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
@@ -684,7 +684,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.Utility
             {
                 var codeBase = source;
                 var className = GetTestClassName(name, fullyQualifiedName, source);
-                var testMethod = new TestMethod(name, className);
+                var testMethod = new TestMethod(fullyQualifiedName, className);
 
                 testElement = new UnitTestElement(testId, name, adapter, testMethod);
                 (testElement as UnitTestElement).CodeBase = codeBase;

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/Utility/ConverterTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/Utility/ConverterTests.cs
@@ -167,9 +167,10 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests.Utility
             TestPlatformObjectModel.TestResult result = new TestPlatformObjectModel.TestResult(testCase);
 
             var unitTestElement = this.converter.ToTestElement(testCase.Id, Guid.Empty, Guid.Empty, testName, TrxLoggerConstants.UnitTestType, testCase) as UnitTestElement;
+            var expectedTestName = fullyQualifiedName.StartsWith(expectedClassName) ? fullyQualifiedName.Remove(0, $"{expectedClassName}.".Length) : fullyQualifiedName;
 
             Assert.AreEqual(expectedClassName, unitTestElement.TestMethod.ClassName);
-            Assert.AreEqual(testName, unitTestElement.TestMethod.Name);
+            Assert.AreEqual(expectedTestName, unitTestElement.TestMethod.Name);
         }
 
         private static TestCase CreateTestCase(string fullyQualifiedName)


### PR DESCRIPTION
Fixing data driven xunit method name.

![image](https://user-images.githubusercontent.com/13175100/69964907-4dc07880-1539-11ea-8542-fd1acf393cbc.png)
![image](https://user-images.githubusercontent.com/13175100/69964952-54e78680-1539-11ea-9bb1-eb9b951427e6.png)

The execution id and the test Id is linking attributes between the 2 nodes. The result node will remain as is and it today contains the display name for the result which translates to test run title in the pipeline. 
In the Unit Test definition node the method name of xunit test is "XUnitTestProject.UnitTest1.Test1(a: 1)" which technically speaking is not correct. It has to be "XUnitTestProject.UnitTest1.Test1" and we are not losing any data this way as the result display name still remains the same.

This fix is taken as part of running the data driven xunit tests in pipeline