### PR TITLE
Print stack trace from executor

### DIFF
--- a/src/Microsoft.TestPlatform.Common/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.Common/Resources/Resources.Designer.cs
@@ -11,8 +11,8 @@
 namespace Microsoft.VisualStudio.TestPlatform.Common.Resources {
     using System;
     using System.Reflection;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -206,6 +206,15 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Inner exception:.
+        /// </summary>
+        internal static string InnerException {
+            get {
+                return ResourceManager.GetString("InnerException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error: Invalid Condition &apos;{0}&apos;.
         /// </summary>
         internal static string InvalidCondition {
@@ -346,6 +355,15 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Resources {
         internal static string SettingsProviderNotFound {
             get {
                 return ResourceManager.GetString("SettingsProviderNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stack trace:.
+        /// </summary>
+        internal static string StackTrace {
+            get {
+                return ResourceManager.GetString("StackTrace", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TestPlatform.Common/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.Common/Resources/Resources.resx
@@ -165,6 +165,9 @@
   <data name="IgnoredDuplicateConfiguration" xml:space="preserve">
     <value>There are multiple configurations that have data collector FriendlyName as '{0}'. Duplicate configurations will be ignored in the test run.</value>
   </data>
+  <data name="InnerException" xml:space="preserve">
+    <value>Inner exception:</value>
+  </data>
   <data name="InvalidCondition" xml:space="preserve">
     <value>Error: Invalid Condition '{0}'</value>
   </data>
@@ -212,6 +215,9 @@
   </data>
   <data name="SettingsProviderNotFound" xml:space="preserve">
     <value>Settings Provider named '{0}' was not found.  The settings can not be loaded.</value>
+  </data>
+  <data name="StackTrace" xml:space="preserve">
+    <value>Stack trace:</value>
   </data>
   <data name="TestCaseFilterFormatException" xml:space="preserve">
     <value>Incorrect format for TestCaseFilter {0}. Specify the correct format and try again. Note that the incorrect format can lead to no test getting executed.</value>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.cs.xlf
@@ -284,6 +284,16 @@
         <target state="translated">{0} Při pokusu o vytvoření složky TestResults v uvedeném umístění došlo k odepření přístupu. Tato výjimka se vyvolala, protože spouštíte vstest.console.exe ze složky, která vyžaduje, abyste měli přístup pro zápis. Pokud chcete problém vyřešit, spusťte prosím vstest.console.exe ze složky, ve které máte oprávnění k zápisu. Další informace najdete v chybové zprávě:</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InnerException">
+        <source>Inner exception:</source>
+        <target state="new">Inner exception:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StackTrace">
+        <source>Stack trace:</source>
+        <target state="new">Stack trace:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.de.xlf
@@ -284,6 +284,16 @@
         <target state="translated">{0} Beim Erstellen des Ordners "TestResults" am angegebenen Speicherort wurde der Zugriff verweigert. Sie erhalten diese Ausnahme, weil Sie "vstest.console.exe" von einem Ordner aus ausführen, für den Schreibzugriff erforderlich ist. So beheben Sie das Problem: Führen Sie "vstest.console.exe" in einem Ordner aus, für den Sie Schreibberechtigungen besitzen. Weitere Informationen finden Sie in der Fehlermeldung:</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InnerException">
+        <source>Inner exception:</source>
+        <target state="new">Inner exception:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StackTrace">
+        <source>Stack trace:</source>
+        <target state="new">Stack trace:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.es.xlf
@@ -284,6 +284,16 @@
         <target state="translated">{0} Se denegó el acceso al intentar crear la carpeta "TestResults" en la ubicación mencionada. Está recibiendo esta excepción porque está ejecutando vstest.console.exe desde una carpeta que requiere acceso de escritura. Para solucionar el problema: ejecute vstest.console.exe desde una carpeta en la que tenga privilegios de escritura. Para obtener más información, consulte el mensaje de error:</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InnerException">
+        <source>Inner exception:</source>
+        <target state="new">Inner exception:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StackTrace">
+        <source>Stack trace:</source>
+        <target state="new">Stack trace:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.fr.xlf
@@ -284,6 +284,16 @@
         <target state="translated">{0} Accès refusé durant la tentative de création du dossier "TestResults" à l'emplacement indiqué. Vous obtenez cette exception, car vous exécutez vstest.console.exe à partir d'un dossier qui nécessite un accès en écriture. Pour résoudre le problème, exécutez vstest.console.exe à partir d'un dossier sur lequel vous disposez de privilèges d'accès en écriture. Pour plus d'informations, consultez le message d'erreur :</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InnerException">
+        <source>Inner exception:</source>
+        <target state="new">Inner exception:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StackTrace">
+        <source>Stack trace:</source>
+        <target state="new">Stack trace:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.it.xlf
@@ -284,6 +284,16 @@
         <target state="translated">{0} Accesso negato durante il tentativo di creare la cartella "TestResults" nel percorso indicato. Si riceve questa eccezione perché si esegue vstest.console.exe da una cartella per cui è necessario l'accesso in scrittura. Per risolvere il problema, eseguire vstest.console.exe da una cartella per cui si hanno privilegi di scrittura. Per altre informazioni, vedere il messaggio di errore:</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InnerException">
+        <source>Inner exception:</source>
+        <target state="new">Inner exception:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StackTrace">
+        <source>Stack trace:</source>
+        <target state="new">Stack trace:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ja.xlf
@@ -284,6 +284,16 @@
         <target state="translated">{0} 記載した場所に "TestResults" フォルダーを作成しようとしたときにアクセスが拒否されました。書き込みアクセスを必要とするフォルダーから vstest.console.exe を実行しているため、この例外が発生しています。この問題を解決するには、書き込み権限のあるフォルダーから vstest.console.exe を実行してください。詳細については、次のエラー メッセージをご覧ください。</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InnerException">
+        <source>Inner exception:</source>
+        <target state="new">Inner exception:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StackTrace">
+        <source>Stack trace:</source>
+        <target state="new">Stack trace:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ko.xlf
@@ -284,6 +284,16 @@
         <target state="translated">{0} "TestResults" 폴더를 언급된 위치에 만드는 동안 액세스가 거부되었습니다. 쓰기 권한이 필요한 폴더에서 vstest.console.exe를 실행하고 있으므로 이 예외가 발생했습니다. 이 문제를 해결하려면 쓰기 권한이 있는 폴더에서 vstest.console.exe를 실행하세요. 자세한 내용은 다음 오류 메시지를 확인하세요.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InnerException">
+        <source>Inner exception:</source>
+        <target state="new">Inner exception:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StackTrace">
+        <source>Stack trace:</source>
+        <target state="new">Stack trace:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pl.xlf
@@ -284,6 +284,16 @@
         <target state="translated">{0} Odmowa dostępu podczas próby utworzenia folderu „TestResults” w określonej lokalizacji. Widzisz ten wyjątek, ponieważ program vstest.console.exe został uruchomiony z folderu wymagającego dostępu do zapisu. Aby rozwiązać ten problem: uruchom program vstest.console.exe z folderu, w którym masz uprawnienia do zapisu. Więcej informacji można znaleźć w komunikacie o błędzie:</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InnerException">
+        <source>Inner exception:</source>
+        <target state="new">Inner exception:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StackTrace">
+        <source>Stack trace:</source>
+        <target state="new">Stack trace:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pt-BR.xlf
@@ -284,6 +284,16 @@
         <target state="translated">{0} Acesso negado ao tentar criar a pasta "TestResults" no local mencionado. Você está recebendo esta exceção porque está executando o vstest.console.exe em uma pasta que requer acesso para gravação. Para resolver o problema: execute vstest.console.exe em uma pasta na qual você tenha privilégios de gravação. Para obter mais informações, verifique a mensagem de erro:</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InnerException">
+        <source>Inner exception:</source>
+        <target state="new">Inner exception:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StackTrace">
+        <source>Stack trace:</source>
+        <target state="new">Stack trace:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ru.xlf
@@ -284,6 +284,16 @@
         <target state="translated">{0} Отказано в доступе при попытке создания папки "TestResults" в указанном расположении. Это исключение возникло, так как вы запускаете файл vstest.console.exe из папки, для которой требуется доступ на запись. Чтобы устранить эту проблему, запустите vstest.console.exe из папки, для которой у вас есть разрешения на запись. Дополнительные сведения см. в сообщении об ошибке:</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InnerException">
+        <source>Inner exception:</source>
+        <target state="new">Inner exception:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StackTrace">
+        <source>Stack trace:</source>
+        <target state="new">Stack trace:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.tr.xlf
@@ -284,6 +284,16 @@
         <target state="translated">{0} Belirtilen konumda "TestResults" klasörü oluşturulmaya çalışılırken erişim engellendi. Yazma erişimi gerektiren bir klasörden vstest.console.exe çalıştırdığınız için bu özel durumu aldınız. Sorunu çözmek için: Lütfen yazma ayrıcalıklarına sahip olduğunuz bir klasörden vstest.console.exe dosyasını çalıştırın. Daha fazla bilgi için lütfen hata iletisine bakın:</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InnerException">
+        <source>Inner exception:</source>
+        <target state="new">Inner exception:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StackTrace">
+        <source>Stack trace:</source>
+        <target state="new">Stack trace:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.xlf
@@ -161,6 +161,16 @@
         <target state="new">Access denied while trying to create "TestResults" folder in current location. You are getting this exception because you are running vstest.console.exe from a folder which requires administrator rights. To solve the issue : please open command line "As Administrator" or run vstest.console.exe from a folder where you have admin privileges.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InnerException">
+        <source>Inner exception:</source>
+        <target state="new">Inner exception:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StackTrace">
+        <source>Stack trace:</source>
+        <target state="new">Stack trace:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hans.xlf
@@ -284,6 +284,16 @@
         <target state="translated">{0} 尝试在所述位置创建 "TestResults" 文件夹时，访问被拒。你收到此异常是因为你正在从需要具有写入权限的文件夹运行 vstest.console.exe。若要解决此问题，请从你具有写入权限的文件夹运行 vstest.console.exe。有关详细信息，请查看错误消息:</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InnerException">
+        <source>Inner exception:</source>
+        <target state="new">Inner exception:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StackTrace">
+        <source>Stack trace:</source>
+        <target state="new">Stack trace:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hant.xlf
@@ -284,6 +284,16 @@
         <target state="translated">{0} 嘗試在提及的位置上建立 "TestResults" 資料夾時存取被拒。因為您正從需要寫入存取權的資料夾執行 vstest.console.exe，所以收到此例外狀況。若要解決此問題: 請從您有權寫入的資料夾執行 vstest.console.exe。如需詳細資訊，請參閱錯誤訊息:</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InnerException">
+        <source>Inner exception:</source>
+        <target state="new">Inner exception:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StackTrace">
+        <source>Stack trace:</source>
+        <target state="new">Stack trace:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Common/Utilities/ExceptionUtilities.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/ExceptionUtilities.cs
@@ -24,15 +24,30 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
             }
 
             var exceptionString = new StringBuilder(exception.Message);
+            AppendStackTrace(exceptionString, exception);
+
             var inner = exception.InnerException;
             while (inner != null)
             {
-                exceptionString.Append(Environment.NewLine);
-                exceptionString.Append(inner.Message);
+                exceptionString
+                    .AppendLine()
+                    .Append(Resources.Resources.InnerException).Append(" ").AppendLine(inner.Message);
+                AppendStackTrace(exceptionString, inner);
                 inner = inner.InnerException;
             }
 
             return exceptionString.ToString();
+        }
+
+        private static void AppendStackTrace(StringBuilder stringBuilder, Exception exception)
+        {
+            if (!string.IsNullOrEmpty(exception.StackTrace))
+            {
+                stringBuilder
+                    .AppendLine()
+                    .AppendLine(Resources.Resources.StackTrace)
+                    .AppendLine(exception.StackTrace);
+            }
         }
     }
 }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Utilities/ExceptionUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Utilities/ExceptionUtilitiesTests.cs
@@ -25,14 +25,39 @@ namespace TestPlatform.Common.UnitTests.Utilities
         }
 
         [TestMethod]
-        public void GetExceptionMessageShouldReturnFormattedExceptionMessageWithInnerExceptionDetails()
+        public void GetExceptionMessageShouldReturnExceptionMessageContainingAllExceptionMessages()
         {
             var innerException = new Exception("Bad stuff internally");
             var innerException2 = new Exception("Bad stuff internally 2", innerException);
             var exception = new ArgumentException("Some bad stuff", innerException2);
-            var expectedMessage = exception.Message + Environment.NewLine + innerException2.Message
-                                  + Environment.NewLine + innerException.Message; 
-            Assert.AreEqual(expectedMessage, ExceptionUtilities.GetExceptionMessage(exception));
+            
+            var message = ExceptionUtilities.GetExceptionMessage(exception);
+            StringAssert.Contains(message, exception.Message);
+            StringAssert.Contains(message, innerException.Message);
+            StringAssert.Contains(message, innerException.Message);
+        }
+
+        [TestMethod]
+        public void GetExceptionMessageShouldReturnExceptionMessageContainingStackTrace()
+        {
+            var message = ExceptionUtilities.GetExceptionMessage(GetExceptionWithStackTrace());
+            StringAssert.Contains(message, "Stack trace:");
+            // this test is where it or
+            StringAssert.Contains(message, "ExceptionUtilitiesTests.GetExceptionWithStackTrace");
+        }
+
+        private Exception GetExceptionWithStackTrace()
+        {
+            try
+            {
+                var innerException = new Exception("Bad stuff internally");
+                var innerException2 = new Exception("Bad stuff internally 2", innerException);
+                throw new ArgumentException("Some bad stuff", innerException2);
+            }
+            catch (Exception e)
+            {
+                return e;
+            }
         }
     }
 }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/BaseRunTestsTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/BaseRunTestsTests.cs
@@ -446,7 +446,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
             var messageFormat = "An exception occurred while invoking executor '{0}': {1}";
             var message = string.Format(messageFormat, BaseRunTestsExecutorUri.ToLower(), "Test influenced.");
             this.mockTestRunEventsHandler.Verify(
-                treh => treh.HandleLogMessage(TestMessageLevel.Error, message),
+                treh => treh.HandleLogMessage(TestMessageLevel.Error, It.Is<string>(s => s.StartsWith(message))),
                 Times.Once);
 
             // Also validate that a test run complete is called.


### PR DESCRIPTION
When executor fails with an error print the message as well as the stacktrace from all the exceptions. 

New behavior:
![image](https://user-images.githubusercontent.com/5735905/106761755-7197b680-6635-11eb-85c0-6ec551e2b3a9.png)


Old behavior (only prints message, which can be very generic):
![image](https://user-images.githubusercontent.com/5735905/106761891-8d02c180-6635-11eb-8b2f-a9324ced71d0.png)

## Related issue
Fix #2729 
