### PR TITLE
Detect runsettings file automatically for assembly invocation and detect coverlet data collector in runsettings

### DIFF
--- a/src/vstest.console/CommandLine/Executor.cs
+++ b/src/vstest.console/CommandLine/Executor.cs
@@ -126,7 +126,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine
             // Quick exit for syntax error
             if (exitCode == 1
                 && argumentProcessors.All(
-                    processor => processor.Metadata.Value.CommandName != HelpArgumentProcessor.CommandName))
+                    processor => processor.Metadata.Value.CommandName != HelpArgumentProcessor.CommandName && !processor.Metadata.Value.IsSpecialCommand))
             {
                 this.testPlatformEventSource.VsTestConsoleStop();
                 return exitCode;
@@ -204,11 +204,18 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine
                 }
             }
 
-            // Add the internal argument processors that should always be executed.
+            // Add the argument processors that should always be executed.
             // Examples: processors to enable loggers that are statically configured, and to start logging,
             // should always be executed.
             var processorsToAlwaysExecute = processorFactory.GetArgumentProcessorsToAlwaysExecute();
-            processors.AddRange(processorsToAlwaysExecute);
+            foreach (var processorToAlwaysExecute in processorsToAlwaysExecute)
+            {
+                if (processorToAlwaysExecute.Metadata.Value.AllowMultiple ||
+                    !processors.Any(p => p.GetType() == processorToAlwaysExecute.GetType()))
+                {
+                    processors.Add(processorToAlwaysExecute);
+                }
+            }
 
             // Initialize Runsettings with defaults
             RunSettingsManager.Instance.AddDefaultRunSettings();

--- a/src/vstest.console/Processors/ListFullyQualifiedTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ListFullyQualifiedTestsArgumentProcessor.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
 
         public override bool IsAction => true;
 
-        public override ArgumentProcessorPriority Priority => ArgumentProcessorPriority.Normal;
+        public override ArgumentProcessorPriority Priority => ArgumentProcessorPriority.Sources;
     }
 
     /// <summary>

--- a/src/vstest.console/Processors/ListTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ListTestsArgumentProcessor.cs
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
 
         public override bool IsAction => true;
 
-        public override ArgumentProcessorPriority Priority => ArgumentProcessorPriority.Normal;
+        public override ArgumentProcessorPriority Priority => ArgumentProcessorPriority.Sources;
 
         public override string HelpContentResourceName => CommandLineResources.ListTestsHelp;
 

--- a/src/vstest.console/Processors/TestSourceArgumentProcessor.cs
+++ b/src/vstest.console/Processors/TestSourceArgumentProcessor.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
     {
         public override string CommandName => TestSourceArgumentProcessor.CommandName;
 
-        public override ArgumentProcessorPriority Priority => ArgumentProcessorPriority.Normal;
+        public override ArgumentProcessorPriority Priority => ArgumentProcessorPriority.Sources;
 
         public override bool IsSpecialCommand => true;
     }

--- a/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
+++ b/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
@@ -36,7 +36,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
         /// </summary>
         private readonly IEnumerable<IArgumentProcessor> argumentProcessors;
         private Dictionary<string, IArgumentProcessor> commandToProcessorMap;
-        private Dictionary<string, IArgumentProcessor> specialCommandToProcessorMap;
 
         #endregion
 
@@ -100,23 +99,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             }
         }
 
-        /// <summary>
-        /// Gets a mapping between special commands and their Argument Processors.
-        /// </summary>
-        internal Dictionary<string, IArgumentProcessor> SpecialCommandToProcessorMap
-        {
-            get
-            {
-                // Build the mapping if it does not already exist.
-                if (this.specialCommandToProcessorMap == null)
-                {
-                    BuildCommandMaps();
-                }
-
-                return this.specialCommandToProcessorMap;
-            }
-        }
-
         #endregion
 
         #region Public Methods
@@ -143,13 +125,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             CommandToProcessorMap.TryGetValue(pair.Command, out argumentProcessor);
 
             // If an argument processor was not found for the command, then consider it as a test source argument.
