### PR TITLE
Generation of CodeCoverage.deps.json file

### DIFF
--- a/scripts/verify-nupkgs.ps1
+++ b/scripts/verify-nupkgs.ps1
@@ -13,7 +13,7 @@ function Verify-Nuget-Packages($packageDirectory)
 {
     Write-Log "Starting Verify-Nuget-Packages."
     $expectedNumOfFiles = @{
-                     "Microsoft.CodeCoverage" = 43;
+                     "Microsoft.CodeCoverage" = 44;
                      "Microsoft.NET.Test.Sdk" = 18;
                      "Microsoft.TestPlatform" = 488;
                      "Microsoft.TestPlatform.Build" = 19;

--- a/src/DataCollectors/TraceDataCollector/VanguardCollector/Interfaces/IDynamicCoverageDataCollectorImpl.cs
+++ b/src/DataCollectors/TraceDataCollector/VanguardCollector/Interfaces/IDynamicCoverageDataCollectorImpl.cs
@@ -14,6 +14,8 @@ namespace Microsoft.VisualStudio.Coverage.Interfaces
     /// </summary>
     internal interface IDynamicCoverageDataCollectorImpl : IDisposable
     {
+        string CodeCoverageDepsJsonFilePath { get; }
+
         string GetSessionName();
 
         void Initialize(

--- a/src/DataCollectors/TraceDataCollector/VanguardCollector/Interfaces/IProfilersLocationProvider.cs
+++ b/src/DataCollectors/TraceDataCollector/VanguardCollector/Interfaces/IProfilersLocationProvider.cs
@@ -49,5 +49,11 @@ namespace Microsoft.VisualStudio.Coverage.Interfaces
         /// </summary>
         /// <returns>x64 CLR IE Path</returns>
         string GetClrInstrumentationEngineX64Path();
+
+        /// <summary>
+        /// Get path to Microsoft.VisualStudio.CodeCoverage.Shim library
+        /// </summary>
+        /// <returns>Path to Microsoft.VisualStudio.CodeCoverage.Shim library</returns>
+        string GetCodeCoverageShimPath();
     }
 }

--- a/src/DataCollectors/TraceDataCollector/VanguardCollector/ProfilersLocationProvider.cs
+++ b/src/DataCollectors/TraceDataCollector/VanguardCollector/ProfilersLocationProvider.cs
@@ -22,6 +22,7 @@ namespace Microsoft.VisualStudio.TraceCollector
         private const string VanguardX64ProfilerPath = @"amd64\covrun64.dll";
         private const string VanguardX86ProfilerConfigPath = @"VanguardInstrumentationProfiler_x86.config";
         private const string VanguardX64ProfilerConfigPath = @"amd64\VanguardInstrumentationProfiler_x64.config";
+        private const string VanguardShimPath = @"coreclr\Microsoft.VisualStudio.CodeCoverage.Shim.dll";
 
         /// <summary>
         /// Vanguard executable name
@@ -74,6 +75,12 @@ namespace Microsoft.VisualStudio.TraceCollector
         public string GetClrInstrumentationEngineX64Path()
         {
             return this.GetClrInstrumentationEnginePath("x64", ClrIeX64FileName, ClrIeX64InstallDirVariable);
+        }
+
+        /// <inheritdoc />
+        public string GetCodeCoverageShimPath()
+        {
+            return Path.Combine(this.GetVanguardDirectory(), VanguardShimPath);
         }
 
         private string GetClrInstrumentationEnginePath(string arch, string fileName, string environmentVariableName)

--- a/src/package/nuspec/Microsoft.CodeCoverage.nuspec
+++ b/src/package/nuspec/Microsoft.CodeCoverage.nuspec
@@ -32,6 +32,8 @@
     <file src="Microsoft.CodeCoverage\CodeCoverage\vcruntime140.dll" target="build\netstandard1.0\CodeCoverage\" />
     <file src="Microsoft.CodeCoverage\CodeCoverage\VanguardInstrumentationProfiler_x86.config" target="build\netstandard1.0\CodeCoverage\" />
     
+    <file src="Microsoft.CodeCoverage\Shim\netcoreapp1.0\Microsoft.VisualStudio.CodeCoverage.Shim.dll" target="build\netstandard1.0\CodeCoverage\coreclr\" />
+    
     <file src="Microsoft.CodeCoverage\CodeCoverage\amd64\CodeCoverage.exe" target="build\netstandard1.0\CodeCoverage\amd64\" />
     <file src="Microsoft.CodeCoverage\CodeCoverage\amd64\covrun64.dll" target="build\netstandard1.0\CodeCoverage\amd64\" />
     <file src="Microsoft.CodeCoverage\CodeCoverage\amd64\msdia140.dll" target="build\netstandard1.0\CodeCoverage\amd64\" />

--- a/test/DataCollectors/TraceDataCollector.UnitTests/DynamicCoverageDataCollectorTests.cs
+++ b/test/DataCollectors/TraceDataCollector.UnitTests/DynamicCoverageDataCollectorTests.cs
@@ -29,6 +29,7 @@ namespace Microsoft.VisualStudio.TraceDataCollector.UnitTests
                 <TargetPlatform>x64</TargetPlatform>
                 <CLRIEInstrumentationNetCore>true</CLRIEInstrumentationNetCore>
                 <CLRIEInstrumentationNetFramework>false</CLRIEInstrumentationNetFramework>
+                <InjectDotnetAdditionalDeps>false</InjectDotnetAdditionalDeps>
             </Configuration>";
 
         private const string ConfigWithClrIeEnabled =
@@ -37,6 +38,7 @@ namespace Microsoft.VisualStudio.TraceDataCollector.UnitTests
                 <TargetPlatform>x64</TargetPlatform>
                 <CLRIEInstrumentationNetCore>true</CLRIEInstrumentationNetCore>
                 <CLRIEInstrumentationNetFramework>true</CLRIEInstrumentationNetFramework>
+                <InjectDotnetAdditionalDeps>true</InjectDotnetAdditionalDeps>
             </Configuration>";
 
         private TestableDynamicCoverageDataCollector collector;
@@ -65,6 +67,8 @@ namespace Microsoft.VisualStudio.TraceDataCollector.UnitTests
             this.vanguardLocationProviderMock.Setup(u => u.GetVanguardProfilerConfigX64Path()).Returns(@"config64");
             this.vanguardLocationProviderMock.Setup(u => u.GetClrInstrumentationEngineX86Path()).Returns(@"clrie86");
             this.vanguardLocationProviderMock.Setup(u => u.GetClrInstrumentationEngineX64Path()).Returns(@"clrie64");
+
+            this.implMock.Setup(i => i.CodeCoverageDepsJsonFilePath).Returns(@"C:\temp\codecoverage.deps.json");
 
             this.environmentMock.Setup(e => e.OperatingSystem).Returns(PlatformOperatingSystem.Windows);
             var configElement = DynamicCoverageDataCollectorImplTests.CreateXmlElement(DynamicCoverageDataCollectorTests.DefaultConfig);
@@ -189,7 +193,8 @@ namespace Microsoft.VisualStudio.TraceDataCollector.UnitTests
                 { "COR_ENABLE_PROFILING", "1" },
                 { "COR_PROFILER", "{E5F256DC-7959-4DD6-8E4F-C11150AB28E0}" },
                 { "MicrosoftInstrumentationEngine_ConfigPath32_VanguardInstrumentationProfiler", "config86" },
-                { "MicrosoftInstrumentationEngine_ConfigPath64_VanguardInstrumentationProfiler", "config64" }
+                { "MicrosoftInstrumentationEngine_ConfigPath64_VanguardInstrumentationProfiler", "config64" },
+                { "VANGUARD_DOTNET_ADDITIONAL_DEPS", @"C:\temp\codecoverage.deps.json" },
             };
 
             this.implMock.Setup(i => i.GetSessionName()).Returns("MTM_123");
@@ -222,6 +227,7 @@ namespace Microsoft.VisualStudio.TraceDataCollector.UnitTests
                 { "MicrosoftInstrumentationEngine_LogLevel_{2A1F2A34-8192-44AC-A9D8-4FCC03DCBAA8}", "Errors" },
                 { "MicrosoftInstrumentationEngine_DisableCodeSignatureValidation", "1" },
                 { "MicrosoftInstrumentationEngine_FileLogPath", @"GENERATED" },
+                { "VANGUARD_DOTNET_ADDITIONAL_DEPS", @"C:\temp\codecoverage.deps.json" }
             };
 
             this.implMock.Setup(i => i.GetSessionName()).Returns("MTM_123");
