### PR TITLE
[rel/16.8] Fix the initial assets location of VSTest assets

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -937,7 +937,7 @@ function Generate-Manifest
     Write-Log "Generate-Manifest: Started."
 
     $sdkTaskPath = Join-Path $env:TP_ROOT_DIR "eng\common\sdk-task.ps1"
-    & $sdkTaskPath -restore -task GenerateBuildManifest /p:PackagesToPublishPattern=$TPB_PackageOutDir\*.nupkg /p:AssetManifestFilePath=$TPB_PackageOutDir\manifest\manifest.xml /p:ManifestBuildData="Location=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" /p:BUILD_BUILDNUMBER=$BuildNumber
+    & $sdkTaskPath -restore -task GenerateBuildManifest /p:PackagesToPublishPattern=$TPB_PackageOutDir\*.nupkg /p:AssetManifestFilePath=$TPB_PackageOutDir\manifest\manifest.xml /p:ManifestBuildData="Location=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" /p:BUILD_BUILDNUMBER=$BuildNumber
 
     Write-Log "Generate-Manifest: Completed."
 }


### PR DESCRIPTION
They are being manually pushed to the dotnet-tools feed, not dotnet-core.