### PR TITLE
switch arguments for expected and actual in Assert.AreEquals in multiple tests

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelRunEventsHandler.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel
             IProxyExecutionManager proxyExecutionManager,
             ITestRunEventsHandler actualRunEventsHandler,
             IParallelProxyExecutionManager parallelProxyExecutionManager,
-            ParallelRunDataAggregator runDataAggregator) : 
+            ParallelRunDataAggregator runDataAggregator) :
             this(requestData, proxyExecutionManager, actualRunEventsHandler, parallelProxyExecutionManager, runDataAggregator, JsonDataSerializer.Instance)
         {
         }
@@ -95,15 +95,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel
         {
             // we get run complete events from each executor process
             // so we cannot "complete" the actual executor operation until all sources/testcases are consumed
-            // We should not block last chunk results while we aggregate overall run data 
+            // We should not block last chunk results while we aggregate overall run data
             if (lastChunkArgs != null)
             {
                 ConvertToRawMessageAndSend(MessageType.TestRunStatsChange, lastChunkArgs);
                 HandleTestRunStatsChange(lastChunkArgs);
             }
 
-            // Update runstats, executorUris, etc. 
-            // we need this data when we send the final runcomplete 
+            // Update runstats, executorUris, etc.
+            // we need this data when we send the final runcomplete
             this.runDataAggregator.Aggregate(
                 testRunCompleteArgs.TestRunStatistics,
                 executorUris,
@@ -128,7 +128,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel
         protected void HandleParallelTestRunComplete(TestRunCompleteEventArgs completedArgs)
         {
             // In case of sequential execution - RawMessage would have contained a 'TestRunCompletePayload' object
-            // To send a rawmessge - we need to create rawmessage from an aggregated payload object 
+            // To send a rawmessge - we need to create rawmessage from an aggregated payload object
             var testRunCompletePayload = new TestRunCompletePayload()
             {
                 ExecutorUris = this.runDataAggregator.ExecutorUris,

--- a/test/DataCollectors/Microsoft.TestPlatform.Extensions.EventLogCollector.UnitTests/CollectorNameValueConfigurationManagerTests.cs
+++ b/test/DataCollectors/Microsoft.TestPlatform.Extensions.EventLogCollector.UnitTests/CollectorNameValueConfigurationManagerTests.cs
@@ -42,14 +42,14 @@ namespace Microsoft.TestPlatform.Extensions.EventLogCollector.UnitTests
             }
 
             var configManager = new CollectorNameValueConfigurationManager(xmlDocument.DocumentElement);
-            Assert.AreEqual(configManager.NameValuePairs.Count, 0);
+            Assert.AreEqual(0, configManager.NameValuePairs.Count);
         }
 
         [TestMethod]
         public void ConstructorShouldNotInitializeNameValuePairNullIsPassed()
         {
             var configManager = new CollectorNameValueConfigurationManager(null);
-            Assert.AreEqual(configManager.NameValuePairs.Count, 0);
+            Assert.AreEqual(0, configManager.NameValuePairs.Count);
         }
     }
 }

--- a/test/DataCollectors/Microsoft.TestPlatform.Extensions.EventLogCollector.UnitTests/EventLogDataCollectorTests.cs
+++ b/test/DataCollectors/Microsoft.TestPlatform.Extensions.EventLogCollector.UnitTests/EventLogDataCollectorTests.cs
@@ -229,21 +229,21 @@ namespace Microsoft.TestPlatform.Extensions.EventLogCollector.UnitTests
         public void TestSessionStartEventShouldCreateEventLogContainer()
         {
             var eventLogDataCollector = new EventLogDataCollector();
-            Assert.AreEqual(eventLogDataCollector.ContextMap.Count, 0);
+            Assert.AreEqual(0, eventLogDataCollector.ContextMap.Count);
             eventLogDataCollector.Initialize(null, this.mockDataCollectionEvents.Object, this.mockDataCollectionSink, this.mockDataCollectionLogger.Object, this.dataCollectionEnvironmentContext);
             this.mockDataCollectionEvents.Raise(x => x.SessionStart += null, new SessionStartEventArgs());
-            Assert.AreEqual(eventLogDataCollector.ContextMap.Count, 1);
+            Assert.AreEqual(1, eventLogDataCollector.ContextMap.Count);
         }
 
         [TestMethod]
         public void TestCaseStartEventShouldCreateEventLogContainer()
         {
             var eventLogDataCollector = new EventLogDataCollector();
-            Assert.AreEqual(eventLogDataCollector.ContextMap.Count, 0);
+            Assert.AreEqual(0, eventLogDataCollector.ContextMap.Count);
 
             eventLogDataCollector.Initialize(null, this.mockDataCollectionEvents.Object, this.mockDataCollectionSink, this.mockDataCollectionLogger.Object, this.dataCollectionEnvironmentContext);
             this.mockDataCollectionEvents.Raise(x => x.TestCaseStart += null, new TestCaseStartEventArgs(new DataCollectionContext(new SessionId(Guid.NewGuid()), new TestExecId(Guid.NewGuid())), new TestCase()));
-            Assert.AreEqual(eventLogDataCollector.ContextMap.Count, 1);
+            Assert.AreEqual(1, eventLogDataCollector.ContextMap.Count);
         }
 
         [TestMethod]

--- a/test/DataCollectors/TraceDataCollector.UnitTests/DynamicCoverageDataCollectorTests.cs
+++ b/test/DataCollectors/TraceDataCollector.UnitTests/DynamicCoverageDataCollectorTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.TraceDataCollector.UnitTests
 
             this.collector.Initialize(null, this.eventsMock.Object, this.sinkMock.Object, this.loggerMock.Object, this.agentContextMock.Object);
 
-            Assert.AreEqual(null, actualConfig);
+            Assert.IsNull(actualConfig);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeTestHostLauncherFactoryTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeTestHostLauncherFactoryTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.DesignMode
             var mockDesignModeClient = new Mock<IDesignModeClient>();
             var testRunRequestPayload = new TestRunRequestPayload { DebuggingEnabled = false };
             var launcher = DesignModeTestHostLauncherFactory.GetCustomHostLauncherForTestRun(mockDesignModeClient.Object, testRunRequestPayload);
-            
+
             Assert.IsFalse(launcher.IsDebug, "Factory must not return debug launcher if debugging is disabled.");
         }
 

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FastFilterTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FastFilterTests.cs
@@ -312,7 +312,7 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Filtering
         {
             var filterExpressionWrapper = new FilterExpressionWrapper("FullyQualifiedName=Test", new FilterOptions() { FilterRegEx = @"^[^\s\(]+\1" });
 
-            Assert.AreEqual(null, filterExpressionWrapper.fastFilter);
+            Assert.IsNull(filterExpressionWrapper.fastFilter);
             Assert.IsFalse(string.IsNullOrEmpty(filterExpressionWrapper.ParseError));
         }
 

--- a/test/Microsoft.TestPlatform.Common.UnitTests/RequestDataTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/RequestDataTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.TestPlatform.Common.UnitTests
             var requestData = new RequestData();
             requestData.IsTelemetryOptedIn = true;
 
-            Assert.AreEqual(true, requestData.IsTelemetryOptedIn);
+            Assert.IsTrue(requestData.IsTelemetryOptedIn);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.Common.UnitTests/RequestDataTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/RequestDataTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.TestPlatform.Common.UnitTests
             var requestData = new RequestData();
             requestData.IsTelemetryOptedIn = false;
 
-            Assert.AreEqual(false, requestData.IsTelemetryOptedIn);
+            Assert.IsFalse(requestData.IsTelemetryOptedIn);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Telemetry/MetricsCollectionTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Telemetry/MetricsCollectionTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Telemetry
             this.metricsCollection.Add("DummyMessage", "DummyValue");
 
             object value;
-            Assert.AreEqual(true, this.metricsCollection.Metrics.TryGetValue("DummyMessage", out value));
+            Assert.IsTrue(this.metricsCollection.Metrics.TryGetValue("DummyMessage", out value));
             Assert.AreEqual("DummyValue", value);
         }
 
@@ -33,13 +33,13 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Telemetry
             this.metricsCollection.Add("DummyMessage", "DummyValue");
 
             object value;
-            Assert.AreEqual(true, this.metricsCollection.Metrics.TryGetValue("DummyMessage", out value));
+            Assert.IsTrue(this.metricsCollection.Metrics.TryGetValue("DummyMessage", out value));
             Assert.AreEqual("DummyValue", value);
 
             this.metricsCollection.Add("DummyMessage", "newValue");
 
             object newValue;
-            Assert.AreEqual(true, this.metricsCollection.Metrics.TryGetValue("DummyMessage", out newValue));
+            Assert.IsTrue(this.metricsCollection.Metrics.TryGetValue("DummyMessage", out newValue));
             Assert.AreEqual("newValue", newValue);
         }
 
@@ -50,8 +50,8 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Telemetry
             this.metricsCollection.Add("DummyMessage2", "DummyValue");
 
             Assert.AreEqual(2, this.metricsCollection.Metrics.Count);
-            Assert.AreEqual(true, this.metricsCollection.Metrics.ContainsKey("DummyMessage"));
-            Assert.AreEqual(true, this.metricsCollection.Metrics.ContainsKey("DummyMessage2"));
+            Assert.IsTrue(this.metricsCollection.Metrics.ContainsKey("DummyMessage"));
+            Assert.IsTrue(this.metricsCollection.Metrics.ContainsKey("DummyMessage2"));
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Telemetry/MetricsCollectionTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Telemetry/MetricsCollectionTests.cs
@@ -23,8 +23,8 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Telemetry
             this.metricsCollection.Add("DummyMessage", "DummyValue");
 
             object value;
-            Assert.AreEqual(this.metricsCollection.Metrics.TryGetValue("DummyMessage", out value), true);
-            Assert.AreEqual(value, "DummyValue");
+            Assert.AreEqual(true, this.metricsCollection.Metrics.TryGetValue("DummyMessage", out value));
+            Assert.AreEqual("DummyValue", value);
         }
 
         [TestMethod]
@@ -33,14 +33,14 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Telemetry
             this.metricsCollection.Add("DummyMessage", "DummyValue");
 
             object value;
-            Assert.AreEqual(this.metricsCollection.Metrics.TryGetValue("DummyMessage", out value), true);
-            Assert.AreEqual(value, "DummyValue");
+            Assert.AreEqual(true, this.metricsCollection.Metrics.TryGetValue("DummyMessage", out value));
+            Assert.AreEqual("DummyValue", value);
 
             this.metricsCollection.Add("DummyMessage", "newValue");
 
             object newValue;
-            Assert.AreEqual(this.metricsCollection.Metrics.TryGetValue("DummyMessage", out newValue), true);
-            Assert.AreEqual(newValue, "newValue");
+            Assert.AreEqual(true, this.metricsCollection.Metrics.TryGetValue("DummyMessage", out newValue));
+            Assert.AreEqual("newValue", newValue);
         }
 
         [TestMethod]
@@ -49,15 +49,15 @@ namespace Microsoft.TestPlatform.Common.UnitTests.Telemetry
             this.metricsCollection.Add("DummyMessage", "DummyValue");
             this.metricsCollection.Add("DummyMessage2", "DummyValue");
 
-            Assert.AreEqual(this.metricsCollection.Metrics.Count, 2);
-            Assert.AreEqual(this.metricsCollection.Metrics.ContainsKey("DummyMessage"), true);
-            Assert.AreEqual(this.metricsCollection.Metrics.ContainsKey("DummyMessage2"), true);
+            Assert.AreEqual(2, this.metricsCollection.Metrics.Count);
+            Assert.AreEqual(true, this.metricsCollection.Metrics.ContainsKey("DummyMessage"));
+            Assert.AreEqual(true, this.metricsCollection.Metrics.ContainsKey("DummyMessage2"));
         }
 
         [TestMethod]
         public void MetricsShouldReturnEmptyDictionaryIfMetricsIsEmpty()
         {
-            Assert.AreEqual(this.metricsCollection.Metrics.Count, 0);
+            Assert.AreEqual(0, this.metricsCollection.Metrics.Count);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Utilities/RunSettingsUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Utilities/RunSettingsUtilitiesTests.cs
@@ -37,7 +37,7 @@ namespace TestPlatform.Common.UnitTests.Utilities
             TestPluginCacheTests.SetupMockExtensions();
             string runsettings = @"<RunSettings><RunConfiguration><ResultsDirectory>.\TestResults</ResultsDirectory></RunConfiguration ><DummyMSTest><FORCEDLEGACYMODE>true</FORCEDLEGACYMODE></DummyMSTest></RunSettings>";
             var result= RunSettingsUtilities.CreateAndInitializeRunSettings(runsettings);
-            Assert.AreEqual(DummyMsTestSetingsProvider.StringToVerify, "<DummyMSTest><FORCEDLEGACYMODE>true</FORCEDLEGACYMODE></DummyMSTest>");
+            Assert.AreEqual("<DummyMSTest><FORCEDLEGACYMODE>true</FORCEDLEGACYMODE></DummyMSTest>", DummyMsTestSetingsProvider.StringToVerify);
             TestPluginCacheTests.ResetExtensionsCache();
         }
 

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/DataCollectionRequestSenderTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/DataCollectionRequestSenderTests.cs
@@ -46,9 +46,9 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
             var attachmentSets = this.requestSender.SendAfterTestRunEndAndGetResult(null, false);
 
             Assert.IsNotNull(attachmentSets);
-            Assert.AreEqual(attachmentSets.Count, 1);
+            Assert.AreEqual(1, attachmentSets.Count);
             Assert.IsNotNull(attachmentSets[0]);
-            Assert.AreEqual(attachmentSets[0].DisplayName, displayName);
+            Assert.AreEqual(displayName, attachmentSets[0].DisplayName);
             Assert.AreEqual(datacollectorUri, attachmentSets[0].Uri);
             Assert.AreEqual(attachmentUri, attachmentSets[0].Attachments[0].Uri);
         }

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/JsonDataSerializerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/JsonDataSerializerTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
             classWithSelfReferencingLoop.InfiniteRefernce.InfiniteRefernce = classWithSelfReferencingLoop;
 
             string serializedPayload = this.jsonDataSerializer.SerializePayload("dummy", classWithSelfReferencingLoop);
-            Assert.AreEqual(serializedPayload, "{\"MessageType\":\"dummy\",\"Payload\":{\"InfiniteRefernce\":{}}}");
+            Assert.AreEqual("{\"MessageType\":\"dummy\",\"Payload\":{\"InfiniteRefernce\":{}}}", serializedPayload);
         }
 
         [TestMethod]
@@ -55,7 +55,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
             };
 
             Message message = this.jsonDataSerializer.DeserializeMessage("{\"MessageType\":\"dummy\",\"Payload\":{\"InfiniteRefernce\":{}}}");
-            Assert.AreEqual(message?.MessageType, "dummy");
+            Assert.AreEqual("dummy", message?.MessageType);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests
         {
             var port = this.SetupFakeCommunicationChannel();
 
-            Assert.AreEqual(port, "123", "Correct port must be returned.");
+            Assert.AreEqual("123", port, "Correct port must be returned.");
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Helpers/CommandLineArgumentsHelperTests.cs
+++ b/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Helpers/CommandLineArgumentsHelperTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.TestPlatform.CoreUtilities.UnitTests.Helpers
             string data = CommandLineArgumentsHelper.GetStringArgFromDict(argsDictionary, "--hello");
 
             Assert.IsTrue(argsDictionary.Count == 2);
-            Assert.AreEqual(null, data);
+            Assert.IsNull(data);
         }
 
         [TestMethod]
@@ -91,8 +91,8 @@ namespace Microsoft.TestPlatform.CoreUtilities.UnitTests.Helpers
             var argsDictionary = CommandLineArgumentsHelper.GetArgumentsDictionary(args.ToArray());
 
             Assert.IsTrue(argsDictionary.Count == 2);
-            Assert.AreEqual(null, argsDictionary["--hello"]);
-            Assert.AreEqual(null, argsDictionary["--world"]);
+            Assert.IsNull(argsDictionary["--hello"]);
+            Assert.IsNull(argsDictionary["--world"]);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Tracing/EqtTraceTests.cs
+++ b/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Tracing/EqtTraceTests.cs
@@ -50,7 +50,7 @@ namespace TestPlatform.CoreUtilities.UnitTests
 #else
             EqtTrace.TraceLevel = PlatformTraceLevel.Verbose;
 #endif
-            Assert.AreEqual(true, EqtTrace.IsVerboseEnabled, "Expected trace state to be verbose actual state {0}", EqtTrace.IsVerboseEnabled);
+            Assert.IsTrue(EqtTrace.IsVerboseEnabled, "Expected trace state to be verbose actual state {0}", EqtTrace.IsVerboseEnabled);
         }
 
         [TestMethod]
@@ -61,7 +61,7 @@ namespace TestPlatform.CoreUtilities.UnitTests
 #else
             EqtTrace.TraceLevel = PlatformTraceLevel.Error;
 #endif
-            Assert.AreEqual(true, EqtTrace.IsErrorEnabled, "Expected trace state to be error actual state {0}", EqtTrace.IsErrorEnabled);
+            Assert.IsTrue(EqtTrace.IsErrorEnabled, "Expected trace state to be error actual state {0}", EqtTrace.IsErrorEnabled);
         }
 
         [TestMethod]
