### PR TITLE
Custom dump path for helix

### DIFF
--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionAttachmentManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionAttachmentManager.cs
@@ -140,7 +140,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
         {
             try
             {
-                Task.WhenAll(this.attachmentTasks[dataCollectionContext].ToArray()).Wait();
+                if (this.attachmentTasks.TryGetValue(dataCollectionContext, out var tasks))
+                {
+                    Task.WhenAll(tasks.ToArray()).Wait();
+                }
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
@@ -570,7 +570,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
             if (string.IsNullOrWhiteSpace(this.tempDirectory))
             {
                 this.tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-                Directory.CreateDirectory(this.tempDirecto);
+                Directory.CreateDirectory(this.tempDirectory);
                 return this.tempDirectory;
             }
 

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/CrashDumperFactory.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/CrashDumperFactory.cs
@@ -31,18 +31,14 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                EqtTrace.Info($"CrashDumperFactory: This is Windows, returning ProcDumpCrashDumper that uses ProcDump utility.");
-                return new ProcDumpCrashDumper();
+                if (!isNet50OrNewer)
+                {
+                    EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework} which is not net5.0 or newer, returning ProcDumpCrashDumper that uses ProcDump utility.");
+                    return new ProcDumpCrashDumper();
+                }
 
-                // enable this once crashdump can trigger itself on exceptions that originate from task, then we can avoid using procdump
-                // if (!string.IsNullOrWhiteSpace(targetFramework) && !targetFramework.Contains("v5.0"))
-                // {
-                //     EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework} which is not net5.0 or newer, returning ProcDumpCrashDumper that uses ProcDump utility.");
-                //     return new ProcDumpCrashDumper();
-                // }
-
-                // EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework}, returning the .NETClient dumper which uses env variables to collect crashdumps of testhost and any child process.");
-                // return new NetClientCrashDumper();
+                EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework}, returning the .NETClient dumper which uses env variables to collect crashdumps of testhost and any child process.");
+                return new NetClientCrashDumper();
             }
 
             if (isNet50OrNewer)

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/Resources.Designer.cs
@@ -106,7 +106,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to All tests finished running, Sequence file will not be generated..
+        ///   Looks up a localized string similar to All tests finished running, Sequence file will not be generated.
         /// </summary>
         internal static string NotGeneratingSequenceFile {
             get {

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/Resources.resx
@@ -134,7 +134,7 @@
   </data>
   <data name="NotGeneratingSequenceFile" xml:space="preserve">
     <value>All tests finished running, Sequence file will not be generated</value>
-    <comment>"Sequence" is the name of the file.</comment>
+    <comment>"Sequence" is the name of the file. No . at the end, because this is a blame message and the . will be added automatically.</comment>
   </data>
   <data name="ProcDumpCouldNotStart" xml:space="preserve">
     <value>Could not start process dump: {0}</value>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/Resources.resx
@@ -133,7 +133,7 @@
     <value>The specified inactivity time of {0} minute/s has elapsed. Collecting a dump and killing the test host process.</value>
   </data>
   <data name="NotGeneratingSequenceFile" xml:space="preserve">
-    <value>All tests finished running, Sequence file will not be generated.</value>
+    <value>All tests finished running, Sequence file will not be generated</value>
     <comment>"Sequence" is the name of the file.</comment>
   </data>
   <data name="ProcDumpCouldNotStart" xml:space="preserve">

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.cs.xlf
@@ -66,7 +66,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="NotGeneratingSequenceFile">
-        <source>All tests finished running, Sequence file will not be generated.</source>
+        <source>All tests finished running, Sequence file will not be generated</source>
         <target state="new">All tests finished running, Sequence file will not be generated.</target>
         <note>"Sequence" is the name of the file.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.de.xlf
@@ -66,7 +66,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="NotGeneratingSequenceFile">
-        <source>All tests finished running, Sequence file will not be generated.</source>
+        <source>All tests finished running, Sequence file will not be generated</source>
         <target state="new">All tests finished running, Sequence file will not be generated.</target>
         <note>"Sequence" is the name of the file.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.es.xlf
@@ -66,7 +66,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="NotGeneratingSequenceFile">
-        <source>All tests finished running, Sequence file will not be generated.</source>
+        <source>All tests finished running, Sequence file will not be generated</source>
         <target state="new">All tests finished running, Sequence file will not be generated.</target>
         <note>"Sequence" is the name of the file.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.fr.xlf
@@ -66,7 +66,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="NotGeneratingSequenceFile">
-        <source>All tests finished running, Sequence file will not be generated.</source>
+        <source>All tests finished running, Sequence file will not be generated</source>
         <target state="new">All tests finished running, Sequence file will not be generated.</target>
         <note>"Sequence" is the name of the file.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.it.xlf
@@ -66,7 +66,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="NotGeneratingSequenceFile">
-        <source>All tests finished running, Sequence file will not be generated.</source>
+        <source>All tests finished running, Sequence file will not be generated</source>
         <target state="new">All tests finished running, Sequence file will not be generated.</target>
         <note>"Sequence" is the name of the file.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.ja.xlf
@@ -66,7 +66,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="NotGeneratingSequenceFile">
-        <source>All tests finished running, Sequence file will not be generated.</source>
+        <source>All tests finished running, Sequence file will not be generated</source>
         <target state="new">All tests finished running, Sequence file will not be generated.</target>
         <note>"Sequence" is the name of the file.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.ko.xlf
@@ -66,7 +66,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="NotGeneratingSequenceFile">
-        <source>All tests finished running, Sequence file will not be generated.</source>
+        <source>All tests finished running, Sequence file will not be generated</source>
         <target state="new">All tests finished running, Sequence file will not be generated.</target>
         <note>"Sequence" is the name of the file.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.pl.xlf
@@ -66,7 +66,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="NotGeneratingSequenceFile">
-        <source>All tests finished running, Sequence file will not be generated.</source>
+        <source>All tests finished running, Sequence file will not be generated</source>
         <target state="new">All tests finished running, Sequence file will not be generated.</target>
         <note>"Sequence" is the name of the file.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.pt-BR.xlf
@@ -66,7 +66,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="NotGeneratingSequenceFile">
-        <source>All tests finished running, Sequence file will not be generated.</source>
+        <source>All tests finished running, Sequence file will not be generated</source>
         <target state="new">All tests finished running, Sequence file will not be generated.</target>
         <note>"Sequence" is the name of the file.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.ru.xlf
@@ -66,7 +66,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="NotGeneratingSequenceFile">
-        <source>All tests finished running, Sequence file will not be generated.</source>
+        <source>All tests finished running, Sequence file will not be generated</source>
         <target state="new">All tests finished running, Sequence file will not be generated.</target>
         <note>"Sequence" is the name of the file.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.tr.xlf
@@ -66,7 +66,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="NotGeneratingSequenceFile">
-        <source>All tests finished running, Sequence file will not be generated.</source>
+        <source>All tests finished running, Sequence file will not be generated</source>
         <target state="new">All tests finished running, Sequence file will not be generated.</target>
         <note>"Sequence" is the name of the file.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.xlf
@@ -48,7 +48,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="NotGeneratingSequenceFile">
-        <source>All tests finished running, Sequence file will not be generated.</source>
+        <source>All tests finished running, Sequence file will not be generated</source>
         <target state="new">All tests finished running, Sequence file will not be generated.</target>
         <note>"Sequence" is the name of the file.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.zh-Hans.xlf
@@ -66,7 +66,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="NotGeneratingSequenceFile">
-        <source>All tests finished running, Sequence file will not be generated.</source>
+        <source>All tests finished running, Sequence file will not be generated</source>
         <target state="new">All tests finished running, Sequence file will not be generated.</target>
         <note>"Sequence" is the name of the file.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.zh-Hant.xlf
@@ -66,7 +66,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="NotGeneratingSequenceFile">
-        <source>All tests finished running, Sequence file will not be generated.</source>
+        <source>All tests finished running, Sequence file will not be generated</source>
         <target state="new">All tests finished running, Sequence file will not be generated.</target>
         <note>"Sequence" is the name of the file.</note>
       </trans-unit>


### PR DESCRIPTION
## Description
Add env variable VSTEST_DUMP_PATH to skip publishing dumps and placing them into a custom destination for a subsequent process to pick them up. 

Use NetClientDumper for net5.0. 

Related #2380 


