### PR TITLE
Enable default compile items for Microsoft.TestPlatform.PlatformAbstractions

### DIFF
--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Microsoft.TestPlatform.PlatformAbstractions.csproj
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Microsoft.TestPlatform.PlatformAbstractions.csproj
@@ -8,7 +8,6 @@
     <AssemblyName>Microsoft.TestPlatform.PlatformAbstractions</AssemblyName>
     <TargetFrameworks>netcoreapp2.1;net451;uap10.0;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">netstandard2.0;netcoreapp2.1</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableCodeAnalysis>true</EnableCodeAnalysis>
     <NoWarn>NU1605</NoWarn>
   </PropertyGroup>
@@ -28,16 +27,7 @@
     <TargetFrameworkVersion Condition="'$(OS)' != 'Windows_NT'">v4.5.1</TargetFrameworkVersion>
   </PropertyGroup>
     
-  <ItemGroup>
-    <Compile Include="Interfaces\**\*.cs" />
-    <Compile Include="Properties\**\*.cs" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <Compile Include="netstandard\**\*.cs" />
-  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <Compile Include="netcore\**\*.cs" />
-    <Compile Include="common\**\*.cs" />
     <PackageReference Include="System.Threading.Thread">
       <Version>4.0.0</Version>
     </PackageReference>
@@ -58,8 +48,6 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Compile Include="net451\**\*.cs" />
-    <Compile Include="common\**\*.cs" />
     <PackageReference Include="Microsoft.Internal.Dia.Interop">
       <Version>14.0.0</Version>
     </PackageReference>
@@ -68,7 +56,6 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <Compile Include="uap10.0\**\*.cs" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation">
       <Version>4.0.0</Version>
     </PackageReference>

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/IO/PlatformStream.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/IO/PlatformStream.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || NETCOREAPP
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System.IO;
@@ -16,3 +18,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || NETCOREAPP
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
@@ -215,3 +217,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/PlatformEqtTrace.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/PlatformEqtTrace.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || NETCOREAPP
+
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 {
     using System;
@@ -435,3 +437,5 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/RollingFileTraceListener.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/RollingFileTraceListener.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || NETCOREAPP
+
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 {
     using System;
@@ -472,3 +474,5 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Interfaces/Tracing/IPlatformEqtTrace.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Interfaces/Tracing/IPlatformEqtTrace.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK
+
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 {
     using System;
@@ -25,3 +27,5 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         void SetupListener(TraceListener listener);
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Runtime/PlatformAssemblyExtensions.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Runtime/PlatformAssemblyExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System.Reflection;
@@ -21,3 +23,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Runtime/PlatformAssemblyLoadContext.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Runtime/PlatformAssemblyLoadContext.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System.Reflection;
@@ -22,3 +24,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Runtime/PlatformAssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Runtime/PlatformAssemblyResolver.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
@@ -75,3 +77,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/PlatformEnvironment.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/PlatformEnvironment.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
@@ -63,3 +65,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/PlatformThread.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/PlatformThread.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
@@ -46,3 +48,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/ProcessHelper.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
@@ -22,3 +24,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/ProcessStartInfoExtensions.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/ProcessStartInfoExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System.Diagnostics;
@@ -19,3 +21,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Tracing/PlatformEqtTrace.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Tracing/PlatformEqtTrace.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK
+
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 {
     using System;
@@ -74,3 +76,5 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Tracing/RemoteEqtTrace.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Tracing/RemoteEqtTrace.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK
+
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 {
     using System;
@@ -39,3 +41,5 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/Runtime/PlatformAssemblyExtensions.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/Runtime/PlatformAssemblyExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETCOREAPP
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System.Reflection;
@@ -21,3 +23,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/Runtime/PlatformAssemblyLoadContext.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/Runtime/PlatformAssemblyLoadContext.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETCOREAPP
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System.Reflection;
@@ -23,3 +25,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/Runtime/PlatformAssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/Runtime/PlatformAssemblyResolver.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETCOREAPP
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
@@ -77,3 +79,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformEnvironment.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformEnvironment.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETCOREAPP
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
@@ -68,3 +70,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformThread.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformThread.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETCOREAPP
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
@@ -49,3 +51,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETCOREAPP
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
@@ -26,3 +28,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessStartInfoExtensions.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessStartInfoExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETCOREAPP
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System.Diagnostics;
@@ -19,3 +21,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/IO/PlatformStream.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/IO/PlatformStream.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETSTANDARD
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
@@ -17,3 +19,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/Runtime/PlatformAssemblyExtensions.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/Runtime/PlatformAssemblyExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETSTANDARD
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
@@ -14,3 +16,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/Runtime/PlatformAssemblyLoadContext.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/Runtime/PlatformAssemblyLoadContext.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETSTANDARD
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System.Reflection;
@@ -22,3 +24,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/Runtime/PlatformAssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/Runtime/PlatformAssemblyResolver.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETSTANDARD
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
@@ -28,3 +30,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/System/PlatformEnvironment.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/System/PlatformEnvironment.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETSTANDARD
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
@@ -49,3 +51,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/System/PlatformThread.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/System/PlatformThread.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETSTANDARD
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
@@ -16,3 +18,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/System/ProcessHelper.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETSTANDARD
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
@@ -103,3 +105,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/Tracing/PlatformEqtTrace.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/Tracing/PlatformEqtTrace.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETSTANDARD
+
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 {
     using System;
@@ -64,3 +66,5 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/IO/PlatformStream.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/IO/PlatformStream.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if WINDOWS_UWP
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System.IO;
@@ -16,3 +18,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Runtime/PlatformAssemblyExtensions.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Runtime/PlatformAssemblyExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if WINDOWS_UWP
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System.IO;
@@ -23,3 +25,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Runtime/PlatformAssemblyLoadContext.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Runtime/PlatformAssemblyLoadContext.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if WINDOWS_UWP
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System.IO;
@@ -24,3 +26,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Runtime/PlatformAssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Runtime/PlatformAssemblyResolver.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if WINDOWS_UWP
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
@@ -26,3 +28,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/PlatformEnvironment.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/PlatformEnvironment.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if WINDOWS_UWP
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
@@ -67,3 +69,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/PlatformThread.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/PlatformThread.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if WINDOWS_UWP
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
@@ -30,3 +32,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/ProcessHelper.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if WINDOWS_UWP
+
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
@@ -109,3 +111,5 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Tracing/FileEventListener.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Tracing/FileEventListener.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if WINDOWS_UWP
+
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 {
     using System;
@@ -94,3 +96,5 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Tracing/PlatformEqtTrace.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Tracing/PlatformEqtTrace.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if WINDOWS_UWP
+
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 {
     using System;
@@ -177,3 +179,5 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         }
     }
 }
+
+#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Tracing/UnitTestEventSource.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Tracing/UnitTestEventSource.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if WINDOWS_UWP
+
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 {
     using System.Diagnostics.Tracing;
@@ -48,3 +50,5 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         }
     }
 }
+
+#endif


### PR DESCRIPTION
This change allows all files to show in Solution Explorer, with the content conditionally included according to well-known compile-time definitions.