### PR TITLE
Remove nuget frameworks dependency

### DIFF
--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -28,7 +28,7 @@
     <ChutzpahAdapterVersion>4.3.7</ChutzpahAdapterVersion>
     <FileSystemGlobbingVersion>1.1.1</FileSystemGlobbingVersion>
 
-    <NuGetFrameworksVersion>5.0.0</NuGetFrameworksVersion>
+    <NuGetFrameworksVersion>5.7.0</NuGetFrameworksVersion>
     <JsonNetVersion>9.0.1</JsonNetVersion>
     <MoqVersion>4.7.63</MoqVersion>
     <TestPlatformExternalsVersion>16.8.0-preview-3968212</TestPlatformExternalsVersion>

--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -28,7 +28,6 @@
     <ChutzpahAdapterVersion>4.3.7</ChutzpahAdapterVersion>
     <FileSystemGlobbingVersion>1.1.1</FileSystemGlobbingVersion>
 
-    <NuGetFrameworksVersion>5.7.0</NuGetFrameworksVersion>
     <JsonNetVersion>9.0.1</JsonNetVersion>
     <MoqVersion>4.7.63</MoqVersion>
     <TestPlatformExternalsVersion>16.8.0-preview-3968212</TestPlatformExternalsVersion>

--- a/scripts/generate/update-supported-nuget.frameworks-versions.ps1
+++ b/scripts/generate/update-supported-nuget.frameworks-versions.ps1
@@ -1,0 +1,148 @@
+<# Helps updating framework name translation in Framework class by taking values from Nuget.Frameworks package
+and generating all common frameworks into the types that vstest console uses. This removes the dependency on Nuget.Frameworks
+from which we consume miniscule part and which causes us a lot of trouble because the VS version and local version differ
+#>
+
+# download a version from nuget and unpack
+
+$dll = Get-Item "~/Downloads/nuget.frameworks.*\lib\net472\NuGet.Frameworks.dll"
+
+Import-Module ($dll.FullName)
+
+$commonFrameworks = [NuGet.Frameworks.FrameworkConstants+CommonFrameworks].GetFields().Name
+
+# thie generates mapping from the full name to the one that we use internally
+@"
+// Generated from Nuget.Frameworks $((Get-Module NuGet.Frameworks ).Version) nuget package, 
+// you can update it by scripts/generate/update-supported-nuget.frameworks-versions.ps1
+static Dictionary<string, Framework> mapping = new Dictionary<string, Framework> {
+$(foreach ($commonFramework in $commonFrameworks) { 
+
+    $fmw = [NuGet.Frameworks.FrameworkConstants+CommonFrameworks]::$commonFramework
+    "[""$($fmw.DotNetFrameworkName)""] = new Framework { 
+        Name = ""$($fmw.DotNetFrameworkName)"",
+        FrameworkName = ""$($fmw.Framework)"",
+        Version = ""$($fmw.Version)"",
+        ShortName = ""$($fmw.GetShortFolderName())"",
+    },`n"
+
+})
+};
+"@
+
+# this will help you taking the method TryParseCommonFramework from the main branch and updating it to have the uncommon name mappings
+# but not use the frameworkconstants
+# Take TryParseCommonFramework from https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs#L586
+# and put it below, in betwwen the @' '@ to get a version that does not need any built in types
+@'
+private static bool TryParseCommonFramework(string frameworkString, out NuGetFramework framework)
+        {
+            framework = null;
+
+            frameworkString = frameworkString.ToLowerInvariant();
+
+            switch (frameworkString)
+            {
+                case "dotnet":
+                case "dotnet50":
+                case "dotnet5.0":
+                    framework = FrameworkConstants.CommonFrameworks.DotNet50;
+                    break;
+                case "net40":
+                case "net4":
+                    framework = FrameworkConstants.CommonFrameworks.Net4;
+                    break;
+                case "net45":
+                    framework = FrameworkConstants.CommonFrameworks.Net45;
+                    break;
+                case "net451":
+                    framework = FrameworkConstants.CommonFrameworks.Net451;
+                    break;
+                case "net46":
+                    framework = FrameworkConstants.CommonFrameworks.Net46;
+                    break;
+                case "net461":
+                    framework = FrameworkConstants.CommonFrameworks.Net461;
+                    break;
+                case "net462":
+                    framework = FrameworkConstants.CommonFrameworks.Net462;
+                    break;
+                case "win8":
+                    framework = FrameworkConstants.CommonFrameworks.Win8;
+                    break;
+                case "win81":
+                    framework = FrameworkConstants.CommonFrameworks.Win81;
+                    break;
+                case "netstandard":
+                    framework = FrameworkConstants.CommonFrameworks.NetStandard;
+                    break;
+                case "netstandard1.0":
+                case "netstandard10":
+                    framework = FrameworkConstants.CommonFrameworks.NetStandard10;
+                    break;
+                case "netstandard1.1":
+                case "netstandard11":
+                    framework = FrameworkConstants.CommonFrameworks.NetStandard11;
+                    break;
+                case "netstandard1.2":
+                case "netstandard12":
+                    framework = FrameworkConstants.CommonFrameworks.NetStandard12;
+                    break;
+                case "netstandard1.3":
+                case "netstandard13":
+                    framework = FrameworkConstants.CommonFrameworks.NetStandard13;
+                    break;
+                case "netstandard1.4":
+                case "netstandard14":
+                    framework = FrameworkConstants.CommonFrameworks.NetStandard14;
+                    break;
+                case "netstandard1.5":
+                case "netstandard15":
+                    framework = FrameworkConstants.CommonFrameworks.NetStandard15;
+                    break;
+                case "netstandard1.6":
+                case "netstandard16":
+                    framework = FrameworkConstants.CommonFrameworks.NetStandard16;
+                    break;
+                case "netstandard1.7":
+                case "netstandard17":
+                    framework = FrameworkConstants.CommonFrameworks.NetStandard17;
+                    break;
+                case "netstandard2.0":
+                case "netstandard20":
+                    framework = FrameworkConstants.CommonFrameworks.NetStandard20;
+                    break;
+                case "netstandard2.1":
+                case "netstandard21":
+                    framework = FrameworkConstants.CommonFrameworks.NetStandard21;
+                    break;
+                case "netcoreapp2.1":
+                case "netcoreapp21":
+                    framework = FrameworkConstants.CommonFrameworks.NetCoreApp21;
+                    break;
+                case "netcoreapp3.1":
+                case "netcoreapp31":
+                    framework = FrameworkConstants.CommonFrameworks.NetCoreApp31;
+                    break;
+                case "netcoreapp5.0":
+                case "netcoreapp50":
+                case "net5.0":
+                case "net50":
+                    framework = FrameworkConstants.CommonFrameworks.Net50;
+                    break;
+            }
+
+            return framework != null;
+        }
+          
+'@ -split "`n" | foreach { 
+    $pattern = "FrameworkConstants.CommonFrameworks.(?<framework>.*);"
+    if ($_ -match $pattern) { 
+        $name = $matches.framework
+        $fullName = ([Nuget.Frameworks.FrameworkConstants+CommonFrameworks]::$name).DotNetFrameworkName
+        $_ -replace $pattern, """$fullName"";"
+    }
+    else {
+        $_ -replace "out NuGetFramework framework", "out string framework"
+    }
+}

--- a/scripts/verify-nupkgs.ps1
+++ b/scripts/verify-nupkgs.ps1
@@ -15,12 +15,12 @@ function Verify-Nuget-Packages($packageDirectory)
     $expectedNumOfFiles = @{
                      "Microsoft.CodeCoverage" = 29;
                      "Microsoft.NET.Test.Sdk" = 13;
-                     "Microsoft.TestPlatform" = 469;
+                     "Microsoft.TestPlatform" = 468;
                      "Microsoft.TestPlatform.Build" = 19;
-                     "Microsoft.TestPlatform.CLI" = 350;
+                     "Microsoft.TestPlatform.CLI" = 348;
                      "Microsoft.TestPlatform.Extensions.TrxLogger" = 33;
                      "Microsoft.TestPlatform.ObjectModel" = 62;
-                     "Microsoft.TestPlatform.Portable" = 566;
+                     "Microsoft.TestPlatform.Portable" = 563;
                      "Microsoft.TestPlatform.TestHost" = 145;
                      "Microsoft.TestPlatform.TranslationLayer" = 121}
 

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/CrashDumperFactory.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/CrashDumperFactory.cs
@@ -6,7 +6,6 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
     using System;
     using System.Runtime.InteropServices;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-    using NuGet.Frameworks;
 
     internal class CrashDumperFactory : ICrashDumperFactory
     {
@@ -19,15 +18,15 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
 
             EqtTrace.Info($"CrashDumperFactory: Creating dumper for {RuntimeInformation.OSDescription} with target framework {targetFramework}.");
 
-            var tfm = NuGetFramework.Parse(targetFramework);
+            var tfm = Framework.FromString(targetFramework);
 
-            if (tfm == null || tfm.IsUnsupported)
+            if (tfm == null)
             {
                 EqtTrace.Error($"CrashDumperFactory: Could not parse target framework {targetFramework}, to a supported framework version.");
                 throw new NotSupportedException($"Could not parse target framework {targetFramework}, to a supported framework version.");
             }
 
-            var isNet50OrNewer = tfm.Framework == ".NETCoreApp" && tfm.Version >= Version.Parse("5.0.0.0");
+            var isNet50OrNewer = tfm.FrameworkName == ".NETCoreApp" && Version.Parse(tfm.Version) >= Version.Parse("5.0.0.0");
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/HangDumperFactory.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/HangDumperFactory.cs
@@ -6,7 +6,6 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
     using System;
     using System.Runtime.InteropServices;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-    using NuGet.Frameworks;
 
     internal class HangDumperFactory : IHangDumperFactory
     {
@@ -21,9 +20,9 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
 
             EqtTrace.Info($"HangDumperFactory: Creating dumper for {RuntimeInformation.OSDescription} with target framework {targetFramework}.");
 
-            var tfm = NuGetFramework.Parse(targetFramework);
+            var tfm = Framework.FromString(targetFramework);
 
-            if (tfm == null || tfm.IsUnsupported)
+            if (tfm == null)
             {
                 EqtTrace.Error($"HangDumperFactory: Could not parse target framework {targetFramework}, to a supported framework version.");
                 throw new NotSupportedException($"Could not parse target framework {targetFramework}, to a supported framework version.");
@@ -37,7 +36,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                var isLessThan31 = tfm.Framework == ".NETCoreApp" && tfm.Version < Version.Parse("3.1.0.0");
+                var isLessThan31 = tfm.FrameworkName == ".NETCoreApp" && Version.Parse(tfm.Version) < Version.Parse("3.1.0.0");
                 if (isLessThan31)
                 {
                     EqtTrace.Info($"HangDumperFactory: This is Linux on netcoreapp2.1, returning SigtrapDumper.");
@@ -51,7 +50,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                var isLessThan50 = tfm.Framework == ".NETCoreApp" && tfm.Version < Version.Parse("5.0.0.0");
+                var isLessThan50 = tfm.FrameworkName == ".NETCoreApp" && Version.Parse(tfm.Version) < Version.Parse("5.0.0.0");
                 if (isLessThan50)
                 {
                     EqtTrace.Info($"HangDumperFactory: This is OSX on {targetFramework}, This combination of OS and framework is not supported.");

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
@@ -22,7 +22,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger
 
     using HtmlResource = Resources.Resources;
     using HtmlLoggerConstants = Constants;
-    using NuGet.Frameworks;
 
     /// <summary>
     /// Logger for generating Html.
@@ -291,7 +290,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger
                 var framework = this.parametersDictionary[DefaultLoggerParameterNames.TargetFramework];
                 if (framework != null)
                 {
-                    framework = NuGetFramework.Parse(framework).GetShortFolderName();
+                    framework = Framework.GetShortFolderName(framework);
                     logFilePrefixValue = logFilePrefixValue + "_" + framework;
                 }
 

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -10,7 +10,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
     using Microsoft.VisualStudio.TestPlatform.Utilities;
     using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
-    using NuGet.Frameworks;
     using ObjectModel.Logging;
     using System;
     using System.Collections.Concurrent;
@@ -509,7 +508,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
             {
                 if (parametersDictionary.TryGetValue(DefaultLoggerParameterNames.TargetFramework, out var framework) && framework != null)
                 {
-                    framework = NuGetFramework.Parse(framework).GetShortFolderName();
+                    framework = Framework.GetShortFolderName(framework);
                     logFilePrefixValue = logFilePrefixValue + "_" + framework;
                 }
 

--- a/src/Microsoft.TestPlatform.ObjectModel/Framework.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Framework.cs
@@ -3,14 +3,592 @@
 
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 {
-    using NuGet.Frameworks;
-    using static NuGet.Frameworks.FrameworkConstants;
+    using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// Class for target Framework for the test container
     /// </summary>
     public class Framework
     {
+        #region Generated code
+        // Generated from Nuget.Frameworks 5.7.0.7 nuget package, 
+        // you can update it by scripts/generate/update-supported-nuget.frameworks-versions.ps1
+        internal static Dictionary<string, Framework> mapping = new Dictionary<string, Framework>
+        {
+            [".NETFramework,Version=v1.1"] = new Framework
+            {
+                Name = ".NETFramework,Version=v1.1",
+                FrameworkName = ".NETFramework",
+                Version = "1.1.0.0",
+                ShortName = "net11",
+            },
+            [".NETFramework,Version=v2.0"] = new Framework
+            {
+                Name = ".NETFramework,Version=v2.0",
+                FrameworkName = ".NETFramework",
+                Version = "2.0.0.0",
+                ShortName = "net20",
+            },
+            [".NETFramework,Version=v3.5"] = new Framework
+            {
+                Name = ".NETFramework,Version=v3.5",
+                FrameworkName = ".NETFramework",
+                Version = "3.5.0.0",
+                ShortName = "net35",
+            },
+            [".NETFramework,Version=v4.0"] = new Framework
+            {
+                Name = ".NETFramework,Version=v4.0",
+                FrameworkName = ".NETFramework",
+                Version = "4.0.0.0",
+                ShortName = "net40",
+            },
+            [".NETFramework,Version=v4.0.3"] = new Framework
+            {
+                Name = ".NETFramework,Version=v4.0.3",
+                FrameworkName = ".NETFramework",
+                Version = "4.0.3.0",
+                ShortName = "net403",
+            },
+            [".NETFramework,Version=v4.5"] = new Framework
+            {
+                Name = ".NETFramework,Version=v4.5",
+                FrameworkName = ".NETFramework",
+                Version = "4.5.0.0",
+                ShortName = "net45",
+            },
+            [".NETFramework,Version=v4.5.1"] = new Framework
+            {
+                Name = ".NETFramework,Version=v4.5.1",
+                FrameworkName = ".NETFramework",
+                Version = "4.5.1.0",
+                ShortName = "net451",
+            },
+            [".NETFramework,Version=v4.5.2"] = new Framework
+            {
+                Name = ".NETFramework,Version=v4.5.2",
+                FrameworkName = ".NETFramework",
+                Version = "4.5.2.0",
+                ShortName = "net452",
+            },
+            [".NETFramework,Version=v4.6"] = new Framework
+            {
+                Name = ".NETFramework,Version=v4.6",
+                FrameworkName = ".NETFramework",
+                Version = "4.6.0.0",
+                ShortName = "net46",
+            },
+            [".NETFramework,Version=v4.6.1"] = new Framework
+            {
+                Name = ".NETFramework,Version=v4.6.1",
+                FrameworkName = ".NETFramework",
+                Version = "4.6.1.0",
+                ShortName = "net461",
+            },
+            [".NETFramework,Version=v4.6.2"] = new Framework
+            {
+                Name = ".NETFramework,Version=v4.6.2",
+                FrameworkName = ".NETFramework",
+                Version = "4.6.2.0",
+                ShortName = "net462",
+            },
+            [".NETFramework,Version=v4.6.3"] = new Framework
+            {
+                Name = ".NETFramework,Version=v4.6.3",
+                FrameworkName = ".NETFramework",
+                Version = "4.6.3.0",
+                ShortName = "net463",
+            },
+            [".NETCore,Version=v4.5"] = new Framework
+            {
+                Name = ".NETCore,Version=v4.5",
+                FrameworkName = ".NETCore",
+                Version = "4.5.0.0",
+                ShortName = "netcore45",
+            },
+            [".NETCore,Version=v4.5.1"] = new Framework
+            {
+                Name = ".NETCore,Version=v4.5.1",
+                FrameworkName = ".NETCore",
+                Version = "4.5.1.0",
+                ShortName = "netcore451",
+            },
+            [".NETCore,Version=v5.0"] = new Framework
+            {
+                Name = ".NETCore,Version=v5.0",
+                FrameworkName = ".NETCore",
+                Version = "5.0.0.0",
+                ShortName = "netcore50",
+            },
+            ["Windows,Version=v8.0"] = new Framework
+            {
+                Name = "Windows,Version=v8.0",
+                FrameworkName = "Windows",
+                Version = "8.0.0.0",
+                ShortName = "win8",
+            },
+            ["Windows,Version=v8.1"] = new Framework
+            {
+                Name = "Windows,Version=v8.1",
+                FrameworkName = "Windows",
+                Version = "8.1.0.0",
+                ShortName = "win81",
+            },
+            ["Windows,Version=v10.0"] = new Framework
+            {
+                Name = "Windows,Version=v10.0",
+                FrameworkName = "Windows",
+                Version = "10.0.0.0",
+                ShortName = "win10.0",
+            },
+            ["Silverlight,Version=v4.0"] = new Framework
+            {
+                Name = "Silverlight,Version=v4.0",
+                FrameworkName = "Silverlight",
+                Version = "4.0.0.0",
+                ShortName = "sl4",
+            },
+            ["Silverlight,Version=v5.0"] = new Framework
+            {
+                Name = "Silverlight,Version=v5.0",
+                FrameworkName = "Silverlight",
+                Version = "5.0.0.0",
+                ShortName = "sl5",
+            },
+            ["WindowsPhone,Version=v7.0"] = new Framework
+            {
+                Name = "WindowsPhone,Version=v7.0",
+                FrameworkName = "WindowsPhone",
+                Version = "7.0.0.0",
+                ShortName = "wp7",
+            },
+            ["WindowsPhone,Version=v7.5"] = new Framework
+            {
+                Name = "WindowsPhone,Version=v7.5",
+                FrameworkName = "WindowsPhone",
+                Version = "7.5.0.0",
+                ShortName = "wp75",
+            },
+            ["WindowsPhone,Version=v8.0"] = new Framework
+            {
+                Name = "WindowsPhone,Version=v8.0",
+                FrameworkName = "WindowsPhone",
+                Version = "8.0.0.0",
+                ShortName = "wp8",
+            },
+            ["WindowsPhone,Version=v8.1"] = new Framework
+            {
+                Name = "WindowsPhone,Version=v8.1",
+                FrameworkName = "WindowsPhone",
+                Version = "8.1.0.0",
+                ShortName = "wp81",
+            },
+            ["WindowsPhoneApp,Version=v8.1"] = new Framework
+            {
+                Name = "WindowsPhoneApp,Version=v8.1",
+                FrameworkName = "WindowsPhoneApp",
+                Version = "8.1.0.0",
+                ShortName = "wpa81",
+            },
+            ["Tizen,Version=v3.0"] = new Framework
+            {
+                Name = "Tizen,Version=v3.0",
+                FrameworkName = "Tizen",
+                Version = "3.0.0.0",
+                ShortName = "tizen30",
+            },
+            ["Tizen,Version=v4.0"] = new Framework
+            {
+                Name = "Tizen,Version=v4.0",
+                FrameworkName = "Tizen",
+                Version = "4.0.0.0",
+                ShortName = "tizen40",
+            },
+            ["Tizen,Version=v6.0"] = new Framework
+            {
+                Name = "Tizen,Version=v6.0",
+                FrameworkName = "Tizen",
+                Version = "6.0.0.0",
+                ShortName = "tizen60",
+            },
+            ["ASP.NET,Version=v0.0"] = new Framework
+            {
+                Name = "ASP.NET,Version=v0.0",
+                FrameworkName = "ASP.NET",
+                Version = "0.0.0.0",
+                ShortName = "aspnet",
+            },
+            ["ASP.NETCore,Version=v0.0"] = new Framework
+            {
+                Name = "ASP.NETCore,Version=v0.0",
+                FrameworkName = "ASP.NETCore",
+                Version = "0.0.0.0",
+                ShortName = "aspnetcore",
+            },
+            ["ASP.NET,Version=v5.0"] = new Framework
+            {
+                Name = "ASP.NET,Version=v5.0",
+                FrameworkName = "ASP.NET",
+                Version = "5.0.0.0",
+                ShortName = "aspnet50",
+            },
+            ["ASP.NETCore,Version=v5.0"] = new Framework
+            {
+                Name = "ASP.NETCore,Version=v5.0",
+                FrameworkName = "ASP.NETCore",
+                Version = "5.0.0.0",
+                ShortName = "aspnetcore50",
+            },
+            ["DNX,Version=v0.0"] = new Framework
+            {
+                Name = "DNX,Version=v0.0",
+                FrameworkName = "DNX",
+                Version = "0.0.0.0",
+                ShortName = "dnx",
+            },
+            ["DNX,Version=v4.5"] = new Framework
+            {
+                Name = "DNX,Version=v4.5",
+                FrameworkName = "DNX",
+                Version = "4.5.0.0",
+                ShortName = "dnx45",
+            },
+            ["DNX,Version=v4.5.1"] = new Framework
+            {
+                Name = "DNX,Version=v4.5.1",
+                FrameworkName = "DNX",
+                Version = "4.5.1.0",
+                ShortName = "dnx451",
+            },
+            ["DNX,Version=v4.5.2"] = new Framework
+            {
+                Name = "DNX,Version=v4.5.2",
+                FrameworkName = "DNX",
+                Version = "4.5.2.0",
+                ShortName = "dnx452",
+            },
+            ["DNXCore,Version=v0.0"] = new Framework
+            {
+                Name = "DNXCore,Version=v0.0",
+                FrameworkName = "DNXCore",
+                Version = "0.0.0.0",
+                ShortName = "dnxcore",
+            },
+            ["DNXCore,Version=v5.0"] = new Framework
+            {
+                Name = "DNXCore,Version=v5.0",
+                FrameworkName = "DNXCore",
+                Version = "5.0.0.0",
+                ShortName = "dnxcore50",
+            },
+            [".NETPlatform,Version=v5.0"] = new Framework
+            {
+                Name = ".NETPlatform,Version=v5.0",
+                FrameworkName = ".NETPlatform",
+                Version = "0.0.0.0",
+                ShortName = "dotnet",
+            },
+            [".NETPlatform,Version=v5.0"] = new Framework
+            {
+                Name = ".NETPlatform,Version=v5.0",
+                FrameworkName = ".NETPlatform",
+                Version = "5.0.0.0",
+                ShortName = "dotnet",
+            },
+            [".NETPlatform,Version=v5.1"] = new Framework
+            {
+                Name = ".NETPlatform,Version=v5.1",
+                FrameworkName = ".NETPlatform",
+                Version = "5.1.0.0",
+                ShortName = "dotnet51",
+            },
+            [".NETPlatform,Version=v5.2"] = new Framework
+            {
+                Name = ".NETPlatform,Version=v5.2",
+                FrameworkName = ".NETPlatform",
+                Version = "5.2.0.0",
+                ShortName = "dotnet52",
+            },
+            [".NETPlatform,Version=v5.3"] = new Framework
+            {
+                Name = ".NETPlatform,Version=v5.3",
+                FrameworkName = ".NETPlatform",
+                Version = "5.3.0.0",
+                ShortName = "dotnet53",
+            },
+            [".NETPlatform,Version=v5.4"] = new Framework
+            {
+                Name = ".NETPlatform,Version=v5.4",
+                FrameworkName = ".NETPlatform",
+                Version = "5.4.0.0",
+                ShortName = "dotnet54",
+            },
+            [".NETPlatform,Version=v5.5"] = new Framework
+            {
+                Name = ".NETPlatform,Version=v5.5",
+                FrameworkName = ".NETPlatform",
+                Version = "5.5.0.0",
+                ShortName = "dotnet55",
+            },
+            [".NETPlatform,Version=v5.6"] = new Framework
+            {
+                Name = ".NETPlatform,Version=v5.6",
+                FrameworkName = ".NETPlatform",
+                Version = "5.6.0.0",
+                ShortName = "dotnet56",
+            },
+            [".NETStandard,Version=v0.0"] = new Framework
+            {
+                Name = ".NETStandard,Version=v0.0",
+                FrameworkName = ".NETStandard",
+                Version = "0.0.0.0",
+                ShortName = "netstandard",
+            },
+            [".NETStandard,Version=v1.0"] = new Framework
+            {
+                Name = ".NETStandard,Version=v1.0",
+                FrameworkName = ".NETStandard",
+                Version = "1.0.0.0",
+                ShortName = "netstandard1.0",
+            },
+            [".NETStandard,Version=v1.1"] = new Framework
+            {
+                Name = ".NETStandard,Version=v1.1",
+                FrameworkName = ".NETStandard",
+                Version = "1.1.0.0",
+                ShortName = "netstandard1.1",
+            },
+            [".NETStandard,Version=v1.2"] = new Framework
+            {
+                Name = ".NETStandard,Version=v1.2",
+                FrameworkName = ".NETStandard",
+                Version = "1.2.0.0",
+                ShortName = "netstandard1.2",
+            },
+            [".NETStandard,Version=v1.3"] = new Framework
+            {
+                Name = ".NETStandard,Version=v1.3",
+                FrameworkName = ".NETStandard",
+                Version = "1.3.0.0",
+                ShortName = "netstandard1.3",
+            },
+            [".NETStandard,Version=v1.4"] = new Framework
+            {
+                Name = ".NETStandard,Version=v1.4",
+                FrameworkName = ".NETStandard",
+                Version = "1.4.0.0",
+                ShortName = "netstandard1.4",
+            },
+            [".NETStandard,Version=v1.5"] = new Framework
+            {
+                Name = ".NETStandard,Version=v1.5",
+                FrameworkName = ".NETStandard",
+                Version = "1.5.0.0",
+                ShortName = "netstandard1.5",
+            },
+            [".NETStandard,Version=v1.6"] = new Framework
+            {
+                Name = ".NETStandard,Version=v1.6",
+                FrameworkName = ".NETStandard",
+                Version = "1.6.0.0",
+                ShortName = "netstandard1.6",
+            },
+            [".NETStandard,Version=v1.7"] = new Framework
+            {
+                Name = ".NETStandard,Version=v1.7",
+                FrameworkName = ".NETStandard",
+                Version = "1.7.0.0",
+                ShortName = "netstandard1.7",
+            },
+            [".NETStandard,Version=v2.0"] = new Framework
+            {
+                Name = ".NETStandard,Version=v2.0",
+                FrameworkName = ".NETStandard",
+                Version = "2.0.0.0",
+                ShortName = "netstandard2.0",
+            },
+            [".NETStandard,Version=v2.1"] = new Framework
+            {
+                Name = ".NETStandard,Version=v2.1",
+                FrameworkName = ".NETStandard",
+                Version = "2.1.0.0",
+                ShortName = "netstandard2.1",
+            },
+            [".NETStandardApp,Version=v1.5"] = new Framework
+            {
+                Name = ".NETStandardApp,Version=v1.5",
+                FrameworkName = ".NETStandardApp",
+                Version = "1.5.0.0",
+                ShortName = "netstandardapp15",
+            },
+            ["UAP,Version=v10.0"] = new Framework
+            {
+                Name = "UAP,Version=v10.0",
+                FrameworkName = "UAP",
+                Version = "10.0.0.0",
+                ShortName = "uap10.0",
+            },
+            [".NETCoreApp,Version=v1.0"] = new Framework
+            {
+                Name = ".NETCoreApp,Version=v1.0",
+                FrameworkName = ".NETCoreApp",
+                Version = "1.0.0.0",
+                ShortName = "netcoreapp1.0",
+            },
+            [".NETCoreApp,Version=v1.1"] = new Framework
+            {
+                Name = ".NETCoreApp,Version=v1.1",
+                FrameworkName = ".NETCoreApp",
+                Version = "1.1.0.0",
+                ShortName = "netcoreapp1.1",
+            },
+            [".NETCoreApp,Version=v2.0"] = new Framework
+            {
+                Name = ".NETCoreApp,Version=v2.0",
+                FrameworkName = ".NETCoreApp",
+                Version = "2.0.0.0",
+                ShortName = "netcoreapp2.0",
+            },
+            [".NETCoreApp,Version=v2.1"] = new Framework
+            {
+                Name = ".NETCoreApp,Version=v2.1",
+                FrameworkName = ".NETCoreApp",
+                Version = "2.1.0.0",
+                ShortName = "netcoreapp2.1",
+            },
+            [".NETCoreApp,Version=v2.2"] = new Framework
+            {
+                Name = ".NETCoreApp,Version=v2.2",
+                FrameworkName = ".NETCoreApp",
+                Version = "2.2.0.0",
+                ShortName = "netcoreapp2.2",
+            },
+            [".NETCoreApp,Version=v3.0"] = new Framework
+            {
+                Name = ".NETCoreApp,Version=v3.0",
+                FrameworkName = ".NETCoreApp",
+                Version = "3.0.0.0",
+                ShortName = "netcoreapp3.0",
+            },
+            [".NETCoreApp,Version=v3.1"] = new Framework
+            {
+                Name = ".NETCoreApp,Version=v3.1",
+                FrameworkName = ".NETCoreApp",
+                Version = "3.1.0.0",
+                ShortName = "netcoreapp3.1",
+            },
+            [".NETCoreApp,Version=v5.0"] = new Framework
+            {
+                Name = ".NETCoreApp,Version=v5.0",
+                FrameworkName = ".NETCoreApp",
+                Version = "5.0.0.0",
+                ShortName = "net5.0",
+            },
+
+        };
+        private static bool TryParseCommonFramework(string frameworkString, out string framework)
+        {
+            framework = null;
+
+            frameworkString = frameworkString.ToLowerInvariant();
+
+            switch (frameworkString)
+            {
+                case "dotnet":
+                case "dotnet50":
+                case "dotnet5.0":
+                    framework = ".NETPlatform,Version=v5.0";
+                    break;
+                case "net40":
+                case "net4":
+                    framework = ".NETFramework,Version=v4.0";
+                    break;
+                case "net45":
+                    framework = ".NETFramework,Version=v4.5";
+                    break;
+                case "net451":
+                    framework = ".NETFramework,Version=v4.5.1";
+                    break;
+                case "net46":
+                    framework = ".NETFramework,Version=v4.6";
+                    break;
+                case "net461":
+                    framework = ".NETFramework,Version=v4.6.1";
+                    break;
+                case "net462":
+                    framework = ".NETFramework,Version=v4.6.2";
+                    break;
+                case "win8":
+                    framework = "Windows,Version=v8.0";
+                    break;
+                case "win81":
+                    framework = "Windows,Version=v8.1";
+                    break;
+                case "netstandard":
+                    framework = ".NETStandard,Version=v0.0";
+                    break;
+                case "netstandard1.0":
+                case "netstandard10":
+                    framework = ".NETStandard,Version=v1.0";
+                    break;
+                case "netstandard1.1":
+                case "netstandard11":
+                    framework = ".NETStandard,Version=v1.1";
+                    break;
+                case "netstandard1.2":
+                case "netstandard12":
+                    framework = ".NETStandard,Version=v1.2";
+                    break;
+                case "netstandard1.3":
+                case "netstandard13":
+                    framework = ".NETStandard,Version=v1.3";
+                    break;
+                case "netstandard1.4":
+                case "netstandard14":
+                    framework = ".NETStandard,Version=v1.4";
+                    break;
+                case "netstandard1.5":
+                case "netstandard15":
+                    framework = ".NETStandard,Version=v1.5";
+                    break;
+                case "netstandard1.6":
+                case "netstandard16":
+                    framework = ".NETStandard,Version=v1.6";
+                    break;
+                case "netstandard1.7":
+                case "netstandard17":
+                    framework = ".NETStandard,Version=v1.7";
+                    break;
+                case "netstandard2.0":
+                case "netstandard20":
+                    framework = ".NETStandard,Version=v2.0";
+                    break;
+                case "netstandard2.1":
+                case "netstandard21":
+                    framework = ".NETStandard,Version=v2.1";
+                    break;
+                case "netcoreapp2.1":
+                case "netcoreapp21":
+                    framework = ".NETCoreApp,Version=v2.1";
+                    break;
+                case "netcoreapp3.1":
+                case "netcoreapp31":
+                    framework = ".NETCoreApp,Version=v3.1";
+                    break;
+                case "netcoreapp5.0":
+                case "netcoreapp50":
+                case "net5.0":
+                case "net50":
+                    framework = ".NETCoreApp,Version=v5.0";
+                    break;
+            }
+
+            return framework != null;
+        }
+
+        #endregion
+
 #if NETFRAMEWORK
         private static readonly Framework Default = Framework.FromString(".NETFramework,Version=v4.0");
 #else
@@ -32,9 +610,19 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         public string Name { get; private set; }
 
         /// <summary>
+        /// Gets the framework name such as .NETCoreApp.
+        /// </summary>
+        public string FrameworkName { get; private set; }
+
+        /// <summary>
         /// Gets the framework version.
         /// </summary>
         public string Version { get; private set; }
+
+        /// <summary>
+        /// Common short name, as well as directory name, such as net5.0.
+        /// </summary>
+        public string ShortName { get; private set; }
 
         /// <summary>
         /// Returns a valid framework else returns null
@@ -48,41 +636,45 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
                 return null;
             }
 
-            NuGetFramework nugetFramework;
             try
             {
                 // IDE always sends framework in form of ENUM, which always throws exception
                 // This throws up in first chance exception, refer Bug https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/591142
                 switch (frameworkString.Trim().ToLower())
                 {
+                    // Maps common names to newer version of a common name,
+                    // not adding it to TryParseCommonFramework below, because that is 
+                    // copied from Nuget.Frameworks, and we might need to update that in the future
+                    // which would likely cause these additional names to get lost.
                     case "framework35":
-                        nugetFramework = CommonFrameworks.Net35;
+                        frameworkString = "net35";
                         break;
                     case "framework40":
-                        nugetFramework = CommonFrameworks.Net4;
+                        frameworkString = "net40";
                         break;
                     case "framework45":
-                        nugetFramework = CommonFrameworks.Net45;
+                        frameworkString = "net45";
                         break;
                     case "frameworkcore10":
-                        nugetFramework = CommonFrameworks.NetCoreApp10;
+                        frameworkString = "netcoreapp1.0";
                         break;
                     case "frameworkuap10":
-                        nugetFramework = CommonFrameworks.UAP10;
-                        break;
-                    default:
-                        nugetFramework = NuGetFramework.Parse(frameworkString);
-                        if (nugetFramework.IsUnsupported)
-                            return null;
+                    case "uap10":
+                        frameworkString = "uap10.0";
                         break;
                 }
+
+                return TryParse(frameworkString, out var framework) ? framework : null;
             }
             catch
             {
                 return null;
             }
+        }
 
-            return new Framework() { Name = nugetFramework.DotNetFrameworkName, Version = nugetFramework.Version.ToString() };
+        public static string GetShortFolderName(string frameworkName)
+        {
+            return FromString(frameworkName)?.ShortName ?? frameworkName;
         }
 
         /// <summary>
@@ -92,6 +684,41 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         public override string ToString()
         {
             return this.Name;
+        }
+
+        internal static bool TryParse(string frameworkString, out Framework framework)
+        {
+            if (string.IsNullOrWhiteSpace(frameworkString))
+            {
+                framework = null;
+                return false;
+            }
+
+            if (mapping.TryGetValue(frameworkString, out framework))
+            {
+                // we found it by long name
+                return true;
+            }
+
+            var byShortName = mapping.Values.SingleOrDefault(t => t.ShortName == frameworkString);
+            if (byShortName != null)
+            {
+                // we found it by a common short name, e.g net5.0
+                framework = byShortName;
+                return true;
+            }
+
+            if (TryParseCommonFramework(frameworkString, out var fullName))
+            {
+                // we found it by uncommon short name e.g. net50 
+                // we get long name, try find it in the mapping
+                if (mapping.TryGetValue(frameworkString, out framework))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj
+++ b/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj
@@ -31,7 +31,6 @@
     <ProjectReference Include="..\Microsoft.TestPlatform.CoreUtilities\Microsoft.TestPlatform.CoreUtilities.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksVersion)" />
     <PackageReference Include="System.Reflection.Metadata">
       <Version>1.6.0</Version>
     </PackageReference>

--- a/src/package/nuspec/Microsoft.TestPlatform.Portable.nuspec
+++ b/src/package/nuspec/Microsoft.TestPlatform.Portable.nuspec
@@ -76,7 +76,6 @@
     <file src="net451\$Runtime$\testhost.net48.x86.exe.config"	target="tools\net451\testhost.net48.x86.exe.config" />
     <file src="net451\$Runtime$\vstest.console.exe"	target="tools\net451\vstest.console.exe" />
     <file src="net451\$Runtime$\vstest.console.exe.config"	target="tools\net451\vstest.console.exe.config" />
-    <file src="net451\$Runtime$\NuGet.Frameworks.dll"	target="tools\net451\NuGet.Frameworks.dll" />
 
     <file src="net451\$Runtime$\cs\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"	target="tools\net451\cs\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" />
     <file src="net451\$Runtime$\cs\Microsoft.TestPlatform.CoreUtilities.resources.dll"	target="tools\net451\cs\Microsoft.TestPlatform.CoreUtilities.resources.dll" />
@@ -291,7 +290,6 @@
     <file src="netcoreapp2.1\vstest.console.dll"	target="tools\netcoreapp2.1\vstest.console.dll" />
     <file src="netcoreapp2.1\vstest.console.dll.config"	target="tools\netcoreapp2.1\vstest.console.dll.config" />
     <file src="netcoreapp2.1\vstest.console.runtimeconfig.json"	target="tools\netcoreapp2.1\vstest.console.runtimeconfig.json" />
-    <file src="netcoreapp2.1\NuGet.Frameworks.dll"	target="tools\netcoreapp2.1\NuGet.Frameworks.dll" />
 
     <file src="netcoreapp2.1\cs\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"	target="tools\netcoreapp2.1\cs\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" />
     <file src="netcoreapp2.1\cs\Microsoft.TestPlatform.CoreUtilities.resources.dll"	target="tools\netcoreapp2.1\cs\Microsoft.TestPlatform.CoreUtilities.resources.dll" />
@@ -426,7 +424,6 @@
     <file src="netcoreapp2.1\TestHost\Microsoft.TestPlatform.Utilities.dll"	target="tools\netcoreapp2.1\TestHost\Microsoft.TestPlatform.Utilities.dll" />
     <file src="netcoreapp2.1\TestHost\Microsoft.VisualStudio.TestPlatform.Common.dll"	target="tools\netcoreapp2.1\TestHost\Microsoft.VisualStudio.TestPlatform.Common.dll" />
     <file src="netcoreapp2.1\TestHost\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll"	target="tools\netcoreapp2.1\TestHost\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" />
-    <file src="netcoreapp2.1\TestHost\NuGet.Frameworks.dll"	target="tools\netcoreapp2.1\TestHost\NuGet.Frameworks.dll" />
     <file src="netcoreapp2.1\TestHost\msdia140typelib_clr0200.dll"	target="tools\netcoreapp2.1\TestHost\msdia140typelib_clr0200.dll" />
     <file src="netcoreapp2.1\TestHost\Newtonsoft.Json.dll"	target="tools\netcoreapp2.1\TestHost\Newtonsoft.Json.dll" />
     <file src="netcoreapp2.1\TestHost\System.Collections.Immutable.dll"	target="tools\netcoreapp2.1\TestHost\System.Collections.Immutable.dll" />

--- a/src/package/nuspec/Microsoft.TestPlatform.nuspec
+++ b/src/package/nuspec/Microsoft.TestPlatform.nuspec
@@ -96,7 +96,6 @@
     <file src="net451\$Runtime$\LegacyTypes.testtype"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\LegacyTypes.testtype" />
     <file src="net451\$Runtime$\ManualTests.testtype"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\ManualTests.testtype" />
     <file src="net451\$Runtime$\Microsoft.DiaSymReader.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Microsoft.DiaSymReader.dll" />
-    <file src="net451\$Runtime$\NuGet.Frameworks.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\NuGet.Frameworks.dll" />
     <file src="net451\$Runtime$\Microsoft.Extensions.DependencyModel.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Microsoft.Extensions.DependencyModel.dll" />
     <file src="net451\$Runtime$\Microsoft.Extensions.FileSystemGlobbing.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Microsoft.Extensions.FileSystemGlobbing.dll" />
     <file src="net451\$Runtime$\Microsoft.IntelliTrace.Core.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Microsoft.IntelliTrace.Core.dll" />

--- a/src/package/nuspec/TestPlatform.ObjectModel.nuspec
+++ b/src/package/nuspec/TestPlatform.ObjectModel.nuspec
@@ -17,10 +17,6 @@
       <group targetFramework="net451">
         <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="[4.0.0, )" />
         <dependency id="System.Reflection.Metadata" version="[1.6.0, )" />
-        <dependency id="NuGet.Frameworks" version="[5.0.0, )" />
-      </group>
-      <group targetFramework="netstandard2.0">
-        <dependency id="NuGet.Frameworks" version="[5.0.0, )" />
       </group>
     </dependencies>
     <frameworkAssemblies>

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -16,7 +16,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
     using Microsoft.VisualStudio.TestPlatform.Utilities;
-    using NuGet.Frameworks;
     using CommandLineResources = Resources.Resources;
     /// <summary>
     /// Logger for sending output to the console.
@@ -239,7 +238,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
             }
 
             parameters.TryGetValue(DefaultLoggerParameterNames.TargetFramework, out this.targetFramework);
-            this.targetFramework = !string.IsNullOrEmpty(this.targetFramework) ? NuGetFramework.Parse(this.targetFramework).GetShortFolderName() : this.targetFramework;
+            this.targetFramework = !string.IsNullOrEmpty(this.targetFramework) ? Framework.GetShortFolderName(this.targetFramework) : this.targetFramework;
 
             Initialize(events, String.Empty);
         }


### PR DESCRIPTION
> ℹ️ Replaced by https://github.com/microsoft/vstest/pull/4693

## Description
Translate short and long framework names ourselves instead of depending on Nuget.Frameworks

