### PR TITLE
Implement Workitem support in TRX logger

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Interfaces/ITestElement.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Interfaces/ITestElement.cs
@@ -16,7 +16,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         TestExecId ParentExecutionId { get; set; }
         TestListCategoryId CategoryId { get; set; }
         TestCategoryItemCollection TestCategories { get; }
-        WorkitemCollection Workitems { get; set; }
+        WorkItemCollection WorkItems { get; set; }
         TestType TestType { get; }
     }
 }

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Interfaces/ITestElement.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Interfaces/ITestElement.cs
@@ -16,6 +16,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         TestExecId ParentExecutionId { get; set; }
         TestListCategoryId CategoryId { get; set; }
         TestCategoryItemCollection TestCategories { get; }
+        WorkitemCollection Workitems { get; set; }
         TestType TestType { get; }
     }
 }

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestElement.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestElement.cs
@@ -30,6 +30,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         protected TestExecId executionId;
         protected TestExecId parentExecutionId;
         protected TestCategoryItemCollection testCategories;
+        protected WorkitemCollection workitems;
         protected TestListCategoryId catId;
 
         public TestElement(Guid id, string name, string adapter)
@@ -162,6 +163,20 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         }
 
         /// <summary>
+        /// Gets or sets the work items.
+        /// </summary>
+        public WorkitemCollection Workitems
+        {
+            get { return this.workitems; }
+
+            set
+            {
+                EqtAssert.ParameterNotNull(value, "value");
+                this.workitems = value;
+            }
+        }
+
+        /// <summary>
         /// Gets the adapter name.
         /// </summary>
         public string Adapter
@@ -230,6 +245,8 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
             if (this.parentExecutionId != null)
                 h.SaveGuid(element, "Execution/@parentId", this.parentExecutionId.Id);
 
+            h.SaveObject(this.workitems, element, "Workitems", parameters);
+
             XmlTestStoreParameters testIdParameters = XmlTestStoreParameters.GetParameters();
             testIdParameters[TestId.IdLocationKey] = "@id";
             h.SaveObject(this.id, element, testIdParameters);
@@ -245,6 +262,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
             this.executionId = TestExecId.Empty;
             this.parentExecutionId = TestExecId.Empty;
             this.testCategories = new TestCategoryItemCollection();
+            this.workitems = new WorkitemCollection();
             this.isRunnable = true;
             this.catId = TestListCategoryId.Uncategorized;
         }

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestElement.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestElement.cs
@@ -30,7 +30,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         protected TestExecId executionId;
         protected TestExecId parentExecutionId;
         protected TestCategoryItemCollection testCategories;
-        protected WorkitemCollection workitems;
+        protected WorkItemCollection workItems;
         protected TestListCategoryId catId;
 
         public TestElement(Guid id, string name, string adapter)
@@ -165,14 +165,14 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         /// <summary>
         /// Gets or sets the work items.
         /// </summary>
-        public WorkitemCollection Workitems
+        public WorkItemCollection WorkItems
         {
-            get { return this.workitems; }
+            get { return this.workItems; }
 
             set
             {
                 EqtAssert.ParameterNotNull(value, "value");
-                this.workitems = value;
+                this.workItems = value;
             }
         }
 
@@ -245,7 +245,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
             if (this.parentExecutionId != null)
                 h.SaveGuid(element, "Execution/@parentId", this.parentExecutionId.Id);
 
-            h.SaveObject(this.workitems, element, "Workitems", parameters);
+            h.SaveObject(this.workItems, element, "Workitems", parameters);
 
             XmlTestStoreParameters testIdParameters = XmlTestStoreParameters.GetParameters();
             testIdParameters[TestId.IdLocationKey] = "@id";
@@ -262,7 +262,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
             this.executionId = TestExecId.Empty;
             this.parentExecutionId = TestExecId.Empty;
             this.testCategories = new TestCategoryItemCollection();
-            this.workitems = new WorkitemCollection();
+            this.workItems = new WorkItemCollection();
             this.isRunnable = true;
             this.catId = TestListCategoryId.Uncategorized;
         }

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/WorkItems.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/WorkItems.cs
@@ -6,15 +6,15 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
     using System;
     using System.Globalization;
     using System.Text;
-
+    using System.Xml;
     using Microsoft.TestPlatform.Extensions.TrxLogger.Utility;
     using Microsoft.TestPlatform.Extensions.TrxLogger.XML;
 
