### PR TITLE
Fix divide by zero in HTML logger

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
@@ -282,7 +282,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger
                 PassedTests = PassedTests,
                 TotalTests = TotalTests,
                 SkippedTests = SkippedTests,
-                PassPercentage = (PassedTests * 100) / TotalTests,
+                PassPercentage = (PassedTests * 100) / (TotalTests >= 1 ? TotalTests : 1),
                 TotalRunTime = GetFormattedDurationString(e.ElapsedTimeInRunningTests),
             };
             if (this.parametersDictionary.TryGetValue(HtmlLoggerConstants.LogFilePrefixKey, out string logFilePrefixValue) && !string.IsNullOrWhiteSpace(logFilePrefixValue))

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
@@ -282,7 +282,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger
                 PassedTests = PassedTests,
                 TotalTests = TotalTests,
                 SkippedTests = SkippedTests,
-                PassPercentage = TotalTests == 0 ? 0 : PassedTests * 100 / TotalTests
+                PassPercentage = TotalTests == 0 ? 0 : PassedTests * 100 / TotalTests,
                 TotalRunTime = GetFormattedDurationString(e.ElapsedTimeInRunningTests),
             };
             if (this.parametersDictionary.TryGetValue(HtmlLoggerConstants.LogFilePrefixKey, out string logFilePrefixValue) && !string.IsNullOrWhiteSpace(logFilePrefixValue))

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
@@ -282,7 +282,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger
                 PassedTests = PassedTests,
                 TotalTests = TotalTests,
                 SkippedTests = SkippedTests,
-                PassPercentage = (PassedTests * 100) / (TotalTests >= 1 ? TotalTests : 1),
+                PassPercentage = TotalTests != 0 ? PassedTests * 100 / TotalTests : 0,
                 TotalRunTime = GetFormattedDurationString(e.ElapsedTimeInRunningTests),
             };
             if (this.parametersDictionary.TryGetValue(HtmlLoggerConstants.LogFilePrefixKey, out string logFilePrefixValue) && !string.IsNullOrWhiteSpace(logFilePrefixValue))

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
@@ -282,7 +282,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger
                 PassedTests = PassedTests,
                 TotalTests = TotalTests,
                 SkippedTests = SkippedTests,
-                PassPercentage = TotalTests != 0 ? PassedTests * 100 / TotalTests : 0,
+                PassPercentage = TotalTests == 0 ? 0 : PassedTests * 100 / TotalTests
                 TotalRunTime = GetFormattedDurationString(e.ElapsedTimeInRunningTests),
             };
             if (this.parametersDictionary.TryGetValue(HtmlLoggerConstants.LogFilePrefixKey, out string logFilePrefixValue) && !string.IsNullOrWhiteSpace(logFilePrefixValue))

--- a/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
@@ -573,6 +573,20 @@ namespace Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests
             Assert.IsTrue(htmlLogger.HtmlFilePath.Contains(".html"));
         }
 
+        [TestMethod]
+        public void TestCompleteHandlerShouldNotDivideByZeroWhenThereAre0TestResults()
+        {
+
+            this.mockFileHelper.Setup(x => x.GetStream(It.IsAny<string>(), FileMode.Create, FileAccess.ReadWrite)).Callback<string, FileMode, FileAccess>((x, y, z) =>
+            {
+            }).Returns(new Mock<Stream>().Object);
+
+            this.htmlLogger.TestRunCompleteHandler(new object(), new TestRunCompleteEventArgs(null, false, true, null, null, TimeSpan.Zero));
+
+            Assert.AreEqual(0, this.htmlLogger.TestRunDetails.Summary.TotalTests);
+            Assert.AreEqual(0, this.htmlLogger.TestRunDetails.Summary.PassPercentage);
+        }
+
         private static TestCase CreateTestCase(string testCaseName)
         {
             return new TestCase(testCaseName, new Uri("some://uri"), "DummySourceFileName");


### PR DESCRIPTION
## Description
Fix division by zero when there are no tests discovered.

## Related issue
Fix #2615
Fix AB#1272732