### PR TITLE
Downgrade externals - tests for test platform nuget

### DIFF
--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -31,7 +31,7 @@
     <NuGetFrameworksVersion>5.0.0</NuGetFrameworksVersion>
     <JsonNetVersion>9.0.1</JsonNetVersion>
     <MoqVersion>4.7.63</MoqVersion>
-    <TestPlatformExternalsVersion>16.9.0-preview-4224421</TestPlatformExternalsVersion>
+    <TestPlatformExternalsVersion>16.9.0-preview-4189539</TestPlatformExternalsVersion>
     <CodeCoverageExternalsVersion>16.9.0-beta.20570.2</CodeCoverageExternalsVersion>
     <MicrosoftFakesVersion>16.8.0-beta.20420.2</MicrosoftFakesVersion>
 

--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -31,7 +31,7 @@
     <NuGetFrameworksVersion>5.0.0</NuGetFrameworksVersion>
     <JsonNetVersion>9.0.1</JsonNetVersion>
     <MoqVersion>4.7.63</MoqVersion>
-    <TestPlatformExternalsVersion>16.9.0-preview-4243816</TestPlatformExternalsVersion>
+    <TestPlatformExternalsVersion>16.9.0-preview-4224421</TestPlatformExternalsVersion>
     <CodeCoverageExternalsVersion>16.9.0-beta.20570.2</CodeCoverageExternalsVersion>
     <MicrosoftFakesVersion>16.8.0-beta.20420.2</MicrosoftFakesVersion>
 

--- a/scripts/verify-nupkgs.ps1
+++ b/scripts/verify-nupkgs.ps1
@@ -15,7 +15,7 @@ function Verify-Nuget-Packages($packageDirectory, $version)
     $expectedNumOfFiles = @{
                      "Microsoft.CodeCoverage" = 44;
                      "Microsoft.NET.Test.Sdk" = 18;
-                     "Microsoft.TestPlatform" = 486;
+                     "Microsoft.TestPlatform" = 487;
                      "Microsoft.TestPlatform.Build" = 19;
                      "Microsoft.TestPlatform.CLI" = 353;
                      "Microsoft.TestPlatform.Extensions.TrxLogger" = 33;

--- a/src/package/nuspec/Microsoft.TestPlatform.nuspec
+++ b/src/package/nuspec/Microsoft.TestPlatform.nuspec
@@ -267,6 +267,7 @@
     <file src="net451\$Runtime$\Extensions\Microsoft.VisualStudio.TestTools.DataCollection.MediaRecorder.Model.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestTools.DataCollection.MediaRecorder.Model.dll" />
     <file src="net451\$Runtime$\Extensions\Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorderCollector.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorderCollector.dll" />
     <file src="net451\$Runtime$\Extensions\Microsoft.VisualStudio.TraceDataCollector.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TraceDataCollector.dll" />
+    <file src="net451\$Runtime$\Extensions\Microsoft.VisualStudio.Coverage.Interop.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.Coverage.Interop.dll" />
     <file src="net451\$Runtime$\Extensions\VideoRecorder\VSTestVideoRecorder.exe"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\VideoRecorder\VSTestVideoRecorder.exe" />
     <file src="net451\$Runtime$\Extensions\Cpp\dbghelp.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Cpp\dbghelp.dll" />
     <file src="net451\$Runtime$\Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.Discoverer.dll"	target="tools\net451\Common7\IDE\Extensions\TestPlatform\Extensions\Cpp\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.Discoverer.dll" />

--- a/src/package/sign/sign.proj
+++ b/src/package/sign/sign.proj
@@ -130,12 +130,13 @@
       <AssembliesToSign Include="$(ArtifactsDirectory)QTDCAgent32.exe" />
 
       <!-- DataCollector related dlls -->
-      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.IntelliTrace.Core.dll" />
+      <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.IntelliTrace.Core.dll" />      
       <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.Coverage.CoreLib.Net.dll" />
       <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.Diagnostics.Utilities.dll" />
       <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.Enterprise.AspNetHelper.dll" />
       <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.ArchitectureTools.PEReader.dll" />
       <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Microsoft.VisualStudio.TraceDataCollector.dll" />
+      <AssembliesToSign Include="$(ArtifactsDirectory)Extensions\Microsoft.VisualStudio.Coverage.Interop.dll" />
 
       <!-- CUIT related dlls -->
       <AssembliesToSign Include="$(ArtifactsDirectory)Microsoft.VisualStudio.Diagnostics.Measurement.dll" />

--- a/test/Microsoft.TestPlatform.AcceptanceTests/CodeCoverageTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/CodeCoverageTests.cs
@@ -283,37 +283,5 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
             Assert.IsTrue(found);
         }
