### PR TITLE
Take non-completed tests instead of last

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameLogger.cs
@@ -152,8 +152,8 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                         var testCaseList = this.blameReaderWriter.ReadTestSequence(filepath);
                         if (testCaseList.Count > 0)
                         {
-                            var testcase = testCaseList.Last();
-                            faultyTestCaseNames.Add(testcase.FullyQualifiedName);
+                            var testcases = testCaseList.Where(t => !t.IsCompleted).Select(t => t.FullyQualifiedName).ToList();
+                            faultyTestCaseNames.AddRange(testcases);
                         }
                     }
                 }


### PR DESCRIPTION
## Description
Take the non-completed tests from the sequence file. This should not make almost any difference in most cases, but just to be sure.

Related #2380 
