### PR TITLE
Temporary code to enable correct Fakes and Code Coverage integration

### DIFF
--- a/test/datacollector.UnitTests/DataCollectionManagerTests.cs
+++ b/test/datacollector.UnitTests/DataCollectionManagerTests.cs
@@ -5,6 +5,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Reflection;
     using System.Xml;
 
@@ -456,11 +457,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
 
     internal class TestableDataCollectionManager : DataCollectionManager
     {
-        DataCollector dataCollector;
+        DataCollector[] dataCollectors;
 
-        public TestableDataCollectionManager(IDataCollectionAttachmentManager datacollectionAttachmentManager, IMessageSink messageSink, DataCollector dataCollector) : this(datacollectionAttachmentManager, messageSink)
+        public TestableDataCollectionManager(IDataCollectionAttachmentManager datacollectionAttachmentManager, IMessageSink messageSink, params DataCollector[] dataCollectors) : this(datacollectionAttachmentManager, messageSink)
         {
-            this.dataCollector = dataCollector;
+            this.dataCollectors = dataCollectors;
         }
 
         internal TestableDataCollectionManager(IDataCollectionAttachmentManager datacollectionAttachmentManager, IMessageSink messageSink) : base(datacollectionAttachmentManager, messageSink)
@@ -479,27 +480,66 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
                 dataCollectorUri = string.Empty;
                 return false;
             }
+
+            //    foreach (var dataCollector in dataCollectors)
+            //{
+            //    var fnAttribute = dataCollector.GetType().GetCustomAttributes(typeof(DataCollectorFriendlyNameAttribute), true).FirstOrDefault() as DataCollectorFriendlyNameAttribute;
+            //    if (fnAttribute != null && fnAttribute.FriendlyName.Equals(friendlyName))
+            //    {
+            //        var uriAttribute = dataCollector.GetType().GetCustomAttributes(typeof(DataCollectorTypeUriAttribute), true).FirstOrDefault() as DataCollectorTypeUriAttribute;
+            //        if (uriAttribute != null)
+            //        {
+            //            dataCollectorUri = uriAttribute.TypeUri;
+            //            return true;
+            //        }
+            //    }
+            //}
+
+            //dataCollectorUri = string.Empty;
+            //return false;
         }
 
         protected override bool IsUriValid(string uri)
         {
-            if (uri.Equals("my://custom/datacollector"))
+            if (uri != null && uri.Equals("my://custom/datacollector"))
             {
                 return true;
             }
-            else
-            {
-                return false;
-            }
+
+            return false;
+
+            //foreach (var dataCollector in dataCollectors)
+            //{
+            //    var uriAttribute = dataCollector.GetType().GetCustomAttributes(typeof(DataCollectorTypeUriAttribute), true).FirstOrDefault() as DataCollectorTypeUriAttribute;
+            //    if (uriAttribute != null)
+            //    {
+            //        if(uriAttribute.TypeUri.Equals(uri)) return true;
+            //    }
+            //}
+
+            //return false;
         }
 
         protected override DataCollector TryGetTestExtension(string extensionUri)
         {
-            if (extensionUri.Equals("my://custom/datacollector"))
+
+            if (extensionUri != null && extensionUri.Equals("my://custom/datacollector"))
             {
-                return dataCollector;
+                return dataCollectors[0];
             }
+
             return null;
+
+            //foreach (var dataCollector in dataCollectors)
+            //{
+            //    var uriAttribute = dataCollector.GetType().GetCustomAttributes(typeof(DataCollectorTypeUriAttribute), false).FirstOrDefault() as DataCollectorTypeUriAttribute;
+            //    if (uriAttribute != null)
+            //    {
+            //        if (uriAttribute.TypeUri.Equals(extensionUri)) return dataCollector;
+            //    }
+            //}
+
+            //return null;
         }
     }
 

--- a/test/datacollector.UnitTests/DataCollectionManagerTests.cs
+++ b/test/datacollector.UnitTests/DataCollectionManagerTests.cs
@@ -28,7 +28,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
         private string uri;
         private Mock<IMessageSink> mockMessageSink;
         private Mock<DataCollector2> mockDataCollector;
+        private Mock<CodeCoverageDataCollector> mockCodeCoverageDataCollector;
         private List<KeyValuePair<string, string>> envVarList;
