### PR TITLE
Wrap error message/stack trace content in <pre>

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Html.xslt
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Html.xslt
@@ -28,6 +28,9 @@
         margin-top: 15px;
         margin-bottom:10px;
         }
+        pre {
+        white-space: pre-wrap;
+        }
         .summary {font-family:monospace;
         display: -webkit-flex; /* Safari */
         -webkit-flex-wrap: wrap; /* Safari 6.1+ */

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Html.xslt
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Html.xslt
@@ -180,11 +180,11 @@
   </xsl:template>
   
   <xsl:template match = "tp:ErrorMessage">
-    Error: <span class="error-message"><xsl:value-of select = "." /></span><br />
+    Error: <span class="error-message"><pre><xsl:value-of select = "." /></pre></span><br />
   </xsl:template>
 
   <xsl:template match = "tp:ErrorStackTrace">
-    Stack trace: <span class="error-stack-trace"><xsl:value-of select = "." /></span><br />
+    Stack trace: <span class="error-stack-trace"><pre><xsl:value-of select = "." /></pre></span><br />
   </xsl:template>
 
   <xsl:template match = "tp:FailedTests">


### PR DESCRIPTION
## Description
This enhances the readability of error messages and stack traces in HTML logs by wrapping the content in the [`<pre>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre) tag.

Here's a side-by-side comparison, where the first test failure shown has no `<pre>` tags and the second test failure does have `<pre>` tags.

![image](https://user-images.githubusercontent.com/5833655/80134797-256f0000-8554-11ea-9312-b34e3305b301.png)

## Related issue
Closes #2414
