### PR TITLE
Don't swallow stacktrace from adapter exception when running in thread

### DIFF
--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/PlatformThread.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/PlatformThread.cs
@@ -6,6 +6,7 @@
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
+    using System.Runtime.ExceptionServices;
     using System.Threading;
 
     using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
@@ -42,7 +43,8 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
                 thread.Join();
                 if (exThrown != null)
                 {
-                    throw exThrown;
+                    // Preserve the stacktrace when re-throwing the exception.
+                    ExceptionDispatchInfo.Capture(exThrown).Throw();
                 }
             }
         }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformThread.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformThread.cs
@@ -6,6 +6,7 @@
 namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
 {
     using System;
+    using System.Runtime.ExceptionServices;
     using System.Threading;
     using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
 
@@ -45,7 +46,8 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
                 thread.Join();
                 if (exThrown != null)
                 {
-                    throw exThrown;
+                    // Preserve the stacktrace when re-throwing the exception.
+                    ExceptionDispatchInfo.Capture(exThrown).Throw();
                 }
             }
         }


### PR DESCRIPTION
## Description
Ensure that we re-throw the exception coming from thread without losing the stacktrace. This path is used in STA thread on net451, netcore runner mostly avoids it.

## Related issue
Fix #2729 