### PR TITLE
Fix race condition on testhost exit before we connect

### DIFF
--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -376,7 +376,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
             if (!this.hostExitedEventRaised)
             {
                 this.hostExitedEventRaised = true;
+                EqtTrace.Verbose("DotnetTestHostManager.OnHostExited: invoking OnHostExited callback");
                 this.HostExited.SafeInvoke(this, e, "HostProviderEvents.OnHostExited");
+            }
+            else
+            {
+                EqtTrace.Verbose("DotnetTestHostManager.OnHostExited: exit event was already raised, skipping");
             }
         }
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
@@ -28,6 +28,7 @@ namespace Microsoft.TestPlatform.TestHostProvider.Hosting
             StringBuilder testHostProcessStdError,
             Action<HostProviderEventArgs> onHostExited)
         {
+            EqtTrace.Verbose("TestHostProvider.ExitCallBack: Host exited starting callback.");
             var exitCode = 0;
             var testHostProcessStdErrorStr = testHostProcessStdError.ToString();
 
@@ -38,8 +39,9 @@ namespace Microsoft.TestPlatform.TestHostProvider.Hosting
             {
                 procId = (process as Process).Id;
             }
-            catch (InvalidOperationException)
+            catch (InvalidOperationException ex)
             {
+                EqtTrace.Error("TestHostProvider.ExitCallBack: could not get proccess id from process, error: {0}.", ex);
             }
 
             if (exitCode != 0)


### PR DESCRIPTION
## Description
Fix incorrectly reporting timeout when test host exits too early.

## Related issue
Fixes #2343 
