### PR TITLE
Do not force .NET4.5 in case legacy test settings are provided

### DIFF
--- a/src/Microsoft.TestPlatform.Utilities/MSTestSettingsUtilities.cs
+++ b/src/Microsoft.TestPlatform.Utilities/MSTestSettingsUtilities.cs
@@ -25,12 +25,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         /// Settings file which need to be imported. The file extension of the settings file will be specified by <paramref name="SettingsFileExtension"/> property.
         /// </param>
         /// <param name="defaultRunSettings"> Input RunSettings document to which settings file need to be imported. </param>
-        /// <param name="architecture"> The architecture. </param>
-        /// <param name="frameworkVersion"> The framework Version. </param>
         /// <returns> Updated RunSetting Xml document with imported settings. </returns>
         [SuppressMessage("Microsoft.Security.Xml", "CA3053:UseXmlSecureResolver",
             Justification = "XmlDocument.XmlResolver is not available in core. Suppress until fxcop issue is fixed.")]
-        public static XmlDocument Import(string settingsFile, XmlDocument defaultRunSettings, Architecture architecture, FrameworkVersion frameworkVersion)
+        public static XmlDocument Import(string settingsFile, XmlDocument defaultRunSettings)
         {
             ValidateArg.NotNull(settingsFile, "settingsFile");
             ValidateArg.NotNull(defaultRunSettings, "defaultRunSettings");
@@ -56,14 +54,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
             {
                 var doc = new XmlDocument();
                 var runConfigurationNode = doc.CreateElement(Constants.RunConfigurationSettingsName);
-
-                var targetPlatformNode = doc.CreateElement("TargetPlatform");
-                targetPlatformNode.InnerXml = architecture.ToString();
-                runConfigurationNode.AppendChild(targetPlatformNode);
-
-                var targetFrameworkVersionNode = doc.CreateElement("TargetFrameworkVersion");
-                targetFrameworkVersionNode.InnerXml = frameworkVersion.ToString();
-                runConfigurationNode.AppendChild(targetFrameworkVersionNode);
 
                 defaultRunSettings.DocumentElement.PrependChild(defaultRunSettings.ImportNode(runConfigurationNode, true));
             }

--- a/src/vstest.console/Processors/RunSettingsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunSettingsArgumentProcessor.cs
@@ -199,7 +199,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             else
             {
                 runSettingsDocument = XmlRunSettingsUtilities.CreateDefaultRunSettings();
-                runSettingsDocument = MSTestSettingsUtilities.Import(runSettingsFile, runSettingsDocument, Architecture.X86, FrameworkVersion.Framework45);
+                runSettingsDocument = MSTestSettingsUtilities.Import(runSettingsFile, runSettingsDocument);
             }
 
             return runSettingsDocument;

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/MSTestSettingsUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/MSTestSettingsUtilitiesTests.cs
@@ -49,9 +49,7 @@ namespace Microsoft.TestPlatform.Utilities.Tests
                 () =>
                 MSTestSettingsUtilities.Import(
                     "C:\\temp\\r.runsettings",
-                    xmlDocument,
-                    Architecture.X86,
-                    FrameworkVersion.Framework45);
+                    xmlDocument);
             Assert.That.Throws<XmlException>(action).WithMessage("Unexpected settings file specified.");
         }
 
@@ -66,9 +64,7 @@ namespace Microsoft.TestPlatform.Utilities.Tests
                 () =>
                 MSTestSettingsUtilities.Import(
                     "C:\\temp\\r.testsettings",
-                    xmlDocument,
-                    Architecture.X86,
-                    FrameworkVersion.Framework45);
+                    xmlDocument);
             Assert.That.Throws<XmlException>(action).WithMessage("Could not find 'RunSettings' node.");
         }
 
@@ -80,9 +76,7 @@ namespace Microsoft.TestPlatform.Utilities.Tests
             xmlDocument.LoadXml(defaultRunSettingsXml);
             var finalxPath = MSTestSettingsUtilities.Import(
                 "C:\\temp\\r.testsettings",
-                xmlDocument,
-                Architecture.X86,
-                FrameworkVersion.Framework45);
+                xmlDocument);
 
             var finalSettingsXml = finalxPath.CreateNavigator().OuterXml;
 
