### PR TITLE
Support /TestCaseFilter and /Tests arguments at the same time

### DIFF
--- a/src/vstest.console/Processors/RunSpecificTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunSpecificTestsArgumentProcessor.cs
@@ -210,11 +210,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
                 throw new CommandLineException(string.Format(CultureInfo.CurrentUICulture, CommandLineResources.MissingTestSourceFile));
             }
 
-            if (!string.IsNullOrWhiteSpace(this.commandLineOptions.TestCaseFilterValue))
-            {
-                throw new CommandLineException(string.Format(CultureInfo.CurrentUICulture, CommandLineResources.InvalidTestCaseFilterValueForSpecificTests));
-            }
-
             this.effectiveRunSettings = this.runSettingsManager.ActiveRunSettings.SettingsXml;
 
             // Discover tests from sources and filter on every discovery reported.

--- a/test/vstest.console.UnitTests/ExecutorUnitTests.cs
+++ b/test/vstest.console.UnitTests/ExecutorUnitTests.cs
@@ -87,27 +87,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests
             Assert.IsTrue(mockOutput.Messages.Any(message => message.Message.Contains(CommandLineResources.NoArgumentsProvided)));
         }
 
-        [TestMethod]
-        public void ExecutorShouldSanitizeNoLogoInputAndShouldProcessOtherArgs()
-        {
-            // Create temp file for testsource dll to pass FileUtil.Exits()
-            var testSourceDllPath = Path.GetTempFileName();
-            string[] args = { testSourceDllPath, "/tests:Test1", "/testCasefilter:Test", "--nologo" };
-            var mockOutput = new MockOutput();
-
-            var exitCode = new Executor(mockOutput, this.mockTestPlatformEventSource.Object).Execute(args);
-
-            var errorMessageCount = mockOutput.Messages.Count(msg => msg.Level == OutputLevel.Error && msg.Message.Contains(CommandLineResources.InvalidTestCaseFilterValueForSpecificTests));
-            Assert.AreEqual(1, errorMessageCount, "Invalid Arguments Combination should display error.");
-            Assert.AreEqual(1, exitCode, "Invalid Arguments Combination execution should exit with error.");
-
-            Assert.IsFalse(mockOutput.Messages.First().Message.Contains(CommandLineResources.MicrosoftCommandLineTitle.Substring(0, 20)),
-                "First Printed message must be Microsoft Copyright");
-
-            File.Delete(testSourceDllPath);
-        }
-
-
         /// <summary>
         /// Executor should Print Error message and Help contents when no arguments are provided.
         /// </summary>
@@ -191,22 +170,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests
         }
 
         [TestMethod]
-        public void ExecuteShouldExitWithErrorOnInvalidArgumentCombination()
-        {
-            // Create temp file for testsource dll to pass FileUtil.Exits()
-            var testSourceDllPath = Path.GetTempFileName();
-            string[] args = { testSourceDllPath, "/tests:Test1", "/testCasefilter:Test" };
-            var mockOutput = new MockOutput();
-
-            var exitCode = new Executor(mockOutput, this.mockTestPlatformEventSource.Object).Execute(args);
-
-            var errorMessageCount = mockOutput.Messages.Count(msg => msg.Level == OutputLevel.Error && msg.Message.Contains(CommandLineResources.InvalidTestCaseFilterValueForSpecificTests));
-            Assert.AreEqual(1, errorMessageCount, "Invalid Arguments Combination should display error.");
-            Assert.AreEqual(1, exitCode, "Invalid Arguments Combination execution should exit with error.");
-            File.Delete(testSourceDllPath);
-        }
-
-        [TestMethod]
         public void ExecuteShouldExitWithErrorOnResponseFileException()
         {
             string[] args = { "@FileDoesNotExist.rsp" };
@@ -243,7 +206,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests
 
                 File.WriteAllText(runSettingsFile, fileContents);
 
-                string[] args = { "/settings:" + runSettingsFile };
+                var testSourceDllPath = Path.GetTempFileName();
+                string[] args = { testSourceDllPath, "/settings:" + runSettingsFile };
                 var mockOutput = new MockOutput();
 
                 var exitCode = new Executor(mockOutput, this.mockTestPlatformEventSource.Object).Execute(args);

--- a/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
     using CoreUtilities.Tracing.Interfaces;
     using Microsoft.Extensions.FileSystemGlobbing;
     using Microsoft.VisualStudio.TestPlatform.Client;
+    using Microsoft.VisualStudio.TestPlatform.Client.Discovery;
     using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
     using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
     using Microsoft.VisualStudio.TestPlatform.CommandLine.Publisher;
@@ -170,6 +171,36 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
 
             Assert.ThrowsException<CommandLineException>(() => executor.Execute());
         }
+
+        [TestMethod]
+        public void ExecutorExecuteForValidSourceWithTestCaseFilterShouldRunTests()
+        {
+            var mockTestPlatform = new Mock<ITestPlatform>();
+            var mockTestRunRequest = new Mock<ITestRunRequest>();
+            var mockDiscoveryRequest = new Mock<IDiscoveryRequest>();
+
+            this.ResetAndAddSourceToCommandLineOptions();
+
+            List<TestCase> list = new List<TestCase>();
+            list.Add(new TestCase("Test1", new Uri("http://FooTestUri1"), "Source1"));
+            list.Add(new TestCase("Test2", new Uri("http://FooTestUri1"), "Source1"));
+            mockDiscoveryRequest.Setup(dr => dr.DiscoverAsync()).Raises(dr => dr.OnDiscoveredTests += null, new DiscoveredTestsEventArgs(list));
+
+            mockTestPlatform.Setup(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockTestRunRequest.Object);
+            mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockDiscoveryRequest.Object);
+
+            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object);
+            var executor = GetExecutor(testRequestManager);
+
+            CommandLineOptions.Instance.TestCaseFilterValue = "Filter";
+            executor.Initialize("Test1");
+            ArgumentProcessorResult argumentProcessorResult = executor.Execute();
+
+            mockOutput.Verify(o => o.WriteLine(It.IsAny<string>(), OutputLevel.Warning), Times.Never);
+            mockTestPlatform.Verify(o => o.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.Is<DiscoveryCriteria>(c => c.TestCaseFilter == "Filter"), It.IsAny<TestPlatformOptions>()), Times.Once());
+            Assert.AreEqual(ArgumentProcessorResult.Success, argumentProcessorResult);
+        }
+
 
         [TestMethod]
         public void ExecutorExecuteShouldThrowTestPlatformExceptionThrownDuringDiscovery()

--- a/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
@@ -172,16 +172,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         }
 
         [TestMethod]
-        public void ExecutorExecuteForValidSourceWithTestCaseFilterShouldThrowCommandLineException()
-        {
-            this.ResetAndAddSourceToCommandLineOptions();
-            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object);
-            var executor = GetExecutor(testRequestManager);
-            CommandLineOptions.Instance.TestCaseFilterValue = "Filter";
-            Assert.ThrowsException<CommandLineException>(() => executor.Execute());
-        }
-
-        [TestMethod]
         public void ExecutorExecuteShouldThrowTestPlatformExceptionThrownDuringDiscovery()
         {
             var mockTestPlatform = new Mock<ITestPlatform>();


### PR DESCRIPTION
## Description
My team has a scenario where I want to be able to pass both the /TestCaseFilter and the /Tests arguments at the same time (yes I know this doesn't seem like it should be necessary but we do have this use case). Right now vstest throws an exception if both are provided but I can't find a reason why. Digging through the code everything is piped through properly and works as expected.
