### PR TITLE
Use OS bitness to figure out .NETCore runner architecture

### DIFF
--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -451,7 +451,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers
                         || chosenFramework.Name.IndexOf("netcoreapp", StringComparison.OrdinalIgnoreCase) >= 0
                         || chosenFramework.Name.IndexOf("net5", StringComparison.OrdinalIgnoreCase) >= 0)
                     {
-                        defaultArchitecture =  Environment.Is64BitProcess ? Architecture.X64 : Architecture.X86;
+                        defaultArchitecture =  Environment.Is64BitOperatingSystem ? Architecture.X64 : Architecture.X86;
                     }
 
                     settingsUpdated |= this.UpdatePlatform(document, navigator, sources, sourcePlatforms, defaultArchitecture, out Architecture chosenPlatform);


### PR DESCRIPTION
Use the OS bitness to figure out if we should use 32-bit or 64-bit dotnet SDK for AnyCPU dlls. On a 64-bit system user is more likely to have the 64-bit SDK installed. This also makes it work on 32-bit system where we previously failed and tried to start the 64-bit testhost.exe
