### PR TITLE
Initialize only coverlet data collector

### DIFF
--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
         private const string DotnetTestHostUri = "HostProvider://DotnetTestHost";
         private const string DotnetTestHostFriendlyName = "DotnetTestHost";
         private const string TestAdapterRegexPattern = @"TestAdapter.dll";
-        private const string DataCollectorRegexPattern = @"Collector.dll";
+        private const string CoverletDataCollectorRegexPattern = @"coverlet.collector.dll";
 
         private IDotnetHostHelper dotnetHostHelper;
         private IEnvironment platformEnvironment;
@@ -318,7 +318,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
 
             if (extensions != null && extensions.Any())
             {
-                extensionPaths.AddRange(extensions.Where(x => x.EndsWith(DataCollectorRegexPattern, StringComparison.OrdinalIgnoreCase)));
+                extensionPaths.AddRange(extensions.Where(x => x.EndsWith(CoverletDataCollectorRegexPattern, StringComparison.OrdinalIgnoreCase)));
             }
 
             return extensionPaths;

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -570,13 +570,23 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
         }
 
         [TestMethod]
-        public void GetTestPlatformExtensionsShouldAddDataCollectorsExtensionsIfPresent()
+        public void GetTestPlatformExtensionsShouldOnlyAddCoverletDataCollectorsExtensionsIfPresent()
         {
             this.mockFileHelper.Setup(fh => fh.DirectoryExists(It.IsAny<string>())).Returns(true);
             this.mockFileHelper.Setup(fh => fh.EnumerateFiles(It.IsAny<string>(), SearchOption.TopDirectoryOnly, It.IsAny<string[]>())).Returns(new[] { "foo.dll" });
-            var extensions = this.dotnetHostManager.GetTestPlatformExtensions(this.testSource, new List<string> { "abc.datacollector.dll" });
+            var extensions = this.dotnetHostManager.GetTestPlatformExtensions(this.testSource, new List<string> { "coverlet.collector.dll" });
 
             Assert.AreEqual(1, extensions.Count());
+        }
+
+        [TestMethod]
+        public void GetTestPlatformExtensionsShouldNotAddNonCoverletDataCollectorsExtensionsIfPresent()
+        {
+            this.mockFileHelper.Setup(fh => fh.DirectoryExists(It.IsAny<string>())).Returns(true);
+            this.mockFileHelper.Setup(fh => fh.EnumerateFiles(It.IsAny<string>(), SearchOption.TopDirectoryOnly, It.IsAny<string[]>())).Returns(new[] { "foo.dll" });
+            var extensions = this.dotnetHostManager.GetTestPlatformExtensions(this.testSource, new List<string> { "abc.dataollector.dll" });
+
+            Assert.AreEqual(0, extensions.Count());
         }
 
         [TestMethod]


### PR DESCRIPTION
Bug: https://developercommunity.visualstudio.com/content/problem/738856/could-not-load-file-or-assembly-microsoftintellitr.html

The last fix https://github.com/microsoft/vstest/pull/2226 did not help because the the data collector extensions (trace data collector) were still being picked up because they were default extensions.

Ideally, https://github.com/microsoft/vstest/blob/master/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginCache.cs#L108 should add default extensions only ending with the given endsWithPattern. At present, its adding all default extensions which even contains data collectors.
