### PR TITLE
Fixing the reminder of crash dumps

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
@@ -419,14 +419,11 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                 // If the last test crashes, it will not invoke a test case end and therefore
                 // In case of crash testStartCount will be greater than testEndCount and we need to write the sequence
                 // And send the attachment
-                if (this.testStartCount > this.testEndCount)
-                {
-                    var filepath = Path.Combine(this.GetTempDirectory(), Constants.AttachmentFileName + "_" + this.attachmentGuid);
+                var filepath = Path.Combine(this.GetTempDirectory(), Constants.AttachmentFileName + "_" + this.attachmentGuid);
 
-                    filepath = this.blameReaderWriter.WriteTestSequence(this.testSequence, this.testObjectDictionary, filepath);
-                    var fileTranferInformation = new FileTransferInformation(this.context.SessionDataCollectionContext, filepath, true);
-                    this.dataCollectionSink.SendFileAsync(fileTranferInformation);
-                }
+                filepath = this.blameReaderWriter.WriteTestSequence(this.testSequence, this.testObjectDictionary, filepath);
+                var fti = new FileTransferInformation(this.context.SessionDataCollectionContext, filepath, true);
+                this.dataCollectionSink.SendFileAsync(fti);
 
                 if (this.collectProcessDumpOnTrigger)
                 {

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
@@ -139,11 +139,19 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                     this.environmentVariables.Add(new KeyValuePair<string, string>("COMPlus_DbgEnableElfDumpOnMacOS", "1"));
                     this.environmentVariables.Add(new KeyValuePair<string, string>("COMPlus_DbgEnableMiniDump", "1"));
 
+                    if (!this.processFullDumpEnabled)
+                    {
+                        // https://github.com/dotnet/coreclr/blob/master/Documentation/botr/xplat-minidump-generation.md
+                        // MiniDumpWithPrivateReadWriteMemory = 2
+                        // MiniDumpNormal = 1
+                        this.environmentVariables.Add(new KeyValuePair<string, string>("COMPlus_DbgMiniDumpType", this.processFullDumpEnabled ? "2" : "1"));
+                    }
+
                     var guid = Guid.NewGuid().ToString();
 
                     var dumpDirectory = Path.Combine(Path.GetTempPath(), guid);
                     Directory.CreateDirectory(dumpDirectory);
-                    var dumpPath = Path.Combine(dumpDirectory, $"dotnet_%d_crashdump.dmp");
+                    var dumpPath = Path.Combine(dumpDirectory, $"%e_%p_%t_crashdump.dmp");
                     this.environmentVariables.Add(new KeyValuePair<string, string>("COMPlus_DbgMiniDumpName", dumpPath));
                 }
 

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
@@ -419,11 +419,18 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                 // If the last test crashes, it will not invoke a test case end and therefore
                 // In case of crash testStartCount will be greater than testEndCount and we need to write the sequence
                 // And send the attachment