-    #region Workitem
+    #region WorkItem
     /// <summary>
     /// Stores an int which represents a workitem
     /// </summary>
-    internal sealed class Workitem : IXmlTestStore
+    internal sealed class WorkItem : IXmlTestStore
     {
         #region Fields
         [StoreXmlField(Location = ".")]
@@ -27,7 +27,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         /// Create a new item with the workitem set
         /// </summary>
         /// <param name="workitemId">The workitem.</param>
-        public Workitem(int workitemId)
+        public WorkItem(int workitemId)
         {
             this.id = workitemId;
         }
@@ -36,7 +36,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
 
         #region Properties/Methods
         /// <summary>
-        /// Gets the id for this Workitem
+        /// Gets the id for this WorkItem
         /// </summary>
         public int Id
         {
@@ -56,7 +56,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         /// <returns>True if the values are the same and false otherwise.</returns>
         public override bool Equals(object other)
         {
-            Workitem otherItem = other as Workitem;
+            WorkItem otherItem = other as WorkItem;
             if (otherItem == null)
             {
                 return false;
@@ -99,30 +99,30 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
     }
     #endregion
 
-    #region WorkitemCollection
+    #region WorkItemCollection
     /// <summary>
     /// A collection of ints represent the workitems
     /// </summary>
-    internal sealed class WorkitemCollection : EqtBaseCollection<Workitem>
+    internal sealed class WorkItemCollection : EqtBaseCollection<WorkItem>
     {
         #region Constructors
         /// <summary>
-        /// Creates an empty WorkitemCollection.
+        /// Creates an empty WorkItemCollection.
         /// </summary>
-        public WorkitemCollection()
+        public WorkItemCollection()
         {
         }
 
         /// <summary>
-        /// Create a new WorkitemCollection based on the int array.
+        /// Create a new WorkItemCollection based on the int array.
         /// </summary>
         /// <param name="items">Add these items to the collection.</param>
-        public WorkitemCollection(int[] items)
+        public WorkItemCollection(int[] items)
         {
             EqtAssert.ParameterNotNull(items, "items");
             foreach (int i in items)
             {
-                this.Add(new Workitem(i));
+                this.Add(new WorkItem(i));
             }
         }
 
@@ -132,24 +132,24 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         /// <summary>
         /// Adds the workitem.
         /// </summary>
-        /// <param name="item">Workitem to be added.</param>
+        /// <param name="item">WorkItem to be added.</param>
         public void Add(int item)
         {
-            this.Add(new Workitem(item));
+            this.Add(new WorkItem(item));
         }
 
         /// <summary>
         /// Adds the workitem.
         /// </summary>
-        /// <param name="item">Workitem to be added.</param>
-        public override void Add(Workitem item)
+        /// <param name="item">WorkItem to be added.</param>
+        public override void Add(WorkItem item)
         {
             EqtAssert.ParameterNotNull(item, "item");
             base.Add(item);
         }
 
         /// <summary>
-        /// Convert the WorkitemCollection to a string.
+        /// Convert the WorkItemCollection to a string.
         /// each item is separated by a comma (,)
         /// </summary>
         /// <returns></returns>
@@ -159,7 +159,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
             if (this.Count > 0)
             {
                 returnString.Append(",");
-                foreach (Workitem item in this)
+                foreach (WorkItem item in this)
                 {
                     returnString.Append(item);
                     returnString.Append(",");
@@ -170,7 +170,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         }
 
         /// <summary>
-        /// Convert the WorkitemCollection to an array of ints.
+        /// Convert the WorkItemCollection to an array of ints.
         /// </summary>
         /// <returns>Array of ints containing the workitems.</returns>
         public int[] ToArray()
@@ -178,7 +178,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
             int[] result = new int[this.Count];
 
             int i = 0;
-            foreach (Workitem item in this)
+            foreach (WorkItem item in this)
             {
                 result[i++] = item.Id;
             }
@@ -193,7 +193,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         /// <returns>true if the collections contain the same items</returns>
         public override bool Equals(object obj)
         {
-            WorkitemCollection other = obj as WorkitemCollection;
+            WorkItemCollection other = obj as WorkItemCollection;
             bool result = false;
 
             if (other == null)
@@ -210,7 +210,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
             }
             else
             {
-                foreach (Workitem item in this)
+                foreach (WorkItem item in this)
                 {
                     if (!other.Contains(item))
                     {
@@ -230,6 +230,12 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         public override int GetHashCode()
         {
             return base.GetHashCode();
+        }
+
+        public override void Save(XmlElement element, XmlTestStoreParameters parameters)
+        {
+            XmlPersistence xmlPersistence = new XmlPersistence();
+            xmlPersistence.SaveHashtable(this.container, element, ".", ".", null, "Workitem", parameters);
         }
         #endregion
     }

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/Workitems.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/Workitems.cs
@@ -1,0 +1,237 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
+{
+    using System;
+    using System.Globalization;
+    using System.Text;
+
+    using Microsoft.TestPlatform.Extensions.TrxLogger.Utility;
+    using Microsoft.TestPlatform.Extensions.TrxLogger.XML;
+
+    #region Workitem
+    /// <summary>
+    /// Stores an int which represents a workitem
+    /// </summary>
+    internal sealed class Workitem : IXmlTestStore
+    {
+        #region Fields
+        [StoreXmlField(Location = ".")]
+        private int id = 0;
+
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Create a new item with the workitem set
+        /// </summary>
+        /// <param name="workitemId">The workitem.</param>
+        public Workitem(int workitemId)
+        {
+            this.id = workitemId;
+        }
+
+        #endregion
+
+        #region Properties/Methods
+        /// <summary>
+        /// Gets the id for this Workitem
+        /// </summary>
+        public int Id
+        {
+            get
+            {
+                return this.id;
+            }
+        }
+
+        #endregion
+
+        #region Methods - overrides
+        /// <summary>
+        /// Compare the values of the items
+        /// </summary>
+        /// <param name="other">Value being compared to.</param>
+        /// <returns>True if the values are the same and false otherwise.</returns>
+        public override bool Equals(object other)
+        {
+            Workitem otherItem = other as Workitem;
+            if (otherItem == null)
+            {
+                return false;
+            }
+            return this.id == otherItem.id;
+        }
+
+        /// <summary>
+        /// Convert the workitem to a hashcode
+        /// </summary>
+        /// <returns>Hashcode of the workitem.</returns>
+        public override int GetHashCode()
+        {
+            return this.id.GetHashCode();
+        }
+
+        /// <summary>
+        /// Convert the workitem to a string
+        /// </summary>
+        /// <returns>The workitem.</returns>
+        public override string ToString()
+        {
+            return this.id.ToString(CultureInfo.InvariantCulture);
+        }
+        #endregion
+
+        #region IXmlTestStore Members
+
+        /// <summary>
+        /// Saves the class under the XmlElement.
+        /// </summary>
+        /// <param name="element"> XmlElement element </param>
+        /// <param name="parameters"> XmlTestStoreParameters parameters</param>
+        public void Save(System.Xml.XmlElement element, XmlTestStoreParameters parameters)
+        {
+            new XmlPersistence().SaveSingleFields(element, this, parameters);
+        }
+
+        #endregion
+    }
+    #endregion
+
+    #region WorkitemCollection
+    /// <summary>
+    /// A collection of ints represent the workitems
+    /// </summary>
+    internal sealed class WorkitemCollection : EqtBaseCollection<Workitem>
+    {
+        #region Constructors
+        /// <summary>
+        /// Creates an empty WorkitemCollection.
+        /// </summary>
+        public WorkitemCollection()
+        {
+        }
+
+        /// <summary>
+        /// Create a new WorkitemCollection based on the int array.
+        /// </summary>
+        /// <param name="items">Add these items to the collection.</param>
+        public WorkitemCollection(int[] items)
+        {
+            EqtAssert.ParameterNotNull(items, "items");
+            foreach (int i in items)
+            {
+                this.Add(new Workitem(i));
+            }
+        }
+
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Adds the workitem.
+        /// </summary>
+        /// <param name="item">Workitem to be added.</param>
+        public void Add(int item)
+        {
+            this.Add(new Workitem(item));
+        }
+
+        /// <summary>
+        /// Adds the workitem.
+        /// </summary>
+        /// <param name="item">Workitem to be added.</param>
+        public override void Add(Workitem item)
+        {
+            EqtAssert.ParameterNotNull(item, "item");
+            base.Add(item);
+        }
+
+        /// <summary>
+        /// Convert the WorkitemCollection to a string.
+        /// each item is separated by a comma (,)
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            StringBuilder returnString = new StringBuilder();
+            if (this.Count > 0)
+            {
+                returnString.Append(",");
+                foreach (Workitem item in this)
+                {
+                    returnString.Append(item);
+                    returnString.Append(",");
+                }
+            }
+
+            return returnString.ToString();
+        }
+
+        /// <summary>
+        /// Convert the WorkitemCollection to an array of ints.
+        /// </summary>
+        /// <returns>Array of ints containing the workitems.</returns>
+        public int[] ToArray()
+        {
+            int[] result = new int[this.Count];
+
+            int i = 0;
+            foreach (Workitem item in this)
+            {
+                result[i++] = item.Id;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Compare the collection items
+        /// </summary>
+        /// <param name="obj">other collection</param>
+        /// <returns>true if the collections contain the same items</returns>
+        public override bool Equals(object obj)
+        {
+            WorkitemCollection other = obj as WorkitemCollection;
+            bool result = false;
+
+            if (other == null)
+            {
+                result = false;
+            }
+            else if (object.ReferenceEquals(this, other))
+            {
+                result = true;
+            }
+            else if (this.Count != other.Count)
+            {
+                result = false;
+            }
+            else
+            {
+                foreach (Workitem item in this)
+                {
+                    if (!other.Contains(item))
+                    {
+                        result = false;
+                        break;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Return the hash code of this collection
+        /// </summary>
+        /// <returns>The hashcode.</returns>
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+        #endregion
+    }
+    #endregion
+}

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
@@ -67,6 +67,13 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.Utility
                 testElement.TestCategories.Add(testCategory);
             }
 
+            var workItems = GetCustomPropertyValueFromTestCase(rockSteadyTestCase, "WorkItemIds")
+                .Select(workItem => int.Parse(workItem));
+            foreach (int workItem in workItems)
+            {
+                testElement.Workitems.Add(workItem);
+            }
+
             return testElement;
         }
 

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
@@ -71,7 +71,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.Utility
                 .Select(workItem => int.Parse(workItem));
             foreach (int workItem in workItems)
             {
-                testElement.Workitems.Add(workItem);
+                testElement.WorkItems.Add(workItem);
             }
 
             return testElement;

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -736,13 +736,11 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             Assert.AreEqual(Path.Combine(TrxLoggerTests.DefaultTestRunDirectory, TrxLoggerTests.DefaultLogFileNameParameterValue), this.testableTrxLogger.trxFile, "Wrong Trx file name");
         }
 
-
-
         /// <summary>
         /// Unit test for reading TestCategories from the TestCase which is part of test result.
         /// </summary>
         [TestMethod]
-        public void GetCustomPropertyValueFromTestCaseShouldReadCategoyrAttributesFromTestCase()
+        public void GetCustomPropertyValueFromTestCaseShouldReadCategoryAttributesFromTestCase()
         {
             ObjectModel.TestCase testCase1 = CreateTestCase("TestCase1");
             TestProperty testProperty = TestProperty.Register("MSTestDiscoverer.TestCategory", "String array property", string.Empty, string.Empty, typeof(string[]), null, TestPropertyAttributes.Hidden, typeof(TestObject));
@@ -757,6 +755,24 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             listCategoriesExpected.Add("AsmLevel");
 
             CollectionAssert.AreEqual(listCategoriesExpected, listCategoriesActual);
+        }
+
+        [TestMethod]
+        public void GetCustomPropertyValueFromTestCaseShouldReadWorkitemAttributesFromTestCase()
+        {
+            ObjectModel.TestCase testCase1 = CreateTestCase("TestCase1");
+            TestProperty testProperty = TestProperty.Register("WorkItemIds", "String array property", string.Empty, string.Empty, typeof(string[]), null, TestPropertyAttributes.Hidden, typeof(TestObject));
+
+            testCase1.SetPropertyValue(testProperty, new[] { "99999", "0" });
+
+            var converter = new Converter(new Mock<IFileHelper>().Object, new TrxFileHelper());
+            List<string> listWorkitemsActual = converter.GetCustomPropertyValueFromTestCase(testCase1, "WorkItemIds");
+
+            List<string> listWorkitemsExpected = new List<string>();
+            listWorkitemsExpected.Add("99999");
+            listWorkitemsExpected.Add("0");
+
+            CollectionAssert.AreEqual(listWorkitemsExpected, listWorkitemsActual);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -758,7 +758,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
         }
 
         [TestMethod]
-        public void GetCustomPropertyValueFromTestCaseShouldReadWorkitemAttributesFromTestCase()
+        public void GetCustomPropertyValueFromTestCaseShouldReadWorkItemAttributesFromTestCase()
         {
             ObjectModel.TestCase testCase1 = CreateTestCase("TestCase1");
             TestProperty testProperty = TestProperty.Register("WorkItemIds", "String array property", string.Empty, string.Empty, typeof(string[]), null, TestPropertyAttributes.Hidden, typeof(TestObject));
@@ -766,13 +766,13 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests
             testCase1.SetPropertyValue(testProperty, new[] { "99999", "0" });
 
             var converter = new Converter(new Mock<IFileHelper>().Object, new TrxFileHelper());
-            List<string> listWorkitemsActual = converter.GetCustomPropertyValueFromTestCase(testCase1, "WorkItemIds");
+            List<string> listWorkItemsActual = converter.GetCustomPropertyValueFromTestCase(testCase1, "WorkItemIds");
 
-            List<string> listWorkitemsExpected = new List<string>();
-            listWorkitemsExpected.Add("99999");
-            listWorkitemsExpected.Add("0");
+            List<string> listWorkItemsExpected = new List<string>();
+            listWorkItemsExpected.Add("99999");
+            listWorkItemsExpected.Add("0");
 
-            CollectionAssert.AreEqual(listWorkitemsExpected, listWorkitemsActual);
+            CollectionAssert.AreEqual(listWorkItemsExpected, listWorkItemsActual);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/Utility/ConverterTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/Utility/ConverterTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests.Utility
 
             int[] expected = new[] { 0, 3, 99999 };
 
-            CollectionAssert.AreEquivalent(expected, unitTestElement.Workitems.ToArray());
+            CollectionAssert.AreEquivalent(expected, unitTestElement.WorkItems.ToArray());
         }
 
         /// <summary>

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/Utility/ConverterTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/Utility/ConverterTests.cs
@@ -98,6 +98,22 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests.Utility
             CollectionAssert.AreEqual(expected, unitTestElement.TestCategories.ToArray().OrderByDescending(x => x.ToString()).ToArray());
         }
 
+        [TestMethod]
+        public void ToTestElementShouldAssignWorkitemOfUnitTestElement()
+        {
+            TestPlatformObjectModel.TestCase testCase = CreateTestCase("TestCase1");
+            TestPlatformObjectModel.TestResult result = new TestPlatformObjectModel.TestResult(testCase);
+            TestProperty testProperty = TestProperty.Register("WorkItemIds", "String array property", string.Empty, string.Empty, typeof(string[]), null, TestPropertyAttributes.Hidden, typeof(TestObject));
+
+            testCase.SetPropertyValue(testProperty, new[] { "3", "99999", "0" });
+
+            var unitTestElement = this.converter.ToTestElement(testCase.Id, Guid.Empty, Guid.Empty, testCase.DisplayName, TrxLoggerConstants.UnitTestType, testCase);
+
+            int[] expected = new[] { 0, 3, 99999 };
+
+            CollectionAssert.AreEquivalent(expected, unitTestElement.Workitems.ToArray());
+        }
+
         /// <summary>
         /// Unit test for regression when there's no test categories.
         /// </summary>


### PR DESCRIPTION
## Description

The former `MSTest.exe` created TRX-files which may contain `Workitem` attributes:

``` XML
...
<UnitTest name="%test_name%" storage="%path_to_dll%" id="7212e5d1-c0ef-d4a3-55b9-4dbcf7611dd6">
  <TestCategory>
	<TestCategoryItem TestCategory="%category%" />
  </TestCategory>
  <Execution id="23e0a237-290e-491d-a858-d8aae2e7ee04" />
  <Workitems>
	<Workitem>%work_item_id%</Workitem>
  </Workitems>
  <TestMethod codeBase="%path_to_dll%" adapterTypeName="%adapter_dll%" className="%test_class_name%" name="%test_method_name%" />
</UnitTest>
...
```

Visual Studio is still able to read this information in its TRX-viewer:

![vs-trx-viewer](https://user-images.githubusercontent.com/20628550/101142526-02421e00-3616-11eb-89d7-458b25c9301f.PNG)

This PR re-adds support for Workitems in TRX-files.

## Related issue
- While MSTestV2 has an implementation for Workitems, there is a bug so that Workitems are not passed on to the test platform. This [PR](https://github.com/microsoft/testfx/pull/749) fixes this bug


