### PR TITLE
Use RunSettingsFilePath from project file when using dotnet test

### DIFF
--- a/TestPlatform.sln
+++ b/TestPlatform.sln
@@ -179,7 +179,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.TestPlatform.Exte
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests", "test\Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests\Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests.csproj", "{41248B96-6E15-4E5E-A78F-859897676814}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "coverlet.collector", "test\TestAssets\coverlet.collector\coverlet.collector.csproj", "{F1D8630D-97D5-4CD7-BC18-A5E1779FA6E3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "coverlet.collector", "test\TestAssets\coverlet.collector\coverlet.collector.csproj", "{F1D8630D-97D5-4CD7-BC18-A5E1779FA6E3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectFileRunSettingsTestProject", "test\TestAssets\ProjectFileRunSettingsTestProject\ProjectFileRunSettingsTestProject.csproj", "{8E87F6E4-E884-4404-B2E5-CBFB28038AE5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -911,6 +913,18 @@ Global
 		{F1D8630D-97D5-4CD7-BC18-A5E1779FA6E3}.Release|x64.Build.0 = Release|Any CPU
 		{F1D8630D-97D5-4CD7-BC18-A5E1779FA6E3}.Release|x86.ActiveCfg = Release|Any CPU
 		{F1D8630D-97D5-4CD7-BC18-A5E1779FA6E3}.Release|x86.Build.0 = Release|Any CPU
+		{8E87F6E4-E884-4404-B2E5-CBFB28038AE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E87F6E4-E884-4404-B2E5-CBFB28038AE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E87F6E4-E884-4404-B2E5-CBFB28038AE5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8E87F6E4-E884-4404-B2E5-CBFB28038AE5}.Debug|x64.Build.0 = Debug|Any CPU
+		{8E87F6E4-E884-4404-B2E5-CBFB28038AE5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8E87F6E4-E884-4404-B2E5-CBFB28038AE5}.Debug|x86.Build.0 = Debug|Any CPU
+		{8E87F6E4-E884-4404-B2E5-CBFB28038AE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E87F6E4-E884-4404-B2E5-CBFB28038AE5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E87F6E4-E884-4404-B2E5-CBFB28038AE5}.Release|x64.ActiveCfg = Release|Any CPU
+		{8E87F6E4-E884-4404-B2E5-CBFB28038AE5}.Release|x64.Build.0 = Release|Any CPU
+		{8E87F6E4-E884-4404-B2E5-CBFB28038AE5}.Release|x86.ActiveCfg = Release|Any CPU
+		{8E87F6E4-E884-4404-B2E5-CBFB28038AE5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -988,6 +1002,7 @@ Global
 		{236A71E3-01DA-4679-9DFF-16A8E079ACFF} = {5E7F18A8-F843-4C8A-AB02-4C7D9205C6CF}
 		{41248B96-6E15-4E5E-A78F-859897676814} = {020E15EA-731F-4667-95AF-226671E0C3AE}
 		{F1D8630D-97D5-4CD7-BC18-A5E1779FA6E3} = {8DA7CBD9-F17E-41B6-90C4-CFF55848A25A}
+		{8E87F6E4-E884-4404-B2E5-CBFB28038AE5} = {8DA7CBD9-F17E-41B6-90C4-CFF55848A25A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0541B30C-FF51-4E28-B172-83F5F3934BCD}

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -213,6 +213,19 @@ function Invoke-Build
     Write-Log "Invoke-Build: Complete. {$(Get-ElapsedTime($timer))}"
 }
 
+function Publish-PatchedDotnet { 
+    Write-Log "Publish-PatchedDotnet: Copy local dotnet installation to testArtifacts"
+    $dotnetPath = "$env:TP_TOOLS_DIR\dotnet\"
+    
+    $dotnetTestArtifactsPath = "$env:TP_TESTARTIFACTS\dotnet\" 
+    $dotnetTestArtifactsSdkPath = "$env:TP_TESTARTIFACTS\dotnet\sdk\$env:DOTNET_CLI_VERSION\"
+    Copy-Item $dotnetPath $dotnetTestArtifactsPath -Force -Recurse
+
+    Write-Log "Publish-PatchedDotnet: Copy VSTest task artifacts to local dotnet installation to allow `dotnet test` to run with it"
+    $buildArtifactsPath = "$env:TP_ROOT_DIR\src\Microsoft.TestPlatform.Build\bin\$TPB_Configuration\$TPB_TargetFrameworkNS2_0\*"
+    Copy-Item $buildArtifactsPath $dotnetTestArtifactsSdkPath -Force
+}
+
 function Publish-Package
 {
     $timer = Start-Timer
@@ -901,9 +914,11 @@ Restore-Package
 Update-LocalizedResources
 Invoke-Build
 Publish-Package
+Publish-PatchedDotnet
 Publish-Tests
 Create-VsixPackage
 Create-NugetPackages
 Generate-Manifest
 Write-Log "Build complete. {$(Get-ElapsedTime($timer))}"
 if ($Script:ScriptFailed) { Exit 1 } else { Exit 0 }
+ 

--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
@@ -31,7 +31,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <Microsoft.TestPlatform.Build.Tasks.VSTestTask
       TestFileFullPath="$(TargetPath)"
-      VSTestSetting="$(VSTestSetting)"
+      VSTestSetting="$([MSBuild]::ValueOrDefault($(VSTestSetting), '$(RunSettingsFilePath)'))"
       VSTestTestAdapterPath="$(VSTestTestAdapterPath)"
       VSTestFramework="$(TargetFrameworkMoniker)"
       VSTestPlatform="$(PlatformTarget)"

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestEnvironment.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestEnvironment.cs
@@ -57,6 +57,7 @@ namespace Microsoft.TestPlatform.TestUtilities
             // Need to remove this assumption when we move to a CDP.
             this.PackageDirectory = Path.Combine(TestPlatformRootDirectory, @"packages");
             this.ToolsDirectory = Path.Combine(TestPlatformRootDirectory, @"tools");
+            this.TestArtifactsDirectory = Path.Combine(TestPlatformRootDirectory, "artifacts", "testArtifacts");
             this.RunnerFramework = "net451";
         }
 
@@ -194,6 +195,15 @@ namespace Microsoft.TestPlatform.TestUtilities
         }
 
         /// <summary>
+        /// Gets the test artifacts directory.
+        /// </summary>
+        public string TestArtifactsDirectory
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
         /// Gets the application type.
         /// Supported values = <c>net451</c>, <c>netcoreapp1.0</c>.
         /// </summary>
@@ -292,6 +302,31 @@ namespace Microsoft.TestPlatform.TestUtilities
             }
 
             return dependencyProps;