-            if (argumentProcessor == null)
+            // Special commands cannot be invoked directly and are therefore ignored.
+            if (argumentProcessor == null || argumentProcessor.Metadata.Value.IsSpecialCommand)
             {
                 // Update the command pair since the command is actually the argument in the case of
                 // a test source.
                 pair = new CommandArgumentPair(TestSourceArgumentProcessor.CommandName, argument);
 
-                argumentProcessor = SpecialCommandToProcessorMap[TestSourceArgumentProcessor.CommandName];
+                argumentProcessor = CommandToProcessorMap[TestSourceArgumentProcessor.CommandName];
             }
 
             if (argumentProcessor != null)
@@ -194,19 +177,21 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
         /// <returns>The default action argument processor.</returns>
         public IArgumentProcessor CreateDefaultActionArgumentProcessor()
         {
-            var argumentProcessor = SpecialCommandToProcessorMap[RunTestsArgumentProcessor.CommandName];
+            var argumentProcessor = CommandToProcessorMap[RunTestsArgumentProcessor.CommandName];
             return WrapLazyProcessorToInitializeOnInstantiation(argumentProcessor);
         }
 
         /// <summary>
-        /// Gets the argument processors that are tagged as special and to be always executed.
+        /// Gets the distinct (by Type) argument processors that are tagged to be always executed.
         /// The Lazy's that are returned will initialize the underlying argument processor when first accessed.
         /// </summary>
-        /// <returns>The argument processors that are tagged as special and to be always executed.</returns>
+        /// <returns>The argument processors that are tagged to be always executed.</returns>
         public IEnumerable<IArgumentProcessor> GetArgumentProcessorsToAlwaysExecute()
         {
-            return SpecialCommandToProcessorMap.Values
-                .Where(lazyProcessor => lazyProcessor.Metadata.Value.IsSpecialCommand && lazyProcessor.Metadata.Value.AlwaysExecute);
+            return CommandToProcessorMap.Values
+                .Where(argProcMap => argProcMap.Metadata.Value.AlwaysExecute)
+                .GroupBy(argProcMap => argProcMap.GetType())
+                .Select(group => WrapLazyProcessorToInitializeOnInstantiation(group.First(), (string)null));
         }
 
         #endregion
@@ -252,30 +237,27 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
         private void BuildCommandMaps()
         {
             this.commandToProcessorMap = new Dictionary<string, IArgumentProcessor>(StringComparer.OrdinalIgnoreCase);
-            this.specialCommandToProcessorMap = new Dictionary<string, IArgumentProcessor>(StringComparer.OrdinalIgnoreCase);
 
             foreach (IArgumentProcessor argumentProcessor in this.argumentProcessors)
             {
-                // Add the command to the appropriate dictionary.
-                var processorsMap = argumentProcessor.Metadata.Value.IsSpecialCommand
-                                      ? this.specialCommandToProcessorMap
-                                      : this.commandToProcessorMap;
-
                 string commandName = argumentProcessor.Metadata.Value.CommandName;
-                processorsMap.Add(commandName, argumentProcessor);
+                commandToProcessorMap.Add(commandName, argumentProcessor);
 
-                // Add xplat name for the command name
-                commandName = string.Concat("--", commandName.Remove(0, 1));
-                processorsMap.Add(commandName, argumentProcessor);
-
-                if (!string.IsNullOrEmpty(argumentProcessor.Metadata.Value.ShortCommandName))
+                // Add xplat name for the command name. Ignore special commands
+                if (!argumentProcessor.Metadata.Value.IsSpecialCommand)
                 {
-                    string shortCommandName = argumentProcessor.Metadata.Value.ShortCommandName;
-                    processorsMap.Add(shortCommandName, argumentProcessor);
+                    commandName = string.Concat("--", commandName.Remove(0, 1));
+                    commandToProcessorMap.Add(commandName, argumentProcessor);
 
-                    // Add xplat short name for the command name
-                    shortCommandName = shortCommandName.Replace('/', '-');
-                    processorsMap.Add(shortCommandName, argumentProcessor);
+                    if (!string.IsNullOrEmpty(argumentProcessor.Metadata.Value.ShortCommandName))
+                    {
+                        string shortCommandName = argumentProcessor.Metadata.Value.ShortCommandName;
+                        commandToProcessorMap.Add(shortCommandName, argumentProcessor);
+
+                        // Add xplat short name for the command name
+                        shortCommandName = shortCommandName.Replace('/', '-');
+                        commandToProcessorMap.Add(shortCommandName, argumentProcessor);
+                    }
                 }
             }
         }