@@ -100,14 +94,12 @@ namespace Microsoft.TestPlatform.Utilities.Tests
             xmlDocument.LoadXml(defaultRunSettingsXml);
             var finalxPath = MSTestSettingsUtilities.Import(
                 "C:\\temp\\r.testsettings",
-                xmlDocument,
-                Architecture.X86,
-                FrameworkVersion.Framework45);
+                xmlDocument);
 
             var finalSettingsXml = finalxPath.CreateNavigator().OuterXml;
 
             var expectedSettingsXml =
-                "<RunSettings>\r\n  <RunConfiguration>\r\n    <TargetPlatform>X86</TargetPlatform>\r\n    <TargetFrameworkVersion>Framework45</TargetFrameworkVersion>\r\n  </RunConfiguration>\r\n  <MSTest>\r\n    <SettingsFile>C:\\temp\\r.testsettings</SettingsFile>\r\n    <ForcedLegacyMode>true</ForcedLegacyMode>\r\n  </MSTest>\r\n</RunSettings>";
+                "<RunSettings>\r\n  <MSTest>\r\n    <SettingsFile>C:\\temp\\r.testsettings</SettingsFile>\r\n    <ForcedLegacyMode>true</ForcedLegacyMode>\r\n  </MSTest>\r\n</RunSettings>";
 
             Assert.AreEqual(expectedSettingsXml, finalSettingsXml);
         }

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/MSTestSettingsUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/MSTestSettingsUtilitiesTests.cs
@@ -8,7 +8,6 @@ namespace Microsoft.TestPlatform.Utilities.Tests
 
     using Microsoft.VisualStudio.TestPlatform.Utilities;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using VisualStudio.TestPlatform.ObjectModel;
     using MSTest.TestFramework.AssertExtensions;
 
     [TestClass]
@@ -81,7 +80,13 @@ namespace Microsoft.TestPlatform.Utilities.Tests
             var finalSettingsXml = finalxPath.CreateNavigator().OuterXml;
 
             var expectedSettingsXml =
-                "<RunSettings>\r\n  <MSTest>\r\n    <SettingsFile>C:\\temp\\r.testsettings</SettingsFile>\r\n    <ForcedLegacyMode>true</ForcedLegacyMode>\r\n  </MSTest>\r\n  <RunConfiguration></RunConfiguration>\r\n</RunSettings>";
+                "<RunSettings>\r\n" +
+                "  <MSTest>\r\n" +
+                "    <SettingsFile>C:\\temp\\r.testsettings</SettingsFile>\r\n" +
+                "    <ForcedLegacyMode>true</ForcedLegacyMode>\r\n" +
+                "  </MSTest>\r\n" +
+                "  <RunConfiguration></RunConfiguration>\r\n" +
+                "</RunSettings>";
 
             Assert.AreEqual(expectedSettingsXml, finalSettingsXml);
         }
@@ -99,7 +104,13 @@ namespace Microsoft.TestPlatform.Utilities.Tests
             var finalSettingsXml = finalxPath.CreateNavigator().OuterXml;
 
             var expectedSettingsXml =
-                "<RunSettings>\r\n  <MSTest>\r\n    <SettingsFile>C:\\temp\\r.testsettings</SettingsFile>\r\n    <ForcedLegacyMode>true</ForcedLegacyMode>\r\n  </MSTest>\r\n</RunSettings>";
+                "<RunSettings>\r\n" +
+                "  <RunConfiguration />\r\n" +
+                "  <MSTest>\r\n" +
+                "    <SettingsFile>C:\\temp\\r.testsettings</SettingsFile>\r\n" +
+                "    <ForcedLegacyMode>true</ForcedLegacyMode>\r\n" +
+                "  </MSTest>\r\n" +
+                "</RunSettings>";
 
             Assert.AreEqual(expectedSettingsXml, finalSettingsXml);
         }

--- a/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
@@ -244,8 +244,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
                 $"<RunSettings>\r\n" +
                 $"  <RunConfiguration>\r\n" +
                 $"    <ResultsDirectory>{Constants.DefaultResultsDirectory}</ResultsDirectory>\r\n" +
