### PR TITLE
[rel/16.6] Fix null reference

### DIFF
--- a/src/testhost.x86/TestHostTraceListener.cs
+++ b/src/testhost.x86/TestHostTraceListener.cs
@@ -31,21 +31,26 @@ namespace Microsoft.VisualStudio.TestPlatform.TestHost
 
             EqtTrace.Verbose("TestPlatformTraceListener.Setup: Added test platform trace listener.");
 
-#if NETCOREAPP2_1
-            try
+            // this is a netcoreapp2.1 only fix, but because we always compile against netcoreapp2.1 
+            // and upgrade the executable as necessary this needs to be a runtime check and not a compile time 
+            // check. This call returns ".NET Core 4.6.xxx" on netcore 2.1 and older, and ".NET Core 3.1.xxx"
+            // or the respective version on the newer runtimes
+            if (System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Core 4.6"))
             {
-                // workaround for netcoreapp2.1 where the trace listener api is not called when 
-                // Debug.Assert fails. This method is internal, but the class is on purpose keeping the 
-                // callback settable so tests can set the callback
-                var field = typeof(Debug).GetField("s_ShowDialog", BindingFlags.Static | BindingFlags.NonPublic);
-                var value = field.GetValue(null);
-                field.SetValue(null, (Action<string, string, string, string>)ShowDialog);
+                try
+                {
+                    // workaround for netcoreapp2.1 where the trace listener api is not called when 
+                    // Debug.Assert fails. This method is internal, but the class is on purpose keeping the 
+                    // callback settable so tests can set the callback
+                    var field = typeof(Debug).GetField("s_ShowDialog", BindingFlags.Static | BindingFlags.NonPublic);
+                    var value = field.GetValue(null);
+                    field.SetValue(null, (Action<string, string, string, string>)ShowDialog);
+                }
+                catch (Exception ex)
+                {
+                    EqtTrace.Error("TestPlatformTraceListener.Setup: Failed to replace inner callback to ShowDialog in Debug.Assert. Calls to Debug.Assert with crash the test host process. {0}", ex);
+                }
             }
-            catch (Exception ex)
-            {
-                EqtTrace.Error("TestPlatformTraceListener.Setup: Failed to replace inner callback to ShowDialog in Debug.Assert. Calls to Debug.Assert with crash the test host process. {0}", ex);
-            }
-#endif
         }
 
         public override void Fail(string message)


### PR DESCRIPTION
## Description
Fix null reference that we catch internally but would pop up in Debug mode, because the default config is to stop at null ref

## Related issue