### PR TITLE
Move test publish to the bottom

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -980,13 +980,13 @@ Restore-Package
 Update-LocalizedResources
 Invoke-Build
 Publish-Package
-Publish-Tests
 Create-VsixPackage
 Create-NugetPackages
 Generate-Manifest
 Publish-PatchedDotnet
 Copy-PackageIntoStaticDirectory
 Invoke-TestAssetsBuild
+Publish-Tests
  
 Write-Log "Build complete. {$(Get-ElapsedTime($timer))}"
 if ($Script:ScriptFailed) { Exit 1 } else { Exit 0 }


### PR DESCRIPTION
## Description
Move the test publish step to the bottom, because it normally does not run during PR CI and it was failing in the signed build, because it was running to early. 

## Related issue
none