+        private List<KeyValuePair<string, string>> codeCoverageEnvVarList;
         private Mock<IDataCollectionAttachmentManager> mockDataCollectionAttachmentManager;
 
         public DataCollectionManagerTests()
@@ -36,14 +38,17 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
             this.friendlyName = "CustomDataCollector";
             this.uri = "my://custom/datacollector";
             this.envVarList = new List<KeyValuePair<string, string>>();
+            this.codeCoverageEnvVarList = new List<KeyValuePair<string, string>>();
             this.mockDataCollector = new Mock<DataCollector2>();
             this.mockDataCollector.As<ITestExecutionEnvironmentSpecifier>().Setup(x => x.GetTestExecutionEnvironmentVariables()).Returns(this.envVarList);
+            this.mockCodeCoverageDataCollector = new Mock<CodeCoverageDataCollector>();
+            this.mockCodeCoverageDataCollector.As<ITestExecutionEnvironmentSpecifier>().Setup(x => x.GetTestExecutionEnvironmentVariables()).Returns(this.codeCoverageEnvVarList);
             this.dataCollectorSettings = string.Format(this.defaultRunSettings, string.Format(this.defaultDataCollectionSettings, this.friendlyName, this.uri, this.mockDataCollector.Object.GetType().AssemblyQualifiedName, typeof(DataCollectionManagerTests).GetTypeInfo().Assembly.Location, string.Empty));
             this.mockMessageSink = new Mock<IMessageSink>();
             this.mockDataCollectionAttachmentManager = new Mock<IDataCollectionAttachmentManager>();
             this.mockDataCollectionAttachmentManager.SetReturnsDefault<List<AttachmentSet>>(new List<AttachmentSet>());
 
-            this.dataCollectionManager = new TestableDataCollectionManager(this.mockDataCollectionAttachmentManager.Object, this.mockMessageSink.Object, this.mockDataCollector.Object);
+            this.dataCollectionManager = new TestableDataCollectionManager(this.mockDataCollectionAttachmentManager.Object, this.mockMessageSink.Object, this.mockDataCollector.Object, this.mockCodeCoverageDataCollector.Object);
         }
 
         [TestMethod]
@@ -218,6 +223,24 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
             var result = this.dataCollectionManager.InitializeDataCollectors(this.dataCollectorSettings);
 
             Assert.AreEqual("value", result["key"]);
+        }
+
+        [TestMethod]
+        public void InitializeDataCollectorsShouldReturnOtherThanCodeCoverageEnvironmentVariableIfMoreThanOneVariablesWithSameKeyIsSpecified()
+        {
+            this.envVarList.Add(new KeyValuePair<string, string>("cor_profiler", "clrie"));
+            this.codeCoverageEnvVarList.Add(new KeyValuePair<string, string>("cor_profiler", "direct"));
+            this.codeCoverageEnvVarList.Add(new KeyValuePair<string, string>("clrie_profiler_vanguard", "path"));
+
+            this.dataCollectorSettings = string.Format(this.defaultRunSettings,
+                string.Format(this.defaultDataCollectionSettings, "Code Coverage", "my://custom/ccdatacollector", this.mockDataCollector.Object.GetType().AssemblyQualifiedName, typeof(DataCollectionManagerTests).GetTypeInfo().Assembly.Location, string.Empty) +
+                string.Format(this.defaultDataCollectionSettings, this.friendlyName, this.uri, this.mockDataCollector.Object.GetType().AssemblyQualifiedName, typeof(DataCollectionManagerTests).GetTypeInfo().Assembly.Location, string.Empty));
+           
+            var result = this.dataCollectionManager.InitializeDataCollectors(this.dataCollectorSettings);           
+
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual("clrie", result["cor_profiler"]);
+            Assert.AreEqual("path", result["clrie_profiler_vanguard"]);
         }
 
         [TestMethod]