+        }
+
+        /// <summary>
+        /// Gets the full path to a test asset.
+        /// </summary>
+        /// <param name="assetName">Name of the asset with extension. E.g. <c>SimpleUnitTest.csproj</c></param>
+        /// <returns>Full path to the test asset.</returns>
+        /// <remarks>
+        /// Test assets follow several conventions:
+        /// (a) They are built for supported frameworks. See <see cref="TargetFramework"/>.
+        /// (b) They are built for provided build configuration.
+        /// (c) Name of the test asset matches the parent directory name. E.g. <c>TestAssets\SimpleUnitTest\SimpleUnitTest.csproj</c> must
+        /// produce <c>TestAssets\SimpleUnitTest\SimpleUnitTest.csproj</c>
+        /// </remarks>
+        public string GetTestProject(string assetName)
+        {
+            var simpleAssetName = Path.GetFileNameWithoutExtension(assetName);
+            var assetPath = Path.Combine(
+                this.TestAssetsPath,
+                simpleAssetName,
+                assetName);
+
+            Assert.IsTrue(File.Exists(assetPath), "GetTestAsset: Path not found: {0}.", assetPath);
+
+            return assetPath;
         }
     }
 }

--- a/test/TestAssets/ProjectFileRunSettingsTestProject/ProjectFileRunSettingsTestProject.csproj
+++ b/test/TestAssets/ProjectFileRunSettingsTestProject/ProjectFileRunSettingsTestProject.csproj
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Imports Common TestAssets props. -->
+  <Import Project="..\..\..\scripts\build\TestAssets.props" />
+  <Import Project="..\..\..\scripts\build\TestPlatform.Dependencies.props" />
+  <!-- Package dependency versions -->
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.1;net451</TargetFrameworks>
+    <PlatformTarget>x64</PlatformTarget>
+    <RunSettingsFilePath>fail.runsettings</RunSettingsFilePath>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestFramework">
+      <Version>$(MSTestFrameworkVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="MSTest.TestAdapter">
+      <Version>$(MSTestAdapterVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk">
+      <Version>$(NETTestSdkPreviousVersion)</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/test/TestAssets/ProjectFileRunSettingsTestProject/UnitTest1.cs
+++ b/test/TestAssets/ProjectFileRunSettingsTestProject/UnitTest1.cs
@@ -1,0 +1,20 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ProjectFileRunSettingsTestProject
+{
+    [TestClass]
+    public class UnitTest1
+    {
+        [TestMethod]
+        public void TestMethod1()
+        {
+            // this project specifies runsettings in it's proj file
+            // that runsettings say that inconclusive should translate to 
+            // failed. 
+            // we can then easily figure out if the settings were applied 
+            // correctly if we set the test as failed, or did not apply if the 
+            // test is shown as skipped
+            Assert.Inconclusive();
+        }
+    }
+}

--- a/test/TestAssets/ProjectFileRunSettingsTestProject/fail.runsettings
+++ b/test/TestAssets/ProjectFileRunSettingsTestProject/fail.runsettings
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <MSTest>
+    <MapInconclusiveToFailed>True</MapInconclusiveToFailed>
+  </MSTest>
+</RunSettings>

--- a/test/TestAssets/ProjectFileRunSettingsTestProject/inconclusive.runsettings
+++ b/test/TestAssets/ProjectFileRunSettingsTestProject/inconclusive.runsettings
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <MSTest>
+    <MapInconclusiveToFailed>False</MapInconclusiveToFailed>
+  </MSTest>
+</RunSettings>

--- a/test/TestAssets/TestAssets.sln/TestAssets.sln
+++ b/test/TestAssets/TestAssets.sln/TestAssets.sln
@@ -47,7 +47,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NewtonSoftDependency", "..\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AppDomainGetAssembliesTestProject", "..\AppDomainGetAssembliesTestProject\AppDomainGetAssembliesTestProject.csproj", "{BF090BCE-CC7D-4359-93E2-30F2B454F751}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EnvironmentVariablesTestProject", "..\EnvironmentVariablesTestProject\EnvironmentVariablesTestProject.csproj", "{BA53C202-55D6-4BBC-A24A-444B2D5F6309}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EnvironmentVariablesTestProject", "..\EnvironmentVariablesTestProject\EnvironmentVariablesTestProject.csproj", "{BA53C202-55D6-4BBC-A24A-444B2D5F6309}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProjectFileRunSettingsTestProject", "..\ProjectFileRunSettingsTestProject\ProjectFileRunSettingsTestProject.csproj", "{A0113409-56D3-4060-BD94-A4BA4739712D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -147,6 +149,10 @@ Global
 		{BA53C202-55D6-4BBC-A24A-444B2D5F6309}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BA53C202-55D6-4BBC-A24A-444B2D5F6309}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BA53C202-55D6-4BBC-A24A-444B2D5F6309}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A0113409-56D3-4060-BD94-A4BA4739712D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A0113409-56D3-4060-BD94-A4BA4739712D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A0113409-56D3-4060-BD94-A4BA4739712D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A0113409-56D3-4060-BD94-A4BA4739712D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Description

Uses the RunSettingsFilePath from project file when specified and falls
back to the one specified in console, or the default setting if none are
provided.

The path to the settings file can be specified in multiple ways,
for example as a path relative to the project file. This enables
`dotnet test` to be invoked against the project file directly.

```xml
<RunSettingsFilePath>$(ProjectDir)..\example.runsettings</RunSettingsFilePath>
```

Alternatively path can also be specified relatively to solution file, but that will
only work when running dotnet test against the solution. On the other hand the
setting will be the same in all projects.

```xml
<RunSettingsFilePath>$(SolutionDir)\example.runsettings</RunSettingsFilePath>
```

The setting file can be overridden by specifying `--settings` from the command line
to give flexibility in providing alternative runsettings.

## Related issue
Fixes #2265
