### PR TITLE
Do not force 32-bit on 64-bit system under VS

### DIFF
--- a/src/vstest.console/vstest.console.csproj
+++ b/src/vstest.console/vstest.console.csproj
@@ -11,7 +11,7 @@
     <WarningsAsErrors>true</WarningsAsErrors>
     <OutputType>Exe</OutputType>
     <PlatformTarget Condition="'$(TargetFramework)' == 'net451'">AnyCPU</PlatformTarget>
-    <Prefer32Bit Condition="'$(TargetFramework)' == 'net451'">true</Prefer32Bit>
+    <Prefer32Bit Condition="'$(TargetFramework)' == 'net451'">false</Prefer32Bit>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">


### PR DESCRIPTION
## Description
Under VS we are running as 32-bit process which is affecting our logic that selects the correct 
dotnet executor bittness based on the current process bitness and the architecture of the target 
assembly. We want to run as 64-bit to choose x64 for AnyCPU assemblies when running under 
VS on a 64-bit system. 

But still run 32-bit when we run on 32-bit system, or when we run from 32-bit dotnet. 
