### PR TITLE
Use jsonSerializer2 for protocol version 3

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.cs
@@ -223,7 +223,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 case 1:
                 // Protocol version 3 was accidentally used with serializer v1 and not
                 // serializer v2, we downgrade to protocol 2 when 3 would be negotiated
-                // unless this is disabled by VSTEST_DISABLE_PROTOCOL_3_VERSION_DOWNGRADE 
+                // unless this is disabled by VSTEST_DISABLE_PROTOCOL_3_VERSION_DOWNGRADE
                 // env variable.
                 case 3:
                     return payloadSerializer;

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.cs
@@ -221,9 +221,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 // 0 is used during negotiation
                 case 0:
                 case 1:
+                // Protocol version 3 was accidentally used with serializer v1 and not
+                // serializer v2, we downgrade to protocol 2 when 3 would be negotiated
+                // unless this is disabled by VSTEST_DISABLE_PROTOCOL_3_VERSION_DOWNGRADE 
+                // env variable.
+                case 3:
                     return payloadSerializer;
                 case 2:
-                case 3:
+                case 4:
                     return payloadSerializer2;
                 default:
                     throw new NotSupportedException($"Protocol version {version} is not supported. " +

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 {
+    using System;
     using System.IO;
 
     using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
@@ -210,7 +211,22 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
         private JsonSerializer GetPayloadSerializer(int? version)
         {
-            return version == 2 ? payloadSerializer2 : payloadSerializer;
+            if (version == null)
+            {
+                version = 1;
+            }
+
+            switch (version)
+            {
+                case 1:
+                    return payloadSerializer;
+                case 2:
+                case 3:
+                    return payloadSerializer2;
+                default:
+                    throw new NotSupportedException($"Protocol version {version} is not supported. " +
+                        "Ensure it is compatible with the latest serializer or add a new one.");
+            }
         }
     }
 }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.cs