-
-        private static string GetCoverageFileNameFromTrx(string trxFilePath, string resultsDirectory)
-        {
-            Assert.IsTrue(File.Exists(trxFilePath), "Trx file not found: {0}", trxFilePath);
-            XmlDocument doc = new XmlDocument();
-            using (var trxStream = new FileStream(trxFilePath, FileMode.Open, FileAccess.Read))
-            {
-                doc.Load(trxStream);
-                var deploymentElements = doc.GetElementsByTagName("Deployment");
-                Assert.IsTrue(deploymentElements.Count == 1,
-                    "None or more than one Deployment tags found in trx file:{0}", trxFilePath);
-                var deploymentDir = deploymentElements[0].Attributes.GetNamedItem("runDeploymentRoot")?.Value;
-                Assert.IsTrue(string.IsNullOrEmpty(deploymentDir) == false,
-                    "runDeploymentRoot attribute not found in trx file:{0}", trxFilePath);
-                var collectors = doc.GetElementsByTagName("Collector");
-
-                string fileName = string.Empty;
-                for (int i = 0; i < collectors.Count; i++)
-                {
-                    if (string.Equals(collectors[i].Attributes.GetNamedItem("collectorDisplayName").Value,
-                        "Code Coverage", StringComparison.OrdinalIgnoreCase))
-                    {
-                        fileName = collectors[i].FirstChild?.FirstChild?.FirstChild?.Attributes.GetNamedItem("href")
-                            ?.Value;
-                    }
-                }
-
-                Assert.IsTrue(string.IsNullOrEmpty(fileName) == false, "Coverage file name not found in trx file: {0}",
-                    trxFilePath);
-                return Path.Combine(resultsDirectory, deploymentDir, "In", fileName);
-            }
-        }
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TestPlatformNugetPackageTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TestPlatformNugetPackageTests.cs
@@ -64,8 +64,6 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             var actualCoverageFile = CodeCoverageTests.GetCoverageFileNameFromTrx(trxFilePath, resultsDirectory);
             Console.WriteLine($@"Coverage file: {actualCoverageFile}  Results directory: {resultsDirectory} trxfile: {trxFilePath}");
             Assert.IsTrue(File.Exists(actualCoverageFile), "Coverage file not found: {0}", actualCoverageFile);
