### PR TITLE
Added parameters to the ConsoleLogger to change the Passed,Failed, an…

### DIFF
--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -39,17 +39,17 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
         /// <summary>
         /// Unicode for tick
         /// </summary>
-        private static string PassedTestIndicator = "\u221a";
+        private const string PassedTestIndicatorDefault = "\u221a";
 
         /// <summary>
         /// Indicator for failed tests
         /// </summary>
-        private static string FailedTestIndicator = "X";
+        private const string FailedTestIndicatorDefault = "X";
 
         /// <summary>
         /// Indicated skipped and not run tests
         /// </summary>
-        private static string SkippedTestIndicator = "!";
+        private const string SkippedTestIndicatorDefault = "!";
 
         /// <summary>
         /// Bool to decide whether Verbose level should be added as prefix or not in log messages.
@@ -132,7 +132,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
         // Keep default verbosity for x-plat command line as minimal
         private Verbosity verbosityLevel = Verbosity.Minimal;
 #endif
-
+        private string PassedTestIndicator = PassedTestIndicatorDefault;
+        private string FailedTestIndicator = FailedTestIndicatorDefault;
+        private string SkippedTestIndicator = SkippedTestIndicatorDefault;
         private bool testRunHasErrorMessages = false;
         private ConcurrentDictionary<Guid, TestOutcome> leafExecutionIdAndTestOutcomePairDictionary = new ConcurrentDictionary<Guid, TestOutcome>();
 

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -39,17 +39,17 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
         /// <summary>
         /// Unicode for tick
         /// </summary>
-        private const char PassedTestIndicator = '\u221a';
+        private static string PassedTestIndicator = "\u221a";
 
         /// <summary>
         /// Indicator for failed tests
         /// </summary>
-        private const char FailedTestIndicator = 'X';
+        private static string FailedTestIndicator = "X";
 
         /// <summary>
         /// Indicated skipped and not run tests
         /// </summary>
-        private const char SkippedTestIndicator = '!';
+        private static string SkippedTestIndicator = "!";
 
         /// <summary>
         /// Bool to decide whether Verbose level should be added as prefix or not in log messages.
@@ -80,6 +80,21 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
         /// Parameter for log message prefix
         /// </summary>
         public const string PrefixParam = "prefix";
+
+        /// <summary>
+		/// Parameter for log message for a passed test
+		/// </summary>
+        public const string PassedTestIndicatorParam = "passedTestIndicator";
+
+        /// <summary>
+		/// Parameter for log message for a failed test
+		/// </summary>
+        public const string FailedTestIndicatorParam = "failedTestIndicator";
+
+        /// <summary>
+		/// Parameter for log message for a skipped test
+		/// </summary>
+        public const string SkippedTestIndicatorParam = "skippedTestIndicator";
 
         /// <summary>
         /// Parameter for disabling progress
@@ -231,6 +246,24 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
             if (progressArgExists)
             {
                 bool.TryParse(enableProgress, out EnableProgress);
+            }
+
+            var passedTestIndiectorExists = parameters.TryGetValue(ConsoleLogger.PassedTestIndicatorParam, out string passedIndicator);
+            if (passedTestIndiectorExists)
+            {
+                PassedTestIndicator = passedIndicator;
+            }
+
+            var failedTestIndecatorExists = parameters.TryGetValue(ConsoleLogger.FailedTestIndicatorParam, out string failedIndicator);
+            if (failedTestIndecatorExists)
+            {
+                FailedTestIndicator = failedIndicator;
+            }
+
+            var skippedTestIndiectorExists = parameters.TryGetValue(ConsoleLogger.SkippedTestIndicatorParam, out string skippedIndicator);
+            if (passedTestIndiectorExists)
+            {
+                SkippedTestIndicator = skippedIndicator;
             }
 
             Initialize(events, String.Empty);


### PR DESCRIPTION
Added parameters to the ConsoleLogger to change the Passed,Failed, and Skipped text

## Description
Added ability to override the default text the ConsoleLogger uses for Passed, Failed, Skipped indicator text
passedTestIndicator
failedTestIndicator
skippedTestIndicator