### PR TITLE
Blame upload on crash even if hang dump started

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/CrashDumperFactory.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/CrashDumperFactory.cs
@@ -44,7 +44,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                 // This proven to be working okay while net5.0 could not create dumps from Task.Run, and I was using this same technique
                 // to get dump of testhost. This needs PROCDUMP_PATH set to directory with procdump.exe, or having it in path.
                 var procdumpOverride = Environment.GetEnvironmentVariable("VSTEST_DUMP_FORCEPROCDUMP")?.Trim();
-                var forceUsingProcdump = string.IsNullOrWhiteSpace(procdumpOverride) && procdumpOverride != "0";
+                var forceUsingProcdump = !string.IsNullOrWhiteSpace(procdumpOverride) && procdumpOverride != "0";
                 if (forceUsingProcdump)
                 {
                     EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework}. Forcing the use of ProcDumpCrashDumper that uses ProcDump utility, via VSTEST_DUMP_FORCEPROCDUMP={procdumpOverride}.");

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameCollectorTests.cs
@@ -404,33 +404,6 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
         }
 
         /// <summary>
-        /// The trigger session ended handler should not dump files if proc dump was enabled and test host did not crash
-        /// </summary>
-        [TestMethod]
-        public void TriggerSessionEndedHandlerShouldNotGetDumpFileIfNoCrash()
-        {
-            // Initializing Blame Data Collector
-            this.blameDataCollector.Initialize(
-                this.GetDumpConfigurationElement(),
-                this.mockDataColectionEvents.Object,
-                this.mockDataCollectionSink.Object,
-                this.mockLogger.Object,
-                this.context);
-
-            // Setup
-            this.mockProcessDumpUtility.Setup(x => x.GetDumpFiles()).Returns(new[] { this.filepath });
-            this.mockBlameReaderWriter.Setup(x => x.WriteTestSequence(It.IsAny<List<Guid>>(), It.IsAny<Dictionary<Guid, BlameTestObject>>(), It.IsAny<string>()))
-                .Returns(this.filepath);
-
-            // Raise
-            this.mockDataColectionEvents.Raise(x => x.TestHostLaunched += null, new TestHostLaunchedEventArgs(this.dataCollectionContext, 1234));
-            this.mockDataColectionEvents.Raise(x => x.SessionEnd += null, new SessionEndEventArgs(this.dataCollectionContext));
-
-            // Verify GetDumpFiles Call
-            this.mockProcessDumpUtility.Verify(x => x.GetDumpFiles(), Times.Never);
-        }
-
-        /// <summary>
         /// The trigger session ended handler should get dump files if collect dump on exit was enabled irrespective of completed test case count
         /// </summary>
         [TestMethod]


### PR DESCRIPTION
## Description
 In rare cases where we have a crashing tests and short hang timeout, we get into situation where hang dumper started dumping, but then session ends because of the crash, and dumps are not uploaded because the session end is only uploading when there is crash dump enabled. After this change we look for any dump in any case and upload all the dumps that hang dumper was able to create.

Remove test, because we want to upload all dumps on session end when hangdump and crash dump run into each other, otherwise hang dumps would not get uploaded and the process would just end, leaving them on the local disk.

## Related issue
Related #2380 
