### PR TITLE
Merge test run parameters that have spaces

### DIFF
--- a/src/vstest.console/CommandLine/Executor.cs
+++ b/src/vstest.console/CommandLine/Executor.cs
@@ -183,6 +183,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine
                     processors.Add(cliRunSettingsProcessor);
                     break;
                 }
+
                 var processor = processorFactory.CreateArgumentProcessor(arg);
 
                 if (processor != null)

--- a/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
@@ -6,18 +6,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
     using System;
     using System.Diagnostics.Contracts;
     using System.Xml.XPath;
+    using System.Collections.Generic;
 
     using Microsoft.VisualStudio.TestPlatform.Common;
     using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
 
-    using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;
-    using System.Text.RegularExpressions;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection.Metadata;
-    using System.Runtime.ExceptionServices;
+    using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;    
 
     /// <summary>
     /// The argument processor for runsettings passed as argument through cli
@@ -146,6 +142,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
            
             foreach (var arg in args)
             {
+                // when we see that the parameter begins with TestRunParameters 
+                // but does not end with ") we start merging the params
                 if (arg.StartsWith("TestRunParameters", StringComparison.OrdinalIgnoreCase))
                 {
                     if (arg.EndsWith("\")")) {
@@ -159,15 +157,19 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
                     }
                 }
 
+                // we merge as long as the flag is set
+                // hoping that we find the end of the parameter
                 if (merge)
                 {
                     mergedArg += string.IsNullOrWhiteSpace(mergedArg) ? arg : $" {arg}";
                 }
                 else
                 {
+                    // if we are not merging just pass the param as is
                     mergedArgs.Add(arg);
                 }
 
+                // once we detect the end we add the whole parameter to the args
                 if (merge && arg.EndsWith("\")")) {
                     mergedArgs.Add(mergedArg);
                     mergedArg = string.Empty;
@@ -175,9 +177,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
                 }
             }
 
-            if (merge == true)
+            if (merge)
             {
-                // we tried to merge but never finished, add what we merged up until now
+                // we tried to merge but never found the end of that 
+                // test paramter, add what we merged up until now
                 mergedArgs.Add(mergedArg);
             }
 

--- a/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
@@ -347,5 +347,46 @@ namespace vstest.console.UnitTests.Processors
             },
         };
         #endregion
+
+        [TestMethod]
+        public void InitializeShouldMergeTestRunParametersWithSpaces()
+        {
+            // in powershell call: ConsoleApp1.exe --% --TestRunParameters.Parameter(name =\"myParam\", value=\"myValue\")
+            // args:
+            //--
+            //TestRunParameters.Parameter(name = "myParam",
+            //value = "myValue")
+
+            // in cmd: ConsoleApp1.exe -- TestRunParameters.Parameter(name=\"myParam\", value=\"myValue\")
+            // args:
+            //--
+            //TestRunParameters.Parameter(name = "myParam",
+            //value = "myValue")
+
+            // in ubuntu wsl without escaping the space: ConsoleApp1.exe-- TestRunParameters.Parameter\(name =\"myParam\", value=\"myValue\"\)
+            // args:
+            //--
+            //TestRunParameters.Parameter(name = "myParam",
+            //value = "myValue")
+
+            // in ubuntu wsl with escaping the space: ConsoleApp1.exe-- TestRunParameters.Parameter\(name =\"myParam\",\ value=\"myValue\"\)
+            // args:
+            //--
+            //TestRunParameters.Parameter(name = "myParam", value = "myValue")
+
+            var args = new string[] {
+                "--",
+                "TestRunParameters.Parameter(name=\"myParam\",",
+                "value=\"myValue\")",
+                "TestRunParameters.Parameter(name=\"myParam2\",",
+                "value=\"myValue 2\")",
+            };
+
+            var runsettings = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"myParam\" value=\"myValue\" />\r\n    <Parameter name=\"myParam2\" value=\"myValue 2\" />\r\n  </TestRunParameters>\r\n</RunSettings>";
+            this.executor.Initialize(args);
+
+            Assert.IsNotNull(this.settingsProvider.ActiveRunSettings);
+            Assert.AreEqual(runsettings, settingsProvider.ActiveRunSettings.SettingsXml);
+        }
     }
 }

--- a/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
@@ -382,7 +382,18 @@ namespace vstest.console.UnitTests.Processors
                 "value=\"myValue 2\")",
             };
 
-            var runsettings = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n  <TestRunParameters>\r\n    <Parameter name=\"myParam\" value=\"myValue\" />\r\n    <Parameter name=\"myParam2\" value=\"myValue 2\" />\r\n  </TestRunParameters>\r\n</RunSettings>";
+            var runsettings = string.Join(Environment.NewLine, new[]{
+                "<?xml version=\"1.0\" encoding=\"utf-16\"?>",
+                "<RunSettings>",
+                "  <DataCollectionRunSettings>",
+                "    <DataCollectors />",
+                "  </DataCollectionRunSettings>",
+                "  <TestRunParameters>",
+                "    <Parameter name=\"myParam\" value=\"myValue\" />",
+                "    <Parameter name=\"myParam2\" value=\"myValue 2\" />",
+                "  </TestRunParameters>",
+                "</RunSettings>"});
+
             this.executor.Initialize(args);
 
             Assert.IsNotNull(this.settingsProvider.ActiveRunSettings);


### PR DESCRIPTION
## Description
First step towards more unified experience when passing test parameters

## Related issue
Partial fix #862