@@ -72,7 +72,7 @@ namespace TestPlatform.CoreUtilities.UnitTests
 #else
             EqtTrace.TraceLevel = PlatformTraceLevel.Info;
 #endif
-            Assert.AreEqual(true, EqtTrace.IsInfoEnabled, "Expected trace state to be info actual state {0}", EqtTrace.IsInfoEnabled);
+            Assert.IsTrue(EqtTrace.IsInfoEnabled, "Expected trace state to be info actual state {0}", EqtTrace.IsInfoEnabled);
         }
 
         [TestMethod]
@@ -83,7 +83,7 @@ namespace TestPlatform.CoreUtilities.UnitTests
 #else
             EqtTrace.TraceLevel = PlatformTraceLevel.Warning;
 #endif
-            Assert.AreEqual(true, EqtTrace.IsWarningEnabled, "Expected trace state to be warning actual state {0}", EqtTrace.IsWarningEnabled);
+            Assert.IsTrue(EqtTrace.IsWarningEnabled, "Expected trace state to be warning actual state {0}", EqtTrace.IsWarningEnabled);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelDiscoveryDataAggregatorTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelDiscoveryDataAggregatorTests.cs
@@ -69,7 +69,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
             object value;
-            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.TotalTestsDiscovered, out value));
+            Assert.IsTrue(runMetrics.TryGetValue(TelemetryDataConstants.TotalTestsDiscovered, out value));
             Assert.AreEqual(4, Convert.ToInt32(value));
         }
 
@@ -87,7 +87,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
             object value;
-            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenToDiscoverTestsByAnAdapter, out value));
+            Assert.IsTrue(runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenToDiscoverTestsByAnAdapter, out value));
             Assert.AreEqual(.04182, value);
         }
 
@@ -105,7 +105,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
             object value;
-            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenInSecByAllAdapters, out value));
+            Assert.IsTrue(runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenInSecByAllAdapters, out value));
             Assert.AreEqual(.04182, value);
         }
 
@@ -123,7 +123,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
             object value;
-            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenToLoadAdaptersInSec, out value));
+            Assert.IsTrue(runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenToLoadAdaptersInSec, out value));
             Assert.AreEqual(.04182, value);
         }
 
@@ -184,7 +184,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
             object value;
-            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterUsedToDiscoverTests, out value));
+            Assert.IsTrue(runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterUsedToDiscoverTests, out value));
             Assert.AreEqual(1, value);
         }
 
@@ -202,7 +202,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
             object value;
-            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringDiscovery, out value));
+            Assert.IsTrue(runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringDiscovery, out value));
             Assert.AreEqual(2, value);
         }
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelDiscoveryDataAggregatorTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelDiscoveryDataAggregatorTests.cs
@@ -52,7 +52,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             aggregator.AggregateDiscoveryDataMetrics(null);
 
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
-            Assert.AreEqual(runMetrics.Count, 0);
+            Assert.AreEqual(0, runMetrics.Count);
         }
 
         [TestMethod]
@@ -69,8 +69,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
             object value;
-            Assert.AreEqual(runMetrics.TryGetValue(TelemetryDataConstants.TotalTestsDiscovered, out value), true);
-            Assert.AreEqual(Convert.ToInt32(value), 4);
+            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.TotalTestsDiscovered, out value));
+            Assert.AreEqual(4, Convert.ToInt32(value));
         }
 
         [TestMethod]
@@ -87,8 +87,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
             object value;
-            Assert.AreEqual(runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenToDiscoverTestsByAnAdapter, out value), true);
-            Assert.AreEqual(value, .04182);
+            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenToDiscoverTestsByAnAdapter, out value));
+            Assert.AreEqual(.04182, value);
         }
 
         [TestMethod]
@@ -105,8 +105,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
             object value;
-            Assert.AreEqual(runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenInSecByAllAdapters, out value), true);
-            Assert.AreEqual(value, .04182);
+            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenInSecByAllAdapters, out value));
+            Assert.AreEqual(.04182, value);
         }
 
         [TestMethod]
@@ -123,8 +123,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
             object value;
-            Assert.AreEqual(runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenToLoadAdaptersInSec, out value), true);
-            Assert.AreEqual(value, .04182);
+            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenToLoadAdaptersInSec, out value));
+            Assert.AreEqual(.04182, value);
         }
 
         [TestMethod]
@@ -141,7 +141,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
             object value;
-            Assert.AreEqual(runMetrics.TryGetValue(TelemetryDataConstants.DiscoveryState, out value), false);
+            Assert.AreEqual(false, runMetrics.TryGetValue(TelemetryDataConstants.DiscoveryState, out value));
         }
 
         [TestMethod]
@@ -154,7 +154,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             aggregator.AggregateDiscoveryDataMetrics(dict);
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
-            Assert.AreEqual(runMetrics.Count, 0);
+            Assert.AreEqual(0, runMetrics.Count);
         }
 
         [TestMethod]
@@ -167,7 +167,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             aggregator.AggregateDiscoveryDataMetrics(null);
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
-            Assert.AreEqual(runMetrics.Count, 0);
+            Assert.AreEqual(0, runMetrics.Count);
         }
 
         [TestMethod]
@@ -184,8 +184,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
             object value;
-            Assert.AreEqual(runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterUsedToDiscoverTests, out value), true);
-            Assert.AreEqual(value, 1);
+            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterUsedToDiscoverTests, out value));
+            Assert.AreEqual(1, value);
         }
 
         [TestMethod]
@@ -202,8 +202,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
             object value;
-            Assert.AreEqual(runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringDiscovery, out value), true);
-            Assert.AreEqual(value, 2);
+            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringDiscovery, out value));
+            Assert.AreEqual(2, value);
         }
 
         [TestMethod]
@@ -217,7 +217,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
             object value;
-            Assert.AreEqual(runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterUsedToDiscoverTests, out value), false);
+            Assert.AreEqual(false, runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterUsedToDiscoverTests, out value));
         }
 
         [TestMethod]
@@ -231,7 +231,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
             object value;
-            Assert.AreEqual(runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringDiscovery, out value), false);
+            Assert.AreEqual(false, runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringDiscovery, out value));
         }
     }
 }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelDiscoveryDataAggregatorTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelDiscoveryDataAggregatorTests.cs
@@ -141,7 +141,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
             object value;
-            Assert.AreEqual(false, runMetrics.TryGetValue(TelemetryDataConstants.DiscoveryState, out value));
+            Assert.IsFalse(runMetrics.TryGetValue(TelemetryDataConstants.DiscoveryState, out value));
         }
 
         [TestMethod]
@@ -217,7 +217,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
             object value;
-            Assert.AreEqual(false, runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterUsedToDiscoverTests, out value));
+            Assert.IsFalse(runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterUsedToDiscoverTests, out value));
         }
 
         [TestMethod]
@@ -231,7 +231,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedDiscoveryDataMetrics();
 
             object value;
-            Assert.AreEqual(false, runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringDiscovery, out value));
+            Assert.IsFalse(runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringDiscovery, out value));
         }
     }
 }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelRunDataAggregatorTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelRunDataAggregatorTests.cs
@@ -319,7 +319,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
             object value;
-            Assert.AreEqual(false, runMetrics.TryGetValue(TelemetryDataConstants.RunState, out value);
+            Assert.AreEqual(false, runMetrics.TryGetValue(TelemetryDataConstants.RunState, out value));
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelRunDataAggregatorTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelRunDataAggregatorTests.cs
@@ -28,10 +28,10 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             Assert.IsNotNull(aggregator.RunCompleteArgsAttachments, "RunCompleteArgsAttachments list must not be null");
             Assert.IsNotNull(aggregator.RunContextAttachments, "RunContextAttachments list must not be null");
 
-            Assert.AreEqual(aggregator.Exceptions.Count, 0, "Exceptions List must be initialized as empty list.");
-            Assert.AreEqual(aggregator.ExecutorUris.Count, 0, "Exceptions List must be initialized as empty list.");
-            Assert.AreEqual(aggregator.RunCompleteArgsAttachments.Count, 0, "RunCompleteArgsAttachments List must be initialized as empty list.");
-            Assert.AreEqual(aggregator.RunContextAttachments.Count, 0, "RunContextAttachments List must be initialized as empty list");
+            Assert.AreEqual(0, aggregator.Exceptions.Count, "Exceptions List must be initialized as empty list.");
+            Assert.AreEqual(0, aggregator.ExecutorUris.Count, "Exceptions List must be initialized as empty list.");
+            Assert.AreEqual(0, aggregator.RunCompleteArgsAttachments.Count, "RunCompleteArgsAttachments List must be initialized as empty list.");
+            Assert.AreEqual(0, aggregator.RunContextAttachments.Count, "RunContextAttachments List must be initialized as empty list");
 
             Assert.IsFalse(aggregator.IsAborted, "Aborted must be false by default");
 
@@ -49,14 +49,14 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             aggregator.Aggregate(null, null, null, TimeSpan.Zero, false, false, null, attachmentSet1);
 
 
-            Assert.AreEqual(aggregator.RunCompleteArgsAttachments.Count, 1, "RunCompleteArgsAttachments List must have data.");
+            Assert.AreEqual(1, aggregator.RunCompleteArgsAttachments.Count, "RunCompleteArgsAttachments List must have data.");
 
             var attachmentSet2 = new Collection<AttachmentSet>();
             attachmentSet2.Add(new AttachmentSet(new Uri("x://hello2"), "hello2"));
 
             aggregator.Aggregate(null, null, null, TimeSpan.Zero, false, false, null, attachmentSet2);
 
-            Assert.AreEqual(aggregator.RunCompleteArgsAttachments.Count, 2, "RunCompleteArgsAttachments List must have aggregated data.");
+            Assert.AreEqual(2, aggregator.RunCompleteArgsAttachments.Count, "RunCompleteArgsAttachments List must have aggregated data.");
         }
 
         [TestMethod]
@@ -69,14 +69,14 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
 
             aggregator.Aggregate(null, null, null, TimeSpan.Zero, false, false, attachmentSet1, null);
 
-            Assert.AreEqual(aggregator.RunContextAttachments.Count, 1, "RunContextAttachments List must have data.");
+            Assert.AreEqual(1, aggregator.RunContextAttachments.Count, "RunContextAttachments List must have data.");
 
             var attachmentSet2 = new Collection<AttachmentSet>();
             attachmentSet2.Add(new AttachmentSet(new Uri("x://hello2"), "hello2"));
 
             aggregator.Aggregate(null, null, null, TimeSpan.Zero, false, false, attachmentSet2, null);
 
-            Assert.AreEqual(aggregator.RunContextAttachments.Count, 2, "RunContextAttachments List must have aggregated data.");
+            Assert.AreEqual(1, aggregator.RunContextAttachments.Count, "RunContextAttachments List must have aggregated data.");
         }
 
         [TestMethod]
@@ -122,23 +122,23 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             aggregator.Aggregate(null, null, null, TimeSpan.Zero, isAborted: false, isCanceled: false, runContextAttachments: null,
                 runCompleteArgsAttachments: null);
 
-            Assert.AreEqual(aggregator.ElapsedTime, TimeSpan.Zero, "Timespan must be zero");
+            Assert.AreEqual(TimeSpan.Zero, aggregator.ElapsedTime, "Timespan must be zero");
 
             aggregator.Aggregate(null, null, null, TimeSpan.FromMilliseconds(100), isAborted: false, isCanceled: false, runContextAttachments: null,
                 runCompleteArgsAttachments: null);
 
-            Assert.AreEqual(aggregator.ElapsedTime, TimeSpan.FromMilliseconds(100), "Timespan must be 100ms");
+            Assert.AreEqual(TimeSpan.FromMilliseconds(100), aggregator.ElapsedTime, "Timespan must be 100ms");
 
 
             aggregator.Aggregate(null, null, null, TimeSpan.FromMilliseconds(200), isAborted: false, isCanceled: false, runContextAttachments: null,
                 runCompleteArgsAttachments: null);
 
-            Assert.AreEqual(aggregator.ElapsedTime, TimeSpan.FromMilliseconds(200), "Timespan should be Max of all 200ms");
+            Assert.AreEqual(TimeSpan.FromMilliseconds(200), aggregator.ElapsedTime, "Timespan should be Max of all 200ms");
 
             aggregator.Aggregate(null, null, null, TimeSpan.FromMilliseconds(150), isAborted: false, isCanceled: false, runContextAttachments: null,
              runCompleteArgsAttachments: null);
 
-            Assert.AreEqual(aggregator.ElapsedTime, TimeSpan.FromMilliseconds(200), "Timespan should be Max of all i.e. 200ms");
+            Assert.AreEqual(TimeSpan.FromMilliseconds(200), aggregator.ElapsedTime, "Timespan should be Max of all i.e. 200ms");
         }
 
         [TestMethod]
@@ -158,8 +158,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var aggregatedException = aggregator.GetAggregatedException() as AggregateException;
             Assert.IsNotNull(aggregatedException, "Aggregated exception must NOT be null");
             Assert.IsNotNull(aggregatedException.InnerExceptions, "Inner exception list must NOT be null");
-            Assert.AreEqual(aggregatedException.InnerExceptions.Count, 1, "Inner exception lsit must have one element");
-            Assert.AreEqual(aggregatedException.InnerExceptions[0], exception1, "Inner exception must be the one set.");
+            Assert.AreEqual(1, aggregatedException.InnerExceptions.Count, "Inner exception list must have one element");
+            Assert.AreEqual(exception1, aggregatedException.InnerExceptions[0], "Inner exception must be the one set.");
 
             var exception2 = new NotSupportedException();
             aggregator.Aggregate(null, null, exception: exception2, elapsedTime: TimeSpan.Zero, isAborted: false, isCanceled: false, runContextAttachments: null,
@@ -168,8 +168,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             aggregatedException = aggregator.GetAggregatedException() as AggregateException;
             Assert.IsNotNull(aggregatedException, "Aggregated exception must NOT be null");
             Assert.IsNotNull(aggregatedException.InnerExceptions, "Inner exception list must NOT be null");
-            Assert.AreEqual(aggregatedException.InnerExceptions.Count, 2, "Inner exception lsit must have one element");
-            Assert.AreEqual(aggregatedException.InnerExceptions[1], exception2, "Inner exception must be the one set.");
+            Assert.AreEqual(2, aggregatedException.InnerExceptions.Count, "Inner exception list must have one element");
+            Assert.AreEqual(exception2, aggregatedException.InnerExceptions[1], "Inner exception must be the one set.");
         }
 
         [TestMethod]
@@ -179,18 +179,18 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
 
             aggregator.Aggregate(null, null, null, TimeSpan.Zero, false, false, null, null);
 
-            Assert.AreEqual(aggregator.ExecutorUris.Count, 0, "ExecutorUris List must not have data.");
+            Assert.AreEqual(0, aggregator.ExecutorUris.Count, "ExecutorUris List must not have data.");
 
             var uri1 = "x://hello1";
             aggregator.Aggregate(null, new List<string>() { uri1 }, null, TimeSpan.Zero, false, false, null, null);
 
-            Assert.AreEqual(aggregator.ExecutorUris.Count, 1, "ExecutorUris List must have data.");
+            Assert.AreEqual(1, aggregator.ExecutorUris.Count, "ExecutorUris List must have data.");
             Assert.IsTrue(aggregator.ExecutorUris.Contains(uri1), "ExecutorUris List must have correct data.");
 
             var uri2 = "x://hello2";
             aggregator.Aggregate(null, new List<string>() { uri2 }, null, TimeSpan.Zero, false, false, null, null);
 
-            Assert.AreEqual(aggregator.ExecutorUris.Count, 2, "ExecutorUris List must have aggregated data.");
+            Assert.AreEqual(2, aggregator.ExecutorUris.Count, "ExecutorUris List must have aggregated data.");
             Assert.IsTrue(aggregator.ExecutorUris.Contains(uri2), "ExecutorUris List must have correct data.");
         }
 
@@ -202,7 +202,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             aggregator.Aggregate(null, null, null, TimeSpan.Zero, false, false, null, null);
 
             var runStats = aggregator.GetAggregatedRunStats();
-            Assert.AreEqual(runStats.ExecutedTests, 0, "RunStats must not have data.");
+            Assert.AreEqual(0, runStats.ExecutedTests, "RunStats must not have data.");
 
             var stats1 = new Dictionary<TestOutcome, long>();
             stats1.Add(TestOutcome.Passed, 2);
@@ -214,12 +214,12 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             aggregator.Aggregate(new TestRunStatistics(12, stats1), null, null, TimeSpan.Zero, false, false, null, null);
 
             runStats = aggregator.GetAggregatedRunStats();