-                var filepath = Path.Combine(this.GetTempDirectory(), Constants.AttachmentFileName + "_" + this.attachmentGuid);
+                if (this.testStartCount > this.testEndCount)
+                {
+                    var filepath = Path.Combine(this.GetTempDirectory(), Constants.AttachmentFileName + "_" + this.attachmentGuid);
 
-                filepath = this.blameReaderWriter.WriteTestSequence(this.testSequence, this.testObjectDictionary, filepath);
-                var fti = new FileTransferInformation(this.context.SessionDataCollectionContext, filepath, true);
-                this.dataCollectionSink.SendFileAsync(fti);
+                    filepath = this.blameReaderWriter.WriteTestSequence(this.testSequence, this.testObjectDictionary, filepath);
+                    var fti = new FileTransferInformation(this.context.SessionDataCollectionContext, filepath, true);
+                    this.dataCollectionSink.SendFileAsync(fti);
+                }
+                else
+                {
+                    this.logger.LogWarning(this.context.SessionDataCollectionContext, Resources.Resources.NotGeneratingSequenceFile);
+                }
 
                 if (this.collectProcessDumpOnTrigger)
                 {

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/CrashDumperFactory.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/CrashDumperFactory.cs
@@ -6,12 +6,29 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
     using System;
     using System.Runtime.InteropServices;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+    using NuGet.Frameworks;
 
     internal class CrashDumperFactory : ICrashDumperFactory
     {
         public ICrashDumper Create(string targetFramework)
         {
+            if (targetFramework is null)
+            {
+                throw new ArgumentNullException(nameof(targetFramework));
+            }
+
             EqtTrace.Info($"CrashDumperFactory: Creating dumper for {RuntimeInformation.OSDescription} with target framework {targetFramework}.");
+
+            var tfm = NuGetFramework.Parse(targetFramework);
+
+            if (tfm == null || tfm.IsUnsupported)
+            {
+                EqtTrace.Error($"CrashDumperFactory: Could not parse target framework {targetFramework}, to a supported framework version.");
+                throw new NotSupportedException($"Could not parse target framework {targetFramework}, to a supported framework version.");
+            }
+
+            var isNet50OrNewer = tfm.Framework == ".NETCoreApp" && tfm.Version >= Version.Parse("5.0.0.0");
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 EqtTrace.Info($"CrashDumperFactory: This is Windows, returning ProcDumpCrashDumper that uses ProcDump utility.");
@@ -28,7 +45,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                 // return new NetClientCrashDumper();
             }
 
-            if (!string.IsNullOrWhiteSpace(targetFramework) && targetFramework.Contains("v5.0"))
+            if (isNet50OrNewer)
             {
                 EqtTrace.Info($"CrashDumperFactory: This is {RuntimeInformation.OSDescription} on {targetFramework} .NETClient dumper which uses env variables to collect crashdumps of testhost and any child process.");
                 return new NetClientCrashDumper();

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Microsoft.TestPlatform.Extensions.BlameDataCollector.csproj
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Microsoft.TestPlatform.Extensions.BlameDataCollector.csproj
@@ -23,7 +23,7 @@
     <ProjectReference Include="..\Microsoft.TestPlatform.ObjectModel\Microsoft.TestPlatform.ObjectModel.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.CoreUtilities\Microsoft.TestPlatform.CoreUtilities.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' AND '$(OS)' != 'Windows_NT' ">
     <Reference Include="System" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Xml" />
@@ -34,7 +34,6 @@
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client">
       <Version>0.2.0-preview.20378.10</Version>
     </PackageReference>
-    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources\Resources.Designer.cs">

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/Resources.Designer.cs
@@ -106,6 +106,15 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to All tests finished running, Sequence file will not be generated..
+        /// </summary>
+        internal static string NotGeneratingSequenceFile {
+            get {
+                return ResourceManager.GetString("NotGeneratingSequenceFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not start process dump: {0}.
         /// </summary>
         internal static string ProcDumpCouldNotStart {

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/Resources.resx
@@ -132,6 +132,10 @@
   <data name="InactivityTimeout" xml:space="preserve">
     <value>The specified inactivity time of {0} minute/s has elapsed. Collecting a dump and killing the test host process.</value>
   </data>
+  <data name="NotGeneratingSequenceFile" xml:space="preserve">
+    <value>All tests finished running, Sequence file will not be generated.</value>
+    <comment>"Sequence" is the name of the file.</comment>
+  </data>
   <data name="ProcDumpCouldNotStart" xml:space="preserve">
     <value>Could not start process dump: {0}</value>
   </data>

--- a/src/testhost.x86/testhost.x86.csproj
+++ b/src/testhost.x86/testhost.x86.csproj
@@ -30,7 +30,7 @@
       <FromP2P>true</FromP2P>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) AND '$(OS)' != 'Windows_NT' ">
     <Reference Include="netstandard" />
     <Reference Include="System" />
     <Reference Include="System.Runtime" />

--- a/src/testhost/testhost.csproj
+++ b/src/testhost/testhost.csproj
@@ -32,7 +32,7 @@
       <FromP2P>true</FromP2P>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup  Condition=" $(TargetFramework.StartsWith('net4')) ">
+  <ItemGroup  Condition=" $(TargetFramework.StartsWith('net4')) AND '$(OS)' != 'Windows_NT' ">
     <Reference Include="netstandard" />
     <Reference Include="System" />
     <Reference Include="System.Runtime" />

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests.csproj
@@ -19,7 +19,7 @@
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.Extensions.BlameDataCollector\Microsoft.TestPlatform.Extensions.BlameDataCollector.csproj" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' AND '$(OS)' != 'Windows_NT' ">
     <Reference Include="System.Runtime" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Microsoft.TestPlatform.TestHostProvider.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Microsoft.TestPlatform.TestHostProvider.UnitTests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.TestHostProvider\Microsoft.TestPlatform.TestHostProvider.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' AND '$(OS)' != 'Windows_NT' ">
     <Reference Include="System.Runtime" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
## Description
- Add process name, and timestamp to crash dump
- Pass on dump type to crash dump
- Fix matching dotnet 5.0 to be generic and match even net6.0
- get rid of netstandard reference warnings on Windows where we don't need them for build

## Related issue
Fix #2498 