### PR TITLE
Use testhost.exe only on Windows x86 and x64

### DIFF
--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -230,7 +230,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting
 
             // If testhost.exe is available use it, unless user specified path to dotnet.exe, then we will use the testhost.dll
             bool testHostExeFound = false;
-            if (!useCustomDotnetHostpath && this.platformEnvironment.OperatingSystem.Equals(PlatformOperatingSystem.Windows))
+            if (!useCustomDotnetHostpath && this.platformEnvironment.OperatingSystem.Equals(PlatformOperatingSystem.Windows) && (this.platformEnvironment.Architecture == PlatformArchitecture.X64 || this.platformEnvironment.Architecture == PlatformArchitecture.X86))
             {
                 var exeName = this.architecture == Architecture.X86 ? "testhost.x86.exe" : "testhost.exe";
                 var fullExePath = Path.Combine(sourceDirectory, exeName);

--- a/src/vstest.console/Processors/EnableBlameArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnableBlameArgumentProcessor.cs
@@ -330,9 +330,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
         private bool IsHangDumpCollectionSupported()
         {
             var dumpCollectionSupported =
-                this.environment.OperatingSystem != PlatformOperatingSystem.OSX
-                && this.environment.Architecture != PlatformArchitecture.ARM64
-                && this.environment.Architecture != PlatformArchitecture.ARM;
+                this.environment.OperatingSystem != PlatformOperatingSystem.OSX;
 
             if (!dumpCollectionSupported)
             {


### PR DESCRIPTION


## Description
 Use testhost.exe only on Windows x86 and x64, and enable hang dumps on ARM and ARM64

## Related issue
Fixes #2473 