### PR TITLE
Excluded some of already signed assemblies

### DIFF
--- a/scripts/Test-Signatures.ps1
+++ b/scripts/Test-Signatures.ps1
@@ -1,10 +1,8 @@
 [CmdletBinding()]
 param (
-    [Parameter()]
     [String]
     $Path = "$PSScriptRoot\packages",
 
-    [Parameter()]
     [Switch]
     $CIBuild
 )
@@ -12,198 +10,288 @@ param (
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 
 # Allowed certificate subjects
-$global:ValidSubjects = @( `
-    "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US", `
-    "CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" `
-);
+$script:ValidSubjects = @( 
+    "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" 
+    "CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" 
+)
 
 # Allowed certificate thumbprints
-$global:ValidThumbprints = @( `
-    "B9EAA034C821C159B05D3521BCF7FEB796EBD6FF", `
-    "98ED99A67886D020C564923B7DF25E9AC019DF26", `
-    "5EAD300DC7E4D637948ECB0ED829A072BD152E17", `
-    "67B1757863E3EFF760EA9EBB02849AF07D3A8080", `
-    "9DC17888B5CFAD98B3CB35C1994E96227F061675", `
-    "62009AAABDAE749FD47D19150958329BF6FF4B34", `
-    "3BDA323E552DB1FDE5F4FBEE75D6D5B2B187EEDC" `
+$script:ValidThumbprints = @( 
+    "B9EAA034C821C159B05D3521BCF7FEB796EBD6FF" 
+    "98ED99A67886D020C564923B7DF25E9AC019DF26" 
+    "5EAD300DC7E4D637948ECB0ED829A072BD152E17" 
+    "67B1757863E3EFF760EA9EBB02849AF07D3A8080" 
+    "9DC17888B5CFAD98B3CB35C1994E96227F061675" 
+    "62009AAABDAE749FD47D19150958329BF6FF4B34" 
+    "3BDA323E552DB1FDE5F4FBEE75D6D5B2B187EEDC" 
+    "899FA016DEE8E665FF2A315A1151C43FB96C430B"  # Microsoft 3rd Party Application Component
 )
 
 # Allow-list for unsigned binaries
-$global:UnsignedAllowList = @{
+# No binaries allow to ship without a valid signature as per policy
+$script:UnsignedAllowList = @{
     # "PackageId" = relative paths
-    "Microsoft.TestPlatform" = @( `
-        ".\tools\net451\Common7\IDE\Extensions\TestPlatform\Newtonsoft.Json.dll" `
-    )
-
-    "Microsoft.TestPlatform.CLI" = @( `
-        ".\contentFiles\any\netcoreapp2.1\TestHost\Newtonsoft.Json.dll", `
-        ".\contentFiles\any\netcoreapp2.1\Newtonsoft.Json.dll"
-    )
-    
-    "Microsoft.TestPlatform.Portable" = @( `
-        ".\tools\net451\Newtonsoft.Json.dll", `
-        ".\tools\netcoreapp2.1\TestHost\Newtonsoft.Json.dll", `
-        ".\tools\netcoreapp2.1\Newtonsoft.Json.dll"
-    )
+    # "Microsoft.TestPlatform" = @( `
+    #     ".\tools\net451\Common7\IDE\Extensions\TestPlatform\Newtonsoft.Json.dll" `
+    # )
 }
 
+$script:Depth = 0
 