-            Assert.AreEqual(runStats.ExecutedTests, 12, "RunStats must have aggregated data.");
-            Assert.AreEqual(runStats.Stats[TestOutcome.Passed], 2, "RunStats must have aggregated data.");
-            Assert.AreEqual(runStats.Stats[TestOutcome.Failed], 3, "RunStats must have aggregated data.");
-            Assert.AreEqual(runStats.Stats[TestOutcome.Skipped], 1, "RunStats must have aggregated data.");
-            Assert.AreEqual(runStats.Stats[TestOutcome.NotFound], 4, "RunStats must have aggregated data.");
-            Assert.AreEqual(runStats.Stats[TestOutcome.None], 2, "RunStats must have aggregated data.");
+            Assert.AreEqual(12, runStats.ExecutedTests, 12, "RunStats must have aggregated data.");
+            Assert.AreEqual(2, runStats.Stats[TestOutcome.Passed], "RunStats must have aggregated data.");
+            Assert.AreEqual(3, runStats.Stats[TestOutcome.Failed], "RunStats must have aggregated data.");
+            Assert.AreEqual(1, runStats.Stats[TestOutcome.Skipped], "RunStats must have aggregated data.");
+            Assert.AreEqual(4, runStats.Stats[TestOutcome.NotFound], "RunStats must have aggregated data.");
+            Assert.AreEqual(2, runStats.Stats[TestOutcome.None], "RunStats must have aggregated data.");
 
 
             var stats2 = new Dictionary<TestOutcome, long>();
@@ -232,12 +232,12 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             aggregator.Aggregate(new TestRunStatistics(11, stats2), null, null, TimeSpan.Zero, false, false, null, null);
 
             runStats = aggregator.GetAggregatedRunStats();
-            Assert.AreEqual(runStats.ExecutedTests, 23, "RunStats must have aggregated data.");
-            Assert.AreEqual(runStats.Stats[TestOutcome.Passed], 5, "RunStats must have aggregated data.");
-            Assert.AreEqual(runStats.Stats[TestOutcome.Failed], 5, "RunStats must have aggregated data.");
-            Assert.AreEqual(runStats.Stats[TestOutcome.Skipped], 3, "RunStats must have aggregated data.");
-            Assert.AreEqual(runStats.Stats[TestOutcome.NotFound], 5, "RunStats must have aggregated data.");
-            Assert.AreEqual(runStats.Stats[TestOutcome.None], 5, "RunStats must have aggregated data.");
+            Assert.AreEqual(23, runStats.ExecutedTests, "RunStats must have aggregated data.");
+            Assert.AreEqual(5, runStats.Stats[TestOutcome.Passed], "RunStats must have aggregated data.");
+            Assert.AreEqual(5, runStats.Stats[TestOutcome.Failed], "RunStats must have aggregated data.");
+            Assert.AreEqual(3, runStats.Stats[TestOutcome.Skipped], "RunStats must have aggregated data.");
+            Assert.AreEqual(5, runStats.Stats[TestOutcome.NotFound], "RunStats must have aggregated data.");
+            Assert.AreEqual(5, runStats.Stats[TestOutcome.None], "RunStats must have aggregated data.");
         }
 
         [TestMethod]
@@ -248,7 +248,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             aggregator.AggregateRunDataMetrics(null);
 
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
-            Assert.AreEqual(runMetrics.Count, 0);
+            Assert.AreEqual(0, runMetrics.Count);
         }
 
         [TestMethod]
@@ -265,8 +265,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
             object value;
-            Assert.AreEqual(runMetrics.TryGetValue(TelemetryDataConstants.TotalTestsRanByAdapter, out value), true);
-            Assert.AreEqual(Convert.ToInt32(value), 4);
+            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.TotalTestsRanByAdapter, out value));
+            Assert.AreEqual(4, Convert.ToInt32(value));
         }
 
         [TestMethod]
@@ -283,8 +283,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
             object value;
-            Assert.AreEqual(runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenToRunTestsByAnAdapter, out value), true);
-            Assert.AreEqual(value, .04182);
+            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenToRunTestsByAnAdapter, out value));
+            Assert.AreEqual(.04182, value);
         }
 
         [TestMethod]
@@ -301,8 +301,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
             object value;
-            Assert.AreEqual(runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenByAllAdaptersInSec, out value), true);
-            Assert.AreEqual(value, .04182);
+            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenByAllAdaptersInSec, out value));
+            Assert.AreEqual(.04182, value);
         }
 
         [TestMethod]
@@ -319,7 +319,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
             object value;
-            Assert.AreEqual(runMetrics.TryGetValue(TelemetryDataConstants.RunState, out value), false);
+            Assert.AreEqual(false, runMetrics.TryGetValue(TelemetryDataConstants.RunState, out value);
         }
 
         [TestMethod]
@@ -332,7 +332,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             aggregator.AggregateRunDataMetrics(dict);
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
-            Assert.AreEqual(runMetrics.Count, 0);
+            Assert.AreEqual(0, runMetrics.Count);
         }
 
         [TestMethod]
@@ -345,7 +345,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             aggregator.AggregateRunDataMetrics(null);
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
-            Assert.AreEqual(runMetrics.Count, 0);
+            Assert.AreEqual(0, runMetrics.Count);
         }
 
         [TestMethod]
@@ -362,8 +362,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
             object value;
-            Assert.AreEqual(runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterUsedToRunTests, out value), true);
-            Assert.AreEqual(value, 1);
+            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterUsedToRunTests, out value));
+            Assert.AreEqual(1, value);
         }
 
         [TestMethod]
@@ -380,8 +380,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
             object value;
-            Assert.AreEqual(runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringExecution, out value), true);
-            Assert.AreEqual(value, 2);
+            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringExecution, out value));
+            Assert.AreEqual(2, value);
         }
 
         [TestMethod]
@@ -395,7 +395,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
             object value;
-            Assert.AreEqual(runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterUsedToRunTests, out value), false);
+            Assert.AreEqual(false, runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterUsedToRunTests, out value));
         }
 
         [TestMethod]
@@ -409,7 +409,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
             object value;
-            Assert.AreEqual(runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringExecution, out value), false);
+            Assert.AreEqual(false, runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringExecution, out value));
         }
     }
 }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelRunDataAggregatorTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelRunDataAggregatorTests.cs
@@ -265,7 +265,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
             object value;
-            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.TotalTestsRanByAdapter, out value));
+            Assert.IsTrue(runMetrics.TryGetValue(TelemetryDataConstants.TotalTestsRanByAdapter, out value));
             Assert.AreEqual(4, Convert.ToInt32(value));
         }
 
@@ -283,7 +283,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
             object value;
-            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenToRunTestsByAnAdapter, out value));
+            Assert.IsTrue(runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenToRunTestsByAnAdapter, out value));
             Assert.AreEqual(.04182, value);
         }
 
@@ -301,7 +301,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
             object value;
-            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenByAllAdaptersInSec, out value));
+            Assert.IsTrue(runMetrics.TryGetValue(TelemetryDataConstants.TimeTakenByAllAdaptersInSec, out value));
             Assert.AreEqual(.04182, value);
         }
 
@@ -362,7 +362,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
             object value;
-            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterUsedToRunTests, out value));
+            Assert.IsTrue(runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterUsedToRunTests, out value));
             Assert.AreEqual(1, value);
         }
 
@@ -380,7 +380,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
             object value;
-            Assert.AreEqual(true, runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringExecution, out value));
+            Assert.IsTrue(runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringExecution, out value));
             Assert.AreEqual(2, value);
         }
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelRunDataAggregatorTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelRunDataAggregatorTests.cs
@@ -319,7 +319,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
             object value;
-            Assert.AreEqual(false, runMetrics.TryGetValue(TelemetryDataConstants.RunState, out value));
+            Assert.IsFalse(runMetrics.TryGetValue(TelemetryDataConstants.RunState, out value));
         }
 
         [TestMethod]
@@ -395,7 +395,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
             object value;
-            Assert.AreEqual(false, runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterUsedToRunTests, out value));
+            Assert.IsFalse(runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterUsedToRunTests, out value));
         }
 
         [TestMethod]
@@ -409,7 +409,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             var runMetrics = aggregator.GetAggregatedRunDataMetrics();
 
             object value;
-            Assert.AreEqual(false, runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringExecution, out value));
+            Assert.IsFalse(runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringExecution, out value));
         }
     }
 }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelRunDataAggregatorTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelRunDataAggregatorTests.cs
@@ -77,7 +77,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
 
             aggregator.Aggregate(null, null, null, TimeSpan.Zero, false, false, attachmentSet2, null);
 
-            Assert.AreEqual(1, aggregator.RunContextAttachments.Count, "RunContextAttachments List must have aggregated data.");
+            Assert.AreEqual(2, aggregator.RunContextAttachments.Count, "RunContextAttachments List must have aggregated data.");
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelRunDataAggregatorTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelRunDataAggregatorTests.cs
@@ -215,7 +215,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
             aggregator.Aggregate(new TestRunStatistics(12, stats1), null, null, TimeSpan.Zero, false, false, null, null);
 
             runStats = aggregator.GetAggregatedRunStats();
-            Assert.AreEqual(12, runStats.ExecutedTests, 12, "RunStats must have aggregated data.");
+            Assert.AreEqual(12, runStats.ExecutedTests, "RunStats must have aggregated data.");
             Assert.AreEqual(2, runStats.Stats[TestOutcome.Passed], "RunStats must have aggregated data.");
             Assert.AreEqual(3, runStats.Stats[TestOutcome.Failed], "RunStats must have aggregated data.");
             Assert.AreEqual(1, runStats.Stats[TestOutcome.Skipped], "RunStats must have aggregated data.");

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelRunDataAggregatorTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelRunDataAggregatorTests.cs
@@ -6,6 +6,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
+    using System.Globalization;
 
     using Microsoft.VisualStudio.TestPlatform.Common.Telemetry;
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel;

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelRunDataAggregatorTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelRunDataAggregatorTests.cs
@@ -6,7 +6,6 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Client.Parallel
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using System.Globalization;
 
     using Microsoft.VisualStudio.TestPlatform.Common.Telemetry;
     using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel;

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/InProcDataCollectionExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/InProcDataCollectionExtensionManagerTests.cs
@@ -57,7 +57,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
             var dataCollector = inProcDataCollectionManager.InProcDataCollectors.First().Value as MockDataCollector;
 
             Assert.IsTrue(inProcDataCollectionManager.IsInProcDataCollectionEnabled, "InProcDataCollection must be enabled if runsettings contains inproc datacollectors.");
-            Assert.AreEqual(inProcDataCollectionManager.InProcDataCollectors.Count, 1, "One Datacollector must be registered");
+            Assert.AreEqual(1, inProcDataCollectionManager.InProcDataCollectors.Count, "One Datacollector must be registered");
 
             Assert.IsTrue(string.Equals(dataCollector.AssemblyQualifiedName, "TestImpactListener.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7ccb7239ffde675a", StringComparison.OrdinalIgnoreCase));
             Assert.IsTrue(string.Equals(dataCollector.CodeBase, @"E:\repos\MSTest\src\managed\TestPlatform\TestImpactListener.Tests\bin\Debug\TestImpactListener.Tests.dll", StringComparison.OrdinalIgnoreCase));
@@ -83,7 +83,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
             this.inProcDataCollectionManager = new TestableInProcDataCollectionExtensionManager(settingsXml, this.mockTestEventsPublisher.Object, this.defaultCodebase, this.testPluginCache, this.mockFileHelper.Object);
 
             var codebase = (inProcDataCollectionManager.InProcDataCollectors.Values.First() as MockDataCollector).CodeBase;
-            Assert.AreEqual(codebase, @"E:\repos\MSTest\src\managed\TestPlatform\TestImpactListener.Tests\bin\Debug\TestImpactListener.Tests.dll");
+            Assert.AreEqual(@"E:\repos\MSTest\src\managed\TestPlatform\TestImpactListener.Tests\bin\Debug\TestImpactListener.Tests.dll", codebase);
         }
 
         [TestMethod]
@@ -107,7 +107,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
             this.inProcDataCollectionManager = new TestableInProcDataCollectionExtensionManager(settingsXml, this.mockTestEventsPublisher.Object, this.defaultCodebase, this.testPluginCache, this.mockFileHelper.Object);
 
             var codebase = (inProcDataCollectionManager.InProcDataCollectors.Values.First() as MockDataCollector).CodeBase;
-            Assert.AreEqual(codebase, @"E:\source\.nuget\TestImpactListenerDataCollector.dll");
+            Assert.AreEqual(@"E:\source\.nuget\TestImpactListenerDataCollector.dll", codebase);
         }
 
         [TestMethod]
@@ -127,7 +127,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
             this.inProcDataCollectionManager = new TestableInProcDataCollectionExtensionManager(settingsXml, this.mockTestEventsPublisher.Object, this.defaultCodebase, this.testPluginCache, this.mockFileHelper.Object);
 
             var codebase = (inProcDataCollectionManager.InProcDataCollectors.Values.First() as MockDataCollector).CodeBase;
-            Assert.AreEqual(codebase, "\\\\DummyPath\\TestImpactListener.Tests.dll");
+            Assert.AreEqual("\\\\DummyPath\\TestImpactListener.Tests.dll", codebase);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/InProcDataCollectionSinkTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/InProcDataCollectionSinkTests.cs
@@ -39,7 +39,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
 
             var dict = ((InProcDataCollectionSink)this.dataCollectionSink).GetDataCollectionDataSetForTestCase(this.testCase.Id);
 
-            Assert.AreEqual<string>(dict["DummyKey"].ToString(), "DummyValue");
+            Assert.AreEqual<string>("DummyValue", dict["DummyKey"].ToString());
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/InProcDataCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/InProcDataCollectorTests.cs
@@ -44,7 +44,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
                 this.assemblyLoadContext.Object,
                 TestPluginCache.Instance);
 
-            Assert.AreEqual(this.inProcDataCollector.AssemblyQualifiedName, null);
+            Assert.AreEqual(null, this.inProcDataCollector.AssemblyQualifiedName);
         }
 
         [TestMethod]
@@ -61,7 +61,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
                 this.assemblyLoadContext.Object,
                 TestPluginCache.Instance);
 
-            Assert.AreEqual(this.inProcDataCollector.AssemblyQualifiedName, null);
+            Assert.AreEqual(null, this.inProcDataCollector.AssemblyQualifiedName);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/InProcDataCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/InProcDataCollectorTests.cs
@@ -44,7 +44,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
                 this.assemblyLoadContext.Object,
                 TestPluginCache.Instance);
 
-            Assert.AreEqual(null, this.inProcDataCollector.AssemblyQualifiedName);
+            Assert.IsNull(this.inProcDataCollector.AssemblyQualifiedName);
         }
 
         [TestMethod]
@@ -61,7 +61,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
                 this.assemblyLoadContext.Object,
                 TestPluginCache.Instance);
 
-            Assert.AreEqual(null, this.inProcDataCollector.AssemblyQualifiedName);
+            Assert.IsNull(this.inProcDataCollector.AssemblyQualifiedName);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
@@ -198,7 +198,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
 
             mockRunEventsHandler.Verify(eh => eh.HandleLogMessage(TestMessageLevel.Error, It.IsRegex("Exception of type 'System.Exception' was thrown..*")), Times.Once);
             Assert.AreEqual(0, result.EnvironmentVariables.Count);
-            Assert.AreEqual(false, result.AreTestCaseLevelEventsRequired);
+            Assert.IsFalse(result.AreTestCaseLevelEventsRequired);
             Assert.AreEqual(0, result.DataCollectionEventsPort);
         }
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
@@ -234,9 +234,9 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.DataCollection
             var result = this.proxyDataCollectionManager.AfterTestRunEnd(false, null);
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(result.Count, 1);
+            Assert.AreEqual(1, result.Count);
             Assert.IsNotNull(result[0]);
-            Assert.AreEqual(result[0].DisplayName, dispName);
+            Assert.AreEqual(dispName, result[0].DisplayName);
             Assert.AreEqual(uri, result[0].Uri);
         }
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/BaseRunTestsTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/BaseRunTestsTests.cs
@@ -113,10 +113,10 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
         {
             var runContext = this.runTestsInstance.GetRunContext;
             Assert.IsNotNull(runContext);
-            Assert.AreEqual(false, runContext.KeepAlive);
-            Assert.AreEqual(false, runContext.InIsolation);
-            Assert.AreEqual(false, runContext.IsDataCollectionEnabled);
-            Assert.AreEqual(false, runContext.IsBeingDebugged);
+            Assert.IsFalse(runContext.KeepAlive);
+            Assert.IsFalse(runContext.InIsolation);
+            Assert.IsFalse(runContext.IsDataCollectionEnabled);
+            Assert.IsFalse(runContext.IsBeingDebugged);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestLoggerManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestLoggerManagerTests.cs
@@ -70,7 +70,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
         {
             var testLoggerManager = new DummyTestLoggerManager();
             string result = testLoggerManager.GetResultsDirectory(null);
-            Assert.AreEqual(null, result);
+            Assert.IsNull(result);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestLoggerManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestLoggerManagerTests.cs
@@ -88,7 +88,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
 
             var testLoggerManager = new DummyTestLoggerManager();
             string result = testLoggerManager.GetResultsDirectory(runSettingsXml);
-            Assert.AreEqual(string.Compare("DummyTestResultsFolder", result), 0);
+            Assert.AreEqual(0, string.Compare("DummyTestResultsFolder", result));
         }
 
         [TestMethod]
@@ -106,7 +106,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
             var testLoggerManager = new DummyTestLoggerManager();
             string result = testLoggerManager.GetResultsDirectory(runSettingsXml);
 
-            Assert.AreEqual(string.Compare(Constants.DefaultResultsDirectory, result), 0);
+            Assert.AreEqual(0, string.Compare(Constants.DefaultResultsDirectory, result));
         }
 
         [TestMethod]