-
-            Directory.Delete(this.resultsDirectory, true);
         }
 
         public override string GetConsoleRunnerPath()

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TestPlatformNugetPackageTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TestPlatformNugetPackageTests.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.TestPlatform.AcceptanceTests
+{
+    using System;
+    using System.IO;
+    using System.IO.Compression;
+    using System.Linq;
+
+    using Microsoft.TestPlatform.TestUtilities;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class TestPlatformNugetPackageTests : CodeCoverageAcceptanceTestBase
+    {
+        private static string nugetPackageFolder;
+        private string resultsDirectory;
+
+        [ClassInitialize]
+        public static void ClassInit(TestContext testContext)
+        {
+            var packageLocation = Path.Combine(IntegrationTestEnvironment.TestPlatformRootDirectory, "artifacts", IntegrationTestEnvironment.BuildConfiguration, "packages");
+            var nugetPackage = Directory.EnumerateFiles(packageLocation, "Microsoft.TestPlatform.*.nupkg").OrderBy(a => a).FirstOrDefault();
+            nugetPackageFolder = Path.Combine(packageLocation, Path.GetFileNameWithoutExtension(nugetPackage));
+            ZipFile.ExtractToDirectory(nugetPackage, nugetPackageFolder);
+
+            Directory.Move(Path.Combine(nugetPackageFolder, "tools", "net451", "Team%20Tools"), Path.Combine(nugetPackageFolder, "tools", "net451", "Team Tools"));
+            Directory.Move(Path.Combine(nugetPackageFolder, "tools", "net451", "Team Tools", "Dynamic%20Code%20Coverage%20Tools"), Path.Combine(nugetPackageFolder, "tools", "net451", "Team Tools", "Dynamic Code Coverage Tools"));
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            //Directory.Delete(nugetPackageFolder, true);
+        }
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            this.resultsDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        }
+
+        [TestCleanup]
+        public void CleanUp()
+        {
+            //Directory.Delete(resultsDirectory, true);
+        }
+
+        [TestMethod]
+        [NetFullTargetFrameworkDataSource(useCoreRunner: false)]
+        [NetCoreTargetFrameworkDataSource(useCoreRunner: false)]
+        public void RunMultipleTestAssembliesWithCodeCoverage(RunnerInfo runnerInfo)
+        {
+            AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+
+            var assemblyPaths = this.BuildMultipleAssemblyPath("SimpleTestProject.dll", "SimpleTestProject2.dll").Trim('\"');
+
+            var arguments = CreateCodeCoverageArguments(runnerInfo, assemblyPaths, out var trxFilePath);
+            this.InvokeVsTest(arguments);
+
+            this.ExitCodeEquals(1); // failing tests
+
+            var actualCoverageFile = CodeCoverageTests.GetCoverageFileNameFromTrx(trxFilePath, resultsDirectory);
+            Console.WriteLine($@"Coverage file: {actualCoverageFile}  Results directory: {resultsDirectory} trxfile: {trxFilePath}");
+            Assert.IsTrue(File.Exists(actualCoverageFile), "Coverage file not found: {0}", actualCoverageFile);
+
+            Directory.Delete(this.resultsDirectory, true);
+        }
+
+        public override string GetConsoleRunnerPath()
+        {
+            string consoleRunnerPath = string.Empty;
+
+            if (this.IsDesktopRunner())
+            {
+                consoleRunnerPath = Path.Combine(nugetPackageFolder, "tools", "net451", "Common7", "IDE", "Extensions", "TestPlatform", "vstest.console.exe");
+            }
+
+            Assert.IsTrue(File.Exists(consoleRunnerPath), "GetConsoleRunnerPath: Path not found: {0}", consoleRunnerPath);
+            return consoleRunnerPath;
+        }
+
+        private string CreateCodeCoverageArguments(
+            RunnerInfo runnerInfo,
+            string assemblyPaths,
+            out string trxFilePath)
+        {
+            string diagFileName = Path.Combine(this.resultsDirectory, "diaglog.txt");
+
+            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty,
+                this.FrameworkArgValue, runnerInfo.InIsolationValue);
+
+            arguments = string.Concat(arguments, $" /ResultsDirectory:{resultsDirectory}", $" /Diag:{diagFileName}", $" /EnableCodeCoverage");
+
+            trxFilePath = Path.Combine(this.resultsDirectory, Guid.NewGuid() + ".trx");
+            arguments = string.Concat(arguments, " /logger:trx;logfilename=" + trxFilePath);
+
+            return arguments;
+        }
+    }
+}

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TestPlatformNugetPackageTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TestPlatformNugetPackageTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         [ClassCleanup]
         public static void ClassCleanup()
         {
-            //Directory.Delete(nugetPackageFolder, true);
+            Directory.Delete(nugetPackageFolder, true);
         }
 
         [TestInitialize]
@@ -44,7 +44,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         [TestCleanup]
         public void CleanUp()
         {
-            //Directory.Delete(resultsDirectory, true);
+            Directory.Delete(resultsDirectory, true);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description
We found out that TraceDataCollector depends on Coverage.Interop.dll so previous deletion of Coverage.Interop.dll results in not be able to get code coverage. This was detected by manual test. PR is also adding automatic test to check TP + TraceDataCollector (from VS) integration.

## Related issue
Kindly link any related issues. E.g. Fixes #xyz.