-$global:Depth = 0;
+function Get-RelativePath($Path, $RelativeTo) {
+    try {
+        Push-Location
+        Set-Location $RelativeTo
+        $Path = Resolve-Path $Path -Relative
+    }
+    finally {
+        Pop-Location
+    }
 
-function Get-RelativePath($path, $relativeTo) {
-    Push-Location
-    Set-Location $relativeTo
-    $path = Resolve-Path $path -Relative
-    Pop-Location
-    
-    return $path
+    $Path
 }
 
 function Push-Depth {
-    $global:Depth = $global:Depth + 1
+    $script:Depth = $script:Depth + 1
 }
 
 function Pop-Depth {
-    $global:Depth = $global:Depth - 1
+    $script:Depth = $script:Depth - 1
 
-    if($global:Depth -lt 0) {
-        $global:Depth = 0;
+    if($script:Depth -lt 0) {
+        $script:Depth = 0
     }
 }
 
-function Clear-Line($message = "") {
-    if(-not $CIBuild) {
-        $x = [System.Console]::get_CursorLeft()
-        Write-Host "`r$(' ' * $x)$message`r" -NoNewline
-    }
-}
-
-function Update-Operation($operation, $message, [switch]$NewLine, $suppress=$false) {
-    if($suppress) {
-        return;
+function Clear-Line($Message = "") {
+    if($CIBuild) {
+        return
     }
     
-    Clear-Line;
-    Write-Host "$('  ' * $Depth)[$operation] " -ForegroundColor Yellow -NoNewline
-    Write-Host $message -NoNewline
+    $x = [System.Console]::get_CursorLeft()
+    Write-Host "`r$(' ' * $x)$Message`r" -NoNewLine
+}
+
+function Update-Operation($Operation, $Message, [switch]$NewLine, [switch]$Suppress) {
+    if($Suppress) {
+        return
+    }
+    
+    Clear-Line
+    Write-Host "$('  ' * $Depth)[$Operation] " -ForegroundColor Yellow -NoNewline
+    Write-Host $Message -NoNewline
 
     if ($newline -or $CIBuild) {
-        Write-Host;
+        Write-Host
     }
 }
 
-function Submit-Operation($operation, $message, [switch]$NoNewLine, $suppress=$false) {
-    if($suppress) {
-        return;
+function Submit-Operation($Operation, $Message, [switch]$NoNewLine, [switch]$Suppress) {
+    if($Suppress) {
+        return
     }
     
-    Clear-Line;
-    Write-Host "$('  ' * $Depth)[$operation] " -ForegroundColor Green -NoNewline
-    Write-Host $message -NoNewline
+    Clear-Line
+    Write-Host "$('  ' * $Depth)[$Operation] " -ForegroundColor Green -NoNewline
+    Write-Host $Message -NoNewline
 
     if (-not $NoNewLine -or $CIBuild) {
-        Write-Host;
+        Write-Host
     }
 }
 
-function Undo-Operation($operation, $message, [switch]$NoNewLine, $suppress=$false) {
-    if($suppress) {
-        return;
+function Undo-Operation($Operation, $Message, [switch]$NoNewLine, [switch]$Suppress) {
+    if($Suppress) {
+        return
     }
     
-    Clear-Line;
-    Write-Host "$('  ' * $Depth)[$operation] " -ForegroundColor Red -NoNewline
-    Write-Host $message -NoNewline
+    Clear-Line
+    Write-Host "$('  ' * $Depth)[$Operation] " -ForegroundColor Red -NoNewline
+    Write-Host $Message -NoNewline
 
     if (-not $NoNewLine -or $CIBuild) {
-        Write-Host;
+        Write-Host
     }
+}
+
+Function Invoke-Command ($Command, $Arguments)
+{
+    $pinfo = New-Object System.Diagnostics.ProcessStartInfo
+    $pinfo.FileName = $Command
+    $pinfo.RedirectStandardError = $true
+    $pinfo.RedirectStandardOutput = $true
+    $pinfo.UseShellExecute = $false
+    $pinfo.Arguments = $Arguments
+    $p = New-Object System.Diagnostics.Process
+    $p.StartInfo = $pinfo
+    $p.Start() | Out-Null
+    $p.WaitForExit()
+    
+    [pscustomobject]@{
+        stdout = $p.StandardOutput.ReadToEnd()
+        stderr = $p.StandardError.ReadToEnd()
+        ExitCode = $p.ExitCode
+    }
+}
+
+function Test-NuGetSignatures {
+    $failed = @{}
+    
+    $nupgks = Get-ChildItem *.nupkg
+ 
+    $nugetDir = "$PSScriptRoot\..\tools\nuget"
+    $nugetPath = "$nugetDir\nuget.exe"
+    
+    Push-Depth
+    if(-not (Test-Path $nugetDir))
+    {
+        # Create the directory for nuget.exe if it does not exist
+        New-Item -ItemType Directory -Force -Path $nugetDir | Out-Null
+
+        try {
+            $progressPreference = 'silentlyContinue'
+            $nugetUrl = "https://dist.nuget.org/win-x86-commandline/v4.6.1/nuget.exe"
+            Update-Operation -operation "downloading" -message $nugetUrl -suppress:$CIBuild
+            Invoke-WebRequest $nugetUrl -OutFile $nugetPath 
+            Submit-Operation -operation "downloaded" -message $nugetUrl
+        }
+        finally {
+            $progressPreference = 'Continue'
+        }
+    }
+
+    $nupgks | ForEach-Object {
+        $relativePath = $_.Name
+        Update-Operation -operation "processing" -message $relativePath -suppress:$CIBuild
+
+        $verificationProcess = Invoke-Command $nugetPath ("verify","-signature","-CertificateFingerprint","3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE", $_.FullName)
+        if ($verificationProcess.ExitCode -eq 0) {
+            Submit-Operation -operation "valid" -message $relativePath
+        }
+        else {
+            Undo-Operation -operation "unsigned" -message $relativePath -NewLine
+            $failed.Add($_.FullName, $null)
+        }
+    }
+
+    if($failed.Count -eq 0) {
+        Submit-Operation -operation "done" -message "$($nupgks.Length) packages passed signature checks."
+    } elseif ($failed.Count -eq $nupgks.Length) {
+        Undo-Operation -operation "failed" -message "$($nupgks.Length) packages failed signature checks." 
+    } else {
+        Undo-Operation -operation "partial" -message "$($nupgks.Length - $failed.Count) packages passed signature checks and $($failed.Count) packages failed!" 
+    }
+
+    Write-Host
+    Pop-Depth
+    $failed.Count
 }
 
 function Expand-NugetPackages {
     $foldersToProcess = [System.Collections.Generic.HashSet[string]]@()
-
     $nupgks = Get-ChildItem *.nupkg
 
     Push-Depth
     $nupgks | ForEach-Object {
         $package = $_.FullName
+        $file = $_.Name
         $expand = Join-Path -Path ([System.IO.Path]::GetDirectoryName($package)) -ChildPath ([System.IO.Path]::GetFileNameWithoutExtension($package))
-        ((Test-Path -Path $expand) -and (Remove-Item $expand -Force -Recurse)) | Out-Null
+        if (Test-Path -Path $expand) {
+            Remove-Item $expand -Force -Recurse
+        }
 
-        Update-Operation -operation "extracting" -message "$([System.IO.Path]::GetFileName($package))"
+        Update-Operation -operation "extracting" -message $file
         [System.IO.Compression.ZipFile]::ExtractToDirectory($package, $expand)
-        Submit-Operation -operation "done" -message "$([System.IO.Path]::GetFileName($package))" -suppress $CIBuild
+        Submit-Operation -operation "done" -message $file -suppress:$CIBuild
 
         $foldersToProcess.Add($expand) | Out-Null
     }
     Pop-Depth
-    Write-Host;
-    return $foldersToProcess
+    Write-Host
+    
+    $foldersToProcess
 }
 
-function Test-Signatures($rootFolder) {
-    $fail = @{}
+function Test-Signatures($RootFolder) {
+    $failed = @{}
 
-    Update-Operation -operation "discovering" -message "Searching binaries..."  -suppress $CIBuild
-    $files = (Get-ChildItem $rootFolder -Recurse -Include "*.dll", "*.exe")
+    Update-Operation -operation "discovering" -message "Searching binaries..."  -suppress:$CIBuild
+    $files = (Get-ChildItem $RootFolder -Recurse -Include "*.dll", "*.exe")
     Update-Operation -operation "discovered" -message "$($files.Length) binaries discovered"
 
-    $packageId = ([XML](Get-Content $rootFolder\*.nuspec)).package.metadata.id;
-    $unsignedAllowList = @();
-    if ($global:UnsignedAllowList.ContainsKey($packageId)) {
-        $unsignedAllowList = $global:UnsignedAllowList[$packageId];
+    $packageId = ([XML](Get-Content $RootFolder\*.nuspec)).package.metadata.id
+    $unsignedAllowList = @()
+    if ($script:UnsignedAllowList.ContainsKey($packageId)) {
+        $unsignedAllowList = $script:UnsignedAllowList[$packageId]
     }
 
     $files | ForEach-Object {
-        $relativePath = Get-RelativePath -path $_.FullName -relativeTo $rootFolder
-        Update-Operation -operation "processing" -message $relativePath -suppress $CIBuild
+        $relativePath = Get-RelativePath -path $_.FullName -relativeTo $RootFolder
+        Update-Operation -operation "processing" -message $relativePath -suppress:$CIBuild
 
         $signature = Get-AuthenticodeSignature -FilePath "$($_.FullName)"
         if ($signature.Status -eq "Valid") {
-            $valid = ($ValidSubjects.Contains($signature.SignerCertificate.Subject) -or $ValidThumbprints.Contains($signature.SignerCertificate.Thumbprint))
+            $valid = ($script:ValidSubjects.Contains($signature.SignerCertificate.Subject) -or $script:ValidThumbprints.Contains($signature.SignerCertificate.Thumbprint))
             
             if ($valid) {
-                Submit-Operation -operation "valid" -message "$relativePath" -NoNewLine -suppress $CIBuild
+                Submit-Operation -operation "valid" -message "$relativePath" -NoNewLine -suppress:$CIBuild
             } else {
                 Update-Operation -operation "inconclusive" -message "$relativePath ($($signature.SignerCertificate.Subject)) [$($signature.SignerCertificate.Thumbprint)]" -NewLine
-                $fail.Add($_.FullName, $signature)
+                $failed.Add($_.FullName, $signature)
             }
         } elseif (-not $unsignedAllowList.Contains($relativePath)) {
             Undo-Operation -operation "unsigned" -message "$relativePath" -NewLine
-            $fail.Add($_.FullName, $null)
+            $failed.Add($_.FullName, $null)
         }
     }
 
-    if($fail.Count -eq 0) {
+    if($failed.Count -eq 0) {
         Submit-Operation -operation "done" -message "$($files.Length) binaries passed signature checks."
-    } elseif ($fail.Count -eq $files.Length) {
+    } elseif ($failed.Count -eq $files.Length) {
         Undo-Operation -operation "failed" -message "$($files.Length) binaries failed signature checks." 
     } else {
-        Undo-Operation -operation "partial" -message "$($files.Length - $fail.Count) binaries passed signature checks and $($fail.Count) binaries failed!" 
+        Undo-Operation -operation "partial" -message "$($files.Length - $failed.Count) binaries passed signature checks and $($failed.Count) binaries failed!" 
     }
-    Write-Host;
-    $fail;
+    Write-Host
+    $failed
 }
-
 
 Clear-Host
 Push-Location
-Set-Location $Path
-$failCount = 0
-Write-Host "Extracting NuGet packages..."
-Expand-NugetPackages | ForEach-Object {
-    Write-Host "Checking `"$([System.IO.Path]::GetFileName($_))`"..."
-    Push-Depth
-    $failures = Test-Signatures -rootFolder $_ 
-    Pop-Depth
+try {
+    if (-not (Test-Path $Path)) {
+        Write-Error "Cannot find path '$Path' because it does not exist."
+        exit
+    }
+    
+    Set-Location $Path
+    
+    Write-Host "Checking NuGet packages..."
+    $nugetFailCount = Test-NuGetSignatures 
+    
+    Write-Host "Extracting NuGet packages..."
+    $failCount = 0
+    Expand-NugetPackages | ForEach-Object {
+        Push-Depth
+        Write-Host "Checking `"$([System.IO.Path]::GetFileName($_))`"..."
+        $failures = Test-Signatures -rootFolder $_ 
+        Pop-Depth
 
-    Remove-Item $_ -Recurse -Force
-    $failCount += $failures.Count
+        Remove-Item $_ -Recurse -Force
+        $failCount += $failures.Count
+    }
+    if($failCount -eq 0) {
+        Write-Host "All binaries passed the check successfully."
+    } else {
+        Write-Error "$failCount binaries failed signature check!"
+    }
+    
+    if($nugetFailCount -eq 0) {
+        Write-Host "All NuGet packages passed the check successfully."
+    } else {
+        Write-Error "$nugetFailCount NuGet packages failed signature check!"
+    }
 }
-Pop-Location
-if($failCount -eq 0) {
-    Write-Host "All binaries passed the check successfully."
-} else {
-    Write-Error "$failCount binaries failed signature check!"
+finally {
+    Pop-Location
 }

--- a/scripts/Test-Signatures.ps1
+++ b/scripts/Test-Signatures.ps1
@@ -1,0 +1,188 @@
+[CmdletBinding()]
+param (
+    [Parameter()]
+    [String]
+    $Path = "$PSScriptRoot\packages",
+
+    [Parameter()]
+    [Switch]
+    $CIBuild
+)
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+# Allowed certificate subjects
+$global:ValidSubjects = @( `
+    "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US", `
+    "CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" `
+);
+
+# Allowed certificate thumbprints
+$global:ValidThumbprints = @( `
+    "B9EAA034C821C159B05D3521BCF7FEB796EBD6FF", `
+    "98ED99A67886D020C564923B7DF25E9AC019DF26", `
+    "5EAD300DC7E4D637948ECB0ED829A072BD152E17", `
+    "67B1757863E3EFF760EA9EBB02849AF07D3A8080", `
+    "9DC17888B5CFAD98B3CB35C1994E96227F061675", `
+    "62009AAABDAE749FD47D19150958329BF6FF4B34", `
+    "3BDA323E552DB1FDE5F4FBEE75D6D5B2B187EEDC" `
+)
+
+# Allow-list for unsigned binaries
+$global:UnsignedAllowList = @( `
+    "Newtonsoft.Json.dll" `
+);
+
+$global:Depth = 0;
+
+function Get-RelativePath($path, $relativeTo) {
+    Push-Location
+    Set-Location $relativeTo
+    $path = Resolve-Path $path -Relative
+    Pop-Location
+    
+    return $path
+}
+
+function Push-Depth {
+    $global:Depth = $global:Depth + 1
+}
+
+function Pop-Depth {
+    $global:Depth = $global:Depth - 1
+
+    if($global:Depth -lt 0) {
+        $global:Depth = 0;
+    }
+}
+
+function Clear-Line($message = "") {
+    if(-not $CIBuild) {
+        $x = [System.Console]::get_CursorLeft()
+        Write-Host "`r$(' ' * $x)$message`r" -NoNewline
+    }
+}
+
+function Update-Operation($operation, $message, [switch]$NewLine, $suppress=$false) {
+    if($suppress) {
+        return;
+    }
+    
+    Clear-Line;
+    Write-Host "$('  ' * $Depth)[$operation] " -ForegroundColor Yellow -NoNewline
+    Write-Host $message -NoNewline
+
+    if ($newline -or $CIBuild) {
+        Write-Host;
+    }
+}
+
+function Submit-Operation($operation, $message, [switch]$NoNewLine, $suppress=$false) {
+    if($suppress) {
+        return;
+    }
+    
+    Clear-Line;
+    Write-Host "$('  ' * $Depth)[$operation] " -ForegroundColor Green -NoNewline
+    Write-Host $message -NoNewline
+
+    if (-not $NoNewLine -or $CIBuild) {
+        Write-Host;
+    }
+}
+
+function Undo-Operation($operation, $message, [switch]$NoNewLine, $suppress=$false) {
+    if($suppress) {
+        return;
+    }
+    
+    Clear-Line;
+    Write-Host "$('  ' * $Depth)[$operation] " -ForegroundColor Red -NoNewline
+    Write-Host $message -NoNewline
+
+    if (-not $NoNewLine -or $CIBuild) {
+        Write-Host;
+    }
+}
+
+function Expand-NugetPackages {
+    $foldersToProcess = [System.Collections.Generic.HashSet[string]]@()
+
+    $nupgks = Get-ChildItem *.nupkg
+
+    Push-Depth
+    $nupgks | ForEach-Object {
+        $package = $_.FullName
+        $expand = Join-Path -Path ([System.IO.Path]::GetDirectoryName($package)) -ChildPath ([System.IO.Path]::GetFileNameWithoutExtension($package))
+        ((Test-Path -Path $expand) -and (Remove-Item $expand -Force -Recurse)) | Out-Null
+
+        Update-Operation -operation "extracting" -message "$([System.IO.Path]::GetFileName($package))"
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($package, $expand)
+        Submit-Operation -operation "done" -message "$([System.IO.Path]::GetFileName($package))" -suppress $CIBuild
+
+        $foldersToProcess.Add($expand) | Out-Null
+    }
+    Pop-Depth
+    Write-Host;
+    return $foldersToProcess
+}
+
+function Test-Signatures($rootFolder) {
+    $fail = @{}
+
+    Update-Operation -operation "discovering" -message "Searching binaries..."  -suppress $CIBuild
+    $files = (Get-ChildItem $rootFolder -Recurse -Include "*.dll", "*.exe")
+    Update-Operation -operation "discovered" -message "$($files.Length) binaries discovered"
+
+    $files | ForEach-Object {
+        $relativePath = Get-RelativePath -path $_.FullName -relativeTo $rootFolder
+        Update-Operation -operation "processing" -message $relativePath -suppress $CIBuild
+
+        $signature = Get-AuthenticodeSignature -FilePath "$($_.FullName)"
+        if ($signature.Status -eq "Valid") {
+            $valid = ($ValidSubjects.Contains($signature.SignerCertificate.Subject) -or $ValidThumbprints.Contains($signature.SignerCertificate.Thumbprint))
+            
+            if ($valid) {
+                Submit-Operation -operation "valid" -message "$relativePath" -NoNewLine -suppress $CIBuild
+            } else {
+                Update-Operation -operation "inconclusive" -message "$relativePath ($($signature.SignerCertificate.Subject)) [$($signature.SignerCertificate.Thumbprint)]" -NewLine
+                $fail.Add($_.FullName, $signature)
+            }
+        } elseif (-not $global:UnsignedAllowList.Contains([System.IO.Path]::GetFileName($_.FullName))) {
+            Undo-Operation -operation "unsigned" -message "$relativePath" -NewLine
+            $fail.Add($_.FullName, $null)
+        }
+    }
+
+    if($fail.Count -eq 0) {
+        Submit-Operation -operation "done" -message "$($files.Length) binaries passed signature checks."
+    } elseif ($fail.Count -eq $files.Length) {
+        Undo-Operation -operation "failed" -message "$($files.Length) binaries failed signature checks." 
+    } else {
+        Undo-Operation -operation "partial" -message "$($files.Length - $fail.Count) binaries passed signature checks and $($fail.Count) binaries failed!" 
+    }
+    Write-Host;
+    $fail;
+}
+
+
+Clear-Host
+Push-Location
+Set-Location $Path
+$failCount = 0
+Write-Host "Extracting NuGet packages..."
+Expand-NugetPackages | ForEach-Object {
+    Write-Host "Checking `"$([System.IO.Path]::GetFileName($_))`"..."
+    Push-Depth
+    $failures = Test-Signatures -rootFolder $_ 
+    Pop-Depth
+
+    Remove-Item $_ -Recurse -Force
+    $failCount += $failures.Count
+}
+Pop-Location
+if($failCount -eq 0) {
+    Write-Host "All binaries passed the check successfully."
+} else {
+    Write-Error "Signature verification failed on $failCount binaries!"
+}

--- a/src/package/sign/sign.proj
+++ b/src/package/sign/sign.proj
@@ -272,27 +272,27 @@
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.Utilities.Internal.dll" />
       
       <!-- Skip StrongName signing for the following -->
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.Profiler.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\1033\Microsoft.IntelliTrace.Profilerui.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\concrt140.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\Microsoft.IntelliTrace.ProfilerProxy.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\msvcp140.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\vccorlib140.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\vcruntime140.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\concrt140.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\Microsoft.IntelliTrace.ProfilerProxy.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\msvcp140.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\vccorlib140.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\vcruntime140.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\x64\Microsoft.IntelliTrace.Profiler.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\x64\1033\Microsoft.IntelliTrace.Profilerui.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\codecoveragemessages.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\covrun32.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\msdia140.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\covrun64.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\msdia140.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\CodeCoverage.exe" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.Profiler.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\1033\Microsoft.IntelliTrace.Profilerui.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\concrt140.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\Microsoft.IntelliTrace.ProfilerProxy.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\msvcp140.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\vccorlib140.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\vcruntime140.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\concrt140.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\Microsoft.IntelliTrace.ProfilerProxy.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\msvcp140.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\vccorlib140.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\vcruntime140.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\x64\Microsoft.IntelliTrace.Profiler.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\x64\1033\Microsoft.IntelliTrace.Profilerui.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\codecoveragemessages.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\covrun32.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\msdia140.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\covrun64.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\msdia140.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\CodeCoverage.exe" />
     </ItemGroup>
 
     <!-- Sign test platform v2 assemblies for .NET Core -->
@@ -382,12 +382,12 @@
       <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\Shim\net45\Microsoft.VisualStudio.CodeCoverage.Shim.dll" />
 
       <!-- Skip StrongName signing for the following -->
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\codecoveragemessages.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\covrun32.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\msdia140.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\amd64\covrun64.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\amd64\msdia140.dll" />>
-      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\CodeCoverage.exe" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\codecoveragemessages.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\covrun32.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\msdia140.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\amd64\covrun64.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\amd64\msdia140.dll" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\CodeCoverage.exe" />
     </ItemGroup>
 
     <!-- Sign Microsoft.TestPlatform.TestHost -->

--- a/src/package/sign/sign.proj
+++ b/src/package/sign/sign.proj
@@ -248,9 +248,6 @@
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.Package.Common.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.Package.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.Profiler.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.SearchMargin.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.TelemetryObserver.Common.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.TelemetryObserver.CoreClr.dll" />
@@ -260,79 +257,42 @@
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.VisualStudio.Diagnostics.Utilities.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.VisualStudio.VIL.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.VisualStudio.VIL.NotifyPointInProcHost.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\1033\Microsoft.IntelliTrace.Profilerui.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
       <!-- Commented out DiaSymReader.dll as it is already signed. Resigning is resulting in some issuesl -->
       <!-- <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\deps\Microsoft.DiaSymReader.dll" /> -->
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\deps\Microsoft.VisualStudio.Enterprise.AspNetHelper.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\concrt140.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\Microsoft.IntelliTrace.ProfilerProxy.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\msvcp140.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\vccorlib140.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\vcruntime140.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\concrt140.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\Microsoft.IntelliTrace.ProfilerProxy.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\msvcp140.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\vccorlib140.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\vcruntime140.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\x64\Microsoft.IntelliTrace.Profiler.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\x64\1033\Microsoft.IntelliTrace.Profilerui.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
+
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\PrivateAssemblies\Microsoft.IntelliTrace.Core.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\PrivateAssemblies\Microsoft.IntelliTrace.ObjectModel.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\PrivateAssemblies\Microsoft.VisualStudio.ArchitectureTools.PEReader.dll" />
-
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\codecoveragemessages.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\covrun32.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\msdia140.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\covrun64.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\msdia140.dll">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\CodeCoverage.exe">
-        <StrongName></StrongName>
-      </IntellitraceAssembliesToSign>
 
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\IntelliTrace.exe" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProcessSnapshotCleanup.exe" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\TDEnvCleanup.exe" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.Telemetry.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.Utilities.Internal.dll" />
+      
+      <!-- Skip StrongName signing for the following -->
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.Profiler.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\1033\Microsoft.IntelliTrace.Profilerui.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\concrt140.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\Microsoft.IntelliTrace.ProfilerProxy.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\msvcp140.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\vccorlib140.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\vcruntime140.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\concrt140.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\Microsoft.IntelliTrace.ProfilerProxy.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\msvcp140.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\vccorlib140.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\vcruntime140.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\x64\Microsoft.IntelliTrace.Profiler.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\x64\1033\Microsoft.IntelliTrace.Profilerui.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\codecoveragemessages.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\covrun32.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\msdia140.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\covrun64.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\msdia140.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\CodeCoverage.exe" />>
     </ItemGroup>
 
     <!-- Sign test platform v2 assemblies for .NET Core -->
@@ -420,36 +380,20 @@
       <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\%(ResxLang.Identity)\*.*" />
       <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\Shim\netcoreapp1.0\Microsoft.VisualStudio.CodeCoverage.Shim.dll" />
       <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\Shim\net45\Microsoft.VisualStudio.CodeCoverage.Shim.dll" />
-      <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\codecoveragemessages.dll">
-        <StrongName></StrongName>
-      </CodeCoverageAssembliesToSign>
-      <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\covrun32.dll">
-        <StrongName></StrongName>
-      </CodeCoverageAssembliesToSign>
-      <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\msdia140.dll">
-        <StrongName></StrongName>
-      </CodeCoverageAssembliesToSign>
-      <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\amd64\covrun64.dll">
-        <StrongName></StrongName>
-      </CodeCoverageAssembliesToSign>
-      <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\amd64\msdia140.dll">
-        <StrongName></StrongName>
-      </CodeCoverageAssembliesToSign>
-      <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\CodeCoverage.exe">
-        <StrongName></StrongName>
-      </CodeCoverageAssembliesToSign>
+
+      <!-- Skip StrongName signing for the following -->
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\codecoveragemessages.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\covrun32.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\msdia140.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\amd64\covrun64.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\amd64\msdia140.dll" />>
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\CodeCoverage.exe" />>
     </ItemGroup>
 
     <!-- Sign Microsoft.TestPlatform.TestHost -->
     <ItemGroup>
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\testhost.dll" />
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x64\testhost.exe">
-        <StrongName></StrongName>
-      </TestHostCoreAssembliesToSign>
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x64\testhost.dll" />
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x86\testhost.x86.exe">
-        <StrongName></StrongName>
-      </TestHostCoreAssembliesToSign>
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x86\testhost.x86.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.TestPlatform.CommunicationUtilities.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.TestPlatform.CrossPlatEngine.dll" />
@@ -458,15 +402,9 @@
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.VisualStudio.TestPlatform.Common.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.TestPlatform.CoreUtilities.dll" />
-
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\testhost.dll" />
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x64\testhost.exe">
-        <StrongName></StrongName>
-      </TestHostCoreAssembliesToSign>
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x64\testhost.dll" />
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x86\testhost.x86.exe">
-        <StrongName></StrongName>
-      </TestHostCoreAssembliesToSign>
+      
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x86\testhost.x86.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\Microsoft.TestPlatform.CommunicationUtilities.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\Microsoft.TestPlatform.CrossPlatEngine.dll" />
@@ -522,6 +460,12 @@
       <ThirdPartyAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\Newtonsoft.Json.dll" />
       <ThirdPartyAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\uap10.0\Newtonsoft.Json.dll" />
       <ThirdPartyAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net451\$(TargetRuntime)\Newtonsoft.Json.dll" />
+      
+      <!-- Skip StrongName signing for the following -->
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x64\testhost.exe" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x86\testhost.x86.exe" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x64\testhost.exe" />
+      <BinariesWithoutStrongNameToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x86\testhost.x86.exe" />
     </ItemGroup>
 
     <ItemGroup>
@@ -575,6 +519,11 @@
         <StrongName>StrongName</StrongName>
       </CodeCoverageAssembliesToSign>
 
+
+      <BinariesWithoutStrongNameToSign>
+        <Authenticode>Microsoft402400</Authenticode>
+      </BinariesWithoutStrongNameToSign>
+
       <ThirdPartyAssembliesToSign>
         <Authenticode>3PartySHA2</Authenticode>
       </ThirdPartyAssembliesToSign>
@@ -582,6 +531,12 @@
 
     <Message Text="Signing 3rd party assemblies using authenticode certificate '%(ThirdPartyAssembliesToSign.Authenticode)' for @(ThirdPartyAssembliesToSign)"/>
     <SignFiles Files="@(ThirdPartyAssembliesToSign)"
+               BinariesDirectory="$(ArtifactsBaseDirectory)"
+               IntermediatesDirectory="$(IntermediatesDirectory)"
+               Type="$(SignType)" />
+
+    <Message Text="Signing using authenticode certificate BinariesWithoutStrongNameToSign:'%(BinariesWithoutStrongNameToSign.Authenticode)' for @(BinariesWithoutStrongNameToSign)"/>
+    <SignFiles Files="@(BinariesWithoutStrongNameToSign)"
                BinariesDirectory="$(ArtifactsBaseDirectory)"
                IntermediatesDirectory="$(IntermediatesDirectory)"
                Type="$(SignType)" />

--- a/src/package/sign/sign.proj
+++ b/src/package/sign/sign.proj
@@ -23,13 +23,13 @@
 
     <!-- Directory with .NETCore binaries -->
     <ArtifactsCoreDirectory Condition="'$(ArtifactsCoreDirectory)' == ''">$(ArtifactsBaseDirectory)netcoreapp2.1\</ArtifactsCoreDirectory>
-    
+
     <!-- Directory with NetStandard1.0 binaries -->
     <ArtifactsNS10Directory Condition="'$(ArtifactsNS10Directory)' == ''">$(ArtifactsBaseDirectory)netstandard1.0\</ArtifactsNS10Directory>
-    
+
     <!-- Directory with NetStandard1.3 binaries -->
     <ArtifactsNS13Directory Condition="'$(ArtifactsNS13Directory)' == ''">$(ArtifactsBaseDirectory)netstandard1.3\</ArtifactsNS13Directory>
-    
+
     <!-- Directory with NetStandard2.0 binaries -->
     <ArtifactsNS20Directory Condition="'$(ArtifactsNS20Directory)' == ''">$(ArtifactsBaseDirectory)netstandard2.0\</ArtifactsNS20Directory>
 
@@ -44,7 +44,7 @@
   <ItemGroup>
     <ResxLang Include="cs;de;es;fr;it;ja;ko;pl;pt-BR;ru;tr;zh-Hans;zh-Hant" />
   </ItemGroup>
-  
+
   <Target Name="SignAssemblies">
     <!-- Sign all files if IncludeLegacyComponents is set to true -->
     <ItemGroup Condition="'$(IncludeLegacyComponents)' == 'true'">
@@ -143,7 +143,7 @@
       <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.Diagnostics.Measurement.dll" />
       <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.QualityTools.Sqm.dll" />
       <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.OLE.Interop.dll" />
-      
+
       <!-- These are already signed, trying to sign them again causes warnings in the build pipeline.
         <AssembliesToSign Include="$(ArtifactsDirectory)Interop.UIAutomationClient.dll" />
         <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.ShDocVw.dll" />
@@ -184,7 +184,7 @@
       <Fw45AssembliesToSign Include="$(ArtifactsFw45Directory)Microsoft.TestPlatform.CoreUtilities.dll" />
       <Fw45AssembliesToSign Include="$(ArtifactsFw45Directory)Microsoft.TestPlatform.PlatformAbstractions.dll" />
       <Fw45AssembliesToSign Include="$(ArtifactsFw45Directory)Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" />
-      
+
       <!-- Localized resources -->
       <Fw45AssembliesToSign Include="$(ArtifactsFw45Directory)%(ResxLang.Identity)\*.*" />
     </ItemGroup>
@@ -223,8 +223,8 @@
       <AssembliesToSign Include="$(ArtifactsDirectory)SettingsMigrator.exe" />
 
       <!-- NetFullExtensions -->
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.dll" />
+      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.dll" Condition="'$(IncludeLegacyComponents)' != 'true'" />
+      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.dll" Condition="'$(IncludeLegacyComponents)' != 'true'" />
       <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Microsoft.TestPlatform.TestHostRuntimeProvider.dll" />
       <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Microsoft.TestPlatform.Extensions.BlameDataCollector.dll" />
       <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Microsoft.TestPlatform.Extensions.EventLogCollector.dll" />
@@ -234,7 +234,7 @@
       <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\%(ResxLang.Identity)\*.*" />
 
       <!-- Third Party assemblies to sign -->
-      <ThirdPartyAssembliesToSign Include="$(ArtifactsDirectory)Newtonsoft.Json.dll" />
+      <ThirdPartyAssembliesToSign Include="$(ArtifactsDirectory)Newtonsoft.Json.dll" Condition="'$(IncludeLegacyComponents)' != 'true'" />
     </ItemGroup>
 
     <!-- Intellitrace -->
@@ -248,7 +248,9 @@
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.Package.Common.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.Package.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.Profiler.dll" />
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.Profiler.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.SearchMargin.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.TelemetryObserver.Common.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.TelemetryObserver.CoreClr.dll" />
@@ -258,35 +260,77 @@
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.VisualStudio.Diagnostics.Utilities.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.VisualStudio.VIL.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.VisualStudio.VIL.NotifyPointInProcHost.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\1033\Microsoft.IntelliTrace.Profilerui.dll" />
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\1033\Microsoft.IntelliTrace.Profilerui.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
       <!-- Commented out DiaSymReader.dll as it is already signed. Resigning is resulting in some issuesl -->
       <!-- <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\deps\Microsoft.DiaSymReader.dll" /> -->
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\deps\Microsoft.VisualStudio.Enterprise.AspNetHelper.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\concrt140.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\Microsoft.IntelliTrace.ProfilerProxy.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\msvcp140.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\vccorlib140.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\vcruntime140.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\concrt140.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\Microsoft.IntelliTrace.ProfilerProxy.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\msvcp140.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\vccorlib140.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\vcruntime140.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\x64\Microsoft.IntelliTrace.Profiler.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\x64\1033\Microsoft.IntelliTrace.Profilerui.dll" />
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\concrt140.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\Microsoft.IntelliTrace.ProfilerProxy.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\msvcp140.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\vccorlib140.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\vcruntime140.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\concrt140.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\Microsoft.IntelliTrace.ProfilerProxy.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\msvcp140.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\vccorlib140.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\vcruntime140.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\x64\Microsoft.IntelliTrace.Profiler.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\x64\1033\Microsoft.IntelliTrace.Profilerui.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\PrivateAssemblies\Microsoft.IntelliTrace.Core.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\PrivateAssemblies\Microsoft.IntelliTrace.ObjectModel.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\PrivateAssemblies\Microsoft.VisualStudio.ArchitectureTools.PEReader.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\codecoveragemessages.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\covrun32.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\msdia140.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\covrun64.dll" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\msdia140.dll" />
+
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\codecoveragemessages.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\covrun32.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\msdia140.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\covrun64.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\msdia140.dll">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
+      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\CodeCoverage.exe">
+        <StrongName>None</StrongName>
+      </IntellitraceAssembliesToSign>
+
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\IntelliTrace.exe" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProcessSnapshotCleanup.exe" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\TDEnvCleanup.exe" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe" />
-      <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\CodeCoverage.exe" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.Telemetry.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.Utilities.Internal.dll" />
     </ItemGroup>
@@ -376,20 +420,36 @@
       <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\%(ResxLang.Identity)\*.*" />
       <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\Shim\netcoreapp1.0\Microsoft.VisualStudio.CodeCoverage.Shim.dll" />
       <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\Shim\net45\Microsoft.VisualStudio.CodeCoverage.Shim.dll" />
-      <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\codecoveragemessages.dll" />
-      <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\covrun32.dll" />
-      <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\msdia140.dll" />
-      <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\amd64\covrun64.dll" />
-      <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\amd64\msdia140.dll" />
-      <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\CodeCoverage.exe" />
+      <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\codecoveragemessages.dll">
+        <StrongName>None</StrongName>
+      </CodeCoverageAssembliesToSign>
+      <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\covrun32.dll">
+        <StrongName>None</StrongName>
+      </CodeCoverageAssembliesToSign>
+      <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\msdia140.dll">
+        <StrongName>None</StrongName>
+      </CodeCoverageAssembliesToSign>
+      <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\amd64\covrun64.dll">
+        <StrongName>None</StrongName>
+      </CodeCoverageAssembliesToSign>
+      <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\amd64\msdia140.dll">
+        <StrongName>None</StrongName>
+      </CodeCoverageAssembliesToSign>
+      <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\CodeCoverage.exe">
+        <StrongName>None</StrongName>
+      </CodeCoverageAssembliesToSign>
     </ItemGroup>
 
     <!-- Sign Microsoft.TestPlatform.TestHost -->
     <ItemGroup>
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\testhost.dll" />
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x64\testhost.exe" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x64\testhost.exe">
+        <StrongName>None</StrongName>
+      </TestHostCoreAssembliesToSign>
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x64\testhost.dll" />
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x86\testhost.x86.exe" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x86\testhost.x86.exe">
+        <StrongName>None</StrongName>
+      </TestHostCoreAssembliesToSign>
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x86\testhost.x86.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.TestPlatform.CommunicationUtilities.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.TestPlatform.CrossPlatEngine.dll" />
@@ -400,9 +460,13 @@
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.TestPlatform.CoreUtilities.dll" />
 
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\testhost.dll" />
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x64\testhost.exe" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x64\testhost.exe">
+        <StrongName>None</StrongName>
+      </TestHostCoreAssembliesToSign>
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x64\testhost.dll" />
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x86\testhost.x86.exe" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x86\testhost.x86.exe">
+        <StrongName>None</StrongName>
+      </TestHostCoreAssembliesToSign>
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x86\testhost.x86.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\Microsoft.TestPlatform.CommunicationUtilities.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\Microsoft.TestPlatform.CrossPlatEngine.dll" />
@@ -412,13 +476,13 @@
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\Microsoft.TestPlatform.CoreUtilities.dll" />
 
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\uap10.0\testhost.dll" />	
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\uap10.0\Microsoft.TestPlatform.CommunicationUtilities.dll" />	
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\uap10.0\Microsoft.TestPlatform.CrossPlatEngine.dll" />	
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\uap10.0\Microsoft.TestPlatform.PlatformAbstractions.dll" />	
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\uap10.0\Microsoft.TestPlatform.Utilities.dll" />	
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\uap10.0\Microsoft.VisualStudio.TestPlatform.Common.dll" />	
-      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\uap10.0\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" />	
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\uap10.0\testhost.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\uap10.0\Microsoft.TestPlatform.CommunicationUtilities.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\uap10.0\Microsoft.TestPlatform.CrossPlatEngine.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\uap10.0\Microsoft.TestPlatform.PlatformAbstractions.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\uap10.0\Microsoft.TestPlatform.Utilities.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\uap10.0\Microsoft.VisualStudio.TestPlatform.Common.dll" />
+      <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\uap10.0\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\uap10.0\Microsoft.TestPlatform.CoreUtilities.dll" />
 
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net451\$(TargetRuntime)\Microsoft.TestPlatform.CommunicationUtilities.dll" />
@@ -452,7 +516,7 @@
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\%(ResxLang.Identity)\*.*" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\net451\$(TargetRuntime)\%(ResxLang.Identity)\*.*" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\uap10.0\%(ResxLang.Identity)\*.*" />
-      
+
       <!-- Third Party assemblies to sign -->
       <ThirdPartyAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\Newtonsoft.Json.dll" />
       <ThirdPartyAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\Newtonsoft.Json.dll" />
@@ -465,12 +529,12 @@
         <Authenticode>Microsoft402400</Authenticode>
         <StrongName>StrongName</StrongName>
       </NetStandard10AssembliesToSign>
-      
+
       <NetStandard13AssembliesToSign>
         <Authenticode>Microsoft402400</Authenticode>
         <StrongName>StrongName</StrongName>
       </NetStandard13AssembliesToSign>
-      
+
       <NetStandard20AssembliesToSign>
         <Authenticode>Microsoft402400</Authenticode>
         <StrongName>StrongName</StrongName>

--- a/src/package/sign/sign.proj
+++ b/src/package/sign/sign.proj
@@ -45,30 +45,34 @@
   <Target Name="SignAssemblies">
     <!-- Sign all files if IncludeLegacyComponents is set to true -->
     <ItemGroup Condition="'$(IncludeLegacyComponents)' == 'true'">
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.Discoverer.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.Executor.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.Executor.Resources.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.Executor.x64.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.Resources.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.TestEngine.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.x64.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\Microsoft.VisualStudio.QualityTools.VideoRecorderEngine.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\Microsoft.VisualStudio.TestTools.DataCollection.EventLog.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorder.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\VSTestVideoRecorder.exe" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\Microsoft.VisualStudio.TestTools.DataCollection.MediaRecorder.Model.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\Microsoft.VisualStudio.TestTools.DataCollection.SystemInfo.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\Microsoft.VisualStudio.TraceCollector.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\Microsoft.VisualStudio.QualityTools.Plugins.CodeCoverage.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\x86\Microsoft.VisualStudio.Coverage.Monitor.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\x64\Microsoft.VisualStudio.Coverage.Monitor.dll" />
+      <!-- These are already signed, trying to sign them again causes warnings in the build pipeline.
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.Executor.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.Executor.Resources.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.Executor.x64.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.Resources.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.x64.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.Discoverer.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.TestEngine.dll" />
+        
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\Microsoft.VisualStudio.QualityTools.Plugins.CodeCoverage.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\Microsoft.VisualStudio.QualityTools.VideoRecorderEngine.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\Microsoft.VisualStudio.TestTools.DataCollection.EventLog.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\Microsoft.VisualStudio.TestTools.DataCollection.MediaRecorder.Model.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\Microsoft.VisualStudio.TestTools.DataCollection.SystemInfo.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorder.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\Microsoft.VisualStudio.TraceCollector.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\VSTestVideoRecorder.exe" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\x86\Microsoft.VisualStudio.Coverage.Monitor.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\V1\x64\Microsoft.VisualStudio.Coverage.Monitor.dll" />
 
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\VideoRecorder\Microsoft.VisualStudio.QualityTools.VideoRecorderEngine.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\VideoRecorder\Microsoft.VisualStudio.TestTools.DataCollection.MediaRecorder.Model.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\VideoRecorder\Microsoft.VisualStudio.QualityTools.VideoRecorderEngine.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\VideoRecorder\Microsoft.VisualStudio.TestTools.DataCollection.MediaRecorder.Model.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\VideoRecorder\VSTestVideoRecorder.exe" />
+      -->
+
       <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Microsoft.VisualStudio.TestTools.DataCollection.MediaRecorder.Model.dll" />
       <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorderCollector.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\VideoRecorder\VSTestVideoRecorder.exe" />
       <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.GenericTestAdapter.dll" />
       <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.OrderedTestAdapter.dll" />
       <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.CodedWebTestAdapter.dll" />
@@ -135,35 +139,39 @@
       <!-- CUIT related dlls -->
       <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.Diagnostics.Measurement.dll" />
       <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.QualityTools.Sqm.dll" />
-      <!-- This is already signed -->
-      <!--AssembliesToSign Include="$(ArtifactsDirectory)Interop.UIAutomationClient.dll" /-->
-      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.ShDocVw.dll" />
       <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.OLE.Interop.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.QualityTools.CodedUITestFramework.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Common.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Extension.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Extension.MSAA.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.ExtensionUtilities.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Framework.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Logging.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Playback.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Playback.Engine.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.WindowsStoreUtility.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITesting.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Extension.IE.Communication.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Extension.IE.Communication.Interop.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Synchronization.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)UIAComwrapper.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.CrossBrowser.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.IE.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.IE.EventHelper.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.IE64.Communication.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.IE64.EventHelper.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.IE.Communication.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.IE.Communication.Interop.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.Uia.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.UiaWidget.dll" />
-      <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.UiaWidget.UIAHtmlElementUtilities.dll" />
+      
+      <!-- These are already signed, trying to sign them again causes warnings in the build pipeline.
+        <AssembliesToSign Include="$(ArtifactsDirectory)Interop.UIAutomationClient.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.ShDocVw.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.QualityTools.CodedUITestFramework.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Extension.IE.Communication.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Extension.IE.Communication.Interop.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Common.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Extension.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Extension.MSAA.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.ExtensionUtilities.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Framework.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Logging.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Playback.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Playback.Engine.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.Synchronization.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITest.WindowsStoreUtility.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.TestTools.UITesting.dll" />
+        
+        <AssembliesToSign Include="$(ArtifactsDirectory)UIAComwrapper.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.CrossBrowser.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.IE.Communication.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.IE.Communication.Interop.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.IE.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.IE.EventHelper.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.IE64.Communication.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.IE64.EventHelper.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.Uia.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.UiaWidget.dll" />
+        <AssembliesToSign Include="$(ArtifactsDirectory)CUITPlugins\Microsoft.VisualStudio.TestTools.UITest.Extension.UiaWidget.UIAHtmlElementUtilities.dll" />
+      -->
+
     </ItemGroup>
 
     <!-- Sign test platform v2 assemblies for .NET 4.6-->
@@ -468,55 +476,55 @@
       </CodeCoverageAssembliesToSign>
     </ItemGroup>
 
-    <Message Text="Signing using authenticode certificate '%(AssembliesToSign.Authenticode)' for @(CoreAssembliesToSign)"/>
+    <Message Text="Signing using authenticode certificate NetStandard10AssembliesToSign:'%(NetStandard10AssembliesToSign.Authenticode)' for @(NetStandard10AssembliesToSign)"/>
     <SignFiles Files="@(NetStandard10AssembliesToSign)"
                BinariesDirectory="$(ArtifactsNS10Directory)"
                IntermediatesDirectory="$(IntermediatesDirectory)"
                Type="$(SignType)" />
 
-    <Message Text="Signing using authenticode certificate '%(AssembliesToSign.Authenticode)' for @(CoreAssembliesToSign)"/>
+    <Message Text="Signing using authenticode certificate NetStandard13AssembliesToSign:'%(NetStandard13AssembliesToSign.Authenticode)' for @(NetStandard13AssembliesToSign)"/>
     <SignFiles Files="@(NetStandard13AssembliesToSign)"
                BinariesDirectory="$(ArtifactsNS13Directory)"
                IntermediatesDirectory="$(IntermediatesDirectory)"
                Type="$(SignType)" />
 
-    <Message Text="Signing using authenticode certificate '%(AssembliesToSign.Authenticode)' for @(CoreAssembliesToSign)"/>
+    <Message Text="Signing using authenticode certificate NetStandard20AssembliesToSign:'%(NetStandard20AssembliesToSign.Authenticode)' for @(NetStandard20AssembliesToSign)"/>
     <SignFiles Files="@(NetStandard20AssembliesToSign)"
                BinariesDirectory="$(ArtifactsNS20Directory)"
                IntermediatesDirectory="$(IntermediatesDirectory)"
                Type="$(SignType)" />
 
-    <Message Text="Signing using authenticode certificate '%(AssembliesToSign.Authenticode)' for @(AssembliesToSign)"/>
+    <Message Text="Signing using authenticode certificate AssembliesToSign:'%(AssembliesToSign.Authenticode)' for @(AssembliesToSign)"/>
     <SignFiles Files="@(AssembliesToSign)"
                BinariesDirectory="$(ArtifactsDirectory)"
                IntermediatesDirectory="$(IntermediatesDirectory)"
                Type="$(SignType)" />
 
-    <Message Text="Signing using authenticode certificate '%(AssembliesToSign.Authenticode)' for @(CoreAssembliesToSign)"/>
+    <Message Text="Signing using authenticode certificate CoreAssembliesToSign:'%(CoreAssembliesToSign.Authenticode)' for @(CoreAssembliesToSign)"/>
     <SignFiles Files="@(CoreAssembliesToSign)"
                BinariesDirectory="$(ArtifactsCoreDirectory)"
                IntermediatesDirectory="$(IntermediatesDirectory)"
                Type="$(SignType)" />
 
-    <Message Text="Signing using authenticode certificate '%(AssembliesToSign.Authenticode)' for @(BuildAssembliesToSign)"/>
+    <Message Text="Signing using authenticode certificate BuildAssembliesToSign:'%(BuildAssembliesToSign.Authenticode)' for @(BuildAssembliesToSign)"/>
     <SignFiles Files="@(BuildAssembliesToSign)"
                BinariesDirectory="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.Build"
                IntermediatesDirectory="$(IntermediatesDirectory)"
                Type="$(SignType)" />
 
-    <Message Text="Signing using authenticode certificate '%(AssembliesToSign.Authenticode)' for @(TestHostCoreAssembliesToSign)"/>
+    <Message Text="Signing using authenticode certificate TestHostCoreAssembliesToSign:'%(TestHostCoreAssembliesToSign.Authenticode)' for @(TestHostCoreAssembliesToSign)"/>
     <SignFiles Files="@(TestHostCoreAssembliesToSign)"
                BinariesDirectory="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost"
                IntermediatesDirectory="$(IntermediatesDirectory)"
                Type="$(SignType)" />
 
-    <Message Text="Signing using authenticode certificate '%(AssembliesToSign.Authenticode)' for @(IntellitraceAssembliesToSign)"/>
+    <Message Text="Signing using authenticode certificate IntellitraceAssembliesToSign:'%(IntellitraceAssembliesToSign.Authenticode)' for @(IntellitraceAssembliesToSign)"/>
     <SignFiles Files="@(IntellitraceAssembliesToSign)"
                BinariesDirectory="$(ArtifactsBaseDirectory)Intellitrace"
                IntermediatesDirectory="$(IntermediatesDirectory)"
                Type="$(SignType)" />
 
-    <Message Text="Signing using authenticode certificate '%(AssembliesToSign.Authenticode)' for @(CodeCoverageAssembliesToSign)"/>
+    <Message Text="Signing using authenticode certificate CodeCoverageAssembliesToSign:'%(CodeCoverageAssembliesToSign.Authenticode)' for @(CodeCoverageAssembliesToSign)"/>
     <SignFiles Files="@(CodeCoverageAssembliesToSign)"
                BinariesDirectory="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage"
                IntermediatesDirectory="$(IntermediatesDirectory)"

--- a/src/package/sign/sign.proj
+++ b/src/package/sign/sign.proj
@@ -234,7 +234,7 @@
       <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\%(ResxLang.Identity)\*.*" />
 
       <!-- Third Party assemblies to sign -->
-      <ThirdPartyAssembliesToSign Include="$(ArtifactsDirectory)Newtonsoft.Json.dll" Condition="'$(IncludeLegacyComponents)' != 'true'" />
+      <ThirdPartyAssembliesToSign Include="$(ArtifactsDirectory)Newtonsoft.Json.dll" Condition="'$(IncludeLegacyComponents)' != 'true'"  />
     </ItemGroup>
 
     <!-- Intellitrace -->
@@ -249,7 +249,7 @@
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.Package.Common.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.Package.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.Profiler.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.SearchMargin.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.IntelliTrace.TelemetryObserver.Common.dll" />
@@ -261,71 +261,71 @@
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.VisualStudio.VIL.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\Microsoft.VisualStudio.VIL.NotifyPointInProcHost.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\1033\Microsoft.IntelliTrace.Profilerui.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <!-- Commented out DiaSymReader.dll as it is already signed. Resigning is resulting in some issuesl -->
       <!-- <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\deps\Microsoft.DiaSymReader.dll" /> -->
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\deps\Microsoft.VisualStudio.Enterprise.AspNetHelper.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\concrt140.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\Microsoft.IntelliTrace.ProfilerProxy.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\msvcp140.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\vccorlib140.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\amd64\vcruntime140.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\concrt140.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\Microsoft.IntelliTrace.ProfilerProxy.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\msvcp140.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\vccorlib140.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\ProfilerProxy\x86\vcruntime140.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\x64\Microsoft.IntelliTrace.Profiler.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\x64\1033\Microsoft.IntelliTrace.Profilerui.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\PrivateAssemblies\Microsoft.IntelliTrace.Core.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\PrivateAssemblies\Microsoft.IntelliTrace.ObjectModel.dll" />
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\PrivateAssemblies\Microsoft.VisualStudio.ArchitectureTools.PEReader.dll" />
 
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\codecoveragemessages.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\covrun32.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\msdia140.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\covrun64.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\msdia140.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Team Tools\Dynamic Code Coverage Tools\amd64\CodeCoverage.exe">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </IntellitraceAssembliesToSign>
 
       <IntellitraceAssembliesToSign Include="$(ArtifactsBaseDirectory)Intellitrace\Common7\IDE\CommonExtensions\Microsoft\IntelliTrace\IntelliTrace.exe" />
@@ -421,22 +421,22 @@
       <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\Shim\netcoreapp1.0\Microsoft.VisualStudio.CodeCoverage.Shim.dll" />
       <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\Shim\net45\Microsoft.VisualStudio.CodeCoverage.Shim.dll" />
       <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\codecoveragemessages.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </CodeCoverageAssembliesToSign>
       <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\covrun32.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </CodeCoverageAssembliesToSign>
       <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\msdia140.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </CodeCoverageAssembliesToSign>
       <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\amd64\covrun64.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </CodeCoverageAssembliesToSign>
       <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\amd64\msdia140.dll">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </CodeCoverageAssembliesToSign>
       <CodeCoverageAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.CodeCoverage\CodeCoverage\CodeCoverage.exe">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </CodeCoverageAssembliesToSign>
     </ItemGroup>
 
@@ -444,11 +444,11 @@
     <ItemGroup>
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\testhost.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x64\testhost.exe">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </TestHostCoreAssembliesToSign>
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x64\testhost.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x86\testhost.x86.exe">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </TestHostCoreAssembliesToSign>
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x86\testhost.x86.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.TestPlatform.CommunicationUtilities.dll" />
@@ -461,11 +461,11 @@
 
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\testhost.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x64\testhost.exe">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </TestHostCoreAssembliesToSign>
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x64\testhost.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x86\testhost.x86.exe">
-        <StrongName>None</StrongName>
+        <StrongName></StrongName>
       </TestHostCoreAssembliesToSign>
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x86\testhost.x86.dll" />
       <TestHostCoreAssembliesToSign Include="$(ArtifactsBaseDirectory)Microsoft.TestPlatform.TestHost\netcoreapp2.1\Microsoft.TestPlatform.CommunicationUtilities.dll" />


### PR DESCRIPTION
 - Refactored our `sign.proj` file exclude already signed files from signing, and fixed some issues which were causing warnings.
 - A new signature verifying script. (Which is not in use yet)