@@ -457,11 +480,13 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
 
     internal class TestableDataCollectionManager : DataCollectionManager
     {
-        DataCollector[] dataCollectors;
+        DataCollector dataCollector;
+        DataCollector ccDataCollector;
 
-        public TestableDataCollectionManager(IDataCollectionAttachmentManager datacollectionAttachmentManager, IMessageSink messageSink, params DataCollector[] dataCollectors) : this(datacollectionAttachmentManager, messageSink)
+        public TestableDataCollectionManager(IDataCollectionAttachmentManager datacollectionAttachmentManager, IMessageSink messageSink, DataCollector dataCollector, DataCollector ccDataCollector) : this(datacollectionAttachmentManager, messageSink)
         {
-            this.dataCollectors = dataCollectors;
+            this.dataCollector = dataCollector;
+            this.ccDataCollector = ccDataCollector;
         }
 
         internal TestableDataCollectionManager(IDataCollectionAttachmentManager datacollectionAttachmentManager, IMessageSink messageSink) : base(datacollectionAttachmentManager, messageSink)
@@ -475,77 +500,55 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector.UnitTests
                 dataCollectorUri = "my://custom/datacollector";
                 return true;
             }
+            else if (friendlyName.Equals("Code Coverage"))
+            {
+                dataCollectorUri = "my://custom/ccdatacollector";
+                return true;
+            }
             else
             {
                 dataCollectorUri = string.Empty;
                 return false;
             }
-
-            //    foreach (var dataCollector in dataCollectors)
-            //{
-            //    var fnAttribute = dataCollector.GetType().GetCustomAttributes(typeof(DataCollectorFriendlyNameAttribute), true).FirstOrDefault() as DataCollectorFriendlyNameAttribute;
-            //    if (fnAttribute != null && fnAttribute.FriendlyName.Equals(friendlyName))
-            //    {
-            //        var uriAttribute = dataCollector.GetType().GetCustomAttributes(typeof(DataCollectorTypeUriAttribute), true).FirstOrDefault() as DataCollectorTypeUriAttribute;
-            //        if (uriAttribute != null)
-            //        {
-            //            dataCollectorUri = uriAttribute.TypeUri;
-            //            return true;
-            //        }
-            //    }
-            //}
-
-            //dataCollectorUri = string.Empty;
-            //return false;
         }
 
         protected override bool IsUriValid(string uri)
         {
-            if (uri != null && uri.Equals("my://custom/datacollector"))
+            if (uri.Equals("my://custom/datacollector") || uri.Equals("my://custom/ccdatacollector"))
             {
                 return true;
             }
-
-            return false;
-
-            //foreach (var dataCollector in dataCollectors)
-            //{
-            //    var uriAttribute = dataCollector.GetType().GetCustomAttributes(typeof(DataCollectorTypeUriAttribute), true).FirstOrDefault() as DataCollectorTypeUriAttribute;
-            //    if (uriAttribute != null)
-            //    {
-            //        if(uriAttribute.TypeUri.Equals(uri)) return true;
-            //    }
-            //}
-
-            //return false;
+            else
+            {
+                return false;
+            }
         }
 
         protected override DataCollector TryGetTestExtension(string extensionUri)
         {
-
-            if (extensionUri != null && extensionUri.Equals("my://custom/datacollector"))
+            if (extensionUri.Equals("my://custom/datacollector"))
             {
-                return dataCollectors[0];
+                return dataCollector;
+            }
+
+            if (extensionUri.Equals("my://custom/ccdatacollector"))
+            {
+                return ccDataCollector;
             }
 
             return null;
-
-            //foreach (var dataCollector in dataCollectors)
-            //{
-            //    var uriAttribute = dataCollector.GetType().GetCustomAttributes(typeof(DataCollectorTypeUriAttribute), false).FirstOrDefault() as DataCollectorTypeUriAttribute;
-            //    if (uriAttribute != null)
-            //    {
-            //        if (uriAttribute.TypeUri.Equals(extensionUri)) return dataCollector;
-            //    }
-            //}
-
-            //return null;
         }
     }
 
     [DataCollectorFriendlyName("CustomDataCollector")]
     [DataCollectorTypeUri("my://custom/datacollector")]
     public abstract class DataCollector2 : DataCollector
+    {
+    }
+
+    [DataCollectorFriendlyName("Code Coverage")]
+    [DataCollectorTypeUri("my://custom/ccdatacollector")]
+    public abstract class CodeCoverageDataCollector : DataCollector
     {
     }
 }


### PR DESCRIPTION
## Description
This is temporary code to enable correct Fakes and Code Coverage integration. We will clean it when both will start using CLR IE. For now it's required to get env variables from code coverage data collector at the end.

## Related issue
Kindly link any related issues. E.g. Fixes #xyz.