@@ -257,6 +263,7 @@ namespace Microsoft.VisualStudio.TraceDataCollector.UnitTests
                 { "MicrosoftInstrumentationEngine_LogLevel_{2A1F2A34-8192-44AC-A9D8-4FCC03DCBAA8}", "Errors" },
                 { "MicrosoftInstrumentationEngine_DisableCodeSignatureValidation", "1" },
                 { "MicrosoftInstrumentationEngine_FileLogPath", @"GENERATED" },
+                { "VANGUARD_DOTNET_ADDITIONAL_DEPS", @"C:\temp\codecoverage.deps.json" }
             };
 
             this.implMock.Setup(i => i.GetSessionName()).Returns("MTM_123");
@@ -288,7 +295,7 @@ namespace Microsoft.VisualStudio.TraceDataCollector.UnitTests
                 { "MicrosoftInstrumentationEngine_LogLevel", "Errors" },
                 { "MicrosoftInstrumentationEngine_LogLevel_{2A1F2A34-8192-44AC-A9D8-4FCC03DCBAA8}", "Errors" },
                 { "MicrosoftInstrumentationEngine_DisableCodeSignatureValidation", "1" },
-                { "MicrosoftInstrumentationEngine_FileLogPath", @"GENERATED" },
+                { "MicrosoftInstrumentationEngine_FileLogPath", @"GENERATED" }
             };
 
             this.implMock.Setup(i => i.GetSessionName()).Returns("MTM_123");
