### PR TITLE
Get symbols of DiaSymReader from externals

### DIFF
--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -31,7 +31,7 @@
     <NuGetFrameworksVersion>5.0.0</NuGetFrameworksVersion>
     <JsonNetVersion>9.0.1</JsonNetVersion>
     <MoqVersion>4.7.63</MoqVersion>
-    <TestPlatformExternalsVersion>16.8.0-preview-3968212</TestPlatformExternalsVersion>
+    <TestPlatformExternalsVersion>16.8.0-preview-4040788</TestPlatformExternalsVersion>
     <MicrosoftFakesVersion>16.8.0-beta.20420.2</MicrosoftFakesVersion>
 
     <MicrosoftBuildPackageVersion>16.0.461</MicrosoftBuildPackageVersion>


### PR DESCRIPTION
## Description
Build from the same drop as the previous version but now includes symbols for DiaSymReader to pass SymCheck on insertion into VS.

## Related issue
Fix #AB1167315