### PR TITLE
Use latest version of VS that is available

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -67,7 +67,7 @@ if([string]::IsNullOrWhiteSpace($Version))
 {
     $Version = ([xml](Get-Content $env:TP_ROOT_DIR\scripts\build\TestPlatform.Settings.targets)).Project.PropertyGroup.TPVersionPrefix | 
         Where-Object { $_ } | 
-        ForEach-Object { $_.Trim() }
+        ForEach-Object { $_.Trim() } |
         Select-Object -First 1 
 
     Write-Verbose "Version was not provided using version '$Version' from TestPlatform.Settings.targets"


### PR DESCRIPTION
## Description
Uses the newest VS you have on system that has the required capabilities. Fixes few other issues like failing to build when there are more than 1 versions of VS that match the capabilities. Allowing the script to be run repeatedly when run as .ps1 and not as .cmd. And a slightly better logging.

## Related issue
Fix #2313 