@@ -324,6 +331,7 @@ namespace Microsoft.VisualStudio.TraceDataCollector.UnitTests
                 { "MicrosoftInstrumentationEngine_LogLevel_{2A1F2A34-8192-44AC-A9D8-4FCC03DCBAA8}", "Errors" },
                 { "MicrosoftInstrumentationEngine_DisableCodeSignatureValidation", "1" },
                 { "MicrosoftInstrumentationEngine_FileLogPath", @"GENERATED" },
+                { "VANGUARD_DOTNET_ADDITIONAL_DEPS", @"C:\temp\codecoverage.deps.json" }
             };
 
             this.implMock.Setup(i => i.GetSessionName()).Returns("MTM_123");

--- a/test/DataCollectors/TraceDataCollector.UnitTests/ProfilersLocationProviderTests.cs
+++ b/test/DataCollectors/TraceDataCollector.UnitTests/ProfilersLocationProviderTests.cs
@@ -68,6 +68,14 @@ namespace Microsoft.VisualStudio.TraceDataCollector.UnitTests
         }
 
         [TestMethod]
+        public void GetCodeCoverageShimPathShouldReturnRightDirectory()
+        {
+            var actualPath = this.vanguardLocationProvider.GetCodeCoverageShimPath();
+
+            Assert.AreEqual(Path.Join(this.GetCurrentAssemblyLocation(), @"CodeCoverage\coreclr\Microsoft.VisualStudio.CodeCoverage.Shim.dll"), actualPath);
+        }
+
+        [TestMethod]
         public void GetClrInstrumentationEngineX86PathShouldReturnRightDirectory()
         {
             var actualDir = this.vanguardLocationProvider.GetClrInstrumentationEngineX86Path();


### PR DESCRIPTION
## Description
Added logic to create by TraceDataCollector CodeCoverage.deps.json. This file is used to add reference to Shim dll to any child process from main test project (if verifiable probes are enabled).

## Related issue
#1263