@@ -124,7 +124,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
             var testLoggerManager = new DummyTestLoggerManager();
             var framework = testLoggerManager.GetTargetFramework(runSettingsXml);
 
-            Assert.AreEqual(framework.Name, ".NETFramework,Version=v4.5");
+            Assert.AreEqual(".NETFramework,Version=v4.5", framework.Name);
         }
 
         [TestMethod]
@@ -139,7 +139,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
             testLoggerManager.HandleTestRunMessage(new TestRunMessageEventArgs(TestMessageLevel.Informational, "TestRunMessage"));
 
             waitHandle.WaitOne();
-            Assert.AreEqual(counter, 1);
+            Assert.AreEqual(1, counter);
         }
 
         [TestMethod]
@@ -154,7 +154,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
             testLoggerManager.Dispose();
             testLoggerManager.HandleTestRunMessage(new TestRunMessageEventArgs(TestMessageLevel.Informational, "TestRunMessage"));
 
-            Assert.AreEqual(counter, 0);
+            Assert.AreEqual(0, counter);
         }
 
         [TestMethod]
@@ -170,7 +170,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
             testLoggerManager.HandleTestRunComplete(new TestRunCompleteEventArgs(null, false, false, null, null, new TimeSpan()));
 
             waitHandle.WaitOne();
-            Assert.AreEqual(counter, 1);
+            Assert.AreEqual(1, counter);
         }
 
         [TestMethod]
@@ -186,7 +186,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
             testLoggerManager.Dispose();
             testLoggerManager.HandleTestRunComplete(new TestRunCompleteEventArgs(null, false, false, null, null, new TimeSpan()));
 
-            Assert.AreEqual(counter, 0);
+            Assert.AreEqual(0, counter);
         }
 
         [TestMethod]
@@ -202,7 +202,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
             testLoggerManager.HandleTestRunComplete(new TestRunCompleteEventArgs(null, false, false, null, null, new TimeSpan()));
             testLoggerManager.HandleTestRunComplete(new TestRunCompleteEventArgs(null, false, false, null, null, new TimeSpan())); // count should not increase because of second call.
 
-            Assert.AreEqual(counter, 1);
+            Assert.AreEqual(1, counter);
         }
 
         [TestMethod]
@@ -229,7 +229,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
                     null));
 
             waitHandle.WaitOne();
-            Assert.AreEqual(counter, 1);
+            Assert.AreEqual(1, counter);
         }
 
         [TestMethod]
@@ -256,7 +256,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
                     },
                     null));
 
-            Assert.AreEqual(counter, 0);
+            Assert.AreEqual(0, counter);
         }
 
         [TestMethod]
@@ -390,7 +390,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
 
             // Assertions when discovery events registered
             waitHandle.WaitOne();
-            Assert.AreEqual(counter, 1);
+            Assert.AreEqual(1, counter);
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
             testLoggerManager.HandleDiscoveryStart(discoveryStartEventArgs);
 
             // Assertions when discovery events registered
-            Assert.AreEqual(counter, 0);
+            Assert.AreEqual(0, counter);
         }
 
         /// <summary>
@@ -438,7 +438,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
 
             // Assertions when discovery events registered
             waitHandle.WaitOne();
-            Assert.AreEqual(counter, 1);
+            Assert.AreEqual(1, counter);
         }
 
         [TestMethod]
@@ -459,7 +459,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
             testLoggerManager.HandleDiscoveredTests(discoveredTestsEventArgs);
 
             // Assertions when discovery events registered
-            Assert.AreEqual(counter, 0);
+            Assert.AreEqual(0, counter);
         }
 
         /// <summary>
@@ -483,7 +483,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
 
             // Assertions when test run events registered
             waitHandle.WaitOne();
-            Assert.AreEqual(counter, 1);
+            Assert.AreEqual(1, counter);
         }
 
         /// <summary>
@@ -507,7 +507,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
             testLoggerManager.HandleTestRunStart(testRunStartEventArgs);
 
             // Assertions when test run events registered
-            Assert.AreEqual(counter, 0);
+            Assert.AreEqual(0, counter);
         }
 
         /// <summary>
@@ -530,7 +530,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
 
             // Assertions when discovery events registered
             waitHandle.WaitOne();
-            Assert.AreEqual(counter, 1);
+            Assert.AreEqual(1, counter);
         }
 
         /// <summary>
@@ -553,7 +553,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
             testLoggerManager.HandleDiscoveryComplete(discoveryCompleteEventArgs);
 
             // Assertions when discovery events registered
-            Assert.AreEqual(counter, 0);
+            Assert.AreEqual(0, counter);
         }
 
         [TestMethod]
@@ -570,7 +570,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
             testLoggerManager.HandleDiscoveryComplete(discoveryCompleteEventArgs);
             testLoggerManager.HandleDiscoveryComplete(discoveryCompleteEventArgs); // count should not increase because of second call.
 
-            Assert.AreEqual(counter, 1);
+            Assert.AreEqual(1, counter);
         }
 
         /// <summary>
@@ -594,7 +594,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
 
             // Assertions when discovery events registered
             waitHandle.WaitOne();
-            Assert.AreEqual(counter, 1);
+            Assert.AreEqual(1, counter);
         }
 
         /// <summary>
@@ -617,7 +617,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
             testLoggerManager.Dispose();
             testLoggerManager.HandleDiscoveryMessage(testRunMessageEventArgs);
 
-            Assert.AreEqual(counter, 0);
+            Assert.AreEqual(0, counter);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Utilities/TestSourcesUtilityTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Utilities/TestSourcesUtilityTests.cs
@@ -22,7 +22,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Adapter
             adapterSourceMap.Add("adapter3", new List<string>() { "source1.dll"});
 
             var sources = TestSourcesUtility.GetSources(adapterSourceMap);
-            Assert.AreEqual(sources.Count(), 5);
+            Assert.AreEqual(5, sources.Count());
             Assert.IsTrue(sources.Contains("source1.dll"));
             Assert.IsTrue(sources.Contains("source2.dll"));
             Assert.IsTrue(sources.Contains("source3.dll"));
@@ -36,7 +36,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Adapter
                                                new TestCase("test3", new Uri("e://d"), "source1.dll")};
 
             var sources = TestSourcesUtility.GetSources(tests);
-            Assert.AreEqual(sources.Count(), 2);
+            Assert.AreEqual(2, sources.Count());
             Assert.IsTrue(sources.Contains("source1.dll"));
             Assert.IsTrue(sources.Contains("source2.dll"));
         }
@@ -66,7 +66,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Adapter
             adapterSourceMap.Add("adapter1", new List<string>() { "c:\\folder1\\source1.dll", "c:\\folder2\\source2.dll" });
 
             var defaultCodeBase = TestSourcesUtility.GetDefaultCodebasePath(adapterSourceMap);
-            Assert.AreEqual(defaultCodeBase, "c:\\folder1");
+            Assert.AreEqual("c:\\folder1", defaultCodeBase);
         }
 
         [TestMethod]
@@ -75,7 +75,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Adapter
             var tests = new List<TestCase>() { new TestCase("test1", new Uri("e://d"), "c:\\folder1\\source1.dll") };
 
             var defaultCodeBase = TestSourcesUtility.GetDefaultCodebasePath(tests);
-            Assert.AreEqual(defaultCodeBase, "c:\\folder1");
+            Assert.AreEqual("c:\\folder1", defaultCodeBase);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/XmlReaderWriterTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/XmlReaderWriterTests.cs
@@ -165,10 +165,10 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             var testCaseList = xmlReaderWriter.ReadTestSequence(filePath);
             File.Delete(filePath);
 
-            Assert.AreEqual(testCaseList.First().FullyQualifiedName, "Abc.UnitTest1");
-            Assert.AreEqual(testCaseList.First().DisplayName, "UnitTest1");
-            Assert.AreEqual(testCaseList.First().Source, "Abc.dll");
-            Assert.AreEqual(testCaseList.First().IsCompleted, false);
+            Assert.AreEqual("Abc.UnitTest1", testCaseList.First().FullyQualifiedName);
+            Assert.AreEqual("UnitTest1", testCaseList.First().DisplayName);
+            Assert.AreEqual("Abc.dll", testCaseList.First().Source);
+            Assert.IsFalse(testCaseList.First().IsCompleted);
         }
 
         /// <summary>
@@ -194,10 +194,10 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             var testCaseList = xmlReaderWriter.ReadTestSequence(filePath);
             File.Delete(filePath);
 
-            Assert.AreEqual(testCaseList.First().FullyQualifiedName, "Abc.UnitTest1");
-            Assert.AreEqual(testCaseList.First().DisplayName, "UnitTest1");
-            Assert.AreEqual(testCaseList.First().Source, "Abc.dll");
-            Assert.AreEqual(testCaseList.First().IsCompleted, true);
+            Assert.AreEqual("Abc.UnitTest1", testCaseList.First().FullyQualifiedName);
+            Assert.AreEqual("UnitTest1", testCaseList.First().DisplayName);
+            Assert.AreEqual("Abc.dll", testCaseList.First().Source);
+            Assert.IsTrue(testCaseList.First().IsCompleted);
         }
 
         /// <summary>

--- a/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
@@ -392,11 +392,11 @@ namespace Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests
 
             this.htmlLogger.TestRunCompleteHandler(new object(), new TestRunCompleteEventArgs(null, false, true, null, null, TimeSpan.Zero));
 
-            Assert.AreEqual(4, this.htmlLogger.TestRunDetails.Summary.TotalTests, 4, "summary should keep track of total tests");
-            Assert.AreEqual(1, this.htmlLogger.TestRunDetails.Summary.FailedTests, 1, "summary should keep track of failed tests");
-            Assert.AreEqual(2, this.htmlLogger.TestRunDetails.Summary.PassedTests, 2, "summary should keep track of passed tests");
-            Assert.AreEqual(1, this.htmlLogger.TestRunDetails.Summary.SkippedTests, 1, "summary should keep track of passed tests");
-            Assert.AreEqual(50, this.htmlLogger.TestRunDetails.Summary.PassPercentage, 50, "summary should keep track of passed tests");
+            Assert.AreEqual(4, this.htmlLogger.TestRunDetails.Summary.TotalTests, "summary should keep track of total tests");
+            Assert.AreEqual(1, this.htmlLogger.TestRunDetails.Summary.FailedTests, "summary should keep track of failed tests");
+            Assert.AreEqual(2, this.htmlLogger.TestRunDetails.Summary.PassedTests, "summary should keep track of passed tests");
+            Assert.AreEqual(1, this.htmlLogger.TestRunDetails.Summary.SkippedTests, "summary should keep track of passed tests");
+            Assert.AreEqual(50, this.htmlLogger.TestRunDetails.Summary.PassPercentage, "summary should keep track of passed tests");
             Assert.IsNull(this.htmlLogger.TestRunDetails.Summary.TotalRunTime, "summary should keep track of passed tests");
         }
 

--- a/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
@@ -118,8 +118,8 @@ namespace Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests
         [TestMethod]
         public void TestMessageHandlerShouldNotInitializelistForInformationErrorAndWarningMessages()
         {
-            Assert.AreEqual(this.htmlLogger.TestRunDetails.RunLevelMessageInformational, null);
-            Assert.AreEqual(this.htmlLogger.TestRunDetails.RunLevelMessageErrorAndWarning, null);
+            Assert.IsNull(this.htmlLogger.TestRunDetails.RunLevelMessageInformational);
+            Assert.IsNull(this.htmlLogger.TestRunDetails.RunLevelMessageErrorAndWarning);
         }
 
         [TestMethod]
@@ -154,7 +154,7 @@ namespace Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests
 
             this.htmlLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(failResult1).Object);
 
-            Assert.AreEqual(this.htmlLogger.FailedTests, 1, "Failed Tests");
+            Assert.AreEqual(1, this.htmlLogger.FailedTests, "Failed Tests");
         }
 
         [TestMethod]
@@ -165,7 +165,7 @@ namespace Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests
 
             this.htmlLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(passResult1).Object);
 
-            Assert.AreEqual(this.htmlLogger.TotalTests, 1, "Total Tests");
+            Assert.AreEqual(1, this.htmlLogger.TotalTests, "Total Tests");
         }
 
         [TestMethod]
@@ -176,7 +176,7 @@ namespace Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests
 
             this.htmlLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(passResult2).Object);
 
-            Assert.AreEqual(this.htmlLogger.PassedTests, 1, "Passed Tests");
+            Assert.AreEqual(1, this.htmlLogger.PassedTests, "Passed Tests");
         }
 
         [TestMethod]
@@ -188,7 +188,7 @@ namespace Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests
 
             this.htmlLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(skipResult1).Object);
 
-            Assert.AreEqual(this.htmlLogger.SkippedTests, 1, "Skipped Tests");
+            Assert.AreEqual(1, this.htmlLogger.SkippedTests, "Skipped Tests");
         }
 
         [TestMethod]
@@ -246,46 +246,46 @@ namespace Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests
 
             var result = this.htmlLogger.TestRunDetails.ResultCollectionList.First().ResultList.First();
 
-            Assert.AreEqual(result.DisplayName, "def");
-            Assert.AreEqual(result.ErrorMessage, "error message");
-            Assert.AreEqual(result.ErrorStackTrace, "Error stack trace");
-            Assert.AreEqual(result.FullyQualifiedName, "fully");
-            Assert.AreEqual(this.htmlLogger.TestRunDetails.ResultCollectionList.First().Source, "abc/def.dll");
-            Assert.AreEqual(result.Duration, "1s");
+            Assert.AreEqual("def", result.DisplayName);
+            Assert.AreEqual("error message", result.ErrorMessage);
+            Assert.AreEqual("Error stack trace", result.ErrorStackTrace);
+            Assert.AreEqual("fully", result.FullyQualifiedName);
+            Assert.AreEqual("abc/def.dll", this.htmlLogger.TestRunDetails.ResultCollectionList.First().Source);
+            Assert.AreEqual("1s", result.Duration);
         }
 
         [TestMethod]
         public void GetFormattedDurationStringShouldGiveCorrectFormat()
         {
             TimeSpan ts1 = new TimeSpan(0, 0, 0, 0, 1);
-            Assert.AreEqual(htmlLogger.GetFormattedDurationString(ts1), "1ms");
+            Assert.AreEqual("1ms", htmlLogger.GetFormattedDurationString(ts1));
 
             TimeSpan ts2 = new TimeSpan(0, 0, 0, 1, 0);
-            Assert.AreEqual(htmlLogger.GetFormattedDurationString(ts2), "1s");
+            Assert.AreEqual("1s", htmlLogger.GetFormattedDurationString(ts2));
 
             TimeSpan ts3 = new TimeSpan(0, 0, 1, 0, 1);
-            Assert.AreEqual(htmlLogger.GetFormattedDurationString(ts3), "1m");
-            ;
+            Assert.AreEqual("1m", htmlLogger.GetFormattedDurationString(ts3));
+
             TimeSpan ts4 = new TimeSpan(0, 1, 0, 2, 3);
-            Assert.AreEqual(htmlLogger.GetFormattedDurationString(ts4), "1h");
+            Assert.AreEqual("1h", htmlLogger.GetFormattedDurationString(ts4));
 
             TimeSpan ts5 = new TimeSpan(0, 1, 2, 3, 4);
-            Assert.AreEqual(htmlLogger.GetFormattedDurationString(ts5), "1h 2m");
+            Assert.AreEqual("1h 2m", htmlLogger.GetFormattedDurationString(ts5));
 
             TimeSpan ts6 = new TimeSpan(0, 0, 1, 2, 3);
-            Assert.AreEqual(htmlLogger.GetFormattedDurationString(ts6), "1m 2s");
+            Assert.AreEqual("1m 2s", htmlLogger.GetFormattedDurationString(ts6));
 
             TimeSpan ts7 = new TimeSpan(0, 0, 0, 1, 3);
-            Assert.AreEqual(htmlLogger.GetFormattedDurationString(ts7), "1s 3ms");
+            Assert.AreEqual("1s 3ms", htmlLogger.GetFormattedDurationString(ts7));
 
             TimeSpan ts8 = new TimeSpan(2);
-            Assert.AreEqual(htmlLogger.GetFormattedDurationString(ts8), "< 1ms");
+            Assert.AreEqual("< 1ms", htmlLogger.GetFormattedDurationString(ts8));
 
             TimeSpan ts10 = new TimeSpan(1, 0, 0, 1, 3);
-            Assert.AreEqual(htmlLogger.GetFormattedDurationString(ts10), "> 1d");
+            Assert.AreEqual("> 1d", htmlLogger.GetFormattedDurationString(ts10));
 
             TimeSpan ts9 = new TimeSpan(0, 0, 0, 0, 0);
-            Assert.AreEqual(htmlLogger.GetFormattedDurationString(ts9), null);
+            Assert.IsNull(htmlLogger.GetFormattedDurationString(ts9));
         }
 
         [TestMethod]
@@ -302,7 +302,7 @@ namespace Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests
             this.htmlLogger.TestResultHandler(new object(), resultEventArg1.Object);
             this.htmlLogger.TestResultHandler(new object(), resultEventArg2.Object);
 
