### PR TITLE
Disable reusing nodes when building localization

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -685,8 +685,8 @@ function Update-LocalizedResources
     }
 
     $localizationProject = Join-Path $env:TP_PACKAGE_PROJ_DIR "Localize\Localize.proj"
-    Write-Verbose "& $dotnetExe msbuild $localizationProject -m -nologo -v:minimal -t:Localize -p:LocalizeResources=true"
-    & $dotnetExe msbuild $localizationProject -m -nologo -v:minimal -t:Localize -p:LocalizeResources=true
+    Write-Verbose "& $dotnetExe msbuild $localizationProject -m -nologo -v:minimal -t:Localize -p:LocalizeResources=true -nodeReuse:False"
+    & $dotnetExe msbuild $localizationProject -m -nologo -v:minimal -t:Localize -p:LocalizeResources=true -nodeReuse:False
 
     Set-ScriptFailedOnError
 


### PR DESCRIPTION
## Description
Adds flag to msbuild to prevent it from keeping the build nodes active.
Keeping the nodes active makes them lock the assemblies that we built,
which in turn prevents the repository from being easily cleaned,
(e.g. by `git clean -Xfd`).

## Related issue
none
