### PR TITLE
Remove duplicate counting of test results in Consolelogger

### DIFF
--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Diagnostics;
@@ -85,6 +86,16 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
         /// </summary>
         public const string NoProgressParam = "noprogress";
 
+        /// <summary>
+        ///  Property Id storing the ParentExecutionId.
+        /// </summary>
+        public const string ParentExecutionIdPropertyIdentifier = "ParentExecId";
+
+        /// <summary>
+        ///  Property Id storing the ExecutionId.
+        /// </summary>
+        public const string ExecutionIdPropertyIdentifier = "ExecutionId";
+
         #endregion
 
         internal enum Verbosity
@@ -107,11 +118,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
         private Verbosity verbosityLevel = Verbosity.Minimal;
 #endif
 
-        private int testsTotal = 0;
-        private int testsPassed = 0;
-        private int testsFailed = 0;
-        private int testsSkipped = 0;
         private bool testRunHasErrorMessages = false;
+        private ConcurrentDictionary<Guid, TestOutcome> leafExecutionIdAndTestOutcomePairDictionary = new ConcurrentDictionary<Guid, TestOutcome>();
 
         #endregion
 
@@ -371,6 +379,29 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
             }
         }
 
+        private Guid GetParentExecutionId(TestResult testResult)
+        {
+            var parentExecutionIdProperty = testResult.Properties.FirstOrDefault(property =>
+                property.Id.Equals(ParentExecutionIdPropertyIdentifier));
+            return parentExecutionIdProperty == null
+                ? Guid.Empty
+                : testResult.GetPropertyValue(parentExecutionIdProperty, Guid.Empty);
+        }
+
+        private Guid GetExecutionId(TestResult testResult)
+        {
+            var executionIdProperty = testResult.Properties.FirstOrDefault(property =>
+                property.Id.Equals(ExecutionIdPropertyIdentifier));
+            var executionId = Guid.Empty;
+
+            if (executionIdProperty != null)
+            {
+                executionId = testResult.GetPropertyValue(executionIdProperty, Guid.Empty);
+            }
+
+            return executionId.Equals(Guid.Empty) ? Guid.NewGuid() : executionId;
+        }
+
         #endregion
 
         #region Event Handlers
@@ -468,9 +499,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
             ValidateArg.NotNull<object>(sender, "sender");
             ValidateArg.NotNull<TestResultEventArgs>(e, "e");
 
-            // Update the test count statistics based on the result of the test. 
-            this.testsTotal++;
-
             var testDisplayName = e.Result.DisplayName;
 
             if (string.IsNullOrWhiteSpace(e.Result.DisplayName))
@@ -484,11 +512,20 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
                 testDisplayName = string.Format("{0} [{1}]", testDisplayName, formattedDuration);
             }
 
