### PR TITLE
Update `azure-pipelines.yml` to publish test results

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,13 @@ jobs:
       modifyEnvironment: false
       failOnStandardError: true
 
+  - task: PublishTestResults@2
+    displayName: 'Publish Test Results **\*.trx'
+    inputs:
+      testResultsFormat: VSTest
+      testResultsFiles: '**\*.trx'
+    condition: succeededOrFailed()
+
   - task: PublishPipelineArtifact@1
     inputs:
       targetPath: '$(Build.SourcesDirectory)\artifacts'
@@ -124,16 +131,25 @@ jobs:
   steps:
   - script: ./build.sh -c $(buildConfiguration)
     displayName: 'Build'
+
   - script: ./test.sh -c $(buildConfiguration) -p Unit
     displayName: 'Unit tests'  
+
   - task: DownloadPipelineArtifact@2
     inputs:
       buildType: 'current'
       artifactName: 'testArtifacts'
       targetPath: '$(Build.SourcesDirectory)/artifacts'
+
   - script: ./tools/dotnet-linux/dotnet build -c $(buildConfiguration) ./test/TestAssets/TestAssets.sln
     displayName: 'Build test assets'
+
   - script: ./test.sh -c $(buildConfiguration) -p Acceptance
     displayName: 'Acceptance tests'   
-
-   
+  
+  - task: PublishTestResults@2
+    displayName: 'Publish Test Results **/*.trx'
+    inputs:
+      testResultsFormat: VSTest
+      testResultsFiles: '**/*.trx'
+    condition: succeededOrFailed()

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -120,7 +120,7 @@ function invoke_test()
     local dotnet=$(_get_dotnet_path)
     local vstest=$TP_OUT_DIR/$TPB_Configuration/$TPB_TargetFrameworkCore/vstest.console.dll
 
-    find ./test -path $PROJECT_NAME_PATTERNS | xargs $dotnet  $vstest --parallel --testcasefilter:"TestCategory!=Windows&TestCategory!=Windows-Review"
+    find ./test -path $PROJECT_NAME_PATTERNS | xargs $dotnet $vstest --parallel --testcasefilter:"TestCategory!=Windows&TestCategory!=Windows-Review" --logger:"trx"
 }
 
 #


### PR DESCRIPTION
Updated `azure-pipelines.yml` to publish test results.

- [x] `test.sh` needs to be updated to generate `.trx` logs.