### PR TITLE
More verbose info in datacollector log

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionTestCaseEventHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionTestCaseEventHandler.cs
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
 
                         if (EqtTrace.IsInfoEnabled)
                         {
-                            EqtTrace.Info("DataCollectionTestCaseEventHandler: Test case started.");
+                            EqtTrace.Info("DataCollectionTestCaseEventHandler: Test case '{0} - {1}' started.", testCaseStartEventArgs.TestCaseName, testCaseStartEventArgs.TestCaseId);
                         }
 
                         break;
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
 
                         if (EqtTrace.IsInfoEnabled)
                         {
-                            EqtTrace.Info("DataCollectionTestCaseEventHandler: Test case completed");
+                            EqtTrace.Info("DataCollectionTestCaseEventHandler: Test case '{0} - {1}' completed", testCaseEndEventArgs.TestCaseName, testCaseEndEventArgs.TestCaseId);
                         }
 
                         break;
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.DataCollect
                     default:
                         if (EqtTrace.IsInfoEnabled)
                         {
-                            EqtTrace.Info("DataCollectionTestCaseEventHandler: Invalid Message types");
+                            EqtTrace.Info("DataCollectionTestCaseEventHandler: Invalid Message type '{0}'", message.MessageType);
                         }
 
                         break;

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/TestRunCache.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/TestRunCache.cs
@@ -259,7 +259,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
 
                 if (this.inProgressTests == null || this.inProgressTests.Count == 0)
                 {
-                    EqtTrace.Warning("InProgressTests is null");
+                    EqtTrace.Warning("TestRunCache: InProgressTests is null");
                     return false;
                 }
 
@@ -394,7 +394,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
             var removed = this.OnTestCompletion(result.TestCase);
             if (!removed)
             {
-                EqtTrace.Warning("TestRunCache: No test found corresponding to testResult '{0}' in inProgress list.", result);
+                EqtTrace.Warning("TestRunCache: No test found corresponding to testResult '{0}' in inProgress list.", result.DisplayName);
             }
         }
 


### PR DESCRIPTION
## Description
Data collector logs what is currently running even without the blame switch, but does not include the test names, this change makes it easier to figure out if there were any tests in progress from the normal diag log that we always ask for when investigating a bug.