+            var executionId = GetExecutionId(e.Result);
+            var parentExecutionId = GetParentExecutionId(e.Result);
+
+            if (parentExecutionId != null && leafExecutionIdAndTestOutcomePairDictionary.ContainsKey(parentExecutionId))
+            {
+                leafExecutionIdAndTestOutcomePairDictionary.TryRemove(parentExecutionId, out var value);
+            }
+
+            leafExecutionIdAndTestOutcomePairDictionary.TryAdd(executionId, e.Result.Outcome);
+
             switch (e.Result.Outcome)
             {
                 case TestOutcome.Skipped:
                     {
-                        this.testsSkipped++;
                         if (this.verbosityLevel == Verbosity.Quiet)
                         {
                             break;
@@ -512,7 +549,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
 
                 case TestOutcome.Failed:
                     {
-                        this.testsFailed++;
                         if (this.verbosityLevel == Verbosity.Quiet)
                         {
                             break;
@@ -533,7 +569,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
 
                 case TestOutcome.Passed:
                     {
-                        this.testsPassed++;
                         if (this.verbosityLevel == Verbosity.Normal || this.verbosityLevel == Verbosity.Detailed)
                         {
                             // Pause the progress indicator before displaying test result information
@@ -617,6 +652,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
         /// </summary>
         private void TestRunCompleteHandler(object sender, TestRunCompleteEventArgs e)
         {
+            var testsTotal = 0;
+            var testsPassed = 0;
+            var testsFailed = 0;
+            var testsSkipped = 0;
             // Stop the progress indicator as we are about to print the summary
             this.progressIndicator?.Stop();
             Output.WriteLine(string.Empty, OutputLevel.Information);
@@ -636,6 +675,25 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
                 }
             }
 
+            foreach (KeyValuePair<Guid, TestOutcome> entry in leafExecutionIdAndTestOutcomePairDictionary)
+            {
+                testsTotal++;
+                switch (entry.Value)
+                {
+                    case TestOutcome.Failed:
+                        testsFailed++;
+                        break;
+                    case TestOutcome.Passed:
+                        testsPassed++;
+                        break;
+                    case TestOutcome.Skipped:
+                        testsSkipped++;
+                        break;
+                    default:
+                        break;
+                }
+            }
+
             if (e.IsCanceled)
             {
                 Output.Error(false, CommandLineResources.TestRunCanceled);
@@ -644,7 +702,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
             {
                 Output.Error(false, CommandLineResources.TestRunAborted);
             }
-            else if (this.testsFailed > 0 || this.testRunHasErrorMessages)
+            else if (testsFailed > 0 || this.testRunHasErrorMessages)
             {
                 Output.Error(false, CommandLineResources.TestRunFailed);
             }

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -525,7 +525,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
             var executionId = GetExecutionId(e.Result);
             var parentExecutionId = GetParentExecutionId(e.Result);
 
-            if (parentExecutionId != null && leafExecutionIdAndTestOutcomePairDictionary.ContainsKey(parentExecutionId))
+            if (parentExecutionId != Guid.Empty && leafExecutionIdAndTestOutcomePairDictionary.ContainsKey(parentExecutionId))
             {
                 leafExecutionIdAndTestOutcomePairDictionary.TryRemove(parentExecutionId, out _);
             }

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -527,7 +527,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
 
             if (parentExecutionId != null && leafExecutionIdAndTestOutcomePairDictionary.ContainsKey(parentExecutionId))
             {
-                leafExecutionIdAndTestOutcomePairDictionary.TryRemove(parentExecutionId, out var value);
+                leafExecutionIdAndTestOutcomePairDictionary.TryRemove(parentExecutionId, out _);
             }
 
             leafExecutionIdAndTestOutcomePairDictionary.TryAdd(executionId, e.Result.Outcome);
@@ -662,7 +662,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
         /// </summary>
         private void TestRunCompleteHandler(object sender, TestRunCompleteEventArgs e)
         {
-            //System.Diagnostics.Debugger.Launch();
             var testsTotal = 0;
             var testsPassed = 0;
             var testsFailed = 0;

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -379,6 +379,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
             }
         }
 
+        /// <summary>
+        /// Returns the parent Execution id of given test result. 
+        /// </summary>
+        /// <param name="testResult"></param>
+        /// <returns></returns>
         private Guid GetParentExecutionId(TestResult testResult)
         {
             var parentExecutionIdProperty = testResult.Properties.FirstOrDefault(property =>
@@ -388,6 +393,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
                 : testResult.GetPropertyValue(parentExecutionIdProperty, Guid.Empty);
         }
 
+        /// <summary>
+        /// Returns execution id of given test result
+        /// </summary>
+        /// <param name="testResult"></param>
+        /// <returns></returns>
         private Guid GetExecutionId(TestResult testResult)
         {
             var executionIdProperty = testResult.Properties.FirstOrDefault(property =>
@@ -652,6 +662,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
         /// </summary>
         private void TestRunCompleteHandler(object sender, TestRunCompleteEventArgs e)
         {
+            //System.Diagnostics.Debugger.Launch();
             var testsTotal = 0;
             var testsPassed = 0;
             var testsFailed = 0;

--- a/test/Microsoft.TestPlatform.AcceptanceTests/OrderedTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/OrderedTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             this.ValidateFailedTests("FailingTest1");
             this.ValidateSkippedTests("FailingTest2");
             // Parent test result should fail as inner results contain failing test.
-            this.ValidateSummaryStatus(2, 2, 1);
+            this.ValidateSummaryStatus(2, 1, 1);
         }
     }
 }

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -1046,6 +1046,51 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
             this.mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.AttachmentOutputFormat, uriDataAttachment1.Uri.LocalPath), OutputLevel.Information), Times.Once());
         }
 
+        [TestMethod]
+        public void ResultscountInhierarchicalOrder()
+        {
+            var loggerEvents = new InternalTestLoggerEvents(TestSessionMessageLogger.Instance);
+            loggerEvents.EnableEvents();
+            var parameters = new Dictionary<string, string>();
+            parameters.Add("verbosity", "normal");
+            this.consoleLogger.Initialize(loggerEvents, parameters);
+
+            TestCase testCase1 = CreateTestCase("TestCase1");
+            TestCase testCase2 = CreateTestCase("TestCase2");
+            TestCase testCase3 = CreateTestCase("TestCase3");
+
+            Guid parentExecutionId = Guid.NewGuid();
+            TestProperty ParentExecIdProperty = TestProperty.Register("ParentExecId", "ParentExecId", typeof(Guid), TestPropertyAttributes.Hidden, typeof(ObjectModel.TestResult));
+            TestProperty ExecutionIdProperty = TestProperty.Register("ExecutionId", "ExecutionId", typeof(Guid), TestPropertyAttributes.Hidden, typeof(ObjectModel.TestResult));
+            TestProperty TestTypeProperty = TestProperty.Register("TestType", "TestType" , typeof(Guid), TestPropertyAttributes.Hidden, typeof(ObjectModel.TestResult));
+
+            var result1 = new ObjectModel.TestResult(testCase1) { Outcome = TestOutcome.Failed };
+            result1.SetPropertyValue(ExecutionIdProperty, parentExecutionId);
+
+            var result2 = new ObjectModel.TestResult(testCase2) { Outcome = TestOutcome.Passed};
+            result2.SetPropertyValue(ExecutionIdProperty, Guid.NewGuid());
+            result2.SetPropertyValue(ParentExecIdProperty, parentExecutionId);
+
+            var result3 = new ObjectModel.TestResult(testCase3) { Outcome = TestOutcome.Failed };
+            result3.SetPropertyValue(ExecutionIdProperty, Guid.NewGuid());
+            result3.SetPropertyValue(ParentExecIdProperty, parentExecutionId);
+
+            loggerEvents.RaiseTestResult(new TestResultEventArgs(result1));
+            loggerEvents.RaiseTestResult(new TestResultEventArgs(result2));
+            loggerEvents.RaiseTestResult(new TestResultEventArgs(result3));
+
+            loggerEvents.CompleteTestRun(null, false, false, null, null, new TimeSpan(1, 0, 0, 0));
+
+            this.mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryFailedTests, 1), OutputLevel.Information), Times.Once());
+            this.mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryPassedTests, 1), OutputLevel.Information), Times.Once());
+            this.mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryTotalTests, 2), OutputLevel.Information), Times.Once());
+        }
+
+        private TestCase CreateTestCase(string testCaseName)
+        {
+            return new TestCase(testCaseName, new Uri("some://uri"), "DummySourceFileName");
+        }
+
         private void Setup()
         {
             this.mockRequestData = new Mock<IRequestData>();

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -1047,7 +1047,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Internal
         }
 
         [TestMethod]
-        public void ResultscountInhierarchicalOrder()
+        public void ResultsInHeirarchichalOrderShouldReportCorrectCount()
         {
             var loggerEvents = new InternalTestLoggerEvents(TestSessionMessageLogger.Instance);
             loggerEvents.EnableEvents();


### PR DESCRIPTION
## Description
Current behavior:
Recognizing parent result as passed ,failed or skipped and adding to respective counts.By this we are showing duplicate count.
ex:
Scenario:
if we have a parent test result(passed) and two child test results in  which one is passed and the other is failed.
current behavior:
total test =3
passed tests =1
Failed =2

expected behavior:
total tests =2
passed tests =1
failed tests =1

Approach :
Storing every result and it's outcome in dictionary. if it is recognized as parent then removing it from dictionary. By this way we end up with the dictionary that has non parent results and it's outcome. Finally counting the passed,failed, skipped and total in the resulting dictionary will give the expected behavior mentioned above

Assumed parent test result comes first and then the child test result comes.


 


## Related issue
Kindly link any related issues. E.g. Fixes #xyz.