--- a/src/vstest.console/Processors/Utilities/ArgumentProcessorPriority.cs
+++ b/src/vstest.console/Processors/Utilities/ArgumentProcessorPriority.cs
@@ -37,9 +37,16 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
         VsixExtensions = 5,
 
         /// <summary>
+        /// Priority of processors related to specifying sources.
+        /// These need to be invoked before runsettings are loaded as the runsettings auto-detection requires
+        /// the test directories to be known.
+        /// </summary>
+        Sources = 6,
+
+        /// <summary>
         /// Priority of processors related to Run Settings.
         /// </summary>
-        RunSettings = 6,
+        RunSettings = 7,
 
         /// <summary>
         /// Priority of TestAdapterPathArgumentProcessor.

--- a/test/vstest.console.UnitTests/Processors/Utilities/ArgumentProcessorFactoryTests.cs
+++ b/test/vstest.console.UnitTests/Processors/Utilities/ArgumentProcessorFactoryTests.cs
@@ -99,62 +99,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors.U
             Assert.AreEqual(typeof(CLIRunSettingsArgumentProcessor), result.GetType());
         }
 
-        [TestMethod]
-        public void BuildCommadMapsForProcessorWithIsSpecialCommandSetAddsProcessorToSpecialMap()
-        {
-            var specialCommands = GetArgumentProcessors(specialCommandFilter: true);
-
-            List<string> xplatspecialCommandNames = new List<string>();
-            List<string> specialCommandNames = new List<string>();
-
-            // for each command add there xplat version
-            foreach (var specialCommand in specialCommands)
-            {
-                specialCommandNames.Add(specialCommand.Metadata.Value.CommandName);
-                if (!specialCommand.Metadata.Value.AlwaysExecute)
-                {
-                    xplatspecialCommandNames.Add(string.Concat("--", specialCommand.Metadata.Value.CommandName.Remove(0, 1)));
-                }
-            }
-            var factory = ArgumentProcessorFactory.Create();
-
-            CollectionAssert.AreEquivalent(
-                specialCommandNames.Concat(xplatspecialCommandNames).ToList(),
-                factory.SpecialCommandToProcessorMap.Keys.ToList());
-        }
-
-        [TestMethod]
-        public void BuildCommadMapsForMultipleProcessorAddsProcessorToAppropriateMaps()
-        {
-            var commandProcessors = GetArgumentProcessors(specialCommandFilter: false);
-            var commands = commandProcessors.Select(a => a.Metadata.Value.CommandName);
-            List<string> xplatCommandName = new List<string>();
-
-            // for each command add there xplat version
-            foreach (string name in commands)
-            {
-                xplatCommandName.Add(string.Concat("--", name.Remove(0, 1)));
-            }
-
-            var shortCommands = commandProcessors.Where(a => !string.IsNullOrEmpty(a.Metadata.Value.ShortCommandName))
-                                    .Select(a => a.Metadata.Value.ShortCommandName);
-
-            List<string> xplatShortCommandName = new List<string>();
-
-            // for each short command add there xplat version
-            foreach (string name in shortCommands)
-            {
-                xplatShortCommandName.Add(name.Replace('/', '-'));
-            }
-
-            ArgumentProcessorFactory factory = ArgumentProcessorFactory.Create();
-
-            // Expect command processors to contain both long and short commands.
-            CollectionAssert.AreEquivalent(
-                commands.Concat(xplatCommandName).Concat(shortCommands).Concat(xplatShortCommandName).ToList(),
-                factory.CommandToProcessorMap.Keys.ToList());
-        }
-
         private static IEnumerable<IArgumentProcessor> GetArgumentProcessors(bool specialCommandFilter)
         {
             var allProcessors = typeof(ArgumentProcessorFactory).GetTypeInfo()


### PR DESCRIPTION
Fixes https://github.com/microsoft/vstest/issues/2418
Fixes https://github.com/microsoft/vstest/issues/2432

Add an auto-detection mechanism that searches for a ".runsettings" in
the test app's directory if no runsettings file was passed in and only
a single test assembly is invoked.

Extend the AlwaysExecute mechanism for ArgumentProcessors so that
processors can run by default without a switch passed in without being a `SpecialCommand`.

cc @nohwnd 