### PR TITLE
Add missing space before parens in message

### DIFF
--- a/src/Microsoft.TestPlatform.Build/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.Build/Resources/Resources.resx
@@ -127,7 +127,7 @@
     <value>Skipping running test for project {0}. To run tests with dotnet test add "&lt;IsTestProject&gt;true&lt;/IsTestProject&gt;" property to project file.</value>
   </data>
   <data name="TestRunningSummary" xml:space="preserve">
-    <value>Test run for {0}({1})</value>
+    <value>Test run for {0} ({1})</value>
   </data>
   <data name="UpdateTestSdkForCollectingCodeCoverage" xml:space="preserve">
     <value>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</value>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.cs.xlf
@@ -31,9 +31,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestRunningSummary">
-        <source>Test run for {0}({1})</source>
-        <target state="translated">Testovací běh pro: {0}({1})</target>
-        <note />
+        <source>Test run for {0} ({1})</source>
+        <target state="new">Testovací běh pro: {0}({1})</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
         <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.de.xlf
@@ -31,9 +31,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestRunningSummary">
-        <source>Test run for {0}({1})</source>
-        <target state="translated">Testlauf für "{0}" ({1})</target>
-        <note />
+        <source>Test run for {0} ({1})</source>
+        <target state="new">Testlauf für "{0}" ({1})</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
         <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.es.xlf
@@ -31,9 +31,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestRunningSummary">
-        <source>Test run for {0}({1})</source>
-        <target state="translated">Serie de pruebas para {0}({1})</target>
-        <note />
+        <source>Test run for {0} ({1})</source>
+        <target state="new">Serie de pruebas para {0}({1})</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
         <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.fr.xlf
@@ -31,9 +31,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestRunningSummary">
-        <source>Test run for {0}({1})</source>
-        <target state="translated">Série de tests pour {0}({1})</target>
-        <note />
+        <source>Test run for {0} ({1})</source>
+        <target state="new">Série de tests pour {0}({1})</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
         <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.it.xlf
@@ -31,9 +31,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestRunningSummary">
-        <source>Test run for {0}({1})</source>
-        <target state="translated">Esecuzione dei test per {0}({1})</target>
-        <note />
+        <source>Test run for {0} ({1})</source>
+        <target state="new">Esecuzione dei test per {0}({1})</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
         <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ja.xlf
@@ -31,9 +31,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestRunningSummary">
-        <source>Test run for {0}({1})</source>
-        <target state="translated">{0}({1}) のテスト実行</target>
-        <note />
+        <source>Test run for {0} ({1})</source>
+        <target state="new">{0}({1}) のテスト実行</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
         <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ko.xlf
@@ -31,9 +31,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestRunningSummary">
-        <source>Test run for {0}({1})</source>
-        <target state="translated">{0}({1})에 대한 테스트 실행</target>
-        <note />
+        <source>Test run for {0} ({1})</source>
+        <target state="new">{0}({1})에 대한 테스트 실행</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
         <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.pl.xlf
@@ -31,9 +31,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestRunningSummary">
-        <source>Test run for {0}({1})</source>
-        <target state="translated">Przebieg testu dla: {0}({1})</target>
-        <note />
+        <source>Test run for {0} ({1})</source>
+        <target state="new">Przebieg testu dla: {0}({1})</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
         <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.pt-BR.xlf
@@ -31,9 +31,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestRunningSummary">
-        <source>Test run for {0}({1})</source>
-        <target state="translated">Execução de teste para {0}({1})</target>
-        <note />
+        <source>Test run for {0} ({1})</source>
+        <target state="new">Execução de teste para {0}({1})</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
         <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.ru.xlf
@@ -31,9 +31,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestRunningSummary">
-        <source>Test run for {0}({1})</source>
-        <target state="translated">Тестовый запуск {0}({1})</target>
-        <note />
+        <source>Test run for {0} ({1})</source>
+        <target state="new">Тестовый запуск {0}({1})</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
         <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.tr.xlf
@@ -31,9 +31,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestRunningSummary">
-        <source>Test run for {0}({1})</source>
-        <target state="translated">{0}({1}) için test çalıştırması</target>
-        <note />
+        <source>Test run for {0} ({1})</source>
+        <target state="new">{0}({1}) için test çalıştırması</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
         <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.tr.xlf
@@ -32,7 +32,7 @@
       </trans-unit>
       <trans-unit id="TestRunningSummary">
         <source>Test run for {0} ({1})</source>
-        <target state="new">{0}({1}) için test çalıştırması</target>
+        <target state="translated">{0} ({1}) için test çalıştırması</target>
         <note></note>
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.xlf
@@ -13,7 +13,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="TestRunningSummary">
-        <source>Test run for {0}({1})</source>
+        <source>Test run for {0} ({1})</source>
         <target state="new">Test run for {0}({1})</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.zh-Hans.xlf
@@ -31,9 +31,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestRunningSummary">
-        <source>Test run for {0}({1})</source>
-        <target state="translated">{0} 的测试运行({1})</target>
-        <note />
+        <source>Test run for {0} ({1})</source>
+        <target state="new">{0} 的测试运行({1})</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
         <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>

--- a/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.Build/Resources/xlf/Resources.zh-Hant.xlf
@@ -31,9 +31,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TestRunningSummary">
-        <source>Test run for {0}({1})</source>
-        <target state="translated">{0}({1}) 的測試回合</target>
-        <note />
+        <source>Test run for {0} ({1})</source>
+        <target state="new">{0}({1}) 的測試回合</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="UpdateTestSdkForCollectingCodeCoverage">
         <source>Warning: Update the Microsoft.NET.Test.Sdk package reference to version 15.8.0 or later to collect code coverage.</source>


### PR DESCRIPTION
Changes
```
Test run for C:\git\runtime\artifacts\bin\System.Buffers.Tests\net5.0-Debug\System.Buffers.Tests.dll(.NETCoreApp,Version=v5.0)
```
to
```
Test run for C:\git\runtime\artifacts\bin\System.Buffers.Tests\net5.0-Debug\System.Buffers.Tests.dll (.NETCoreApp,Version=v5.0)
```
Which is correctly spaced and consistent with other messages.