### PR TITLE
Fixing a typo for the method arguments for the Fakes utility method.

### DIFF
--- a/src/Microsoft.TestPlatform.Common/Utilities/FakesUtilities.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/FakesUtilities.cs
@@ -208,7 +208,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
             {
                 Assembly assembly = Assembly.Load(FakesConfiguratorAssembly);
                 var type = assembly?.GetType(ConfiguratorAssemblyQualifiedName, false);
-                var method = type?.GetMethod(ConfiguratorMethodName, new Type[] { typeof(IEnumerable<string>), typeof(FrameworkVersion) });
+                var method = type?.GetMethod(ConfiguratorMethodName, new Type[] { typeof(IDictionary<string, FrameworkVersion>) });
                 if (method != null)
                 {
                     return (Func<IDictionary<string, FrameworkVersion>, DataCollectorSettings>)method.CreateDelegate(typeof(Func<IDictionary<string, FrameworkVersion>, DataCollectorSettings>));


### PR DESCRIPTION
Fixing a typo from an earlier insertion that missed updating the right method params we were searching for. This changed as part of addressing PR comments.