-            Assert.AreEqual(this.htmlLogger.TestRunDetails.ResultCollectionList.First().ResultList.Count, 2, "TestResultHandler is not creating test result entry for each test case");
+            Assert.AreEqual(2, this.htmlLogger.TestRunDetails.ResultCollectionList.First().ResultList.Count, "TestResultHandler is not creating test result entry for each test case");
         }
 
         [TestMethod]
@@ -320,9 +320,9 @@ namespace Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests
             this.htmlLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(result1).Object);
             this.htmlLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(result2).Object);
 
-            Assert.AreEqual(this.htmlLogger.TestRunDetails.ResultCollectionList.Count, 2);
-            Assert.AreEqual(this.htmlLogger.TestRunDetails.ResultCollectionList.First().Source, "abc.dll");
-            Assert.AreEqual(this.htmlLogger.TestRunDetails.ResultCollectionList.Last().Source, "def.dll");
+            Assert.AreEqual(2, this.htmlLogger.TestRunDetails.ResultCollectionList.Count);
+            Assert.AreEqual("abc.dll", this.htmlLogger.TestRunDetails.ResultCollectionList.First().Source);
+            Assert.AreEqual("def.dll", this.htmlLogger.TestRunDetails.ResultCollectionList.Last().Source);
         }
 
         [TestMethod]
@@ -333,7 +333,7 @@ namespace Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests
 
             this.htmlLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(result1).Object);
 
-            Assert.AreEqual(this.htmlLogger.TestRunDetails.ResultCollectionList.First().FailedResultList.Count, 1);
+            Assert.AreEqual(1, this.htmlLogger.TestRunDetails.ResultCollectionList.First().FailedResultList.Count);
         }
 
         [TestMethod]
@@ -351,7 +351,7 @@ namespace Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests
 
             this.htmlLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(result1).Object);
 
-            Assert.AreEqual(this.htmlLogger.TestRunDetails.ResultCollectionList.First().ResultList.Count, 1, "test handler is adding parent result correctly");
+            Assert.AreEqual(1, this.htmlLogger.TestRunDetails.ResultCollectionList.First().ResultList.Count, "test handler is adding parent result correctly");
             Assert.IsNull(this.htmlLogger.TestRunDetails.ResultCollectionList.First().ResultList.First().InnerTestResults, "test handler is adding child result correctly");
 
             var result2 = new ObjectModel.TestResult(testCase2);
@@ -365,8 +365,8 @@ namespace Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests
             this.htmlLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(result2).Object);
             this.htmlLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(result3).Object);
 
-            Assert.AreEqual(this.htmlLogger.TestRunDetails.ResultCollectionList.First().ResultList.Count, 1, "test handler is adding parent result correctly");
-            Assert.AreEqual(this.htmlLogger.TestRunDetails.ResultCollectionList.First().ResultList.First().InnerTestResults.Count, 2, "test handler is adding child result correctly");
+            Assert.AreEqual(1, this.htmlLogger.TestRunDetails.ResultCollectionList.First().ResultList.Count, "test handler is adding parent result correctly");
+            Assert.AreEqual(2, this.htmlLogger.TestRunDetails.ResultCollectionList.First().ResultList.First().InnerTestResults.Count, "test handler is adding child result correctly");
         }
 
         [TestMethod]
@@ -392,12 +392,12 @@ namespace Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests
 
             this.htmlLogger.TestRunCompleteHandler(new object(), new TestRunCompleteEventArgs(null, false, true, null, null, TimeSpan.Zero));
 
-            Assert.AreEqual(this.htmlLogger.TestRunDetails.Summary.TotalTests, 4, "summary should keep track of total tests");
-            Assert.AreEqual(this.htmlLogger.TestRunDetails.Summary.FailedTests, 1, "summary should keep track of failed tests");
-            Assert.AreEqual(this.htmlLogger.TestRunDetails.Summary.PassedTests, 2, "summary should keep track of passed tests");
-            Assert.AreEqual(this.htmlLogger.TestRunDetails.Summary.SkippedTests, 1, "summary should keep track of passed tests");
-            Assert.AreEqual(this.htmlLogger.TestRunDetails.Summary.PassPercentage, 50, "summary should keep track of passed tests");
-            Assert.AreEqual(this.htmlLogger.TestRunDetails.Summary.TotalRunTime, null, "summary should keep track of passed tests");
+            Assert.AreEqual(4, this.htmlLogger.TestRunDetails.Summary.TotalTests, 4, "summary should keep track of total tests");
+            Assert.AreEqual(1, this.htmlLogger.TestRunDetails.Summary.FailedTests, 1, "summary should keep track of failed tests");
+            Assert.AreEqual(2, this.htmlLogger.TestRunDetails.Summary.PassedTests, 2, "summary should keep track of passed tests");
+            Assert.AreEqual(1, this.htmlLogger.TestRunDetails.Summary.SkippedTests, 1, "summary should keep track of passed tests");
+            Assert.AreEqual(50, this.htmlLogger.TestRunDetails.Summary.PassPercentage, 50, "summary should keep track of passed tests");
+            Assert.IsNull(this.htmlLogger.TestRunDetails.Summary.TotalRunTime, "summary should keep track of passed tests");
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             this.testableTrxLogger.TestMessageHandler(new object(), trme);
             this.testableTrxLogger.TestMessageHandler(new object(), trme);
 
-            Assert.AreEqual(this.testableTrxLogger.GetRunLevelErrorsAndWarnings().Count, 2);
+            Assert.AreEqual(2, this.testableTrxLogger.GetRunLevelErrorsAndWarnings().Count);
         }
 
         [TestMethod]
@@ -140,7 +140,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             TestRunMessageEventArgs trme = new TestRunMessageEventArgs(TestMessageLevel.Error, message);
             this.testableTrxLogger.TestMessageHandler(new object(), trme);
 
-            Assert.AreEqual(this.testableTrxLogger.GetRunLevelErrorsAndWarnings().Count, 1);
+            Assert.AreEqual(1, this.testableTrxLogger.GetRunLevelErrorsAndWarnings().Count);
         }
 
         [TestMethod]
@@ -185,8 +185,8 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             this.testableTrxLogger.TestResultHandler(new object(), fail1.Object);
             this.testableTrxLogger.TestResultHandler(new object(), skip1.Object);
 
-            Assert.AreEqual(this.testableTrxLogger.PassedTestCount, 2, "Passed Tests");
-            Assert.AreEqual(this.testableTrxLogger.FailedTestCount, 1, "Failed Tests");
+            Assert.AreEqual(2, this.testableTrxLogger.PassedTestCount, "Passed Tests");
+            Assert.AreEqual(1, this.testableTrxLogger.FailedTestCount, "Failed Tests");
         }
 
         [TestMethod]
@@ -219,7 +219,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             this.testableTrxLogger.TestResultHandler(new object(), fail1.Object);
             this.testableTrxLogger.TestResultHandler(new object(), skip1.Object);
 
-            Assert.AreEqual(this.testableTrxLogger.TotalTestCount, 4, "Passed Tests");
+            Assert.AreEqual(4, this.testableTrxLogger.TotalTestCount, "Passed Tests");
         }
 
         [TestMethod]
@@ -257,7 +257,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg1.Object);
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg2.Object);
 
-            Assert.AreEqual(this.testableTrxLogger.TestResultCount, 2, "TestResultHandler is not creating test result entry for each test case");
+            Assert.AreEqual(2, this.testableTrxLogger.TestResultCount, "TestResultHandler is not creating test result entry for each test case");
         }
 
         [TestMethod]
@@ -278,7 +278,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg1.Object);
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg2.Object);
 
-            Assert.AreEqual(this.testableTrxLogger.TestEntryCount, 2, "TestResultHandler is not creating test result entry for each test case");
+            Assert.AreEqual(2, this.testableTrxLogger.TestEntryCount, "TestResultHandler is not creating test result entry for each test case");
         }
 
         [TestMethod]
@@ -298,7 +298,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg1.Object);
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg2.Object);
 
-            Assert.AreEqual(this.testableTrxLogger.UnitTestElementCount, 2, "TestResultHandler is not creating test result entry for each test case");
+            Assert.AreEqual(2, this.testableTrxLogger.UnitTestElementCount, "TestResultHandler is not creating test result entry for each test case");
         }
 
         [TestMethod]
@@ -323,7 +323,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg1.Object);
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg2.Object);
 
-            Assert.AreEqual(this.testableTrxLogger.TestResultCount, 2, "TestResultHandler is not creating flat results when parent result is not present.");
+            Assert.AreEqual(2, this.testableTrxLogger.TestResultCount, "TestResultHandler is not creating flat results when parent result is not present.");
         }
 
         [TestMethod]
@@ -365,8 +365,8 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg2.Object);
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg3.Object);
 
-            Assert.AreEqual(this.testableTrxLogger.TestResultCount, 1, "TestResultHandler is not creating hierarchical results when parent result is present.");
-            Assert.AreEqual(this.testableTrxLogger.TotalTestCount, 3, "TestResultHandler is not adding all inner results in parent test result.");
+            Assert.AreEqual(1, this.testableTrxLogger.TestResultCount, "TestResultHandler is not creating hierarchical results when parent result is present.");
+            Assert.AreEqual(3, this.testableTrxLogger.TotalTestCount, "TestResultHandler is not adding all inner results in parent test result.");
         }
 
         [TestMethod]
@@ -396,7 +396,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg2.Object);
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg3.Object);
 
-            Assert.AreEqual(this.testableTrxLogger.UnitTestElementCount, 1, "TestResultHandler is adding multiple test elements for data driven tests.");
+            Assert.AreEqual(1, this.testableTrxLogger.UnitTestElementCount, "TestResultHandler is adding multiple test elements for data driven tests.");
         }
 
         [TestMethod]
@@ -426,7 +426,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg2.Object);
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg3.Object);
 
-            Assert.AreEqual(this.testableTrxLogger.TestEntryCount, 1, "TestResultHandler is adding multiple test entries for data driven tests.");
+            Assert.AreEqual(1, this.testableTrxLogger.TestEntryCount, "TestResultHandler is adding multiple test entries for data driven tests.");
         }
 
         [TestMethod]
@@ -459,8 +459,8 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg2.Object);
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg3.Object);
 
-            Assert.AreEqual(this.testableTrxLogger.TestResultCount, 1, "TestResultHandler is not creating hierarchical results for ordered test.");
-            Assert.AreEqual(this.testableTrxLogger.TotalTestCount, 3, "TestResultHandler is not adding all inner results in ordered test.");
+            Assert.AreEqual(1, this.testableTrxLogger.TestResultCount, "TestResultHandler is not creating hierarchical results for ordered test.");
+            Assert.AreEqual(3, this.testableTrxLogger.TotalTestCount, "TestResultHandler is not adding all inner results in ordered test.");
         }
 
         [TestMethod]
@@ -493,7 +493,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg2.Object);
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg3.Object);
 
-            Assert.AreEqual(this.testableTrxLogger.UnitTestElementCount, 3, "TestResultHandler is not adding multiple test elements for ordered test.");
+            Assert.AreEqual(3, this.testableTrxLogger.UnitTestElementCount, "TestResultHandler is not adding multiple test elements for ordered test.");
         }
 
         [TestMethod]
@@ -526,7 +526,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg2.Object);
             this.testableTrxLogger.TestResultHandler(new object(), resultEventArg3.Object);
 
-            Assert.AreEqual(this.testableTrxLogger.TestEntryCount, 1, "TestResultHandler is adding multiple test entries for ordered test.");
+            Assert.AreEqual(1, this.testableTrxLogger.TestEntryCount, "TestResultHandler is adding multiple test entries for ordered test.");
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/XmlPersistenceTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/XmlPersistenceTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             xmlPersistence.SaveObject(strWithInvalidCharForXml, node, null, "dummy");
 
             string expectedResult = "\\u0005\\u000b\\u000f\\ud800\\udc00\\ufffe\\u0000";
-            Assert.AreEqual(string.Compare(expectedResult, node.InnerXml), 0);
+            Assert.AreEqual(0, string.Compare(expectedResult, node.InnerXml));
         }
 
         [TestMethod]
@@ -54,7 +54,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             xmlPersistence.SaveObject(strWithValidCharForXml, node, null, "dummy");
 
             string expectedResult = "\t\n\r 섣�";
-            Assert.AreEqual(string.Compare(expectedResult, node.InnerXml), 0);
+            Assert.AreEqual(0, string.Compare(expectedResult, node.InnerXml));
         }
 
         [TestMethod]
@@ -65,7 +65,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             string strWithInvalidCharForXml = "This string has these \0 \v invalid characters";
             xmlPersistence.SaveObject(strWithInvalidCharForXml, node, null, "dummy");
             string expectedResult = "This string has these \\u0000 \\u000b invalid characters";
-            Assert.AreEqual(string.Compare(expectedResult, node.InnerXml), 0);
+            Assert.AreEqual(0, string.Compare(expectedResult, node.InnerXml));
         }
     }
 }

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/CustomKeyValueConverterTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/CustomKeyValueConverterTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests
         {
             var data = this.customKeyValueConverter.ConvertFrom(null, CultureInfo.InvariantCulture, null) as KeyValuePair<string, string>[];
 
-            Assert.AreEqual(null, data);
+            Assert.IsNull(data);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/CustomStringArrayConverterTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/CustomStringArrayConverterTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests
             var data = this.customStringArrayConverter.ConvertFrom(null, CultureInfo.InvariantCulture, json) as string[];
 
             Assert.AreEqual(2, data.Length);
-            Assert.AreEqual(null, data[0]);
+            Assert.IsNull(data[0]);
             Assert.AreEqual("val", data[1]);
         }
 
@@ -74,7 +74,7 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests
         {
             var data = this.customStringArrayConverter.ConvertFrom(null, CultureInfo.InvariantCulture, null) as string[];
 
-            Assert.AreEqual(null, data);
+            Assert.IsNull(data);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunConfigurationTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunConfigurationTests.cs
@@ -97,16 +97,16 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests
             var expectedSolutionPath = Environment.ExpandEnvironmentVariables("%temp%");
             Assert.AreEqual(expectedSolutionPath, runConfiguration.SolutionDirectory);
 
-            Assert.AreEqual(true, runConfiguration.TreatTestAdapterErrorsAsWarnings);
+            Assert.IsTrue(runConfiguration.TreatTestAdapterErrorsAsWarnings);
             Assert.AreEqual(@"E:\x\z", runConfiguration.BinariesRoot);
             Assert.AreEqual(@"C:\a\b;D:\x\y", runConfiguration.TestAdaptersPaths);
             Assert.AreEqual(2, runConfiguration.MaxCpuCount);
             Assert.AreEqual(5, runConfiguration.BatchSize);
             Assert.AreEqual(10000, runConfiguration.TestSessionTimeout);
-            Assert.AreEqual(true, runConfiguration.DisableAppDomain);
-            Assert.AreEqual(true, runConfiguration.DisableParallelization);
-            Assert.AreEqual(true, runConfiguration.DesignMode);
-            Assert.AreEqual(true, runConfiguration.InIsolation);
+            Assert.IsTrue(runConfiguration.DisableAppDomain);
+            Assert.IsTrue(runConfiguration.DisableParallelization);
+            Assert.IsTrue(runConfiguration.DesignMode);
+            Assert.IsTrue(runConfiguration.InIsolation);
             Assert.AreEqual(false, runConfiguration.ShouldCollectSourceInformation);
             Assert.AreEqual(PlatformApartmentState.STA, runConfiguration.ExecutionThreadApartmentState);
         }

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunConfigurationTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunConfigurationTests.cs
@@ -30,10 +30,10 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests
             Assert.AreEqual(null, runConfiguration.BinariesRoot);
             Assert.AreEqual(null, runConfiguration.TestAdaptersPaths);
             Assert.AreEqual(Constants.DefaultCpuCount, runConfiguration.MaxCpuCount);
-            Assert.AreEqual(false, runConfiguration.DisableAppDomain);
-            Assert.AreEqual(false, runConfiguration.DisableParallelization);
-            Assert.AreEqual(false, runConfiguration.DesignMode);
-            Assert.AreEqual(false, runConfiguration.InIsolation);
+            Assert.IsFalse(runConfiguration.DisableAppDomain);
+            Assert.IsFalse(runConfiguration.DisableParallelization);
+            Assert.IsFalse(runConfiguration.DesignMode);
+            Assert.IsFalse(runConfiguration.InIsolation);
             Assert.AreEqual(runConfiguration.DesignMode, runConfiguration.ShouldCollectSourceInformation);
             Assert.AreEqual(Constants.DefaultExecutionThreadApartmentState, runConfiguration.ExecutionThreadApartmentState);
         }
@@ -107,7 +107,7 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests
             Assert.IsTrue(runConfiguration.DisableParallelization);
             Assert.IsTrue(runConfiguration.DesignMode);
             Assert.IsTrue(runConfiguration.InIsolation);
-            Assert.AreEqual(false, runConfiguration.ShouldCollectSourceInformation);
+            Assert.IsFalse(runConfiguration.ShouldCollectSourceInformation);
             Assert.AreEqual(PlatformApartmentState.STA, runConfiguration.ExecutionThreadApartmentState);
         }
 

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunConfigurationTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunConfigurationTests.cs
@@ -25,10 +25,10 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests
             Assert.AreEqual(Constants.DefaultBatchSize, runConfiguration.BatchSize);
             Assert.AreEqual(0, runConfiguration.TestSessionTimeout);
             Assert.AreEqual(Constants.DefaultResultsDirectory, runConfiguration.ResultsDirectory);
