### PR TITLE
Ensure that a supplied vstest.console path is escape sequenced

### DIFF
--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
@@ -227,11 +227,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         private string GetConsoleRunner()
-        {
-            var runnerPath = isNetCoreRunner ? ( string.IsNullOrEmpty(this.dotnetExePath) ? new DotnetHostHelper().GetDotnetPath() : this.dotnetExePath) : GetEscapeSequencedPath(this.vstestConsolePath);
-
-            return runnerPath;
-        }
+            => isNetCoreRunner ? ( string.IsNullOrEmpty(this.dotnetExePath) ? new DotnetHostHelper().GetDotnetPath() : this.dotnetExePath) : GetEscapeSequencedPath(this.vstestConsolePath);
 
         private string GetEscapeSequencedPath(string path)
         {

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
@@ -220,7 +220,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
 
             if (isNetCoreRunner)
             {
-                args.Insert(0, vstestConsolePath);
+                args.Insert(0, GetEscapeSequencedPath(vstestConsolePath));
             }
 
             return args.ToArray();
@@ -228,7 +228,20 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
 
         private string GetConsoleRunner()
         {
-            return isNetCoreRunner ? ( string.IsNullOrEmpty(this.dotnetExePath) ? new DotnetHostHelper().GetDotnetPath() : this.dotnetExePath) : vstestConsolePath;
+            var runnerPath = isNetCoreRunner ? ( string.IsNullOrEmpty(this.dotnetExePath) ? new DotnetHostHelper().GetDotnetPath() : this.dotnetExePath) : this.vstestConsolePath;
+
+            return GetEscapeSequencedPath(runnerPath);
+        }
+
+        private string GetEscapeSequencedPath(string path)
+        {
+            if (path == null || (path.StartsWith("\"") && path.EndsWith("\"")))
+            {
+                // The path is already escape sequenced. 
+                return path;
+            }
+
+            return $"\"{path}\"";
         }
     }
 }

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
@@ -228,9 +228,9 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
 
         private string GetConsoleRunner()
         {
-            var runnerPath = isNetCoreRunner ? ( string.IsNullOrEmpty(this.dotnetExePath) ? new DotnetHostHelper().GetDotnetPath() : this.dotnetExePath) : this.vstestConsolePath;
+            var runnerPath = isNetCoreRunner ? ( string.IsNullOrEmpty(this.dotnetExePath) ? new DotnetHostHelper().GetDotnetPath() : this.dotnetExePath) : GetEscapeSequencedPath(this.vstestConsolePath);
 
-            return GetEscapeSequencedPath(runnerPath);
+            return runnerPath;
         }
 
         private string GetEscapeSequencedPath(string path)

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
@@ -150,7 +150,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         public void ShutdownProcess()
         {
             // Ideally process should die by itself
-            if(!processExitedEvent.WaitOne(ENDSESSIONTIMEOUT) && IsProcessInitialized())
+            if (!processExitedEvent.WaitOne(ENDSESSIONTIMEOUT) && IsProcessInitialized())
             {
                 EqtTrace.Info($"VsTestConsoleProcessManager.ShutDownProcess : Terminating vstest.console process after waiting for {ENDSESSIONTIMEOUT} milliseconds.");
                 vstestConsoleExited = true;
@@ -227,17 +227,9 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         private string GetConsoleRunner()
-            => isNetCoreRunner ? ( string.IsNullOrEmpty(this.dotnetExePath) ? new DotnetHostHelper().GetDotnetPath() : this.dotnetExePath) : GetEscapeSequencedPath(this.vstestConsolePath);
+            => isNetCoreRunner ? (string.IsNullOrEmpty(this.dotnetExePath) ? new DotnetHostHelper().GetDotnetPath() : this.dotnetExePath) : GetEscapeSequencedPath(this.vstestConsolePath);
 
         private string GetEscapeSequencedPath(string path)
-        {
-            if (path == null || (path.StartsWith("\"") && path.EndsWith("\"")))
-            {
-                // The path is already escape sequenced. 
-                return path;
-            }
-
-            return $"\"{path}\"";
-        }
+            => string.IsNullOrEmpty(path) ? path : $"\"{path.Trim('"')}\"";
     }
 }


### PR DESCRIPTION
## Description
A supplied path to vstest.console currently may have spaces and could break the logic we have in place. Fixed this to ensure we escape-sequence this path. This is required for a change on the Test Explorer side.

