### PR TITLE
Better error when discoverer defaultExecutorUri is not set.

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscovererEnumerator.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscovererEnumerator.cs
@@ -213,6 +213,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Discovery
                     "DiscovererEnumerator.DiscoverTestsFromSingleDiscoverer: Loading tests for {0}",
                         discoverer.Value.GetType().FullName);
 
+                if (discoverer.Metadata.DefaultExecutorUri == null)
+                {
+                    throw new Exception($@"DefaultExecutorUri is null, did you decorate the discoverer class with [DefaultExecutorUri()] attribute? For example [DefaultExecutorUri(""executor://example.testadapter"")].");
+                }
+
                 var currentTotalTests = this.discoveryResultCache.TotalDiscoveredTests;
                 var newTimeStart = DateTime.UtcNow;
 


### PR DESCRIPTION
## Description
Report the actual error instead of reporting null ref when the user forgets to decorate their custom test adapter with the correct attribute.