### PR TITLE
Add binaries to enable running Fakes in Net Core

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -717,7 +717,7 @@ function Create-NugetPackages
 
     # Additional external dependency folders
     $microsoftFakesVersion = ([xml](Get-Content $env:TP_ROOT_DIR\scripts\build\TestPlatform.Dependencies.props)).Project.PropertyGroup.MicrosoftFakesVersion
-    $FakesPackageDir = Join-Path $env:TP_PACKAGES_DIR "Microsoft.VisualStudio.TestPlatform.Fakes\$microsoftFakesVersion\lib"
+    $FakesPackageDir = Join-Path $env:TP_PACKAGES_DIR "Microsoft.QualityTools.Testing.Fakes.TestRunnerHarness\$microsoftFakesVersion\contentFiles"
 
     # package them from stagingDir
     foreach ($file in $nuspecFiles) {

--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -32,7 +32,7 @@
     <JsonNetVersion>9.0.1</JsonNetVersion>
     <MoqVersion>4.7.63</MoqVersion>
     <TestPlatformExternalsVersion>16.8.0-preview-3968212</TestPlatformExternalsVersion>
-    <MicrosoftFakesVersion>16.6.3-beta.20221.2</MicrosoftFakesVersion>
+    <MicrosoftFakesVersion>16.8.0-beta.20420.2</MicrosoftFakesVersion>
 
     <MicrosoftBuildPackageVersion>16.0.461</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>

--- a/scripts/verify-nupkgs.ps1
+++ b/scripts/verify-nupkgs.ps1
@@ -14,7 +14,7 @@ function Verify-Nuget-Packages($packageDirectory)
     Write-Log "Starting Verify-Nuget-Packages."
     $expectedNumOfFiles = @{"Microsoft.CodeCoverage" = 29;
                      "Microsoft.NET.Test.Sdk" = 13;
-                     "Microsoft.TestPlatform" = 469;
+                     "Microsoft.TestPlatform" = 477;
                      "Microsoft.TestPlatform.Build" = 19;
                      "Microsoft.TestPlatform.CLI" = 350;
                      "Microsoft.TestPlatform.Extensions.TrxLogger" = 33;

--- a/scripts/vsts-prebuild.ps1
+++ b/scripts/vsts-prebuild.ps1
@@ -30,5 +30,5 @@ $JsonNetVersion = ([xml](Get-Content $TP_ROOT_DIR\scripts\build\TestPlatform.Dep
 Write-Host "##vso[task.setvariable variable=JsonNetVersion;]$JsonNetVersion"
 
 $microsoftFakesVersion = ([xml](Get-Content $TP_ROOT_DIR\scripts\build\TestPlatform.Dependencies.props)).Project.PropertyGroup.MicrosoftFakesVersion
-$FakesPackageDir = Join-Path $TP_ROOT_DIR "packages\Microsoft.VisualStudio.TestPlatform.Fakes\$microsoftFakesVersion\lib"
+$FakesPackageDir = Join-Path $TP_ROOT_DIR "packages\Microsoft.QualityTools.Testing.Fakes.TestRunnerHarness\$microsoftFakesVersion\contentFiles"
 Write-Host "##vso[task.setvariable variable=FakesPackageDir;]$FakesPackageDir"

--- a/src/package/external/external.csproj
+++ b/src/package/external/external.csproj
@@ -89,7 +89,7 @@
       <Version>16.3.23</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.TestPlatform.Fakes">
+    <PackageReference Include="Microsoft.QualityTools.Testing.Fakes.TestRunnerHarness">
       <Version>$(MicrosoftFakesVersion)</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/package/nuspec/Microsoft.TestPlatform.nuspec
+++ b/src/package/nuspec/Microsoft.TestPlatform.nuspec
@@ -495,7 +495,7 @@
     <file src="$FakesPackageDir$\DataCollector\Microsoft.Cci.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.Cci.dll" />
 
     <file src="$FakesPackageDir$\Instrumentation\x86\Microsoft.QualityTools.Testing.Fakes.Instrumentation.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Fakes\x86\Microsoft.QualityTools.Testing.Fakes.Instrumentation.dll" />
-    <file src="$FakesPackageDir$\Instrumentation\x86\FakesInstrumentationProfiler_x86.config"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Fakes\x86\FakesInstrumentationProfiler_x64.config" />
+    <file src="$FakesPackageDir$\Instrumentation\x86\FakesInstrumentationProfiler_x86.config"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Fakes\x86\FakesInstrumentationProfiler_x86.config" />
     <file src="$FakesPackageDir$\Instrumentation\x64\Microsoft.QualityTools.Testing.Fakes.Instrumentation.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Fakes\x64\Microsoft.QualityTools.Testing.Fakes.Instrumentation.dll" />
     <file src="$FakesPackageDir$\Instrumentation\x64\FakesInstrumentationProfiler_x64.config"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Fakes\x64\FakesInstrumentationProfiler_x64.config" />
 

--- a/src/package/nuspec/Microsoft.TestPlatform.nuspec
+++ b/src/package/nuspec/Microsoft.TestPlatform.nuspec
@@ -245,7 +245,7 @@
     <file src="net451\$Runtime$\es\Microsoft.VisualStudio.TestPlatform.Client.resources.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\es\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" />
     <file src="net451\$Runtime$\es\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\es\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" />
     <file src="net451\$Runtime$\Extensions\es\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\es\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" />
- <file src="net451\$Runtime$\Extensions\es\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\es\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" />
+    <file src="net451\$Runtime$\Extensions\es\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\es\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" />
     <file src="net451\$Runtime$\es\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\es\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll" />
     <file src="net451\$Runtime$\es\vstest.console.resources.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\es\vstest.console.resources.dll" />
 	<file src="net451\$Runtime$\es\SettingsMigrator.resources.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\es\SettingsMigrator.resources.dll" />
@@ -404,7 +404,7 @@
     <file src="net451\$Runtime$\tr\Microsoft.VisualStudio.TestPlatform.Client.resources.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\tr\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" />
     <file src="net451\$Runtime$\tr\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\tr\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" />
     <file src="net451\$Runtime$\Extensions\tr\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\tr\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" />
-<file src="net451\$Runtime$\Extensions\tr\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\tr\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" />
+    <file src="net451\$Runtime$\Extensions\tr\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\tr\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" />
     <file src="net451\$Runtime$\tr\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\tr\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll" />
     <file src="net451\$Runtime$\tr\vstest.console.resources.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\tr\vstest.console.resources.dll" />
 	<file src="net451\$Runtime$\tr\SettingsMigrator.resources.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\tr\SettingsMigrator.resources.dll" />
@@ -489,6 +489,17 @@
     <file src="net451\$Runtime$\CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.UiaWidget.UIAHtmlElementUtilities.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.UiaWidget.UIAHtmlElementUtilities.dll" />
 
     <!-- External dependencies-->
-    <file src="$FakesPackageDir$\net451\Microsoft.VisualStudio.TestPlatform.Fakes.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.TestPlatform.Fakes.dll" />
+    <file src="$FakesPackageDir$\TestPlatform\Microsoft.VisualStudio.TestPlatform.Fakes.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.TestPlatform.Fakes.dll" />
+
+    <file src="$FakesPackageDir$\DataCollector\Microsoft.VisualStudio.Fakes.DataCollector.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.Fakes.DataCollector.dll" />
+    <file src="$FakesPackageDir$\DataCollector\Microsoft.Cci.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.Cci.dll" />
+
+    <file src="$FakesPackageDir$\Instrumentation\x86\Microsoft.QualityTools.Testing.Fakes.Instrumentation.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Fakes\x86\Microsoft.QualityTools.Testing.Fakes.Instrumentation.dll" />
+    <file src="$FakesPackageDir$\Instrumentation\x86\FakesInstrumentationProfiler_x86.config"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Fakes\x86\FakesInstrumentationProfiler_x64.config" />
+    <file src="$FakesPackageDir$\Instrumentation\x64\Microsoft.QualityTools.Testing.Fakes.Instrumentation.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Fakes\x64\Microsoft.QualityTools.Testing.Fakes.Instrumentation.dll" />
+    <file src="$FakesPackageDir$\Instrumentation\x64\FakesInstrumentationProfiler_x64.config"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Fakes\x64\FakesInstrumentationProfiler_x64.config" />
+
+    <file src="$FakesPackageDir$\MicrosoftInstrumentationEngine\x86\MicrosoftInstrumentationEngine_x86.dll"	target="tools\net451\Common7\IDE\CommonExtensions\Platform\InstrumentationEngine\x86\MicrosoftInstrumentationEngine_x86.dll" />
+    <file src="$FakesPackageDir$\MicrosoftInstrumentationEngine\x64\MicrosoftInstrumentationEngine_x64.dll"	target="tools\net451\Common7\IDE\CommonExtensions\Platform\InstrumentationEngine\x64\MicrosoftInstrumentationEngine_x64.dll" />
   </files>
 </package>


### PR DESCRIPTION
## Description
The .NetCore implementation for Fakes requires the CLRIE instrumentation engine, which is different from the .NET Framework implementation that uses Intellitrace. 
This PR adds the necessary binaries that allow for Fakes tests to run through the TestPlatform package alone. The internal package used to provide the Fakes binaries has also been renamed and will constitute of all binaries that will be shared between Fakes in VS and TestPlatform.