-                $"    <TargetPlatform>X86</TargetPlatform>\r\n" +
-                $"    <TargetFrameworkVersion>.NETCoreApp,Version=v1.0</TargetFrameworkVersion>\r\n" +
+                $"    <TargetPlatform>{Constants.DefaultPlatform}</TargetPlatform>\r\n" +
+                $"    <TargetFrameworkVersion>{Framework.DefaultFramework.Name}</TargetFrameworkVersion>\r\n" +
                 $"  </RunConfiguration>\r\n" +
                 $"  <MSTest>\r\n" +
                 $"    <SettingsFile>C:\\temp\\r.testsettings</SettingsFile>\r\n" +

--- a/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
@@ -237,7 +237,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
 
             // Assert.
             Assert.IsNotNull(this.settingsProvider.ActiveRunSettings);
-            StringAssert.Contains(this.settingsProvider.ActiveRunSettings.SettingsXml, $"<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <RunConfiguration>\r\n    <TargetPlatform>{Constants.DefaultPlatform}</TargetPlatform>\r\n    <TargetFrameworkVersion>{Framework.FromString(FrameworkVersion.Framework45.ToString()).Name}</TargetFrameworkVersion>\r\n    <ResultsDirectory>{Constants.DefaultResultsDirectory}</ResultsDirectory>\r\n  </RunConfiguration>\r\n  <MSTest>\r\n    <SettingsFile>C:\\temp\\r.testsettings</SettingsFile>\r\n    <ForcedLegacyMode>true</ForcedLegacyMode>\r\n  </MSTest>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n</RunSettings>");
+            StringAssert.Contains(this.settingsProvider.ActiveRunSettings.SettingsXml, $"<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <RunConfiguration>\r\n    <TargetFrameworkVersion>.NETCoreApp,Version=v1.0</TargetFrameworkVersion>\r\n    <ResultsDirectory>{Constants.DefaultResultsDirectory}</ResultsDirectory>\r\n  </RunConfiguration>\r\n  <MSTest>\r\n    <SettingsFile>C:\\temp\\r.testsettings</SettingsFile>\r\n    <ForcedLegacyMode>true</ForcedLegacyMode>\r\n  </MSTest>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n</RunSettings>");
         }
 
 

--- a/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
@@ -235,9 +235,27 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             // Act.
             executor.Initialize(fileName);
 
+
             // Assert.
             Assert.IsNotNull(this.settingsProvider.ActiveRunSettings);
-            StringAssert.Contains(this.settingsProvider.ActiveRunSettings.SettingsXml, $"<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <RunConfiguration>\r\n    <TargetFrameworkVersion>.NETCoreApp,Version=v1.0</TargetFrameworkVersion>\r\n    <ResultsDirectory>{Constants.DefaultResultsDirectory}</ResultsDirectory>\r\n  </RunConfiguration>\r\n  <MSTest>\r\n    <SettingsFile>C:\\temp\\r.testsettings</SettingsFile>\r\n    <ForcedLegacyMode>true</ForcedLegacyMode>\r\n  </MSTest>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors />\r\n  </DataCollectionRunSettings>\r\n</RunSettings>");
+
+            var expected = 
+                $"<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n" +
+                $"<RunSettings>\r\n" +
+                $"  <RunConfiguration>\r\n" +
+                $"    <ResultsDirectory>{Constants.DefaultResultsDirectory}</ResultsDirectory>\r\n" +
+                $"    <TargetPlatform>X86</TargetPlatform>\r\n" +
+                $"    <TargetFrameworkVersion>.NETCoreApp,Version=v1.0</TargetFrameworkVersion>\r\n" +
+                $"  </RunConfiguration>\r\n" +
+                $"  <MSTest>\r\n" +
+                $"    <SettingsFile>C:\\temp\\r.testsettings</SettingsFile>\r\n" +
+                $"    <ForcedLegacyMode>true</ForcedLegacyMode>\r\n" +
+                $"  </MSTest>\r\n" +
+                $"  <DataCollectionRunSettings>\r\n" +
+                $"    <DataCollectors />\r\n" +
+                $"  </DataCollectionRunSettings>\r\n" +
+                $"</RunSettings>";
+            StringAssert.Contains(this.settingsProvider.ActiveRunSettings.SettingsXml, expected);
         }
 
 


### PR DESCRIPTION
## Description
Legacy settings were forcing .NET4.5 when used, which prevents projects targetting other TFMs from running tests.