@@ -218,6 +218,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
             switch (version)
             {
+                // 0 is used during negotiation
+                case 0:
                 case 1:
                     return payloadSerializer;
                 case 2:

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -52,7 +52,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         // that implies host is using version 1.
         private int protocolVersion = 1;
 
-        private int highestSupportedVersion = 3;
+        // Also check TestRequestHandler.
+        private int highestSupportedVersion = 4;
 
         private TestHostConnectionInfo connectionInfo;
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
@@ -286,7 +286,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                         var dowgradeIsDisabled = flagIsEnabled;
                         if (dowgradeIsDisabled)
                         {
-                            this.protocolVersion = 4;
+                            this.protocolVersion = negotiatedVersion;
                         }
                         else
                         {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
@@ -24,7 +24,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
     public class TestRequestHandler : ITestRequestHandler
     {
         private int protocolVersion = 1;
-        private int highestSupportedVersion = 3;
+        
+        // Also check TestRequestSender.
+        private int highestSupportedVersion = 4;
 
         private readonly IDataSerializer dataSerializer;
         private ITestHostManagerFactory testHostManagerFactory;
@@ -261,7 +263,36 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             {
                 case MessageType.VersionCheck:
                     var version = this.dataSerializer.DeserializePayload<int>(message);
-                    this.protocolVersion = Math.Min(version, highestSupportedVersion);
+                    // choose the highest version that we both support
+                    var negotiatedVersion = Math.Min(version, highestSupportedVersion);
+                    // BUT don't choose 3, because protocol version 3 has performance problems in 16.7.1-16.8. Those problems are caused
+                    // by choosing payloadSerializer instead of payloadSerializer2 for protocol version 3.
+                    //
+                    // We cannot just update the code to choose the new serializer, because then that change would apply only to testhost.
+                    // Testhost is is delivered by Microsoft.NET.Test.SDK nuget package, and can be used with an older vstest.console.
+                    // An older vstest.console, that supports protocol version 3, would serialize its messages using payloadSerializer,
+                    // but the fixed testhost would serialize it using payloadSerializer2, resulting in incompatible messages.
+                    //
+                    // Instead we must downgrade to protocol version 2 when 3 would be negotiated. Or higher when higher version
+                    // would be negotiated.
+                    if (negotiatedVersion != 3)
+                    {
+                        this.protocolVersion = negotiatedVersion;
+                    }
+                    else
+                    {
+                        var flag = Environment.GetEnvironmentVariable("VSTEST_DISABLE_PROTOCOL_3_VERSION_DOWNGRADE");
+                        var flagIsEnabled = flag != null && flag != "0";
+                        var dowgradeIsDisabled = flagIsEnabled;
+                        if (dowgradeIsDisabled)
+                        {
+                            this.protocolVersion = 3;
+                        }
+                        else
+                        {
+                            this.protocolVersion = 2;
+                        }
+                    }
 
                     // Send the negotiated protocol to request sender
                     this.channel.Send(this.dataSerializer.SerializePayload(MessageType.VersionCheck, this.protocolVersion));

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
@@ -286,7 +286,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                         var dowgradeIsDisabled = flagIsEnabled;
                         if (dowgradeIsDisabled)
                         {
-                            this.protocolVersion = 3;
+                            this.protocolVersion = 4;
                         }
                         else
                         {

--- a/src/Microsoft.TestPlatform.ObjectModel/Constants.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Constants.cs
@@ -168,7 +168,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         /// <summary>
         /// The default protocol version
         /// </summary>
-        public static readonly ProtocolConfig DefaultProtocolConfig = new ProtocolConfig { Version = 3 };
+        public static readonly ProtocolConfig DefaultProtocolConfig = new ProtocolConfig { Version = 4 };
 
         /// <summary>
         /// The minimum protocol version that has debug support

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleRequestSender.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleRequestSender.cs
@@ -37,7 +37,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
 
         private bool handShakeSuccessful = false;
 
-        private int protocolVersion = 3;
+        private int protocolVersion = 4;
 
         /// <summary>
         /// Use to cancel blocking tasks associated with vstest.console process

--- a/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeClientTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeClientTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.DesignMode
 
         private readonly DesignModeClient designModeClient;
 
-        private readonly int protocolVersion = 3;
+        private readonly int protocolVersion = 4;
 
         private readonly AutoResetEvent complateEvent;
 

--- a/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeClientTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeClientTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.DesignMode
         [TestMethod]
         public void DesignModeClientDuringConnectShouldHighestCommonVersionWhenReceivedVersionIsGreaterThanSupportedVersion()
         {
-            var verCheck = new Message { MessageType = MessageType.VersionCheck, Payload = 3 };
+            var verCheck = new Message { MessageType = MessageType.VersionCheck, Payload = 4 };
             var sessionEnd = new Message { MessageType = MessageType.SessionEnd };
             this.mockCommunicationManager.Setup(cm => cm.WaitForServerConnection(It.IsAny<int>())).Returns(true);
             this.mockCommunicationManager.SetupSequence(cm => cm.ReceiveMessage()).Returns(verCheck).Returns(sessionEnd);

--- a/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeClientTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeClientTests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.DesignMode
 
         [TestMethod]
         public void DesignModeClientDuringConnectShouldHighestCommonVersionWhenReceivedVersionIsGreaterThanSupportedVersion()
-        {
+        
             var verCheck = new Message { MessageType = MessageType.VersionCheck, Payload = 4 };
             var sessionEnd = new Message { MessageType = MessageType.SessionEnd };
             this.mockCommunicationManager.Setup(cm => cm.WaitForServerConnection(It.IsAny<int>())).Returns(true);

--- a/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeClientTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeClientTests.cs
@@ -131,6 +131,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.UnitTests.DesignMode
 
         [TestMethod]
         public void DesignModeClientDuringConnectShouldHighestCommonVersionWhenReceivedVersionIsGreaterThanSupportedVersion()
+        { 
         
             var verCheck = new Message { MessageType = MessageType.VersionCheck, Payload = 4 };
             var sessionEnd = new Message { MessageType = MessageType.SessionEnd };

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/Serialization/TestResultSerializationTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/Serialization/TestResultSerializationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization
@@ -264,7 +264,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization
         #region future
 
         [TestMethod]
-        public void TestResultSerializationShouldThrowWhenAVersionOfProtocolThatDoesNotExistYetIsProvided()
+        public void TestResultSerializationShouldThrowWhenProvidedProtocolVersionDoesNotExist()
         {
             // this is to ensure that introducing a new version is a conscious choice and
             // and that we don't fallback to version 1 as it happened with version 3, because the serializer

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/Serialization/TestResultSerializationTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/Serialization/TestResultSerializationTests.cs
@@ -36,12 +36,14 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization
             EndTime = DateTimeOffset.MaxValue
         };
 
-        #region v1 serializer tests
+        #region v1 serializer Tests (used with protocol 1 and accidentally with 3)
 
         [TestMethod]
-        public void TestResultJsonShouldContainAllPropertiesOnSerialization()
+        [DataRow(1)]
+        [DataRow(3)]
+        public void TestResultJsonShouldContainAllPropertiesOnSerialization(int version)
         {
-            var json = Serialize(testResult);
+            var json = Serialize(testResult, version);
 
             // Use raw deserialization to validate basic properties
             dynamic data = JObject.Parse(json);
@@ -67,11 +69,13 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization
         }
 
         [TestMethod]
-        public void TestResultObjectShouldContainAllPropertiesOnDeserialization()
+        [DataRow(1)]
+        [DataRow(3)]
+        public void TestResultObjectShouldContainAllPropertiesOnDeserialization(int version)
         {
             var json = "{\"TestCase\":{\"Properties\":[{\"Key\":{\"Id\":\"TestCase.FullyQualifiedName\",\"Label\":\"FullyQualifiedName\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.String\"},\"Value\":\"sampleTestClass.sampleTestCase\"},{\"Key\":{\"Id\":\"TestCase.ExecutorUri\",\"Label\":\"Executor Uri\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.Uri\"},\"Value\":\"executor://sampleTestExecutor\"},{\"Key\":{\"Id\":\"TestCase.Source\",\"Label\":\"Source\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":\"sampleTest.dll\"}]},\"Attachments\":[],\"Messages\":[],\"Properties\":[{\"Key\":{\"Id\":\"TestResult.Outcome\",\"Label\":\"Outcome\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome\"},\"Value\":1},{\"Key\":{\"Id\":\"TestResult.ErrorMessage\",\"Label\":\"Error Message\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":\"sampleError\"},{\"Key\":{\"Id\":\"TestResult.ErrorStackTrace\",\"Label\":\"Error Stack Trace\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":\"sampleStackTrace\"},{\"Key\":{\"Id\":\"TestResult.DisplayName\",\"Label\":\"TestResult Display Name\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.String\"},\"Value\":\"sampleTestResult\"},{\"Key\":{\"Id\":\"TestResult.ComputerName\",\"Label\":\"Computer Name\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":\"sampleComputerName\"},{\"Key\":{\"Id\":\"TestResult.Duration\",\"Label\":\"Duration\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.TimeSpan\"},\"Value\":\"10675199.02:48:05.4775807\"},{\"Key\":{\"Id\":\"TestResult.StartTime\",\"Label\":\"Start Time\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.DateTimeOffset\"},\"Value\":\"2007-03-10T00:00:00+00:00\"},{\"Key\":{\"Id\":\"TestResult.EndTime\",\"Label\":\"End Time\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.DateTimeOffset\"},\"Value\":\"9999-12-31T23:59:59.9999999+00:00\"}]}";
 
-            var test = Deserialize<TestResult>(json);
+            var test = Deserialize<TestResult>(json, version);
 
             Assert.AreEqual(testResult.TestCase.Id, test.TestCase.Id);
             Assert.AreEqual(testResult.Attachments.Count, test.Attachments.Count);
@@ -88,7 +92,9 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization
         }
 
         [TestMethod]
-        public void TestResultObjectShouldSerializeAttachments()
+        [DataRow(1)]
+        [DataRow(3)]
+        public void TestResultObjectShouldSerializeAttachments(int version)
         {
             var result = new TestResult(testCase);
             result.StartTime = default(DateTimeOffset);
@@ -96,17 +102,19 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization
             result.Attachments.Add(new AttachmentSet(new Uri("http://dummyUri"), "sampleAttachment"));
             var expectedJson = "{\"TestCase\":{\"Properties\":[{\"Key\":{\"Id\":\"TestCase.FullyQualifiedName\",\"Label\":\"FullyQualifiedName\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.String\"},\"Value\":\"sampleTestClass.sampleTestCase\"},{\"Key\":{\"Id\":\"TestCase.ExecutorUri\",\"Label\":\"Executor Uri\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.Uri\"},\"Value\":\"executor://sampleTestExecutor\"},{\"Key\":{\"Id\":\"TestCase.Source\",\"Label\":\"Source\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":\"sampleTest.dll\"},{\"Key\":{\"Id\":\"TestCase.CodeFilePath\",\"Label\":\"File Path\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":null},{\"Key\":{\"Id\":\"TestCase.DisplayName\",\"Label\":\"Name\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":\"sampleTestClass.sampleTestCase\"},{\"Key\":{\"Id\":\"TestCase.Id\",\"Label\":\"Id\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.Guid\"},\"Value\":\"28e7a7ed-8fb9-05b7-5e90-4a8c52f32b5b\"},{\"Key\":{\"Id\":\"TestCase.LineNumber\",\"Label\":\"Line Number\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.Int32\"},\"Value\":-1}]},\"Attachments\":[{\"Uri\":\"http://dummyUri\",\"DisplayName\":\"sampleAttachment\",\"Attachments\":[]}],\"Messages\":[],\"Properties\":[{\"Key\":{\"Id\":\"TestResult.Outcome\",\"Label\":\"Outcome\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome, Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a\"},\"Value\":0},{\"Key\":{\"Id\":\"TestResult.ErrorMessage\",\"Label\":\"Error Message\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":null},{\"Key\":{\"Id\":\"TestResult.ErrorStackTrace\",\"Label\":\"Error Stack Trace\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":null},{\"Key\":{\"Id\":\"TestResult.DisplayName\",\"Label\":\"TestResult Display Name\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.String\"},\"Value\":null},{\"Key\":{\"Id\":\"TestResult.ComputerName\",\"Label\":\"Computer Name\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":\"\"},{\"Key\":{\"Id\":\"TestResult.Duration\",\"Label\":\"Duration\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.TimeSpan\"},\"Value\":\"00:00:00\"},{\"Key\":{\"Id\":\"TestResult.StartTime\",\"Label\":\"Start Time\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.DateTimeOffset\"},\"Value\":\"0001-01-01T00:00:00+00:00\"},{\"Key\":{\"Id\":\"TestResult.EndTime\",\"Label\":\"End Time\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.DateTimeOffset\"},\"Value\":\"0001-01-01T00:00:00+00:00\"}]}";
 
-            var json = Serialize(result);
+            var json = Serialize(result, version);
 
             Assert.AreEqual(expectedJson, json);
         }
 
         [TestMethod]
-        public void TestResultObjectShouldDeserializeAttachments()
+        [DataRow(1)]
+        [DataRow(3)]
+        public void TestResultObjectShouldDeserializeAttachments(int version)
         {
             var json = "{\"TestCase\":{\"Properties\":[{\"Key\":{\"Id\":\"TestCase.FullyQualifiedName\",\"Label\":\"FullyQualifiedName\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.String\"},\"Value\":\"sampleTestClass.sampleTestCase\"},{\"Key\":{\"Id\":\"TestCase.ExecutorUri\",\"Label\":\"Executor Uri\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.Uri\"},\"Value\":\"executor://sampleTestExecutor\"},{\"Key\":{\"Id\":\"TestCase.Source\",\"Label\":\"Source\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":\"sampleTest.dll\"}]},\"Attachments\":[{\"Uri\":\"http://dummyUri\",\"DisplayName\":\"sampleAttachment\",\"Attachments\":[]}],\"Messages\":[],\"Properties\":[]}";
 
-            var result = Deserialize<TestResult>(json);
+            var result = Deserialize<TestResult>(json, version);
 
             Assert.AreEqual(1, result.Attachments.Count);
             Assert.AreEqual(new Uri("http://dummyUri"), result.Attachments[0].Uri);
@@ -114,14 +122,16 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization
         }
 
         [TestMethod]
-        public void TestResultObjectShouldSerializeDefaultValues()
+        [DataRow(1)]
+        [DataRow(3)]
+        public void TestResultObjectShouldSerializeDefaultValues(int version)
         {
             var result = new TestResult(testCase);
             result.StartTime = default(DateTimeOffset);
             result.EndTime = default(DateTimeOffset);
             var expectedJson = "{\"TestCase\":{\"Properties\":[{\"Key\":{\"Id\":\"TestCase.FullyQualifiedName\",\"Label\":\"FullyQualifiedName\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.String\"},\"Value\":\"sampleTestClass.sampleTestCase\"},{\"Key\":{\"Id\":\"TestCase.ExecutorUri\",\"Label\":\"Executor Uri\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.Uri\"},\"Value\":\"executor://sampleTestExecutor\"},{\"Key\":{\"Id\":\"TestCase.Source\",\"Label\":\"Source\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":\"sampleTest.dll\"},{\"Key\":{\"Id\":\"TestCase.CodeFilePath\",\"Label\":\"File Path\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":null},{\"Key\":{\"Id\":\"TestCase.DisplayName\",\"Label\":\"Name\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":\"sampleTestClass.sampleTestCase\"},{\"Key\":{\"Id\":\"TestCase.Id\",\"Label\":\"Id\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.Guid\"},\"Value\":\"28e7a7ed-8fb9-05b7-5e90-4a8c52f32b5b\"},{\"Key\":{\"Id\":\"TestCase.LineNumber\",\"Label\":\"Line Number\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.Int32\"},\"Value\":-1}]},\"Attachments\":[],\"Messages\":[],\"Properties\":[{\"Key\":{\"Id\":\"TestResult.Outcome\",\"Label\":\"Outcome\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome, Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a\"},\"Value\":0},{\"Key\":{\"Id\":\"TestResult.ErrorMessage\",\"Label\":\"Error Message\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":null},{\"Key\":{\"Id\":\"TestResult.ErrorStackTrace\",\"Label\":\"Error Stack Trace\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":null},{\"Key\":{\"Id\":\"TestResult.DisplayName\",\"Label\":\"TestResult Display Name\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.String\"},\"Value\":null},{\"Key\":{\"Id\":\"TestResult.ComputerName\",\"Label\":\"Computer Name\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":\"\"},{\"Key\":{\"Id\":\"TestResult.Duration\",\"Label\":\"Duration\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.TimeSpan\"},\"Value\":\"00:00:00\"},{\"Key\":{\"Id\":\"TestResult.StartTime\",\"Label\":\"Start Time\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.DateTimeOffset\"},\"Value\":\"0001-01-01T00:00:00+00:00\"},{\"Key\":{\"Id\":\"TestResult.EndTime\",\"Label\":\"End Time\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.DateTimeOffset\"},\"Value\":\"0001-01-01T00:00:00+00:00\"}]}";
 
-            var json = Serialize(result);
+            var json = Serialize(result, version);
 
             // Values that should be null: DisplayName, ErrorMessage, ErrorStackTrace
             // Values that should be empty: ComputerName
@@ -129,11 +139,13 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization
         }
 
         [TestMethod]
-        public void TestResultObjectShouldDeserializeDefaultValues()
+        [DataRow(1)]
+        [DataRow(3)]
+        public void TestResultObjectShouldDeserializeDefaultValues(int version)
         {
             var json = "{\"TestCase\":{\"Properties\":[{\"Key\":{\"Id\":\"TestCase.FullyQualifiedName\",\"Label\":\"FullyQualifiedName\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.String\"},\"Value\":\"sampleTestClass.sampleTestCase\"},{\"Key\":{\"Id\":\"TestCase.ExecutorUri\",\"Label\":\"Executor Uri\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.Uri\"},\"Value\":\"executor://sampleTestExecutor\"},{\"Key\":{\"Id\":\"TestCase.Source\",\"Label\":\"Source\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":\"sampleTest.dll\"},{\"Key\":{\"Id\":\"TestCase.CodeFilePath\",\"Label\":\"File Path\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":null},{\"Key\":{\"Id\":\"TestCase.DisplayName\",\"Label\":\"Name\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":\"sampleTestClass.sampleTestCase\"},{\"Key\":{\"Id\":\"TestCase.Id\",\"Label\":\"Id\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.Guid\"},\"Value\":\"28e7a7ed-8fb9-05b7-5e90-4a8c52f32b5b\"},{\"Key\":{\"Id\":\"TestCase.LineNumber\",\"Label\":\"Line Number\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.Int32\"},\"Value\":-1}]},\"Attachments\":[],\"Messages\":[],\"Properties\":[{\"Key\":{\"Id\":\"TestResult.Outcome\",\"Label\":\"Outcome\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome, Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a\"},\"Value\":0},{\"Key\":{\"Id\":\"TestResult.ErrorMessage\",\"Label\":\"Error Message\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":null},{\"Key\":{\"Id\":\"TestResult.ErrorStackTrace\",\"Label\":\"Error Stack Trace\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":null},{\"Key\":{\"Id\":\"TestResult.DisplayName\",\"Label\":\"TestResult Display Name\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.String\"},\"Value\":null},{\"Key\":{\"Id\":\"TestResult.ComputerName\",\"Label\":\"Computer Name\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":\"\"},{\"Key\":{\"Id\":\"TestResult.Duration\",\"Label\":\"Duration\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.TimeSpan\"},\"Value\":\"00:00:00\"},{\"Key\":{\"Id\":\"TestResult.StartTime\",\"Label\":\"Start Time\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.DateTimeOffset\"},\"Value\":\"0001-01-01T00:00:00+00:00\"},{\"Key\":{\"Id\":\"TestResult.EndTime\",\"Label\":\"End Time\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.DateTimeOffset\"},\"Value\":\"0001-01-01T00:00:00+00:00\"}]}";
 
-            var result = Deserialize<TestResult>(json);
+            var result = Deserialize<TestResult>(json, version);
 
             Assert.AreEqual(0, result.Attachments.Count);
             Assert.AreEqual(0, result.Messages.Count);
@@ -144,7 +156,9 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization
         }
 
         [TestMethod]
-        public void TestResultPropertiesShouldGetRegisteredAsPartOfDeserialization()
+        [DataRow(1)]
+        [DataRow(3)]
+        public void TestResultPropertiesShouldGetRegisteredAsPartOfDeserialization(int version)
         {
             TestProperty.TryUnregister("DummyProperty", out var property);
             var json = "{\"TestCase\":{\"Properties\":[{\"Key\":{\"Id\":\"TestCase.FullyQualifiedName\",\"Label\":\"FullyQualifiedName\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.String\"},\"Value\":\"sampleTestClass.sampleTestCase\"}," +
@@ -161,18 +175,18 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization
                 "{\"Key\":{\"Id\":\"TestResult.Duration\",\"Label\":\"Duration\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.TimeSpan\"},\"Value\":\"00:00:00\"},{\"Key\":{\"Id\":\"TestResult.StartTime\",\"Label\":\"Start Time\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.DateTimeOffset\"},\"Value\":\"0001-01-01T00:00:00+00:00\"}," +
                 "{\"Key\":{\"Id\":\"DummyProperty\",\"Label\":\"DummyPropertyLabel\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":5,\"ValueType\":\"System.String\"},\"Value\":\"dummyString\"}," +
                 "{\"Key\":{\"Id\":\"TestResult.EndTime\",\"Label\":\"End Time\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.DateTimeOffset\"},\"Value\":\"0001-01-01T00:00:00+00:00\"}]}";
-            var test = Deserialize<TestResult>(json);
+            var test = Deserialize<TestResult>(json, version);
 
             this.VerifyDummyPropertyIsRegistered();
         }
 
         #endregion
 
-        #region v2 serializer Tests (used with protocol 2 and 3)
+        #region v2 serializer Tests (used with protocol 2 and 4)
 
         [TestMethod]
         [DataRow(2)]
-        [DataRow(3)]
+        [DataRow(4)]
         public void TestResultJsonShouldContainAllPropertiesOnSerializationV2(int version)
         {
             var json = Serialize(testResult, version);
@@ -194,7 +208,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization
 
         [TestMethod]
         [DataRow(2)]
-        [DataRow(3)]
+        [DataRow(4)]
         public void TestResultObjectShouldContainAllPropertiesOnDeserializationV2(int version)
         {
             var json = "{\"TestCase\":{\"Id\":\"28e7a7ed-8fb9-05b7-5e90-4a8c52f32b5b\",\"FullyQualifiedName\":\"sampleTestClass.sampleTestCase\",\"DisplayName\":\"sampleTestClass.sampleTestCase\",\"ExecutorUri\":\"executor://sampleTestExecutor\",\"Source\":\"sampleTest.dll\",\"CodeFilePath\":null,\"LineNumber\":-1,\"Properties\":[]},\"Attachments\":[],\"Outcome\":1,\"ErrorMessage\":\"sampleError\",\"ErrorStackTrace\":\"sampleStackTrace\",\"DisplayName\":\"sampleTestResult\",\"Messages\":[],\"ComputerName\":\"sampleComputerName\",\"Duration\":\"10675199.02:48:05.4775807\",\"StartTime\":\"2007-03-10T00:00:00+00:00\",\"EndTime\":\"9999-12-31T23:59:59.9999999+00:00\",\"Properties\":[]}";
@@ -217,7 +231,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization
 
         [TestMethod]
         [DataRow(2)]
-        [DataRow(3)]
+        [DataRow(4)]
         public void TestResultObjectShouldSerializeAttachmentsV2(int version)
         {
             var result = new TestResult(testCase);
@@ -233,7 +247,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization
 
         [TestMethod]
         [DataRow(2)]
-        [DataRow(3)]
+        [DataRow(4)]
         public void TestResultObjectShouldDeserializeAttachmentsV2(int version)
         {
             var json = "{\"TestCase\":{\"Properties\":[{\"Key\":{\"Id\":\"TestCase.FullyQualifiedName\",\"Label\":\"FullyQualifiedName\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.String\"},\"Value\":\"sampleTestClass.sampleTestCase\"},{\"Key\":{\"Id\":\"TestCase.ExecutorUri\",\"Label\":\"Executor Uri\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.Uri\"},\"Value\":\"executor://sampleTestExecutor\"},{\"Key\":{\"Id\":\"TestCase.Source\",\"Label\":\"Source\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":0,\"ValueType\":\"System.String\"},\"Value\":\"sampleTest.dll\"},{\"Key\":{\"Id\":\"TestCase.Id\",\"Label\":\"Id\",\"Category\":\"\",\"Description\":\"\",\"Attributes\":1,\"ValueType\":\"System.Guid\"},\"Value\":\"28e7a7ed-8fb9-05b7-5e90-4a8c52f32b5b\"}]},\"Attachments\":[{\"Uri\":\"http://dummyUri\",\"DisplayName\":\"sampleAttachment\",\"Attachments\":[]}],\"Messages\":[],\"Properties\":[]}";
@@ -247,7 +261,7 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization
 
         [TestMethod]
         [DataRow(2)]
-        [DataRow(3)]
+        [DataRow(4)]
         public void TestResultPropertiesShouldGetRegisteredAsPartOfDeserializationV2(int version)
         {
             TestProperty.TryUnregister("DummyProperty", out var property);
@@ -276,12 +290,12 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization
 
         #endregion
 
-        private static string Serialize<T>(T data, int version = 1)
+        private static string Serialize<T>(T data, int version)
         {
             return JsonDataSerializer.Instance.Serialize(data, version);
         }
 
-        private static T Deserialize<T>(string json, int version = 1)
+        private static T Deserialize<T>(string json, int version)
         {
             return JsonDataSerializer.Instance.Deserialize<T>(json, version);
         }

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/Serialization/TestResultSerializationTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/Serialization/TestResultSerializationTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization

--- a/test/TranslationLayer.UnitTests/VsTestConsoleRequestSenderTests.cs
+++ b/test/TranslationLayer.UnitTests/VsTestConsoleRequestSenderTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.UnitTests
 
         private readonly int WaitTimeout = 2000;
 
-        private int protocolVersion = 3;
+        private int protocolVersion = 4;
         private IDataSerializer serializer = JsonDataSerializer.Instance;
 
         public VsTestConsoleRequestSenderTests()


### PR DESCRIPTION
## Description
Updating the protocol to version 3 resulted in using serializer for v1, which sends two to three times more data. We cannot easily update how vstest.console behaves (e. g. the one shipped with net sdd 3.1.402), which will ask for protocol 3. So this PR will downgrade protocol 3 to 2. Any newer version would still be negotiable. Such as the protocol version 4 this PR introduces. Similarly protocol 3 is still using the old serializer, to keep compatibility in situations where we actually negotiate protocol 3. E.g. new console asking Test.SDK 16.7.1 for protocol version, where console would offer 4, but testhost would return 3. So 3 would be used with that specific version of SDK.

## Related issue
Fix #2623 
