### PR TITLE
Use patched version of Internal.TestPlatform.Extensions

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -500,7 +500,7 @@ function Create-VsixPackage
     $testPlatformExternalsVersion = ([xml](Get-Content $env:TP_ROOT_DIR\scripts\build\TestPlatform.Dependencies.props)).Project.PropertyGroup.TestPlatformExternalsVersion
 
     # Copy legacy dependencies
-    $legacyDir = Join-Path $env:TP_PACKAGES_DIR "Microsoft.Internal.TestPlatform.Extensions\$testPlatformExternalsVersion\contentFiles\any\any"
+    $legacyDir = Join-Path $env:TP_PACKAGES_DIR "Microsoft.Internal.TestPlatform.Extensions\$testPlatformExternalsVersion-patched\contentFiles\any\any"
     Copy-Item -Recurse $legacyDir\* $packageDir -Force
 
     # Copy Microsoft.VisualStudio.ArchitectureTools.PEReader to Extensions

--- a/src/package/external/external.csproj
+++ b/src/package/external/external.csproj
@@ -50,7 +50,7 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Internal.TestPlatform.Extensions">
-      <Version>$(TestPlatformExternalsVersion)</Version>
+      <Version>$(TestPlatformExternalsVersion)-patched</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.QualityTools">


### PR DESCRIPTION
## Description

A quick fix for updating Microsoft.Internal.TestPlatform.Extensions that is coming from VS build, the version of the package is tied to all other external packages. The easiest approach to do this is to publish a patched version on myget and change the build script. 

This allows updating just a single binary in the package without updating all the other external dependencies. 

And avoids hardcoding the version number for just the single package because then we would have to remember it for the next time we update it.

The current package on myget contains non-signed dll at the moment.

## Related issue

None