-            Assert.AreEqual(null, runConfiguration.SolutionDirectory);
+            Assert.IsNull(runConfiguration.SolutionDirectory);
             Assert.AreEqual(Constants.DefaultTreatTestAdapterErrorsAsWarnings, runConfiguration.TreatTestAdapterErrorsAsWarnings);
-            Assert.AreEqual(null, runConfiguration.BinariesRoot);
-            Assert.AreEqual(null, runConfiguration.TestAdaptersPaths);
+            Assert.IsNull(runConfiguration.BinariesRoot);
+            Assert.IsNull(runConfiguration.TestAdaptersPaths);
             Assert.AreEqual(Constants.DefaultCpuCount, runConfiguration.MaxCpuCount);
             Assert.IsFalse(runConfiguration.DisableAppDomain);
             Assert.IsFalse(runConfiguration.DisableParallelization);

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Utilities/AssemblyHelperTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Utilities/AssemblyHelperTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests.Utilities
 
             AssemblyHelper.SetNETFrameworkCompatiblityMode(appDomainSetup, runContext.Object);
 
-            Assert.AreEqual(null, appDomainSetup.TargetFrameworkName);
+            Assert.IsNull(appDomainSetup.TargetFrameworkName);
         }
 
         [TestMethod]
@@ -70,7 +70,7 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests.Utilities
 
             AssemblyHelper.SetNETFrameworkCompatiblityMode(appDomainSetup, runContext.Object);
 
-            Assert.AreEqual(null, appDomainSetup.TargetFrameworkName);
+            Assert.IsNull(appDomainSetup.TargetFrameworkName);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Utilities/XmlRunSettingsUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Utilities/XmlRunSettingsUtilitiesTests.cs
@@ -153,7 +153,7 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests.Utilities
 
             // Verify Parameter Values.
             Assert.IsTrue(trp.ContainsKey("webAppUrl"));
-            Assert.AreEqual(trp["webAppUrl"], "http://localhost");
+            Assert.AreEqual("http://localhost", trp["webAppUrl"]);
         }
 
         [TestMethod]
@@ -180,11 +180,11 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests.Utilities
 
             // Verify Parameter Values.
             Assert.IsTrue(trp.ContainsKey("webAppUrl"));
-            Assert.AreEqual(trp["webAppUrl"], "http://localhost");
+            Assert.AreEqual("http://localhost", trp["webAppUrl"]);
             Assert.IsTrue(trp.ContainsKey("webAppUserName"));
-            Assert.AreEqual(trp["webAppUserName"], "Admin");
+            Assert.AreEqual("Admin", trp["webAppUserName"]);
             Assert.IsTrue(trp.ContainsKey("webAppPassword"));
-            Assert.AreEqual(trp["webAppPassword"], "Password");
+            Assert.AreEqual("Password",trp["webAppPassword"]);
         }
 
         [TestMethod]
@@ -263,7 +263,7 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests.Utilities
                                 </RunSettings>";
             var inProcDCRunSettings = XmlRunSettingsUtilities.GetInProcDataCollectionRunSettings(settingsXml);
             Assert.IsNotNull(inProcDCRunSettings);
-            Assert.AreEqual(inProcDCRunSettings.DataCollectorSettingsList.Count, 1);
+            Assert.AreEqual(1, inProcDCRunSettings.DataCollectorSettingsList.Count);
         }
 
         [TestMethod]
@@ -726,7 +726,7 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests.Utilities
                 </RunSettings>";
 
             var loggerRunSettings = XmlRunSettingsUtilities.GetLoggerRunSettings(runSettingsWithEmptyLoggerRunSettingsNode);
-            Assert.AreEqual(loggerRunSettings.LoggerSettingsList.Count, 0);
+            Assert.AreEqual(0, loggerRunSettings.LoggerSettingsList.Count);
         }
 
         [TestMethod]
@@ -741,7 +741,7 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests.Utilities
                 </RunSettings>";
 
             var loggerRunSettings = XmlRunSettingsUtilities.GetLoggerRunSettings(runSettingsWithEmptyLoggerRunSettingsNode);
-            Assert.AreEqual(loggerRunSettings.LoggerSettingsList.Count, 0);
+            Assert.AreEqual(0, loggerRunSettings.LoggerSettingsList.Count);
         }
 
         [TestMethod]
@@ -823,7 +823,7 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests.Utilities
                 </RunSettings>";
 
             var loggerRunSettings = XmlRunSettingsUtilities.GetLoggerRunSettings(runSettingsWithEmptyLoggersNode);
-            Assert.AreEqual(loggerRunSettings.LoggerSettingsList.Count, 0);
+            Assert.AreEqual(0, loggerRunSettings.LoggerSettingsList.Count);
         }
 
         [TestMethod]
@@ -840,7 +840,7 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests.Utilities
                 </RunSettings>";
 
             var loggerRunSettings = XmlRunSettingsUtilities.GetLoggerRunSettings(runSettingsWithEmptyLoggersNode);
-            Assert.AreEqual(loggerRunSettings.LoggerSettingsList.Count, 0);
+            Assert.AreEqual(0, loggerRunSettings.LoggerSettingsList.Count);
         }
 
         [TestMethod]
@@ -967,7 +967,7 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests.Utilities
             {
                 exceptionMessage = ex.Message;
             }
-            
+
             Assert.AreEqual(string.Format(
                 Resources.InvalidSettingsXmlElement,
                 "Logger",
@@ -1185,7 +1185,7 @@ namespace Microsoft.TestPlatform.ObjectModel.UnitTests.Utilities
 
             var friendlyNameList = XmlRunSettingsUtilities.GetDataCollectorsFriendlyName(settingsXml).ToList<string>();
 
-            Assert.AreEqual(friendlyNameList.Count, 2, "There should be two friendly name");
+            Assert.AreEqual(2, friendlyNameList.Count, "There should be two friendly name");
             CollectionAssert.AreEqual(friendlyNameList, new List<string> { "DummyDataCollector1", "DummyDataCollector2" });
         }
 

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -430,7 +430,7 @@ namespace TestPlatform.TestHostProvider.Hosting.UnitTests
 
             await this.testableTestHostManager.LaunchTestHostAsync(this.GetDefaultStartInfo(), CancellationToken.None);
 
-            Assert.AreEqual(null, this.errorMessage);
+            Assert.IsNull(this.errorMessage);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -216,7 +216,7 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
             this.mockFileHelper.Setup(ph => ph.Exists("testhost.dll")).Returns(false);
 
             var ex = Assert.ThrowsException<TestPlatformException>(() => this.GetDefaultStartInfo());
-            Assert.AreEqual(ex.Message, "Unable to find test.deps.json. Make sure test project has a nuget reference of package \"Microsoft.NET.Test.Sdk\".");
+            Assert.AreEqual("Unable to find test.deps.json. Make sure test project has a nuget reference of package \"Microsoft.NET.Test.Sdk\".", ex.Message);
         }
 
         [TestMethod]
@@ -236,7 +236,7 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
             this.mockFileHelper.Setup(ph => ph.Exists("testhost.dll")).Returns(false);
 
             var ex = Assert.ThrowsException<TestPlatformException>(() => this.GetDefaultStartInfo());
-            Assert.AreEqual(ex.Message, "Unable to find testhost.dll. Please publish your test project and retry.");
+            Assert.AreEqual("Unable to find testhost.dll. Please publish your test project and retry.", ex.Message);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/InferRunSettingsHelperTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/InferRunSettingsHelperTests.cs
@@ -573,8 +573,8 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
             var envVars = InferRunSettingsHelper.GetEnvironmentVariables(runSettingsXml);
 
             Assert.AreEqual(2, envVars.Count);
-            Assert.AreEqual(envVars["RANDOM_PATH"], @"C:\temp");
-            Assert.AreEqual(envVars["RANDOM_PATH2"], @"C:\temp2");
+            Assert.AreEqual(@"C:\temp", envVars["RANDOM_PATH"]);
+            Assert.AreEqual(@"C:\temp2", envVars["RANDOM_PATH2"]);
         }
 
         [TestMethod]
@@ -592,7 +592,7 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
             var envVars = InferRunSettingsHelper.GetEnvironmentVariables(runSettingsXml);
 
             Assert.AreEqual(1, envVars.Count);
-            Assert.AreEqual(envVars["RANDOM_PATH"], @"C:\temp");
+            Assert.AreEqual(@"C:\temp", envVars["RANDOM_PATH"]);
         }
 
         [TestMethod]

--- a/test/SettingsMigrator.UnitTests/MigratorTests.cs
+++ b/test/SettingsMigrator.UnitTests/MigratorTests.cs
@@ -165,7 +165,7 @@ namespace Microsoft.VisualStudio.TestPlatform.SettingsMigrator.UnitTests
 
                 var testSessionTimeoutNode = root.SelectSingleNode(@"/RunSettings/RunConfiguration/TestSessionTimeout");
                 Assert.IsNotNull(testSessionTimeoutNode, "There should be a TestSessionTimeout node");
-                Assert.AreEqual(testSessionTimeoutNode.InnerText, "60000", "Timeout value does not match.");
+                Assert.AreEqual("60000", testSessionTimeoutNode.InnerText, "Timeout value does not match.");
 
                 var dataCollectorNode = root.SelectSingleNode(@"/RunSettings/DataCollectionRunSettings/DataCollectors/DataCollector");
                 Assert.IsNotNull(dataCollectorNode, "There should be a DataCollector node");

--- a/test/TranslationLayer.UnitTests/VsTestConsoleRequestSenderTests.cs
+++ b/test/TranslationLayer.UnitTests/VsTestConsoleRequestSenderTests.cs
@@ -1427,7 +1427,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
             var traits = receivedChangeEventArgs.NewTestResults.ToArray()[0].TestCase.Traits;
             Assert.IsNotNull(traits);
             Assert.AreEqual("a", traits.ToArray()[0].Name);
-            Assert.AreEqual("b", traits.ToArray()[0].Name);
+            Assert.AreEqual("b", traits.ToArray()[0].Value);
         }
 
         [TestMethod]
@@ -1483,7 +1483,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
             var traits = receivedChangeEventArgs.NewTestResults.ToArray()[0].TestCase.Traits;
             Assert.IsNotNull(traits);
             Assert.AreEqual("a", traits.ToArray()[0].Name);
-            Assert.AreEqual("b", traits.ToArray()[0].Name);
+            Assert.AreEqual("b", traits.ToArray()[0].Value);
         }
 
         [TestMethod]
@@ -1540,7 +1540,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
             var traits = receivedChangeEventArgs.NewTestResults.ToArray()[0].TestCase.Traits;
             Assert.IsNotNull(traits);
             Assert.AreEqual("a", traits.ToArray()[0].Name);
-            Assert.AreEqual("b", traits.ToArray()[0].Name);
+            Assert.AreEqual("b", traits.ToArray()[0].Value);
         }
 
         [TestMethod]
@@ -1597,7 +1597,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
             var traits = receivedChangeEventArgs.NewTestResults.ToArray()[0].TestCase.Traits;
             Assert.IsNotNull(traits);
             Assert.AreEqual("a", traits.ToArray()[0].Name);
-            Assert.AreEqual("b", traits.ToArray()[0].Name);
+            Assert.AreEqual("b", traits.ToArray()[0].Value);
         }
 
         [TestMethod]

--- a/test/TranslationLayer.UnitTests/VsTestConsoleRequestSenderTests.cs
+++ b/test/TranslationLayer.UnitTests/VsTestConsoleRequestSenderTests.cs
@@ -468,8 +468,8 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
             // Verify that the traits are passed through properly.
             var traits = receivedTestCases.ToArray()[0].Traits;
             Assert.IsNotNull(traits);
-            Assert.AreEqual(traits.ToArray()[0].Name, "a");
-            Assert.AreEqual(traits.ToArray()[0].Value, "b");
+            Assert.AreEqual("a", traits.ToArray()[0].Name);
+            Assert.AreEqual("b", traits.ToArray()[0].Value);
         }
 
         [TestMethod]
@@ -506,8 +506,8 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
             // Verify that the traits are passed through properly.
             var traits = receivedTestCases.ToArray()[0].Traits;
             Assert.IsNotNull(traits);
-            Assert.AreEqual(traits.ToArray()[0].Name, "a");
-            Assert.AreEqual(traits.ToArray()[0].Value, "b");
+            Assert.AreEqual("a", traits.ToArray()[0].Name);
+            Assert.AreEqual("b", traits.ToArray()[0].Value);
         }
 
         [TestMethod]
@@ -542,8 +542,8 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
             // Verify that the traits are passed through properly.
             var traits = receivedTestCases.ToArray()[0].Traits;
             Assert.IsNotNull(traits);
-            Assert.AreEqual(traits.ToArray()[0].Name, "a");
-            Assert.AreEqual(traits.ToArray()[0].Value, "b");
+            Assert.AreEqual("a", traits.ToArray()[0].Name);
+            Assert.AreEqual("b", traits.ToArray()[0].Value);
         }
 
         [TestMethod]
@@ -578,8 +578,8 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
             // Verify that the traits are passed through properly.
             var traits = receivedTestCases.ToArray()[0].Traits;
             Assert.IsNotNull(traits);
-            Assert.AreEqual(traits.ToArray()[0].Name, "a");
-            Assert.AreEqual(traits.ToArray()[0].Value, "b");
+            Assert.AreEqual("a", traits.ToArray()[0].Name);
+            Assert.AreEqual("b", traits.ToArray()[0].Value);
         }
 
         [TestMethod]
@@ -931,7 +931,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
             this.SetupMockCommunicationForRunRequest(mockHandler);
             this.mockCommunicationManager.Setup(cm => cm.SendMessage(MessageType.TestRunAllSourcesWithDefaultHost, It.IsAny<TestRunRequestPayload>(), It.IsAny<int>())).
                 Callback((string msg, object requestpayload, int protocol) => { receivedRequest = (TestRunRequestPayload)requestpayload; });
-            
+
             // Act.
             this.requestSender.StartTestRun(sources, null, new TestPlatformOptions() { TestCaseFilter = filter }, mockHandler.Object);
 
@@ -1426,8 +1426,8 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
             // Verify that the traits are passed through properly.
             var traits = receivedChangeEventArgs.NewTestResults.ToArray()[0].TestCase.Traits;
             Assert.IsNotNull(traits);
-            Assert.AreEqual(traits.ToArray()[0].Name, "a");
-            Assert.AreEqual(traits.ToArray()[0].Value, "b");
+            Assert.AreEqual("a", traits.ToArray()[0].Name);
+            Assert.AreEqual("b", traits.ToArray()[0].Name);
         }
 
         [TestMethod]
@@ -1482,8 +1482,8 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
             // Verify that the traits are passed through properly.
             var traits = receivedChangeEventArgs.NewTestResults.ToArray()[0].TestCase.Traits;
             Assert.IsNotNull(traits);
-            Assert.AreEqual(traits.ToArray()[0].Name, "a");
-            Assert.AreEqual(traits.ToArray()[0].Value, "b");
+            Assert.AreEqual("a", traits.ToArray()[0].Name);
+            Assert.AreEqual("b", traits.ToArray()[0].Name);
         }
 
         [TestMethod]
@@ -1539,8 +1539,8 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
             // Verify that the traits are passed through properly.
             var traits = receivedChangeEventArgs.NewTestResults.ToArray()[0].TestCase.Traits;
             Assert.IsNotNull(traits);
-            Assert.AreEqual(traits.ToArray()[0].Name, "a");
-            Assert.AreEqual(traits.ToArray()[0].Value, "b");
+            Assert.AreEqual("a", traits.ToArray()[0].Name);
+            Assert.AreEqual("b", traits.ToArray()[0].Name);
         }
 
         [TestMethod]
@@ -1596,8 +1596,8 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
             // Verify that the traits are passed through properly.
             var traits = receivedChangeEventArgs.NewTestResults.ToArray()[0].TestCase.Traits;
             Assert.IsNotNull(traits);
-            Assert.AreEqual(traits.ToArray()[0].Name, "a");
-            Assert.AreEqual(traits.ToArray()[0].Value, "b");
+            Assert.AreEqual("a", traits.ToArray()[0].Name);
+            Assert.AreEqual("b", traits.ToArray()[0].Name);
         }
 
         [TestMethod]
@@ -1938,7 +1938,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
             var connectionSuccess = this.requestSender.WaitForRequestHandlerConnection(this.WaitTimeout);
             Assert.IsTrue(connectionSuccess, "Connection must succeed.");
         }
-        
+
         private void SetupMockCommunicationForRunRequest(Mock<ITestRunEventsHandler> mockHandler)
         {
             this.InitializeCommunication();

--- a/test/datacollector.UnitTests/DataCollectionAttachmentManagerTests.cs
+++ b/test/datacollector.UnitTests/DataCollectionAttachmentManagerTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
 
             this.attachmentManager.AddAttachment(dataCollectorDataMessage, null, uri, friendlyName);
 
-            Assert.AreEqual(this.attachmentManager.AttachmentSets.Count, 0);
+            Assert.AreEqual(0, this.attachmentManager.AttachmentSets.Count);
         }
 
         [TestMethod]

