### PR TITLE
Optionally force procdump

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/CrashDumperFactory.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/CrashDumperFactory.cs
@@ -31,29 +31,6 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-<<<<<<< Updated upstream
-                EqtTrace.Info($"CrashDumperFactory: This is Windows, returning ProcDumpCrashDumper that uses ProcDump utility.");
-                return new ProcDumpCrashDumper();
-
-                // enable this once crashdump can trigger itself on exceptions that originate from task, then we can avoid using procdump
-                // if (!string.IsNullOrWhiteSpace(targetFramework) && !targetFramework.Contains("v5.0"))
-                // {
-                //     EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework} which is not net5.0 or newer, returning ProcDumpCrashDumper that uses ProcDump utility.");
-                //     return new ProcDumpCrashDumper();
-                // }
-
-                // EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework}, returning the .NETClient dumper which uses env variables to collect crashdumps of testhost and any child process.");
-                // return new NetClientCrashDumper();
-||||||| constructed merge base
-                if (!isNet50OrNewer)
-                {
-                    EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework} which is not net5.0 or newer, returning ProcDumpCrashDumper that uses ProcDump utility.");
-                    return new ProcDumpCrashDumper();
-                }
-
-                EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework}, returning the .NETClient dumper which uses env variables to collect crashdumps of testhost and any child process.");
-                return new NetClientCrashDumper();
-=======
                 if (!isNet50OrNewer)
                 {
                     EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework} which is not net5.0 or newer, returning ProcDumpCrashDumper that uses ProcDump utility.");
@@ -76,7 +53,6 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
 
                 EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework}, returning the .NETClient dumper which uses env variables to collect crashdumps of testhost and any child process.");
                 return new NetClientCrashDumper();
->>>>>>> Stashed changes
             }
 
             if (isNet50OrNewer)

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/CrashDumperFactory.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/CrashDumperFactory.cs
@@ -31,6 +31,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+<<<<<<< Updated upstream
                 EqtTrace.Info($"CrashDumperFactory: This is Windows, returning ProcDumpCrashDumper that uses ProcDump utility.");
                 return new ProcDumpCrashDumper();
 
@@ -43,6 +44,39 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
 
                 // EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework}, returning the .NETClient dumper which uses env variables to collect crashdumps of testhost and any child process.");
                 // return new NetClientCrashDumper();
+||||||| constructed merge base
+                if (!isNet50OrNewer)
+                {
+                    EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework} which is not net5.0 or newer, returning ProcDumpCrashDumper that uses ProcDump utility.");
+                    return new ProcDumpCrashDumper();
+                }
+
+                EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework}, returning the .NETClient dumper which uses env variables to collect crashdumps of testhost and any child process.");
+                return new NetClientCrashDumper();
+=======
+                if (!isNet50OrNewer)
+                {
+                    EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework} which is not net5.0 or newer, returning ProcDumpCrashDumper that uses ProcDump utility.");
+                    return new ProcDumpCrashDumper();
+                }
+
+                // On net5.0 we don't have the capability to crash dump on exit, which is useful in rare cases
+                // like when user exits the testhost process with a random exit code, adding this evn variable
+                // to force using procdump. This relies on netclient dumper actualy doing all it's work in blame collector
+                // where it sets all the environment variables, so in effect we will have two crash dumpers active at the same time.
+                // This proven to be working okay while net5.0 could not create dumps from Task.Run, and I was using this same technique
+                // to get dump of testhost. This needs PROCDUMP_PATH set to directory with procdump.exe, or having it in path.
+                var procdumpOverride = Environment.GetEnvironmentVariable("VSTEST_DUMP_FORCEPROCDUMP")?.Trim();
+                var forceUsingProcdump = string.IsNullOrWhiteSpace(procdumpOverride) && procdumpOverride != "0";
+                if (forceUsingProcdump)
+                {
+                    EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework}. Forcing the use of ProcDumpCrashDumper that uses ProcDump utility, via VSTEST_DUMP_FORCEPROCDUMP={procdumpOverride}.");
+                    return new ProcDumpCrashDumper();
+                }
+
+                EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework}, returning the .NETClient dumper which uses env variables to collect crashdumps of testhost and any child process.");
+                return new NetClientCrashDumper();
+>>>>>>> Stashed changes
             }
 
             if (isNet50OrNewer)


### PR DESCRIPTION
## Description
Add env variable to force usage of ProcDump on net5.0 in the rare cases when we would need dump on exit. 

## Related issue
Related #2380 
