### PR TITLE
Change logic of code coverage attachments merging to merge only files with coverage extension

### DIFF
--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/CodeCoverageDataAttachmentsHandlerTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/CodeCoverageDataAttachmentsHandlerTests.cs
@@ -45,8 +45,8 @@
         [TestMethod]
         public async Task HandleDataCollectionAttachmentSetsShouldReturnInputIfOnly1Attachment()
         {
-            var attachmentSet = new AttachmentSet(new Uri("//badrui//"), string.Empty);
-            attachmentSet.Attachments.Add(new UriDataAttachment(new Uri("C:\\temp\\aa"), "coverage"));
+            var attachmentSet = new AttachmentSet(new Uri("datacollector://microsoft/CodeCoverage/2.0"), string.Empty);
+            attachmentSet.Attachments.Add(new UriDataAttachment(new Uri("C:\\temp\\aa.coverage"), "coverage"));
 
             Collection<AttachmentSet> attachment = new Collection<AttachmentSet> { attachmentSet };
             ICollection<AttachmentSet> resultAttachmentSets = await
@@ -54,15 +54,53 @@
 
             Assert.IsNotNull(resultAttachmentSets);
             Assert.IsTrue(resultAttachmentSets.Count == 1);
+            Assert.IsTrue(resultAttachmentSets.First().Attachments.Count == 1);
             Assert.AreEqual("datacollector://microsoft/CodeCoverage/2.0", resultAttachmentSets.First().Uri.AbsoluteUri);
-            Assert.AreEqual("file:///C:/temp/aa", resultAttachmentSets.First().Attachments.First().Uri.AbsoluteUri);
+            Assert.AreEqual("file:///C:/temp/aa.coverage", resultAttachmentSets.First().Attachments.First().Uri.AbsoluteUri);
+        }
+
+        [TestMethod]
+        public async Task HandleDataCollectionAttachmentSetsShouldReturnInputIfOnly1LogsAttachment()
+        {
+            var attachmentSet = new AttachmentSet(new Uri("datacollector://microsoft/CodeCoverage/2.0"), string.Empty);
+            attachmentSet.Attachments.Add(new UriDataAttachment(new Uri("C:\\temp\\aa.logs"), "coverage"));
+
+            Collection<AttachmentSet> attachment = new Collection<AttachmentSet> { attachmentSet };
+            ICollection<AttachmentSet> resultAttachmentSets = await
+                coverageDataAttachmentsHandler.ProcessAttachmentSetsAsync(attachment, mockProgressReporter.Object, null, CancellationToken.None);
+
+            Assert.IsNotNull(resultAttachmentSets);
+            Assert.IsTrue(resultAttachmentSets.Count == 1);
+            Assert.IsTrue(resultAttachmentSets.First().Attachments.Count == 1);
+            Assert.AreEqual("datacollector://microsoft/CodeCoverage/2.0", resultAttachmentSets.First().Uri.AbsoluteUri);
+            Assert.AreEqual("file:///C:/temp/aa.logs", resultAttachmentSets.First().Attachments.First().Uri.AbsoluteUri);
+        }
+
+        [TestMethod]
+        public async Task HandleDataCollectionAttachmentSetsShouldReturnInputIfOnlySeveralLogsAttachmentAnd1Report()
+        {
+            var attachmentSet = new AttachmentSet(new Uri("datacollector://microsoft/CodeCoverage/2.0"), string.Empty);
+            attachmentSet.Attachments.Add(new UriDataAttachment(new Uri("C:\\temp\\aa.coverage"), "coverage"));
+
+            var attachmentSet1 = new AttachmentSet(new Uri("datacollector://microsoft/CodeCoverage/2.0"), string.Empty);
+            attachmentSet1.Attachments.Add(new UriDataAttachment(new Uri("C:\\temp\\aa.logs"), "coverage"));
+            attachmentSet1.Attachments.Add(new UriDataAttachment(new Uri("C:\\temp\\bb.logs"), "coverage"));
+
+            Collection<AttachmentSet> attachment = new Collection<AttachmentSet> { attachmentSet, attachmentSet1 };
+            ICollection<AttachmentSet> resultAttachmentSets = await
+                coverageDataAttachmentsHandler.ProcessAttachmentSetsAsync(attachment, mockProgressReporter.Object, null, CancellationToken.None);
+
+            Assert.IsNotNull(resultAttachmentSets);
+            Assert.IsTrue(resultAttachmentSets.Count == 2);
+            Assert.IsTrue(resultAttachmentSets.First().Attachments.Count == 1);
+            Assert.IsTrue(resultAttachmentSets.Last().Attachments.Count == 2);
         }
 
         [TestMethod]
         public async Task HandleDataCollectionAttachmentSetsShouldThrowIfCancellationRequested()
         {
             var attachmentSet = new AttachmentSet(new Uri("//badrui//"), string.Empty);
-            attachmentSet.Attachments.Add(new UriDataAttachment(new Uri("C:\\temp\\aa"), "coverage"));
+            attachmentSet.Attachments.Add(new UriDataAttachment(new Uri("C:\\temp\\aa.coverage"), "coverage"));
             CancellationTokenSource cts = new CancellationTokenSource();
             cts.Cancel();
 


### PR DESCRIPTION
## Description
Change logic of code coverage attachments merging to merge only files with *.coverage extension. This will allow code coverage data collectors to send additional files, for example logs.