--- a/test/datacollector.UnitTests/DataCollectionManagerTests.cs
+++ b/test/datacollector.UnitTests/DataCollectionManagerTests.cs
@@ -298,11 +298,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
 
             var sessionStartEventArgs = new SessionStartEventArgs();
 
-            Assert.AreEqual(sessionStartEventArgs.Context.SessionId, new SessionId(Guid.Empty));
+            Assert.AreEqual(new SessionId(Guid.Empty), sessionStartEventArgs.Context.SessionId);
 
             this.dataCollectionManager.SessionStarted(sessionStartEventArgs);
 
-            Assert.AreNotEqual(sessionStartEventArgs.Context.SessionId, new SessionId(Guid.Empty));
+            Assert.AreNotEqual(new SessionId(Guid.Empty), sessionStartEventArgs.Context.SessionId);
         }
 
         [TestMethod]

--- a/test/datacollector.UnitTests/DataCollectorMainTests.cs
+++ b/test/datacollector.UnitTests/DataCollectorMainTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
         {
             this.mockDataCollectionRequestHandler.Setup(rh => rh.WaitForRequestSenderConnection(It.IsAny<int>())).Returns(false);
             var message = Assert.ThrowsException<TestPlatformException>(() => this.dataCollectorMain.Run(args)).Message;
-            Assert.AreEqual(message, DataCollectorMainTests.TimoutErrorMessage);
+            Assert.AreEqual(DataCollectorMainTests.TimoutErrorMessage, message);
         }
 
     }

--- a/test/testhost.UnitTests/AppDomainEngineInvokerTests.cs
+++ b/test/testhost.UnitTests/AppDomainEngineInvokerTests.cs
@@ -51,7 +51,7 @@ namespace testhost.UnitTests
 
             Assert.IsNotNull(appDomainInvoker.NewAppDomain, "New AppDomain must be created.");
             Assert.IsNotNull(appDomainInvoker.ActualInvoker, "Invoker must be created.");
-            Assert.AreNotEqual(AppDomain.CurrentDomain.FriendlyName, appDomainInvoker.NewAppDomain.FriendlyName, 
+            Assert.AreNotEqual(AppDomain.CurrentDomain.FriendlyName, appDomainInvoker.NewAppDomain.FriendlyName,
                 "New AppDomain must be different from default one.");
         }
 
@@ -65,7 +65,7 @@ namespace testhost.UnitTests
 
             Assert.IsNotNull(newAppDomain, "New AppDomain must be created.");
             Assert.IsNotNull(appDomainInvoker.ActualInvoker, "Invoker must be created.");
-            Assert.AreNotEqual(AppDomain.CurrentDomain.FriendlyName, 
+            Assert.AreNotEqual(AppDomain.CurrentDomain.FriendlyName,
                 (appDomainInvoker.ActualInvoker as MockEngineInvoker).DomainFriendlyName,
                 "Engine must be invoked in new domain.");
 
@@ -78,7 +78,7 @@ namespace testhost.UnitTests
         {
             string appConfig = @"<?xml version=""1.0"" encoding=""utf-8""?>
                                 <configuration>
-                                    <startup> 
+                                    <startup>
                                         <supportedRuntime version=""v4.0"" sku="".NETFramework,Version=v4.5.2"" />
                                     </startup>
                                 </configuration>";
@@ -90,7 +90,7 @@ namespace testhost.UnitTests
             Assert.AreEqual(1, startupElements.Count(), "Merged config must have only one 'startup' element");
 
             var supportedRuntimeXml = startupElements.First().Descendants("supportedRuntime").FirstOrDefault()?.ToString();
-            Assert.AreEqual(supportedRuntimeXml, @"<supportedRuntime version=""v4.0"" sku="".NETFramework,Version=v4.0"" />",
+            Assert.AreEqual(@"<supportedRuntime version=""v4.0"" sku="".NETFramework,Version=v4.0"" />", supportedRuntimeXml,
                 "TestHost Supported Runtime must be used on merging");
 
             var runtimeEle = doc.Descendants("runtime").FirstOrDefault();
@@ -189,7 +189,7 @@ namespace testhost.UnitTests
 
             var diagAddNodes = diagEle.Descendants("add");
             Assert.AreEqual(1, diagAddNodes.Count(), "Only switches from user config should be present.");
-            Assert.AreEqual(@"<add name=""SampleSwitch"" value=""1"" />", diagAddNodes.First().ToString(), 
+            Assert.AreEqual(@"<add name=""SampleSwitch"" value=""1"" />", diagAddNodes.First().ToString(),
                 "Correct Switch must be merged.");
 
             var appSettingsAddNodes = appSettingsEle.Descendants("add");
@@ -207,7 +207,7 @@ namespace testhost.UnitTests
             public static XDocument MergeConfigXmls(string userConfigText, string testHostConfigText)
             {
                 return MergeApplicationConfigFiles(
-                    XDocument.Load(new MemoryStream(Encoding.UTF8.GetBytes(userConfigText))), 
+                    XDocument.Load(new MemoryStream(Encoding.UTF8.GetBytes(userConfigText))),
                     XDocument.Load(new MemoryStream(Encoding.UTF8.GetBytes(testHostConfigText))));
             }
 

--- a/test/testhost.UnitTests/UnitTestClientTests.cs
+++ b/test/testhost.UnitTests/UnitTestClientTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.TestPlatform.TestExecutor.Tests
             var argument = "--port 8080 --endpoint 127.0.0.1:8020 --diag \"abc txt\"";
             string[] argsArr = UnitTestClient.SplitArguments(argument);
 
-            Assert.AreEqual(argsArr.Length, 6);
+            Assert.AreEqual(6, argsArr.Length);
             CollectionAssert.AreEqual(argsArr, expected);
         }
 
@@ -27,8 +27,8 @@ namespace Microsoft.VisualStudio.TestPlatform.TestExecutor.Tests
             var argument = "--port 8080 --endpoint 127.0.0.1:8020 --diag \'abc txt\'";
             string[] argsArr = UnitTestClient.SplitArguments(argument);
 
-            Assert.AreEqual(argsArr.Length, 6);
-            CollectionAssert.AreEqual(argsArr, expected);
+            Assert.AreEqual(6, argsArr.Length);
+            CollectionAssert.AreEqual(expected, argsArr);
         }
 
         [TestMethod]
@@ -38,8 +38,8 @@ namespace Microsoft.VisualStudio.TestPlatform.TestExecutor.Tests
             var argument = "--port 8080 --endpoint 127.0.0.1:8020 --diag abc txt";
             string[] argsArr = UnitTestClient.SplitArguments(argument);
 
-            Assert.AreEqual(argsArr.Length, 7);
-            CollectionAssert.AreEqual(argsArr, expected);
+            Assert.AreEqual(7, argsArr.Length);
+            CollectionAssert.AreEqual(expected, argsArr);
         }
     }
 }

--- a/test/vstest.console.PlatformTests/AssemblyMetadataProviderTests.cs
+++ b/test/vstest.console.PlatformTests/AssemblyMetadataProviderTests.cs
@@ -120,11 +120,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.PlatformTests
             {
                 // Reason is unknown for why full framework it is taking more time. Need to investigate.
                 expectedElapsedTime = 100;
-                Assert.AreEqual(actualFx.FullName, Constants.DotNetFramework451);
+                Assert.AreEqual(Constants.DotNetFramework451, actualFx.FullName);
             }
             else
             {
-                Assert.AreEqual(actualFx.FullName, ".NETCoreApp,Version=v2.1");
+                Assert.AreEqual(".NETCoreApp,Version=v2.1", actualFx.FullName);
             }
 
             Console.WriteLine("Framework:{0}, {1}", framework, string.Format(PerfAssertMessageFormat, expectedElapsedTime, stopWatch.ElapsedMilliseconds));

--- a/test/vstest.console.UnitTests/CommandLine/GenerateFakesUtilitiesTests.cs
+++ b/test/vstest.console.UnitTests/CommandLine/GenerateFakesUtilitiesTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.CommandLine
         [TestMethod]
         public void CommandLineOptionsDefaultDisableAutoFakesIsFalse()
         {
-            Assert.AreEqual(false, CommandLineOptions.Instance.DisableAutoFakes);
+            Assert.IsFalse(CommandLineOptions.Instance.DisableAutoFakes);
         }
 
         [TestMethod]

--- a/test/vstest.console.UnitTests/ExecutorUnitTests.cs
+++ b/test/vstest.console.UnitTests/ExecutorUnitTests.cs
@@ -167,9 +167,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests
             var mockOutput = new MockOutput();
             var exitCode = new Executor(mockOutput, this.mockTestPlatformEventSource.Object).Execute(null);
             RunConfiguration runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(RunSettingsManager.Instance.ActiveRunSettings.SettingsXml);
-            Assert.AreEqual(runConfiguration.ResultsDirectory, Constants.DefaultResultsDirectory);
-            Assert.AreEqual(runConfiguration.TargetFramework.ToString(), Framework.DefaultFramework.ToString());
-            Assert.AreEqual(runConfiguration.TargetPlatform, Constants.DefaultPlatform);
+            Assert.AreEqual(Constants.DefaultResultsDirectory, runConfiguration.ResultsDirectory);
+            Assert.AreEqual(Framework.DefaultFramework.ToString(), runConfiguration.TargetFramework.ToString());
+            Assert.AreEqual(Constants.DefaultPlatform, runConfiguration.TargetPlatform);
         }
 
         [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
@@ -65,12 +65,12 @@ namespace vstest.console.UnitTests.Processors
             Assert.AreEqual("RunSettings arguments:" + Environment.NewLine + "      Arguments to pass runsettings configurations through commandline. Arguments may be specified as name-value pair of the form [name]=[value] after \"-- \". Note the space after --. " + Environment.NewLine + "      Use a space to separate multiple [name]=[value]." + Environment.NewLine + "      More info on RunSettings arguments support: https://aka.ms/vstest-runsettings-arguments", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.CLIRunSettingsArgumentProcessorHelpPriority, capabilities.HelpPriority);
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.CLIRunSettings, capabilities.Priority);
 
-            Assert.AreEqual(false, capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AllowMultiple);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
 
         #endregion

--- a/test/vstest.console.UnitTests/Processors/CollectArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CollectArgumentProcessorTests.cs
@@ -56,7 +56,7 @@ namespace vstest.console.UnitTests.Processors
             Assert.AreEqual(false, capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.AutoUpdateRunSettings, capabilities.Priority);
 
-            Assert.AreEqual(true, capabilities.AllowMultiple);
+            Assert.IsTrue(capabilities.AllowMultiple);
             Assert.AreEqual(false, capabilities.AlwaysExecute);
             Assert.AreEqual(false, capabilities.IsSpecialCommand);
         }

--- a/test/vstest.console.UnitTests/Processors/CollectArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CollectArgumentProcessorTests.cs
@@ -53,12 +53,12 @@ namespace vstest.console.UnitTests.Processors
             Assert.AreEqual("--Collect|/Collect:<DataCollector FriendlyName>" + Environment.NewLine + "      Enables data collector for the test run. More info here : https://aka.ms/vstest-collect", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.CollectArgumentProcessorHelpPriority, capabilities.HelpPriority);
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.AutoUpdateRunSettings, capabilities.Priority);
 
             Assert.IsTrue(capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
 
         #endregion

--- a/test/vstest.console.UnitTests/Processors/DisableAutoFakesArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/DisableAutoFakesArgumentProcessorTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.IsFalse(this.disableAutoFakesArgumentProcessor.Metadata.Value.IsAction);
             Assert.IsFalse(this.disableAutoFakesArgumentProcessor.Metadata.Value.IsSpecialCommand);
             Assert.AreEqual(DisableAutoFakesArgumentProcessor.CommandName, this.disableAutoFakesArgumentProcessor.Metadata.Value.CommandName);
-            Assert.AreEqual(null, this.disableAutoFakesArgumentProcessor.Metadata.Value.ShortCommandName);
+            Assert.IsNull(this.disableAutoFakesArgumentProcessor.Metadata.Value.ShortCommandName);
             Assert.AreEqual(ArgumentProcessorPriority.Normal, this.disableAutoFakesArgumentProcessor.Metadata.Value.Priority);
             Assert.AreEqual(HelpContentPriority.DisableAutoFakesArgumentProcessorHelpPriority, this.disableAutoFakesArgumentProcessor.Metadata.Value.HelpPriority);
         }

--- a/test/vstest.console.UnitTests/Processors/DisableAutoFakesArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/DisableAutoFakesArgumentProcessorTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         public void DisableAutoFakesArgumentProcessorExecutorShouldSetCommandLineDisableAutoFakeValueAsPerArgumentProvided()
         {
             this.disableAutoFakesArgumentProcessor.Executor.Value.Initialize("true");
-            Assert.AreEqual(CommandLineOptions.Instance.DisableAutoFakes, true);
+            Assert.IsTrue(CommandLineOptions.Instance.DisableAutoFakes);
         }
     }
 }

--- a/test/vstest.console.UnitTests/Processors/EnableBlameArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableBlameArgumentProcessorTests.cs
@@ -57,14 +57,14 @@ namespace vstest.console.UnitTests.Processors
             var capabilities = new EnableBlameArgumentProcessorCapabilities();
 
             Assert.AreEqual("/Blame", capabilities.CommandName);
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Logging, capabilities.Priority);
             Assert.AreEqual(HelpContentPriority.EnableDiagArgumentProcessorHelpPriority, capabilities.HelpPriority);
             Assert.AreEqual(CommandLineResources.EnableBlameUsage, capabilities.HelpContentResourceName);
 
-            Assert.AreEqual(false, capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AllowMultiple);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
 
         [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/EnableCodeCoverageArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableCodeCoverageArgumentProcessorTests.cs
@@ -47,12 +47,12 @@ namespace vstest.console.UnitTests.Processors
             var capabilities = new EnableCodeCoverageArgumentProcessorCapabilities();
 
             Assert.AreEqual("/EnableCodeCoverage", capabilities.CommandName);
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.AutoUpdateRunSettings, capabilities.Priority);
 
-            Assert.AreEqual(false, capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AllowMultiple);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
 
         #endregion

--- a/test/vstest.console.UnitTests/Processors/EnableDiagArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableDiagArgumentProcessorTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.IsFalse(this.diagProcessor.Metadata.Value.IsAction);
             Assert.IsFalse(this.diagProcessor.Metadata.Value.IsSpecialCommand);
             Assert.AreEqual(EnableDiagArgumentProcessor.CommandName, this.diagProcessor.Metadata.Value.CommandName);
-            Assert.AreEqual(null, this.diagProcessor.Metadata.Value.ShortCommandName);
+            Assert.IsNull(this.diagProcessor.Metadata.Value.ShortCommandName);
             Assert.AreEqual(ArgumentProcessorPriority.Diag, this.diagProcessor.Metadata.Value.Priority);
             Assert.AreEqual(HelpContentPriority.EnableDiagArgumentProcessorHelpPriority, this.diagProcessor.Metadata.Value.HelpPriority);
             Assert.AreEqual(CommandLineResources.EnableDiagUsage, this.diagProcessor.Metadata.Value.HelpContentResourceName);

--- a/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual(false, capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Logging, capabilities.Priority);
 
-            Assert.AreEqual(true, capabilities.AllowMultiple);
+            Assert.IsTrue(capabilities.AllowMultiple);
             Assert.AreEqual(false, capabilities.AlwaysExecute);
             Assert.AreEqual(false, capabilities.IsSpecialCommand);
         }

--- a/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
@@ -47,12 +47,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
 #endif
 
             Assert.AreEqual(HelpContentPriority.EnableLoggerArgumentProcessorHelpPriority, capabilities.HelpPriority);
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Logging, capabilities.Priority);
 
             Assert.IsTrue(capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
 
         [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/FrameworkArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/FrameworkArgumentProcessorTests.cs
@@ -53,12 +53,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             StringAssert.Contains(capabilities.HelpContentResourceName, "Valid values are \".NETFramework,Version=v4.5.1\", \".NETCoreApp,Version=v1.0\"");
 
             Assert.AreEqual(HelpContentPriority.FrameworkArgumentProcessorHelpPriority, capabilities.HelpPriority);
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.AutoUpdateRunSettings, capabilities.Priority);
 
-            Assert.AreEqual(false, capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AllowMultiple);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
 
         #endregion

--- a/test/vstest.console.UnitTests/Processors/HelpArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/HelpArgumentProcessorTests.cs
@@ -43,12 +43,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual("-?|--Help|/?|/Help" + Environment.NewLine + "      Display this usage message.", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.HelpArgumentProcessorHelpPriority, capabilities.HelpPriority);
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Help, capabilities.Priority);
 
             Assert.IsTrue(capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
 
         #endregion

--- a/test/vstest.console.UnitTests/Processors/HelpArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/HelpArgumentProcessorTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual(false, capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Help, capabilities.Priority);
 
-            Assert.AreEqual(true, capabilities.AllowMultiple);
+            Assert.IsTrue(capabilities.AllowMultiple);
             Assert.AreEqual(false, capabilities.AlwaysExecute);
             Assert.AreEqual(false, capabilities.IsSpecialCommand);
         }

