### PR TITLE
Upgrade externals except CUIT

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,8 +9,6 @@
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="vstest.myget" value="https://dotnet.myget.org/F/vstest/api/v3/index.json" />
-    <add key="nuint.myget" value="https://www.myget.org/F/nunit/api/v3/index.json" />
-    <add key="xunit.myget" value="https://www.myget.org/F/xunit/api/v3/index.json" />
     <add key="mstest.myget" value="https://dotnet.myget.org/F/mstestv2/api/v3/index.json" />
     <add key="pdb2pdb.myget" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" />
     <add key="vsunittesting.myget" value="https://dotnet.myget.org/F/vsunittesting/api/v3/index.json" />

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -690,7 +690,7 @@ function Create-VsixPackage
     Copy-Item -Recurse $legacyDir\* $packageDir -Force
 
     # Copy CUIT Related depedencies
-    $legacyDir = Join-Path $env:TP_PACKAGES_DIR "Microsoft.VisualStudio.CUIT\$testPlatformExternalsVersion\contentFiles\any\any"
+    $legacyDir = Join-Path $env:TP_PACKAGES_DIR "Microsoft.VisualStudio.CUIT\16.8.0-preview-4040788\contentFiles\any\any"
     Copy-Item -Recurse $legacyDir\* $packageDir -Force
 
     # Copy COM Components and their manifests over

--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -31,7 +31,7 @@
     <NuGetFrameworksVersion>5.0.0</NuGetFrameworksVersion>
     <JsonNetVersion>9.0.1</JsonNetVersion>
     <MoqVersion>4.7.63</MoqVersion>
-    <TestPlatformExternalsVersion>16.8.0-preview-4040788</TestPlatformExternalsVersion>
+    <TestPlatformExternalsVersion>16.9.0-preview-4189539</TestPlatformExternalsVersion>
     <MicrosoftFakesVersion>16.8.0-beta.20420.2</MicrosoftFakesVersion>
 
     <MicrosoftBuildPackageVersion>16.0.461</MicrosoftBuildPackageVersion>

--- a/src/package/external/external.csproj
+++ b/src/package/external/external.csproj
@@ -62,7 +62,7 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.CUIT">
-      <Version>$(TestPlatformExternalsVersion)</Version>
+      <Version>16.8.0-preview-4040788</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Internal.Intellitrace">

--- a/test/TestAssets/CUITTestProject/CUITTestProject.csproj
+++ b/test/TestAssets/CUITTestProject/CUITTestProject.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.cuit">
-      <Version>$(TestPlatformExternalsVersion)</Version>
+      <Version>16.8.0-preview-4040788</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.QualityTools">
       <Version>$(TestPlatformExternalsVersion)</Version>


### PR DESCRIPTION
## Description
Upgrading externals except CUIT package. CUIT package can't be created anymore - some lib missing in VS.

## Related issue
Kindly link any related issues. E.g. Fixes #xyz.
