### PR TITLE
Added a command-line argument to vstest.console.exe for setting environment variables

### DIFF
--- a/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
@@ -215,7 +215,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
             return node;
         }
 
-        private static XmlDocument GetRunSettingXmlDocument(this IRunSettingsProvider runSettingsProvider)
+        public static XmlDocument GetRunSettingXmlDocument(this IRunSettingsProvider runSettingsProvider)
         {
             ValidateArg.NotNull(runSettingsProvider, nameof(runSettingsProvider));
 

--- a/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
@@ -215,7 +215,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
             return node;
         }
 
-        public static XmlDocument GetRunSettingXmlDocument(this IRunSettingsProvider runSettingsProvider)
+        private static XmlDocument GetRunSettingXmlDocument(this IRunSettingsProvider runSettingsProvider)
         {
             ValidateArg.NotNull(runSettingsProvider, nameof(runSettingsProvider));
 

--- a/src/vstest.console/Processors/EnvironmentArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnvironmentArgumentProcessor.cs
@@ -6,23 +6,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
 {
     using System;
     using System.Diagnostics.Contracts;
-    using System.Globalization;
-    using System.Linq;
     using System.Xml;
-    using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
-    using Microsoft.VisualStudio.TestPlatform.CommandLine.Internal;
-    using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
     using Microsoft.VisualStudio.TestPlatform.Common;
-    using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
     using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+    using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
     using Microsoft.VisualStudio.TestPlatform.Utilities;
-
-
     using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;
-    using System.Xml.Linq;
-
 
     /// <summary>
     /// Argument Executor for the "-e|--Environment|/e|/Environment" command line argument.

--- a/src/vstest.console/Processors/EnvironmentArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnvironmentArgumentProcessor.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
-
 {
     using System;
     using System.Diagnostics.Contracts;
-    using System.Xml;
     using Microsoft.VisualStudio.TestPlatform.Common;
     using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
     using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
@@ -19,7 +17,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
     internal class EnvironmentArgumentProcessor : IArgumentProcessor
     {
         #region Constants
-
         /// <summary>
         /// The short name of the command line argument that the EnvironmentArgumentProcessor handles.
         /// </summary>
@@ -29,13 +26,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
         /// The name of the command line argument that the EnvironmentArgumentProcessor handles.
         /// </summary>
         public const string CommandName = "/Environment";
-
         #endregion
 
         private Lazy<IArgumentProcessorCapabilities> metadata;
 
         private Lazy<IArgumentExecutor> executor;
-
 
         public Lazy<IArgumentExecutor> Executor
         {
@@ -72,16 +67,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
         internal class ArgumentProcessorCapabilities : BaseArgumentProcessorCapabilities
         {
             public override string CommandName => EnvironmentArgumentProcessor.CommandName;
-
             public override string ShortCommandName => EnvironmentArgumentProcessor.ShortCommandName;
-
             public override bool AllowMultiple => true;
-
             public override bool IsAction => false;
-
-            public override ArgumentProcessorPriority Priority => ArgumentProcessorPriority.Normal;
             public override string HelpContentResourceName => CommandLineResources.EnvironmentArgumentHelp;
-
+            public override ArgumentProcessorPriority Priority => ArgumentProcessorPriority.Normal;
             public override HelpContentPriority HelpPriority => HelpContentPriority.EnvironmentArgumentProcessorHelpPriority;
         }
 
@@ -98,13 +88,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             /// </summary>
             private IRunSettingsProvider runSettingsProvider;
 
+            /// <summary>
+            /// Used when checking and forcing InIsolation mode.
+            /// </summary>
             private CommandLineOptions commandLineOptions;
             #endregion
 
-            public ArgumentExecutor(
-                CommandLineOptions commandLineOptions,
-                IRunSettingsProvider runSettingsProvider,
-                IOutput output)
+            public ArgumentExecutor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider, IOutput output)
             {
                 this.commandLineOptions = commandLineOptions;
                 this.output = output;
@@ -133,26 +123,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
                     value = key.Substring(key.IndexOf("=") + 1);
                     key = key.Substring(0, key.IndexOf("="));
                 }
-                              
-                var xml = this.runSettingsProvider.GetRunSettingXmlDocument();
-                var runSettings = CreateOrSelectSingleNode(xml, "RunSettings");
-                var runConfiguration = CreateOrSelectSingleNode(runSettings, "RunConfiguration");
-                var environmentVariables = CreateOrSelectSingleNode(runConfiguration, "EnvironmentVariables");
 
-                var variable = environmentVariables.SelectSingleNode(key);
-                if(variable == null)
-                {
-                    variable = CreateOrSelectSingleNode(environmentVariables, key);
-                }
-                else
+                var node = this.runSettingsProvider.QueryRunSettingsNode($"RunConfiguration.EnvironmentVariables.{key}");
+                if(node != null)
                 {
                     output.Warning(true, CommandLineResources.EnvironmentVariableXIsOverriden, key);
                 }
 
-                variable.InnerText = value;
-
-                this.runSettingsProvider.UpdateRunSettings(xml.OuterXml);
-
+                this.runSettingsProvider.UpdateRunSettingsNode($"RunConfiguration.EnvironmentVariables.{key}", value);
+                
                 if(!this.commandLineOptions.InIsolation) { 
                     this.commandLineOptions.InIsolation = true;
                     this.runSettingsProvider.UpdateRunSettingsNode(InIsolationArgumentExecutor.RunSettingsPath, "true");
@@ -161,18 +140,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
 
             // Nothing to do here, the work was done in initialization.
             public ArgumentProcessorResult Execute() => ArgumentProcessorResult.Success;
-
-            private XmlNode CreateOrSelectSingleNode(XmlNode parent, string name)
-            {
-                var node = parent.SelectSingleNode(name);
-                if(node == null)
-                {
-                    var element = parent.OwnerDocument.CreateElement(name);
-                    node = parent.AppendChild(element);
-                }
-
-                return node;
-            }
         }
     }
 }

--- a/src/vstest.console/Processors/EnvironmentArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnvironmentArgumentProcessor.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
+
+{
+    using System;
+    using System.Diagnostics.Contracts;
+    using System.Globalization;
+    using System.Linq;
+    using System.Xml;
+    using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
+    using Microsoft.VisualStudio.TestPlatform.CommandLine.Internal;
+    using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
+    using Microsoft.VisualStudio.TestPlatform.Common;
+    using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
+    using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+    using Microsoft.VisualStudio.TestPlatform.Utilities;
+
+
+    using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;
+    using System.Xml.Linq;
+
+
+    /// <summary>
+    /// Argument Executor for the "-e|--Environment|/e|/Environment" command line argument.
+    /// </summary>
+    internal class EnvironmentArgumentProcessor : IArgumentProcessor
+    {
+        #region Constants
+
+        /// <summary>
+        /// The short name of the command line argument that the EnvironmentArgumentProcessor handles.
+        /// </summary>
+        public const string ShortCommandName = "/e";
+
+        /// <summary>
+        /// The name of the command line argument that the EnvironmentArgumentProcessor handles.
+        /// </summary>
+        public const string CommandName = "/Environment";
+
+        #endregion
+
+        private Lazy<IArgumentProcessorCapabilities> metadata;
+
+        private Lazy<IArgumentExecutor> executor;
+
+
+        public Lazy<IArgumentExecutor> Executor
+        {
+            get
+            {
+                if (this.executor == null)
+                {
+                    this.executor = new Lazy<IArgumentExecutor>(
+                        () => new ArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance, ConsoleOutput.Instance)
+                    );
+                }
+
+                return this.executor;
+            }
+            set
+            {
+                this.executor = value;
+            }
+        }
+
+        public Lazy<IArgumentProcessorCapabilities> Metadata
+        {
+            get
+            {
+                if (this.metadata == null)
+                {
+                    this.metadata = new Lazy<IArgumentProcessorCapabilities>(() => new ArgumentProcessorCapabilities());
+                }
+
+                return this.metadata;
+            }
+        }
+
+        internal class ArgumentProcessorCapabilities : BaseArgumentProcessorCapabilities
+        {
+            public override string CommandName => EnvironmentArgumentProcessor.CommandName;
+
+            public override string ShortCommandName => EnvironmentArgumentProcessor.ShortCommandName;
+
+            public override bool AllowMultiple => true;
+
+            public override bool IsAction => false;
+
+            public override ArgumentProcessorPriority Priority => ArgumentProcessorPriority.Normal;
+            public override string HelpContentResourceName => CommandLineResources.EnvironmentArgumentHelp;
+
+            public override HelpContentPriority HelpPriority => HelpContentPriority.EnvironmentArgumentProcessorHelpPriority;
+        }
+
+        internal class ArgumentExecutor : IArgumentExecutor
+        {
+            #region Fields
+            /// <summary>
+            /// Used when warning about overriden environment variables.
+            /// </summary>
+            private IOutput output;
+
+            /// <summary>
+            /// Used when setting Environemnt variables.
+            /// </summary>
+            private IRunSettingsProvider runSettingsProvider;
+
+            private CommandLineOptions commandLineOptions;
+            #endregion
+
+            public ArgumentExecutor(
+                CommandLineOptions commandLineOptions,
+                IRunSettingsProvider runSettingsProvider,
+                IOutput output)
+            {
+                this.commandLineOptions = commandLineOptions;
+                this.output = output;
+                this.runSettingsProvider = runSettingsProvider;
+            }
+
+            /// <summary>
+            /// Set the environment variables in RunSettings.xml
+            /// </summary>
+            /// <param name="argument">
+            /// Environment variable to set. 
+            /// </param>
+            public void Initialize(string argument)
+            {
+                Contract.Assert(!string.IsNullOrWhiteSpace(argument));
+                Contract.Assert(this.output != null);
+                Contract.Assert(this.commandLineOptions != null);
+                Contract.Assert(!string.IsNullOrWhiteSpace(this.runSettingsProvider.ActiveRunSettings.SettingsXml));
+                Contract.EndContractBlock();
+
+                var key = argument;
+                var value = string.Empty;
+
+                if(key.Contains("="))
+                {
+                    value = key.Substring(key.IndexOf("=") + 1);
+                    key = key.Substring(0, key.IndexOf("="));
+                }
+                              
+                var xml = this.runSettingsProvider.GetRunSettingXmlDocument();
+                var runSettings = CreateOrSelectSingleNode(xml, "RunSettings");
+                var runConfiguration = CreateOrSelectSingleNode(runSettings, "RunConfiguration");
+                var environmentVariables = CreateOrSelectSingleNode(runConfiguration, "EnvironmentVariables");
+
+                var variable = environmentVariables.SelectSingleNode(key);
+                if(variable == null)
+                {
+                    variable = CreateOrSelectSingleNode(environmentVariables, key);
+                }
+                else
+                {
+                    output.Warning(true, CommandLineResources.EnvironmentVariableXIsOverriden, key);
+                }
+
+                variable.InnerText = value;
+
+                this.runSettingsProvider.UpdateRunSettings(xml.OuterXml);
+
+                if(!this.commandLineOptions.InIsolation) { 
+                    this.commandLineOptions.InIsolation = true;
+                    this.runSettingsProvider.UpdateRunSettingsNode(InIsolationArgumentExecutor.RunSettingsPath, "true");
+                }
+            }
+
+            // Nothing to do here, the work was done in initialization.
+            public ArgumentProcessorResult Execute() => ArgumentProcessorResult.Success;
+
+            private XmlNode CreateOrSelectSingleNode(XmlNode parent, string name)
+            {
+                var node = parent.SelectSingleNode(name);
+                if(node == null)
+                {
+                    var element = parent.OwnerDocument.CreateElement(name);
+                    node = parent.AppendChild(element);
+                }
+
+                return node;
+            }
+        }
+    }
+}

--- a/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
+++ b/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
@@ -243,7 +243,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
                 new ListLoggersArgumentProcessor(),
                 new ListSettingsProvidersArgumentProcessor(),
                 new ListFullyQualifiedTestsArgumentProcessor(),
-                new ListTestsTargetPathArgumentProcessor()
+                new ListTestsTargetPathArgumentProcessor(),
+                new EnvironmentArgumentProcessor()
         };
 
         /// <summary>