--- a/test/vstest.console.UnitTests/Processors/InIsolationArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/InIsolationArgumentProcessorTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.IsFalse(isolationProcessor.Metadata.Value.IsAction);
             Assert.IsFalse(isolationProcessor.Metadata.Value.IsSpecialCommand);
             Assert.AreEqual(InIsolationArgumentProcessor.CommandName, isolationProcessor.Metadata.Value.CommandName);
-            Assert.AreEqual(null, isolationProcessor.Metadata.Value.ShortCommandName);
+            Assert.IsNull(isolationProcessor.Metadata.Value.ShortCommandName);
             Assert.AreEqual(ArgumentProcessorPriority.AutoUpdateRunSettings, isolationProcessor.Metadata.Value.Priority);
             Assert.AreEqual(HelpContentPriority.InIsolationArgumentProcessorHelpPriority, isolationProcessor.Metadata.Value.HelpPriority);
             Assert.AreEqual("--InIsolation|/InIsolation" + Environment.NewLine + "      Runs the tests in an isolated process. This makes vstest.console.exe " + Environment.NewLine + "      process less likely to be stopped on an error in the tests, but tests " + Environment.NewLine + "      may run slower.", isolationProcessor.Metadata.Value.HelpContentResourceName);

--- a/test/vstest.console.UnitTests/Processors/ListFullyQualifiedTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListFullyQualifiedTestsArgumentProcessorTests.cs
@@ -111,9 +111,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.IsTrue(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Normal, capabilities.Priority);
 
-            Assert.AreEqual(false, capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AllowMultiple);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
         #endregion
 

--- a/test/vstest.console.UnitTests/Processors/ListFullyQualifiedTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListFullyQualifiedTestsArgumentProcessorTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             var capabilities = new ListFullyQualifiedTestsArgumentProcessorCapabilities();
             Assert.AreEqual("/ListFullyQualifiedTests", capabilities.CommandName);
 
-            Assert.AreEqual(true, capabilities.IsAction);
+            Assert.IsTrue(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Normal, capabilities.Priority);
 
             Assert.AreEqual(false, capabilities.AllowMultiple);

--- a/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
@@ -112,9 +112,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.IsTrue(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Normal, capabilities.Priority);
 
-            Assert.AreEqual(false, capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AllowMultiple);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
         #endregion
 

--- a/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual("-lt|--ListTests|/lt|/ListTests:<File Name>" + Environment.NewLine + "      Lists all discovered tests from the given test container.", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.ListTestsArgumentProcessorHelpPriority, capabilities.HelpPriority);
-            Assert.AreEqual(true, capabilities.IsAction);
+            Assert.IsTrue(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Normal, capabilities.Priority);
 
             Assert.AreEqual(false, capabilities.AllowMultiple);

--- a/test/vstest.console.UnitTests/Processors/ListTestsTargetPathArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListTestsTargetPathArgumentProcessorTests.cs
@@ -34,12 +34,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             ListTestsTargetPathArgumentProcessorCapabilities capabilities = new ListTestsTargetPathArgumentProcessorCapabilities();
             Assert.AreEqual("/ListTestsTargetPath", capabilities.CommandName);
             
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Normal, capabilities.Priority);
 
-            Assert.AreEqual(false, capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AllowMultiple);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
 
         #endregion

--- a/test/vstest.console.UnitTests/Processors/ParallelArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ParallelArgumentProcessorTests.cs
@@ -53,12 +53,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual("--Parallel|/Parallel" + Environment.NewLine + "      Specifies that the tests be executed in parallel. By default up" + Environment.NewLine + "      to all available cores on the machine may be used." + Environment.NewLine + "      The number of cores to use may be configured using a settings file.", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.ParallelArgumentProcessorHelpPriority, capabilities.HelpPriority);
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.AutoUpdateRunSettings, capabilities.Priority);
 
-            Assert.AreEqual(false, capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AllowMultiple);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
 
         #endregion

--- a/test/vstest.console.UnitTests/Processors/ParentProcessIdArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ParentProcessIdArgumentProcessorTests.cs
@@ -42,12 +42,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual("--ParentProcessId|/ParentProcessId:<ParentProcessId>" + Environment.NewLine + "      Process Id of the Parent Process responsible for launching current process.", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.ParentProcessIdArgumentProcessorHelpPriority, capabilities.HelpPriority);
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.DesignMode, capabilities.Priority);
 
-            Assert.AreEqual(false, capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AllowMultiple);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
 
         [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
@@ -53,12 +53,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual("--Platform|/Platform:<Platform type>" + Environment.NewLine + "      Target platform architecture to be used for test execution. " + Environment.NewLine + "      Valid values are x86, x64 and ARM.", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.PlatformArgumentProcessorHelpPriority, capabilities.HelpPriority);
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.AutoUpdateRunSettings, capabilities.Priority);
 
-            Assert.AreEqual(false, capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AllowMultiple);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
 
         #endregion

--- a/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
@@ -53,12 +53,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual("--Port|/Port:<Port>" + Environment.NewLine + "      The Port for socket connection and receiving the event messages.", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.PortArgumentProcessorHelpPriority, capabilities.HelpPriority);
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.DesignMode, capabilities.Priority);
 
-            Assert.AreEqual(false, capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AllowMultiple);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
 
         #endregion

--- a/test/vstest.console.UnitTests/Processors/ResponseFileArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ResponseFileArgumentProcessorTests.cs
@@ -39,11 +39,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             StringAssert.Contains(capabilities.HelpContentResourceName, "Read response file for more options");
 
             Assert.AreEqual(HelpContentPriority.ResponseFileArgumentProcessorHelpPriority, capabilities.HelpPriority);
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Normal, capabilities.Priority);
 
             Assert.IsTrue(capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.AlwaysExecute);
             Assert.IsTrue(capabilities.IsSpecialCommand);
         }
 

--- a/test/vstest.console.UnitTests/Processors/ResponseFileArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ResponseFileArgumentProcessorTests.cs
@@ -42,9 +42,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual(false, capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Normal, capabilities.Priority);
 
-            Assert.AreEqual(true, capabilities.AllowMultiple);
+            Assert.IsTrue(capabilities.AllowMultiple);
             Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(true, capabilities.IsSpecialCommand);
+            Assert.IsTrue(capabilities.IsSpecialCommand);
         }
 
         #endregion

--- a/test/vstest.console.UnitTests/Processors/ResultsDirectoryArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ResultsDirectoryArgumentProcessorTests.cs
@@ -53,12 +53,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual("--ResultsDirectory|/ResultsDirectory" + Environment.NewLine + "      Test results directory will be created in specified path if not exists." + Environment.NewLine + "      Example  /ResultsDirectory:<pathToResultsDirectory>", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.ResultsDirectoryArgumentProcessorHelpPriority, capabilities.HelpPriority);
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.AutoUpdateRunSettings, capabilities.Priority);
 
-            Assert.AreEqual(false, capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AllowMultiple);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
 
         #endregion

--- a/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
@@ -63,12 +63,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual("--Settings|/Settings:<Settings File>" + Environment.NewLine + "      Settings to use when running tests.", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.RunSettingsArgumentProcessorHelpPriority, capabilities.HelpPriority);
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.RunSettings, capabilities.Priority);
 
-            Assert.AreEqual(false, capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AllowMultiple);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
 
         #endregion

--- a/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
@@ -97,9 +97,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.IsTrue(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Normal, capabilities.Priority);
 
-            Assert.AreEqual(false, capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AllowMultiple);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
         #endregion
 

--- a/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             StringAssert.Contains(capabilities.HelpContentResourceName, "/Tests:<Test Names>" + Environment.NewLine + "      Run tests with names that match the provided values.");
 
             Assert.AreEqual(HelpContentPriority.RunSpecificTestsArgumentProcessorHelpPriority, capabilities.HelpPriority);
-            Assert.AreEqual(true, capabilities.IsAction);
+            Assert.IsTrue(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Normal, capabilities.Priority);
 
             Assert.AreEqual(false, capabilities.AllowMultiple);

--- a/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
@@ -93,8 +93,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.IsTrue(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Normal, capabilities.Priority);
 
-            Assert.AreEqual(false, capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.AllowMultiple);
+            Assert.IsFalse(capabilities.AlwaysExecute);
             Assert.IsTrue(capabilities.IsSpecialCommand);
         }
         #endregion

--- a/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
@@ -90,12 +90,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual("[TestFileNames]" + Environment.NewLine + "      Run tests from the specified files or wild card pattern. Separate multiple test file names or pattern" + Environment.NewLine + "      by spaces. Set console logger verbosity to detailed to view matched test files." + Environment.NewLine + "      Examples: mytestproject.dll" + Environment.NewLine + "                mytestproject.dll myothertestproject.exe" + Environment.NewLine + @"                testproject*.dll my*project.dll", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.RunTestsArgumentProcessorHelpPriority, capabilities.HelpPriority);
-            Assert.AreEqual(true, capabilities.IsAction);
+            Assert.IsTrue(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Normal, capabilities.Priority);
 
             Assert.AreEqual(false, capabilities.AllowMultiple);
             Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(true, capabilities.IsSpecialCommand);
+            Assert.IsTrue(capabilities.IsSpecialCommand);
         }
         #endregion
 

--- a/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
@@ -62,12 +62,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual("--TestAdapterPath|/TestAdapterPath" + Environment.NewLine + "      This makes vstest.console.exe process use custom test adapters" + Environment.NewLine + "      from a given path (if any) in the test run. " + Environment.NewLine + "      Example  /TestAdapterPath:<pathToCustomAdapters>", capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.TestAdapterPathArgumentProcessorHelpPriority, capabilities.HelpPriority);
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.TestAdapterPath, capabilities.Priority);
 
             Assert.IsTrue(capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
 
         #endregion

--- a/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual(false, capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.TestAdapterPath, capabilities.Priority);
 
-            Assert.AreEqual(true, capabilities.AllowMultiple);
+            Assert.IsTrue(capabilities.AllowMultiple);
             Assert.AreEqual(false, capabilities.AlwaysExecute);
             Assert.AreEqual(false, capabilities.IsSpecialCommand);
         }

--- a/test/vstest.console.UnitTests/Processors/TestCaseFilterArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestCaseFilterArgumentProcessorTests.cs
@@ -36,12 +36,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             StringAssert.Contains(capabilities.HelpContentResourceName, "/TestCaseFilter:<Expression>" + Environment.NewLine + "      Run tests that match the given expression." + Environment.NewLine + "      <Expression> is of the format <property>Operator<value>[|&<Expression>]");
 
             Assert.AreEqual(HelpContentPriority.TestCaseFilterArgumentProcessorHelpPriority, capabilities.HelpPriority);
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Normal, capabilities.Priority);
 
-            Assert.AreEqual(false, capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AllowMultiple);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
 
         #endregion

--- a/test/vstest.console.UnitTests/Processors/TestSourceArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestSourceArgumentProcessorTests.cs
@@ -49,11 +49,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.IsNull(capabilities.HelpContentResourceName);
 
             Assert.AreEqual(HelpContentPriority.None, capabilities.HelpPriority);
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Normal, capabilities.Priority);
 
             Assert.IsTrue(capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.AlwaysExecute);
             Assert.IsTrue(capabilities.IsSpecialCommand);
         }
 

--- a/test/vstest.console.UnitTests/Processors/TestSourceArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestSourceArgumentProcessorTests.cs
@@ -52,9 +52,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual(false, capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.Normal, capabilities.Priority);
 
-            Assert.AreEqual(true, capabilities.AllowMultiple);
+            Assert.IsTrue(capabilities.AllowMultiple);
             Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(true, capabilities.IsSpecialCommand);
+            Assert.IsTrue(capabilities.IsSpecialCommand);
         }
 
         #endregion

--- a/test/vstest.console.UnitTests/Processors/UseVsixExtensionsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/UseVsixExtensionsArgumentProcessorTests.cs
@@ -54,12 +54,12 @@ namespace vstest.console.UnitTests.Processors
             Assert.AreEqual("/UseVsixExtensions", capabilities.CommandName);
             Assert.AreEqual(null, capabilities.HelpContentResourceName);
             Assert.AreEqual(HelpContentPriority.None, capabilities.HelpPriority);
-            Assert.AreEqual(false, capabilities.IsAction);
+            Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.AutoUpdateRunSettings, capabilities.Priority);
 
-            Assert.AreEqual(false, capabilities.AllowMultiple);
-            Assert.AreEqual(false, capabilities.AlwaysExecute);
-            Assert.AreEqual(false, capabilities.IsSpecialCommand);
+            Assert.IsFalse(capabilities.AllowMultiple);
+            Assert.IsFalse(capabilities.AlwaysExecute);
+            Assert.IsFalse(capabilities.IsSpecialCommand);
         }
 
         #endregion

--- a/test/vstest.console.UnitTests/Processors/UseVsixExtensionsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/UseVsixExtensionsArgumentProcessorTests.cs
@@ -52,7 +52,7 @@ namespace vstest.console.UnitTests.Processors
             var capabilities = new UseVsixExtensionsArgumentProcessorCapabilities();
 
             Assert.AreEqual("/UseVsixExtensions", capabilities.CommandName);
-            Assert.AreEqual(null, capabilities.HelpContentResourceName);
+            Assert.IsNull(capabilities.HelpContentResourceName);
             Assert.AreEqual(HelpContentPriority.None, capabilities.HelpPriority);
             Assert.IsFalse(capabilities.IsAction);
             Assert.AreEqual(ArgumentProcessorPriority.AutoUpdateRunSettings, capabilities.Priority);

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -110,7 +110,7 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
             // Opt out the Telemetry
             Environment.SetEnvironmentVariable("VSTEST_TELEMETRY_OPTEDIN", "0");
         }
-        
+
         [TestMethod]
         public void TestRequestManagerShouldNotInitializeConsoleLoggerIfDesignModeIsSet()
         {
@@ -210,7 +210,7 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
 
             Assert.AreEqual(testCaseFilterValue, actualDiscoveryCriteria.TestCaseFilter, "TestCaseFilter must be set");
 
-            Assert.AreEqual(createDiscoveryRequestCalled, 1, "CreateDiscoveryRequest must be invoked only once.");
+            Assert.AreEqual(1, createDiscoveryRequestCalled, "CreateDiscoveryRequest must be invoked only once.");
             Assert.AreEqual(2, actualDiscoveryCriteria.Sources.Count(), "All Sources must be used for discovery request");
             Assert.AreEqual("a", actualDiscoveryCriteria.Sources.First(), "First Source in list is incorrect");
             Assert.AreEqual("b", actualDiscoveryCriteria.Sources.ElementAt(1), "Second Source in list is incorrect");
@@ -315,7 +315,7 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
             Assert.AreEqual("Other", targetDevice);
             Assert.AreEqual(2, maxcount);
             Assert.AreEqual("X86", targetPlatform.ToString());
-            Assert.IsTrue(disableAppDomain);
+            Assert.AreEqual(true, disableAppDomain);
         }
 
         [TestMethod]
@@ -1017,7 +1017,7 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
                 this.inferHelper,
                 this.mockMetricsPublisherTask,
                 this.mockProcessHelper.Object);
-            
+
             // Act.
             this.testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, mockProtocolConfig);
 
@@ -1126,7 +1126,7 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
             Assert.AreEqual("Other", targetDevice);
             Assert.AreEqual(2, maxcount);
             Assert.AreEqual("X86", targetPlatform.ToString());
-            Assert.IsTrue(disableAppDomain);
+            Assert.AreEqual(true, disableAppDomain);
         }
 
         [TestMethod]
@@ -1165,7 +1165,7 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
 
             Assert.AreEqual(testCaseFilterValue, observedCriteria.TestCaseFilter, "TestCaseFilter must be set");
 
-            Assert.AreEqual(createRunRequestCalled, 1, "CreateRunRequest must be invoked only once.");
+            Assert.AreEqual(1, createRunRequestCalled, "CreateRunRequest must be invoked only once.");
             Assert.AreEqual(2, observedCriteria.Sources.Count(), "All Sources must be used for discovery request");
             Assert.AreEqual("a", observedCriteria.Sources.First(), "First Source in list is incorrect");
             Assert.AreEqual("b", observedCriteria.Sources.ElementAt(1), "Second Source in list is incorrect");

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -315,7 +315,7 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
             Assert.AreEqual("Other", targetDevice);
             Assert.AreEqual(2, maxcount);
             Assert.AreEqual("X86", targetPlatform.ToString());
-            Assert.AreEqual(true, disableAppDomain);
+            Assert.IsTrue(disableAppDomain);
         }
 
         [TestMethod]
@@ -1126,7 +1126,7 @@ namespace vstest.console.UnitTests.TestPlatformHelpers
             Assert.AreEqual("Other", targetDevice);
             Assert.AreEqual(2, maxcount);
             Assert.AreEqual("X86", targetPlatform.ToString());
-            Assert.AreEqual(true, disableAppDomain);
+            Assert.IsTrue(disableAppDomain);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description
This PR is to fix some asserts in the TestPlatform.sln solution, the expected and actual are round the wrong way.

e.g.

`Assert.AreEqual(aggregator.RunContextAttachments.Count, 1, "RunContextAttachments List must have data.");`

should be

`Assert.AreEqual(1, aggregator.RunContextAttachments.Count, "RunContextAttachments List must have data.");`

## Related issue
Fixes #2328 
