### PR TITLE
Enable F5 debugging support for test projects

### DIFF
--- a/src/package/nuspec/netcoreapp/Microsoft.NET.Test.Sdk.targets
+++ b/src/package/nuspec/netcoreapp/Microsoft.NET.Test.Sdk.targets
@@ -25,6 +25,11 @@
     <GenerateProgramFile Condition="'$(GenerateProgramFile)' == ''">true</GenerateProgramFile>
   </PropertyGroup>
 
+  <!-- Overwrite the sdk's RunArguments property to support F5 debugging. -->
+  <PropertyGroup>
+    <RunArguments>test $(TargetName)</RunArguments>
+  </PropertyGroup>
+
   <!--
     ============================================================
     GenerateProgramFile

--- a/src/package/nuspec/netfx/Microsoft.NET.Test.Sdk.targets
+++ b/src/package/nuspec/netfx/Microsoft.NET.Test.Sdk.targets
@@ -22,4 +22,10 @@
     <GenerateBindingRedirectsOutputType Condition="'$(GenerateBindingRedirectsOutputType)' == ''">true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
 
+  <!-- If vstest.console is available, overwrite the sdk's run properties to support F5 debugging. -->
+  <PropertyGroup Condition="'$(DevEnvDir)' != ''">
+    <RunCommand>$(DevEnvDir)Extensions\TestPlatform\vstest.console.exe</RunCommand>
+    <RunArguments>$(TargetPath)</RunArguments>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
Fixes https://github.com/microsoft/vstest/issues/2425

Settings the sdk's run properties to invoke vstest.console to actually
test the test application instead of just invoking the generated test
app's no-op Main entry point.