--- a/src/vstest.console/Processors/Utilities/HelpContentPriority.cs
+++ b/src/vstest.console/Processors/Utilities/HelpContentPriority.cs
@@ -67,6 +67,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
         /// </summary>
         PlatformArgumentProcessorHelpPriority,
 
+
+        /// <summary>
+        /// EnvironmentArgumentProcessor Help
+        /// </summary>
+        EnvironmentArgumentProcessorHelpPriority,
+
         /// <summary>
         /// RunSettingsArgumentProcessor Help
         /// </summary>

--- a/src/vstest.console/Resources/Resources.Designer.cs
+++ b/src/vstest.console/Resources/Resources.Designer.cs
@@ -510,11 +510,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources {
         
         /// <summary>
         ///   Looks up a localized string similar to -e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-        ///      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
+        ///      Sets the value of an environment variable. Creates the variable if it does not exist, overrides if it does. This will imply /InIsolation switch and force the tests to be run in an isolated process.
+        ///      
+        ///      This argument can be specified multiple times to provide multiple variables.
         ///
         ///      Example: -e:VARIABLE1=VALUE1
         ///               -e:ANOTHER_VARIABLE=&quot;VALUE WITH SPACES&quot;
-        ///               -e:ANOTHER_VARIABLE=&quot;VALUE;seperated with;semi-columns&quot;.
+        ///               -e:ANOTHER_VARIABLE=&quot;VALUE;seperated with;semicolons&quot;.
         /// </summary>
         internal static string EnvironmentArgumentHelp {
             get {

--- a/src/vstest.console/Resources/Resources.Designer.cs
+++ b/src/vstest.console/Resources/Resources.Designer.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("vstest.console.Resources.Resources", typeof(Resources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -505,6 +505,29 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources {
         internal static string EnableLoggersArgumentHelp {
             get {
                 return ResourceManager.GetString("EnableLoggersArgumentHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to -e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+        ///      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
+        ///
+        ///      Example: -e:VARIABLE1=VALUE1
+        ///               -e:ANOTHER_VARIABLE=&quot;VALUE WITH SPACES&quot;
+        ///               -e:ANOTHER_VARIABLE=&quot;VALUE;seperated with;semi-columns&quot;.
+        /// </summary>
+        internal static string EnvironmentArgumentHelp {
+            get {
+                return ResourceManager.GetString("EnvironmentArgumentHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Environment variable &apos;{0}&apos; was already defined, but it&apos;s overridden by -Environment argument..
+        /// </summary>
+        internal static string EnvironmentVariableXIsOverriden {
+            get {
+                return ResourceManager.GetString("EnvironmentVariableXIsOverriden", resourceCulture);
             }
         }
         

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -752,11 +752,13 @@
   </data>
   <data name="EnvironmentArgumentHelp" xml:space="preserve">
     <value>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
+      Sets the value of an environment variable. Creates the variable if it does not exist, overrides if it does. This will imply /InIsolation switch and force the tests to be run in an isolated process.
+      
+      This argument can be specified multiple times to provide multiple variables.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
-               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</value>
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</value>
   </data>
   <data name="EnvironmentVariableXIsOverriden" xml:space="preserve">
     <value>Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</value>

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -750,4 +750,15 @@
   <data name="BlameCollectDumpTestTimeoutNotSupportedForPlatform" xml:space="preserve">
     <value>Collecting hang dumps by option CollectDump with TestTimeout for Blame is not supported for this platform.</value>
   </data>
+  <data name="EnvironmentArgumentHelp" xml:space="preserve">
+    <value>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</value>
+  </data>
+  <data name="EnvironmentVariableXIsOverriden" xml:space="preserve">
+    <value>Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</value>
+  </data>
 </root>

--- a/src/vstest.console/Resources/xlf/Resources.cs.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.cs.xlf
@@ -1683,6 +1683,26 @@
         <target state="new">- {0} {1}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EnvironmentArgumentHelp">
+        <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+        <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariableXIsOverriden">
+        <source>Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</source>
+        <target state="new">Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.cs.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.cs.xlf
@@ -1685,7 +1685,7 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"

--- a/src/vstest.console/Resources/xlf/Resources.cs.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.cs.xlf
@@ -1685,11 +1685,13 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
+      Sets the value of an environment variable. Creates the variable if it does not exist, overrides if it does. This will imply /InIsolation switch and force the tests to be run in an isolated process.
+      
+      This argument can be specified multiple times to provide multiple variables.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
-               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
         <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
       Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
 

--- a/src/vstest.console/Resources/xlf/Resources.de.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.de.xlf
@@ -1683,6 +1683,26 @@
         <target state="new">- {0} {1}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EnvironmentArgumentHelp">
+        <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+        <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariableXIsOverriden">
+        <source>Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</source>
+        <target state="new">Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.de.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.de.xlf
@@ -1685,7 +1685,7 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"

--- a/src/vstest.console/Resources/xlf/Resources.de.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.de.xlf
@@ -1685,11 +1685,13 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
+      Sets the value of an environment variable. Creates the variable if it does not exist, overrides if it does. This will imply /InIsolation switch and force the tests to be run in an isolated process.
+      
+      This argument can be specified multiple times to provide multiple variables.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
-               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
         <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
       Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
 

--- a/src/vstest.console/Resources/xlf/Resources.es.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.es.xlf
@@ -1688,7 +1688,7 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"

--- a/src/vstest.console/Resources/xlf/Resources.es.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.es.xlf
@@ -1688,11 +1688,13 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
+      Sets the value of an environment variable. Creates the variable if it does not exist, overrides if it does. This will imply /InIsolation switch and force the tests to be run in an isolated process.
+      
+      This argument can be specified multiple times to provide multiple variables.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
-               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
         <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
       Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
 

--- a/src/vstest.console/Resources/xlf/Resources.es.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.es.xlf
@@ -1686,6 +1686,26 @@
         <target state="new">- {0} {1}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EnvironmentArgumentHelp">
+        <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+        <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariableXIsOverriden">
+        <source>Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</source>
+        <target state="new">Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.fr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.fr.xlf
@@ -1683,6 +1683,26 @@
         <target state="new">- {0} {1}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EnvironmentArgumentHelp">
+        <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+        <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariableXIsOverriden">
+        <source>Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</source>
+        <target state="new">Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.fr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.fr.xlf
@@ -1685,7 +1685,7 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"

--- a/src/vstest.console/Resources/xlf/Resources.fr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.fr.xlf
@@ -1685,11 +1685,13 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
+      Sets the value of an environment variable. Creates the variable if it does not exist, overrides if it does. This will imply /InIsolation switch and force the tests to be run in an isolated process.
+      
+      This argument can be specified multiple times to provide multiple variables.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
-               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
         <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
       Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
 

--- a/src/vstest.console/Resources/xlf/Resources.it.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.it.xlf
@@ -1683,6 +1683,26 @@
         <target state="new">- {0} {1}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EnvironmentArgumentHelp">
+        <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+        <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariableXIsOverriden">
+        <source>Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</source>
+        <target state="new">Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.it.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.it.xlf
@@ -1685,7 +1685,7 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"

--- a/src/vstest.console/Resources/xlf/Resources.it.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.it.xlf
@@ -1685,11 +1685,13 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
+      Sets the value of an environment variable. Creates the variable if it does not exist, overrides if it does. This will imply /InIsolation switch and force the tests to be run in an isolated process.
+      
+      This argument can be specified multiple times to provide multiple variables.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
-               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
         <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
       Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
 

--- a/src/vstest.console/Resources/xlf/Resources.ja.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ja.xlf
@@ -1683,6 +1683,26 @@
         <target state="new">- {0} {1}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EnvironmentArgumentHelp">
+        <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+        <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariableXIsOverriden">
+        <source>Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</source>
+        <target state="new">Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.ja.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ja.xlf
@@ -1685,7 +1685,7 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"

--- a/src/vstest.console/Resources/xlf/Resources.ja.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ja.xlf
@@ -1685,11 +1685,13 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
+      Sets the value of an environment variable. Creates the variable if it does not exist, overrides if it does. This will imply /InIsolation switch and force the tests to be run in an isolated process.
+      
+      This argument can be specified multiple times to provide multiple variables.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
-               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
         <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
       Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
 

--- a/src/vstest.console/Resources/xlf/Resources.ko.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ko.xlf
@@ -1683,6 +1683,26 @@
         <target state="new">- {0} {1}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EnvironmentArgumentHelp">
+        <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+        <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariableXIsOverriden">
+        <source>Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</source>
+        <target state="new">Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.ko.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ko.xlf
@@ -1685,7 +1685,7 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"

--- a/src/vstest.console/Resources/xlf/Resources.ko.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ko.xlf
@@ -1685,11 +1685,13 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
+      Sets the value of an environment variable. Creates the variable if it does not exist, overrides if it does. This will imply /InIsolation switch and force the tests to be run in an isolated process.
+      
+      This argument can be specified multiple times to provide multiple variables.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
-               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
         <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
       Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
 

--- a/src/vstest.console/Resources/xlf/Resources.pl.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pl.xlf
@@ -1683,6 +1683,26 @@
         <target state="new">- {0} {1}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EnvironmentArgumentHelp">
+        <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+        <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariableXIsOverriden">
+        <source>Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</source>
+        <target state="new">Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.pl.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pl.xlf
@@ -1685,7 +1685,7 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"

--- a/src/vstest.console/Resources/xlf/Resources.pl.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pl.xlf
@@ -1685,11 +1685,13 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
+      Sets the value of an environment variable. Creates the variable if it does not exist, overrides if it does. This will imply /InIsolation switch and force the tests to be run in an isolated process.
+      
+      This argument can be specified multiple times to provide multiple variables.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
-               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
         <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
       Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
 

--- a/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
@@ -1685,7 +1685,7 @@ Altere o prefixo de nível de diagnóstico do agente de console, como mostrado a
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"

--- a/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
@@ -1683,6 +1683,26 @@ Altere o prefixo de nível de diagnóstico do agente de console, como mostrado a
         <target state="new">- {0} {1}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EnvironmentArgumentHelp">
+        <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+        <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariableXIsOverriden">
+        <source>Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</source>
+        <target state="new">Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
@@ -1685,11 +1685,13 @@ Altere o prefixo de nível de diagnóstico do agente de console, como mostrado a
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
+      Sets the value of an environment variable. Creates the variable if it does not exist, overrides if it does. This will imply /InIsolation switch and force the tests to be run in an isolated process.
+      
+      This argument can be specified multiple times to provide multiple variables.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
-               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
         <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
       Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
 

--- a/src/vstest.console/Resources/xlf/Resources.ru.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ru.xlf
@@ -1683,6 +1683,26 @@
         <target state="new">- {0} {1}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EnvironmentArgumentHelp">
+        <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+        <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariableXIsOverriden">
+        <source>Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</source>
+        <target state="new">Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.ru.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ru.xlf
@@ -1685,7 +1685,7 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"

--- a/src/vstest.console/Resources/xlf/Resources.ru.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ru.xlf
@@ -1685,11 +1685,13 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
+      Sets the value of an environment variable. Creates the variable if it does not exist, overrides if it does. This will imply /InIsolation switch and force the tests to be run in an isolated process.
+      
+      This argument can be specified multiple times to provide multiple variables.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
-               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
         <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
       Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
 

--- a/src/vstest.console/Resources/xlf/Resources.tr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.tr.xlf
@@ -1685,7 +1685,7 @@ Günlükler için izleme düzeyini aşağıda gösterildiği gibi değiştirin
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"

--- a/src/vstest.console/Resources/xlf/Resources.tr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.tr.xlf
@@ -1683,6 +1683,26 @@ Günlükler için izleme düzeyini aşağıda gösterildiği gibi değiştirin
         <target state="new">- {0} {1}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EnvironmentArgumentHelp">
+        <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+        <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariableXIsOverriden">
+        <source>Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</source>
+        <target state="new">Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.tr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.tr.xlf
@@ -1685,11 +1685,13 @@ Günlükler için izleme düzeyini aşağıda gösterildiği gibi değiştirin
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
+      Sets the value of an environment variable. Creates the variable if it does not exist, overrides if it does. This will imply /InIsolation switch and force the tests to be run in an isolated process.
+      
+      This argument can be specified multiple times to provide multiple variables.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
-               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
         <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
       Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
 

--- a/src/vstest.console/Resources/xlf/Resources.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.xlf
@@ -874,6 +874,26 @@ Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")
         <target state="new">- {0} {1}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EnvironmentArgumentHelp">
+        <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+        <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariableXIsOverriden">
+        <source>Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</source>
+        <target state="new">Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.xlf
@@ -876,11 +876,13 @@ Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
+      Sets the value of an environment variable. Creates the variable if it does not exist, overrides if it does. This will imply /InIsolation switch and force the tests to be run in an isolated process.
+      
+      This argument can be specified multiple times to provide multiple variables.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
-               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
         <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
       Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
 

--- a/src/vstest.console/Resources/xlf/Resources.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.xlf
@@ -876,7 +876,7 @@ Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
@@ -1683,6 +1683,26 @@
         <target state="new">- {0} {1}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EnvironmentArgumentHelp">
+        <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+        <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariableXIsOverriden">
+        <source>Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</source>
+        <target state="new">Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
@@ -1685,7 +1685,7 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
@@ -1685,11 +1685,13 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
+      Sets the value of an environment variable. Creates the variable if it does not exist, overrides if it does. This will imply /InIsolation switch and force the tests to be run in an isolated process.
+      
+      This argument can be specified multiple times to provide multiple variables.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
-               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
         <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
       Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
 

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
@@ -1684,6 +1684,26 @@
         <target state="new">- {0} {1}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EnvironmentArgumentHelp">
+        <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+        <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+
+      Example: -e:VARIABLE1=VALUE1
+               -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariableXIsOverriden">
+        <source>Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</source>
+        <target state="new">Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
@@ -1686,7 +1686,7 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
+      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
@@ -1686,11 +1686,13 @@
       </trans-unit>
       <trans-unit id="EnvironmentArgumentHelp">
         <source>-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
-      Sets the value of an environment variable. Creates the variable if one with the requested name does not exist. This will force the tests to be run in an isolated process.
+      Sets the value of an environment variable. Creates the variable if it does not exist, overrides if it does. This will imply /InIsolation switch and force the tests to be run in an isolated process.
+      
+      This argument can be specified multiple times to provide multiple variables.
 
       Example: -e:VARIABLE1=VALUE1
                -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
-               -e:ANOTHER_VARIABLE="VALUE;seperated with;semi-columns"</source>
+               -e:ANOTHER_VARIABLE="VALUE;seperated with;semicolons"</source>
         <target state="new">-e|--Environment|/e|/Environment:&lt;NAME&gt;=&lt;VALUE&gt;
       Sets the value of an environment variable. Creates the variable if one with the requested name does not exist.
 

--- a/src/vstest.console/vstest.console.csproj
+++ b/src/vstest.console/vstest.console.csproj
@@ -13,10 +13,11 @@
     <PlatformTarget Condition="'$(TargetFramework)' == 'net451'">AnyCPU</PlatformTarget>
     <Prefer32Bit Condition="'$(TargetFramework)' == 'net451'">true</Prefer32Bit>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <RootNamespace>Microsoft.VisualStudio.TestPlatform.CommandLine</RootNamespace>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
-  </PropertyGroup>
+  </PropertyGroup> 
   <ItemGroup>
     <EmbeddedResource Include="Resources\Resources.resx" />
   </ItemGroup>

--- a/src/vstest.console/vstest.console.csproj
+++ b/src/vstest.console/vstest.console.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
-  </PropertyGroup> 
+  </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\Resources.resx" />
   </ItemGroup>

--- a/test/vstest.console.UnitTests/Processors/EnvironmentArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnvironmentArgumentProcessorTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             // Act
             executor1.Initialize("VARIABLE_ONE=VALUE");
             executor2.Initialize("VARIABLE_TWO=VALUE WITH SPACE");
-            executor3.Initialize("VARIABLE_THREE=VALUE WITH SPACE;AND SEMICOLUMN");
+            executor3.Initialize("VARIABLE_THREE=VALUE WITH SPACE;AND SEMICOLON");
 
             // Assert
             var (environmentVariables, inIsolation) = ParseSettingsXML(this.settingsProvider);
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             Assert.AreEqual("VALUE WITH SPACE", variables[1].Value);
 
             Assert.AreEqual("VARIABLE_THREE", variables[2].Name.LocalName);
-            Assert.AreEqual("VALUE WITH SPACE;AND SEMICOLUMN", variables[2].Value);
+            Assert.AreEqual("VALUE WITH SPACE;AND SEMICOLON", variables[2].Value);
         }
 
         [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/EnvironmentArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnvironmentArgumentProcessorTests.cs
@@ -1,0 +1,179 @@
+﻿namespace vstest.console.UnitTests.Processors.Utilities
+{
+    using System;
+    using System.Linq;
+    using System.Xml.Linq;
+    using Microsoft.VisualStudio.TestPlatform.CommandLine;
+    using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
+    using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
+    using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
+    using Microsoft.VisualStudio.TestPlatform.Utilities;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;
+
+    [TestClass]
+    public class EnvironmentArgumentProcessorTests
+    {
+        private const string DefaultRunSettings = "<?xml version=\"1.0\" encoding=\"utf-16\"?><RunSettings></RunSettings>";
+
+        private TestableRunSettingsProvider settingsProvider;
+        private Mock<IOutput> mockOutput;
+        private CommandLineOptions commandLineOptions;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            this.commandLineOptions = CommandLineOptions.Instance;
+            this.settingsProvider = new TestableRunSettingsProvider();
+            this.settingsProvider.UpdateRunSettings(DefaultRunSettings);
+            this.mockOutput = new Mock<IOutput>();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            this.commandLineOptions.Reset();
+        }
+
+        [TestMethod]
+        public void CapabilitiesShouldReturnAppropriateValues()
+        {
+            // Arrange & Act
+            var capabilities = new EnvironmentArgumentProcessor.ArgumentProcessorCapabilities();
+
+            // Assert
+            Assert.AreEqual("/Environment", capabilities.CommandName);
+            Assert.AreEqual("/e", capabilities.ShortCommandName);
+            Assert.IsTrue(capabilities.AllowMultiple);
+            Assert.IsFalse(capabilities.IsAction);
+            Assert.AreEqual(ArgumentProcessorPriority.Normal, capabilities.Priority);
+            Assert.AreEqual(HelpContentPriority.EnvironmentArgumentProcessorHelpPriority, capabilities.HelpPriority);
+        }
+
+        [TestMethod]
+        public void AppendsEnvironmentVariableToRunSettings()
+        {
+            // Arrange
+            var executor = GetExecutor();
+
+            // Act
+            executor.Initialize("VARIABLE=VALUE");
+
+            // Assert
+            var (environmentVariables, inIsolation) = ParseSettingsXML(this.settingsProvider);
+            var variables = environmentVariables?.Elements()?.ToArray();
+
+            Assert.IsNotNull(environmentVariables, "Environment variable cannot found in RunSettings.xml.");
+            Assert.IsNotNull(inIsolation, "Isolation must be forced, an InIsolation entry was missing!");
+            Assert.AreEqual(1, variables?.Length ?? 0, "Environment variable count mismatched!");
+
+            Assert.AreEqual("true", inIsolation.Value, "Isolation must be forced, InIsolation is not set to true.");
+            Assert.AreEqual("VARIABLE", variables[0].Name.LocalName);
+            Assert.AreEqual("VALUE", variables[0].Value);
+
+        }
+
+        [TestMethod]
+        public void AppendsMultipleEnvironmentVariablesToRunSettings()
+        {
+            // Arrange
+            var (executor1, executor2, executor3) = (GetExecutor(), GetExecutor(), GetExecutor());
+
+            // Act
+            executor1.Initialize("VARIABLE_ONE=VALUE");
+            executor2.Initialize("VARIABLE_TWO=VALUE WITH SPACE");
+            executor3.Initialize("VARIABLE_THREE=VALUE WITH SPACE;AND SEMICOLUMN");
+
+            // Assert
+            var (environmentVariables, inIsolation) = ParseSettingsXML(this.settingsProvider);
+            var variables = environmentVariables?.Elements()?.ToArray();
+
+            Assert.IsNotNull(environmentVariables, "Environment variable cannot found in RunSettings.xml.");
+            Assert.IsNotNull(inIsolation, "Isolation must be forced, an InIsolation entry was missing!");
+
+            Assert.AreEqual("true", inIsolation.Value, "Isolation must be forced, InIsolation is not set to true.");
+            Assert.AreEqual(3, variables?.Length ?? 0, "Environment variable count mismatched!");
+
+            Assert.AreEqual("VARIABLE_ONE", variables[0].Name.LocalName);
+            Assert.AreEqual("VALUE", variables[0].Value);
+
+            Assert.AreEqual("VARIABLE_TWO", variables[1].Name.LocalName);
+            Assert.AreEqual("VALUE WITH SPACE", variables[1].Value);
+
+            Assert.AreEqual("VARIABLE_THREE", variables[2].Name.LocalName);
+            Assert.AreEqual("VALUE WITH SPACE;AND SEMICOLUMN", variables[2].Value);
+        }
+
+        [TestMethod]
+        public void InIsolationValueShouldBeOverriden()
+        {
+            // Arrange
+            this.commandLineOptions.InIsolation = false;
+            this.settingsProvider.UpdateRunSettingsNode(InIsolationArgumentExecutor.RunSettingsPath, "false");
+            var executor = GetExecutor();
+
+            // Act
+            executor.Initialize("VARIABLE=VALUE");
+
+            // Assert
+            var (environmentVariables, inIsolation) = ParseSettingsXML(this.settingsProvider);
+            var variables = environmentVariables?.Elements()?.ToArray();
+
+            Assert.IsNotNull(environmentVariables, "Environment variable cannot found in RunSettings.xml.");
+            Assert.IsNotNull(inIsolation, "Isolation must be forced, an InIsolation entry was missing!");
+
+            Assert.AreEqual("true", inIsolation.Value, "Isolation must be forced, InIsolation is overriden to true.");
+            Assert.AreEqual(1, variables?.Length ?? 0, "Environment variable count mismatched!");
+
+            Assert.AreEqual("VARIABLE", variables[0].Name.LocalName);
+            Assert.AreEqual("VALUE", variables[0].Value);
+        }
+
+        [TestMethod]
+        public void ShoudWarnWhenAValueIsOverriden()
+        {
+            // Arrange
+            this.settingsProvider.UpdateRunSettingsNode("RunConfiguration.EnvironmentVariables.VARIABLE", "Initial value");
+            var warningMessage = String.Format(CommandLineResources.CommandLineWarning,
+                    String.Format(CommandLineResources.EnvironmentVariableXIsOverriden, "VARIABLE")
+                );
+            this.mockOutput.Setup(mock =>
+                mock.WriteLine(
+                    It.Is<string>(message => message == warningMessage),
+                    It.Is<OutputLevel>(level => level == OutputLevel.Warning)
+                )
+            ).Verifiable();
+            var executor = GetExecutor();
+            
+            // Act
+            executor.Initialize("VARIABLE=New value");
+
+            // Assert
+            this.mockOutput.VerifyAll();
+        }
+
+        private (XElement variables, XElement inIsolation) ParseSettingsXML(IRunSettingsProvider provider)
+        {
+            var document = XDocument.Parse(provider.ActiveRunSettings.SettingsXml);
+
+            var runConfiguration = document
+                                ?.Root
+                                ?.Element("RunConfiguration");
+
+            var variables = runConfiguration?.Element("EnvironmentVariables");
+            var inIsolation = runConfiguration?.Element("InIsolation");
+
+            return (variables, inIsolation);
+        }
+
+        private IArgumentExecutor GetExecutor()
+        {
+            return new EnvironmentArgumentProcessor.ArgumentExecutor(
+               this.commandLineOptions,
+               this.settingsProvider,
+               mockOutput.Object
+            );
+        }
+    }
+}

--- a/test/vstest.console.UnitTests/Processors/EnvironmentArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnvironmentArgumentProcessorTests.cs
@@ -1,4 +1,7 @@
-﻿namespace vstest.console.UnitTests.Processors.Utilities
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
 {
     using System;
     using System.Linq;
@@ -10,6 +13,7 @@
     using Microsoft.VisualStudio.TestPlatform.Utilities;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
+    using vstest.console.UnitTests.Processors;
     using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;
 
     [TestClass]

--- a/test/vstest.console.UnitTests/vstest.console.UnitTests.csproj
+++ b/test/vstest.console.UnitTests/vstest.console.UnitTests.csproj
@@ -1,33 +1,33 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TestPlatformRoot Condition="$(TestPlatformRoot) == ''">..\..\</TestPlatformRoot>
-        <TestProject>true</TestProject>
-    </PropertyGroup>
-    <Import Project="$(TestPlatformRoot)scripts/build/TestPlatform.Settings.targets" />
-    <PropertyGroup>
-        <OutputType Condition=" '$(TargetFramework)' != 'net451' ">Exe</OutputType>
-        <TargetFrameworks>netcoreapp2.1;net451</TargetFrameworks>
-        <AssemblyName>vstest.console.UnitTests</AssemblyName>
-    </PropertyGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\vstest.console\vstest.console.csproj" />
-        <ProjectReference Include="..\..\src\Microsoft.TestPlatform.Utilities\Microsoft.TestPlatform.Utilities.csproj">
-            <FromP2P>true</FromP2P>
-        </ProjectReference>
-        <ProjectReference Include="..\..\src\Microsoft.TestPlatform.PlatformAbstractions\Microsoft.TestPlatform.PlatformAbstractions.csproj">
-            <FromP2P>true</FromP2P>
-        </ProjectReference>
-    </ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    </ItemGroup>
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-        <Reference Include="System.Runtime" />
-        <Reference Include="System" />
-        <Reference Include="Microsoft.CSharp" />
-        <Reference Include="System.Xml" />
-        <Reference Include="System.Runtime.Serialization" />
-    </ItemGroup>
-    <Import Project="$(TestPlatformRoot)scripts\build\TestPlatform.targets" />
+  <PropertyGroup>
+    <TestPlatformRoot Condition="$(TestPlatformRoot) == ''">..\..\</TestPlatformRoot>
+    <TestProject>true</TestProject>
+  </PropertyGroup>
+  <Import Project="$(TestPlatformRoot)scripts/build/TestPlatform.Settings.targets" />
+  <PropertyGroup>
+    <OutputType Condition=" '$(TargetFramework)' != 'net451' ">Exe</OutputType>
+    <TargetFrameworks>netcoreapp2.1;net451</TargetFrameworks>
+    <AssemblyName>vstest.console.UnitTests</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\vstest.console\vstest.console.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.TestPlatform.Utilities\Microsoft.TestPlatform.Utilities.csproj">
+      <FromP2P>true</FromP2P>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.TestPlatform.PlatformAbstractions\Microsoft.TestPlatform.PlatformAbstractions.csproj">
+      <FromP2P>true</FromP2P>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+    <Reference Include="System.Runtime" />
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Runtime.Serialization" />
+  </ItemGroup>
+  <Import Project="$(TestPlatformRoot)scripts\build\TestPlatform.targets" />
 </Project>

--- a/test/vstest.console.UnitTests/vstest.console.UnitTests.csproj
+++ b/test/vstest.console.UnitTests/vstest.console.UnitTests.csproj
@@ -1,30 +1,33 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TestPlatformRoot Condition="$(TestPlatformRoot) == ''">..\..\</TestPlatformRoot>
-    <TestProject>true</TestProject>
-  </PropertyGroup>
-  <Import Project="$(TestPlatformRoot)scripts/build/TestPlatform.Settings.targets" />
-  <PropertyGroup>
-    <OutputType Condition=" '$(TargetFramework)' != 'net451' ">Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;net451</TargetFrameworks>
-    <AssemblyName>vstest.console.UnitTests</AssemblyName>
-  </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\vstest.console\vstest.console.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.TestPlatform.Utilities\Microsoft.TestPlatform.Utilities.csproj">
-      <FromP2P>true</FromP2P>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\Microsoft.TestPlatform.PlatformAbstractions\Microsoft.TestPlatform.PlatformAbstractions.csproj">
-      <FromP2P>true</FromP2P>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Reference Include="System.Runtime" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Xml" />
-    <Reference Include=" System.Runtime.Serialization" />
-  </ItemGroup>
-  <Import Project="$(TestPlatformRoot)scripts\build\TestPlatform.targets" />
+    <PropertyGroup>
+        <TestPlatformRoot Condition="$(TestPlatformRoot) == ''">..\..\</TestPlatformRoot>
+        <TestProject>true</TestProject>
+    </PropertyGroup>
+    <Import Project="$(TestPlatformRoot)scripts/build/TestPlatform.Settings.targets" />
+    <PropertyGroup>
+        <OutputType Condition=" '$(TargetFramework)' != 'net451' ">Exe</OutputType>
+        <TargetFrameworks>netcoreapp2.1;net451</TargetFrameworks>
+        <AssemblyName>vstest.console.UnitTests</AssemblyName>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\vstest.console\vstest.console.csproj" />
+        <ProjectReference Include="..\..\src\Microsoft.TestPlatform.Utilities\Microsoft.TestPlatform.Utilities.csproj">
+            <FromP2P>true</FromP2P>
+        </ProjectReference>
+        <ProjectReference Include="..\..\src\Microsoft.TestPlatform.PlatformAbstractions\Microsoft.TestPlatform.PlatformAbstractions.csproj">
+            <FromP2P>true</FromP2P>
+        </ProjectReference>
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+        <Reference Include="System.Runtime" />
+        <Reference Include="System" />
+        <Reference Include="Microsoft.CSharp" />
+        <Reference Include="System.Xml" />
+        <Reference Include="System.Runtime.Serialization" />
+    </ItemGroup>
+    <Import Project="$(TestPlatformRoot)scripts\build\TestPlatform.targets" />
 </Project>


### PR DESCRIPTION
## Description
Added `/Environment` command-line argument to vstest.console.exe for setting up environment variables. Using this switch will force the tests to be run in an isolated process.

## Related issue
#669 
