### PR TITLE
Modified integration tests to use temp folder

### DIFF
--- a/test/Microsoft.TestPlatform.AcceptanceTests/AcceptanceTestBase.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/AcceptanceTestBase.cs
@@ -4,8 +4,8 @@
 namespace Microsoft.TestPlatform.AcceptanceTests
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
+    using System.IO;
+
     using Microsoft.TestPlatform.TestUtilities;
 
     public class AcceptanceTestBase : IntegrationTestBase

--- a/test/Microsoft.TestPlatform.AcceptanceTests/AppDomainTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/AppDomainTests.cs
@@ -24,6 +24,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
 
+            var testResults = GetResultsDirectory();
             var testAppDomainDetailFileName = Path.Combine(Path.GetTempPath(), "appdomain_test.txt");
             var dataCollectorAppDomainDetailFileName = Path.Combine(Path.GetTempPath(), "appdomain_datacollector.txt");
 
@@ -36,13 +37,15 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 this.GetTestAdapterPath(),
                 runsettingsFilePath,
                 this.FrameworkArgValue,
-                runnerInfo.InIsolationValue);
+                runnerInfo.InIsolationValue,
+                testResults);
 
             this.InvokeVsTest(arguments);
 
             Assert.IsTrue(IsFilesContentEqual(testAppDomainDetailFileName, dataCollectorAppDomainDetailFileName), "Different AppDomains, test: {0} datacollector: {1}", File.ReadAllText(testAppDomainDetailFileName), File.ReadAllText(dataCollectorAppDomainDetailFileName));
             this.ValidateSummaryStatus(1, 1, 1);
             File.Delete(runsettingsFilePath);
+            TryRemoveDirectory(testResults);
         }
 
         private static bool IsFilesContentEqual(string filePath1, string filePath2)

--- a/test/Microsoft.TestPlatform.AcceptanceTests/ArgumentProcessorTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/ArgumentProcessorTests.cs
@@ -38,7 +38,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
 
-            var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue);
+            var testResults = GetResultsDirectory();
+            var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, resultsDirectory: testResults);
             arguments = string.Concat(arguments, " /badArgument");
 
             this.InvokeVsTest(arguments);
@@ -56,6 +57,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
             //Check for message which guides using help option
             this.StdErrorContains("Please use the /help option to check the list of valid arguments");
+
+            TryRemoveDirectory(testResults);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/BlameDataCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/BlameDataCollectorTests.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.TestPlatform.AcceptanceTests
 {
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     using System;
     using System.Collections.Generic;
     using System.IO;
@@ -24,7 +25,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
         public BlameDataCollectorTests()
         {
-            this.resultsDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            this.resultsDir = GetResultsDirectory();
         }
 
         [TestCleanup]
@@ -32,10 +33,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         {
             Environment.SetEnvironmentVariable("PROCDUMP_PATH", null);
 
-            if (Directory.Exists(this.resultsDir))
-            {
-                Directory.Delete(this.resultsDir, true);
-            }
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -64,7 +62,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         {
             Environment.SetEnvironmentVariable("PROCDUMP_PATH", Path.Combine(this.testEnvironment.PackageDirectory, @"procdump\0.0.1\bin"));
 
-            AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);            
+            AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
             var assemblyPaths = this.BuildMultipleAssemblyPath("SimpleTestProject3.dll").Trim('\"');
             var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, string.Empty, runnerInfo.InIsolationValue);
             arguments = string.Concat(arguments, $" /Blame:CollectDump");
@@ -91,7 +89,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             arguments = string.Concat(arguments, $" /ResultsDirectory:{resultsDir}");
             arguments = string.Concat(arguments, " /testcasefilter:PassingTest");
             this.InvokeVsTest(arguments);
-            
+
             Assert.IsFalse(this.StdOut.Contains(".dmp"), "it should not collect a dump, because nothing crashed");
         }
 
@@ -245,8 +243,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
             if (dumps.Count < expectedDumpCount)
             {
-                throw new AssertFailedException($"Expected at least {expectedDumpCount} dump file in Attachments, but there were {dumps.Count}." 
-                    + Environment.NewLine 
+                throw new AssertFailedException($"Expected at least {expectedDumpCount} dump file in Attachments, but there were {dumps.Count}."
+                    + Environment.NewLine
                     + string.Join(Environment.NewLine, dumps));
             }
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/CUITTest.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/CUITTest.cs
@@ -27,14 +27,13 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             }
 
             var assemblyAbsolutePath = testEnvironment.GetTestAsset("CUITTestProject.dll", "net451");
-            var arguments = PrepareArguments(
-                assemblyAbsolutePath,
-                string.Empty,
-                string.Empty,
-                this.FrameworkArgValue);
+            var resultsDirectory = GetResultsDirectory();
+            var arguments = PrepareArguments(assemblyAbsolutePath, string.Empty, string.Empty, this.FrameworkArgValue, resultsDirectory: resultsDirectory);
 
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 0, 0);
+
+            TryRemoveDirectory(resultsDirectory);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/CodeCoverageTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/CodeCoverageTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
         public CodeCoverageTests()
         {
-            this.resultsDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            this.resultsDirectory = GetResultsDirectory();
         }
 
         [TestMethod]
@@ -208,8 +208,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
             string diagFileName = Path.Combine(this.resultsDirectory, "diaglog.txt");
             var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty,
-                this.FrameworkArgValue, runnerInfo.InIsolationValue);
-            arguments = string.Concat(arguments, $" /ResultsDirectory:{resultsDirectory}", $" /Diag:{diagFileName}",
+                this.FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory);
+            arguments = string.Concat(arguments, $" /Diag:{diagFileName}",
                 $" /TestAdapterPath:{traceDataCollectorDir}");
             arguments = string.Concat(arguments, $" /Platform:{testParameters.TargetPlatform}");
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DebugAssertTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DebugAssertTests.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.TestPlatform.AcceptanceTests
 {
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     using System;
 
     [TestClass]
@@ -18,14 +19,17 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             // is to not crash the process when we are running in debug, and debugger is attached
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
 
+            var resultsDir = GetResultsDirectory();
             var assemblyPath = this.BuildMultipleAssemblyPath("CrashingOnDebugAssertTestProject.dll").Trim('\"');
-            var arguments = PrepareArguments(assemblyPath, null, null, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            var arguments = PrepareArguments(assemblyPath, null, null, this.FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             this.InvokeVsTest(arguments);
 
             // this will have failed tests when our trace listener works and crash the testhost process when it does not
             // because crashing processes is what a failed Debug.Assert does by default, unless you have a debugger attached
             this.ValidateSummaryStatus(passedTestsCount: 4, failedTestsCount: 4, 0);
             StringAssert.Contains(this.StdOut, "threw exception: Microsoft.VisualStudio.TestPlatform.TestHost.DebugAssertException:");
+
+            TryRemoveDirectory(resultsDir);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DeprecateExtensionsPathWarningTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DeprecateExtensionsPathWarningTests.cs
@@ -2,6 +2,7 @@
 {
     using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     using System.Collections.Generic;
     using System.IO;
     using System.Reflection;
@@ -66,15 +67,13 @@
         [TestMethod]
         public void VerifyDeprecatedWarningIsThrownWhenAdaptersPickedFromExtensionDirectory()
         {
-            var arguments = PrepareArguments(
-                this.GetSampleTestAssembly(),
-                null,
-                null,
-                this.FrameworkArgValue);
+            var resultsDir = GetResultsDirectory();
+            var arguments = PrepareArguments(this.GetSampleTestAssembly(), null, null, this.FrameworkArgValue, resultsDirectory: resultsDir);
 
             this.InvokeVsTest(arguments);
-
             this.StdOutputContains("Adapter lookup is being changed, please follow");
+
+            TryRemoveDirectory(resultsDir);
         }
 
         public override string GetConsoleRunnerPath()

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DifferentTestFrameworkSimpleTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DifferentTestFrameworkSimpleTests.cs
@@ -5,6 +5,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 {
     using System;
     using System.IO;
+
     using Microsoft.TestPlatform.TestUtilities;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -17,15 +18,14 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void ChutzpahRunAllTestExecution(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
-
+            var resultsDir = GetResultsDirectory();
             var testJSFileAbsolutePath = Path.Combine(this.testEnvironment.TestAssetsPath, "test.js");
-            var arguments = PrepareArguments(
-                testJSFileAbsolutePath,
-                this.GetTestAdapterPath(UnitTestFramework.Chutzpah),
-                string.Empty, this.FrameworkArgValue,
-                runnerInfo.InIsolationValue);
+            var arguments = PrepareArguments(testJSFileAbsolutePath, this.GetTestAdapterPath(UnitTestFramework.Chutzpah), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
+
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 1, 0);
+
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -85,13 +85,16 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
 
+            var resultsDir = GetResultsDirectory();
             var arguments = PrepareArguments(
                 this.GetAssetFullPath("NUTestProject.dll"),
                 this.GetTestAdapterPath(UnitTestFramework.NUnit),
                 string.Empty, this.FrameworkArgValue,
-                runnerInfo.InIsolationValue);
+                runnerInfo.InIsolationValue, resultsDir);
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 1, 0);
+
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -100,8 +103,9 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void XUnitRunAllTestExecution(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
-            string testAssemblyPath = null;
+            var resultsDir = GetResultsDirectory();
 
+            string testAssemblyPath;
             // Xunit >= 2.2 won't support net451, Minimum target framework it supports is net452.
             if (this.testEnvironment.TargetFramework.Equals("net451"))
             {
@@ -116,9 +120,11 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 testAssemblyPath,
                 this.GetTestAdapterPath(UnitTestFramework.XUnit),
                 string.Empty, this.FrameworkArgValue,
-                runnerInfo.InIsolationValue);
+                runnerInfo.InIsolationValue, resultsDir);
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 1, 0);
+
+            TryRemoveDirectory(resultsDir);
         }
 
         private void CppRunAllTests(string runnerFramework, string platform)
@@ -129,23 +135,22 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 return;
             }
 
+            var resultsDir = GetResultsDirectory();
             string assemblyRelativePathFormat =
                 @"microsoft.testplatform.testasset.nativecpp\2.0.0\contentFiles\any\any\{0}\Microsoft.TestPlatform.TestAsset.NativeCPP.dll";
             var assemblyRelativePath = platform.Equals("x64", StringComparison.OrdinalIgnoreCase)
                 ? string.Format(assemblyRelativePathFormat, platform)
                 : string.Format(assemblyRelativePathFormat, "");
             var assemblyAbsolutePath = Path.Combine(this.testEnvironment.PackageDirectory, assemblyRelativePath);
-            var arguments = PrepareArguments(
-                assemblyAbsolutePath,
-                string.Empty,
-                string.Empty, this.FrameworkArgValue,
-                this.testEnvironment.InIsolationValue);
+            var arguments = PrepareArguments(assemblyAbsolutePath, string.Empty, string.Empty, this.FrameworkArgValue, this.testEnvironment.InIsolationValue, resultsDirectory: resultsDir);
 
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 1, 0);
+
+            TryRemoveDirectory(resultsDir);
         }
 
-        private void WebTestRunAllTests(string runnerFramework, string runSettingsFilePath=null, int minWebTestResultFileSizeInKB=0)
+        private void WebTestRunAllTests(string runnerFramework, string runSettingsFilePath = null, int minWebTestResultFileSizeInKB = 0)
         {
             if (runnerFramework.StartsWith("netcoreapp"))
             {
@@ -157,7 +162,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 @"microsoft.testplatform.qtools.assets\2.0.0\contentFiles\any\any\WebTestAssets\WebTest1.webtest";
 
             var assemblyAbsolutePath = Path.Combine(this.testEnvironment.PackageDirectory, assemblyRelativePath);
-            var resultsDirectory = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
+            var resultsDirectory = GetResultsDirectory();
             var arguments = PrepareArguments(
                 assemblyAbsolutePath,
                 string.Empty,
@@ -176,6 +181,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 var fileSizeInKB = files[0].Length / 1024;
                 Assert.IsTrue(fileSizeInKB > minWebTestResultFileSizeInKB, $"Size of the file {webtestResultFile} is {fileSizeInKB} KB. It is not greater than {minWebTestResultFileSizeInKB} KB indicating iterationCount in run settings not honored.");
             }
+
+            TryRemoveDirectory(resultsDirectory);
         }
 
         private void CodedWebTestRunAllTests(string runnerFramework)
@@ -186,16 +193,19 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 return;
             }
 
+            var resultsDir = GetResultsDirectory();
             string assemblyRelativePath =
                 @"microsoft.testplatform.qtools.assets\2.0.0\contentFiles\any\any\WebTestAssets\BingWebTest.dll";
             var assemblyAbsolutePath = Path.Combine(this.testEnvironment.PackageDirectory, assemblyRelativePath);
             var arguments = PrepareArguments(
                 assemblyAbsolutePath,
                 string.Empty,
-                string.Empty, this.FrameworkArgValue);
+                string.Empty, this.FrameworkArgValue, resultsDirectory: resultsDir);
 
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 0, 0);
+
+            TryRemoveDirectory(resultsDir);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DisableAppdomainTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DisableAppdomainTests.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.TestPlatform.AcceptanceTests
 {
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     using System;
     using System.Collections.Generic;
     using System.IO;
@@ -50,16 +51,19 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                                                          { "DisableAppDomain", "true" }
                                                  };
 
+            var resultsDir = GetResultsDirectory();
             var diableAppdomainTest1 = testEnvironment.GetTestAsset("DisableAppdomainTest1.dll", "net451");
             var diableAppdomainTest2 = testEnvironment.GetTestAsset("DisableAppdomainTest2.dll", "net451");
             var arguments = PrepareArguments(
                 testAssembly,
                 string.Empty,
                 GetRunsettingsFilePath(runConfigurationDictionary),
-                this.FrameworkArgValue);
+                this.FrameworkArgValue, resultsDirectory: resultsDir);
 
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(passedTestCount, 0, 0);
+
+            TryRemoveDirectory(resultsDir);
         }
 
         private string GetRunsettingsFilePath(Dictionary<string, string> runConfigurationDictionary)

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DiscoveryTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DiscoveryTests.cs
@@ -59,12 +59,15 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         [NetFullTargetFrameworkDataSource(inIsolation: true, inProcess: true)]
         public void DiscoverFullyQualifiedTests(RunnerInfo runnerInfo)
         {
+            var resultsDir = GetResultsDirectory();
+
             try
             {
                 AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+
                 var listOfTests = new[] { "SampleUnitTestProject.UnitTest1.PassingTest", "SampleUnitTestProject.UnitTest1.FailingTest", "SampleUnitTestProject.UnitTest1.SkippingTest" };
 
-                var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, this.testEnvironment.InIsolationValue);
+                var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, this.testEnvironment.InIsolationValue, resultsDirectory: resultsDir);
                 arguments = string.Concat(arguments, " /ListFullyQualifiedTests", " /ListTestsTargetPath:\"" + dummyFilePath + "\"");
                 this.InvokeVsTest(arguments);
 
@@ -74,6 +77,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             finally
             {
                 File.Delete(this.dummyFilePath);
+                TryRemoveDirectory(resultsDir);
             }
         }
 
@@ -83,19 +87,20 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void DiscoverTestsShouldShowProperWarningIfNoTestsOnTestCaseFilter(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var assetFullPath = this.GetAssetFullPath("SimpleTestProject2.dll");
-            var arguments = PrepareArguments(assetFullPath, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, this.testEnvironment.InIsolationValue);
-            arguments = string.Concat(arguments, " /listtests" );
+            var arguments = PrepareArguments(assetFullPath, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, this.testEnvironment.InIsolationValue, resultsDirectory: resultsDir);
+            arguments = string.Concat(arguments, " /listtests");
             arguments = string.Concat(arguments, " /testcasefilter:NonExistTestCaseName");
             arguments = string.Concat(arguments, " /logger:\"console;prefix=true\"");
             this.InvokeVsTest(arguments);
 
             StringAssert.Contains(this.StdOut, "Warning: No test matches the given testcase filter `NonExistTestCaseName` in");
-
             StringAssert.Contains(this.StdOut, "SimpleTestProject2.dll");
-
             this.ExitCodeEquals(0);
+
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.AcceptanceTests/EventLogCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/EventLogCollectorTests.cs
@@ -7,6 +7,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 
@@ -18,7 +19,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
         public EventLogCollectorTests()
         {
-            this.resultsDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            this.resultsDir = GetResultsDirectory();
         }
 
         // Fails randomly https://ci.dot.net/job/Microsoft_vstest/job/master/job/Windows_NT_Release_prtest/2084/console
@@ -33,8 +34,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             var assemblyPaths = this.testEnvironment.GetTestAsset("EventLogUnitTestProject.dll");
 
             string runSettings = this.GetRunsettingsFilePath();
-            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), runSettings, this.FrameworkArgValue);
-            arguments = string.Concat(arguments, $" /ResultsDirectory:{resultsDir}");
+            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), runSettings, this.FrameworkArgValue, resultsDirectory: resultsDir);
 
             this.InvokeVsTest(arguments);
 
@@ -55,8 +55,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             var assemblyPaths = this.testEnvironment.GetTestAsset("SimpleTestProject.dll");
 
             string runSettings = this.GetRunsettingsFilePath();
-            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), runSettings, this.FrameworkArgValue);
-            arguments = string.Concat(arguments, $" /ResultsDirectory:{resultsDir}");
+            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), runSettings, this.FrameworkArgValue, resultsDirectory: resultsDir);
 
             this.InvokeVsTest(arguments);
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionThreadApartmentStateTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionThreadApartmentStateTests.cs
@@ -14,12 +14,15 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void UITestShouldPassIfApartmentStateIsSTA(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var assemblyPaths = this.BuildMultipleAssemblyPath("SimpleTestProject3.dll").Trim('\"');
-            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " /testcasefilter:UITestMethod");
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 0, 0);
+
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -27,14 +30,17 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void WarningShouldBeShownWhenValueIsSTAForNetCore(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var assemblyPaths =
                 this.BuildMultipleAssemblyPath("SimpleTestProject2.dll").Trim('\"');
-            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " /testcasefilter:PassingTest2 -- RunConfiguration.ExecutionThreadApartmentState=STA");
             this.InvokeVsTest(arguments);
             this.StdOutputContains("ExecutionThreadApartmentState option not supported for framework:");
             this.ValidateSummaryStatus(1, 0, 0);
+
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -42,13 +48,16 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void UITestShouldFailWhenDefaultApartmentStateIsMTA(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var assemblyPaths =
                 this.BuildMultipleAssemblyPath("SimpleTestProject3.dll").Trim('\"');
-            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " /testcasefilter:UITestMethod -- RunConfiguration.ExecutionThreadApartmentState=MTA");
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(0, 1, 0);
+
+            TryRemoveDirectory(resultsDir);
         }
 
         [Ignore(@"Issue with TestSessionTimeout:  https://github.com/Microsoft/vstest/issues/980")]
@@ -57,14 +66,17 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void CancelTestExectionShouldWorkWhenApartmentStateIsSTA(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var assemblyPaths =
                 this.BuildMultipleAssemblyPath("SimpleTestProject3.dll").Trim('\"');
-            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " /tests:UITestWithSleep1,UITestMethod -- RunConfiguration.ExecutionThreadApartmentState=STA RunConfiguration.TestSessionTimeout=2000");
             this.InvokeVsTest(arguments);
             this.StdOutputContains("Canceling test run: test run timeout of");
             this.ValidateSummaryStatus(1, 0, 0);
+
+            TryRemoveDirectory(resultsDir);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/FilePatternParserTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/FilePatternParserTests.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.TestPlatform.AcceptanceTests
 {
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     using System.IO;
 
     [TestClass]
@@ -15,6 +16,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void WildCardPatternShouldCorrectlyWorkOnFiles(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var testAssembly = this.GetSampleTestAssembly();
             testAssembly = testAssembly.Replace("SimpleTestProject.dll", "*TestProj*.dll");
@@ -23,10 +25,11 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                testAssembly,
                this.GetTestAdapterPath(),
                string.Empty, this.FrameworkArgValue,
-               runnerInfo.InIsolationValue);
+               runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
 
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 1, 1);
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -35,6 +38,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void WildCardPatternShouldCorrectlyWorkOnArbitraryDepthDirectories(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var testAssembly = this.GetSampleTestAssembly();
             var oldAssemblyPath = Path.Combine("Debug", this.testEnvironment.TargetFramework, "SimpleTestProject.dll");
@@ -45,10 +49,11 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                testAssembly,
                this.GetTestAdapterPath(),
                string.Empty, string.Empty,
-               runnerInfo.InIsolationValue);
+               runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
 
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 1, 1);
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -57,6 +62,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void WildCardPatternShouldCorrectlyWorkForRelativeAssemblyPath(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var testAssembly = this.GetSampleTestAssembly();
             testAssembly = testAssembly.Replace("SimpleTestProject.dll", "*TestProj*.dll");
@@ -71,10 +77,11 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                testAssembly,
                this.GetTestAdapterPath(),
                string.Empty, string.Empty,
-               runnerInfo.InIsolationValue);
+               runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
 
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 1, 1);
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -83,6 +90,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void WildCardPatternShouldCorrectlyWorkOnMultipleFiles(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var testAssembly = this.BuildMultipleAssemblyPath("SimpleTestProject.dll", "SimpleTestProject2.dll").Trim('\"'); ;
             testAssembly = testAssembly.Replace("SimpleTestProject.dll", "*TestProj*.dll");
@@ -92,10 +100,11 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                testAssembly,
                this.GetTestAdapterPath(),
                string.Empty, this.FrameworkArgValue,
-               runnerInfo.InIsolationValue);
+               runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
 
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(2, 2, 2);
+            TryRemoveDirectory(resultsDir);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/FrameworkTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/FrameworkTests.cs
@@ -15,12 +15,14 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void FrameworkArgumentShouldWork(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
-            var arguments = PrepareArguments(GetSampleTestAssembly(), string.Empty, string.Empty, string.Empty);
+            var arguments = PrepareArguments(GetSampleTestAssembly(), string.Empty, string.Empty, string.Empty, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " ", $"/Framework:{this.FrameworkArgValue}");
 
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 1, 1);
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -29,12 +31,14 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void FrameworkShortNameArgumentShouldWork(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
-            var arguments = PrepareArguments(GetSampleTestAssembly(), string.Empty, string.Empty, string.Empty);
+            var arguments = PrepareArguments(GetSampleTestAssembly(), string.Empty, string.Empty, string.Empty, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " ", $"/Framework:{this.testEnvironment.TargetFramework}");
 
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 1, 1);
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -45,8 +49,9 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void OnWrongFrameworkPassedTestRunShouldNotRun(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
-            var arguments = PrepareArguments(GetSampleTestAssembly(), string.Empty, string.Empty, string.Empty);
+            var arguments = PrepareArguments(GetSampleTestAssembly(), string.Empty, string.Empty, string.Empty, resultsDirectory: resultsDir);
             if (runnerInfo.TargetFramework.Contains("netcore"))
             {
                 arguments = string.Concat(arguments, " ", "/Framework:Framework45");
@@ -65,6 +70,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             {
                 this.StdErrorContains("Test Run Aborted.");
             }
+
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -73,8 +80,9 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void RunSpecificTestsShouldWorkWithFrameworkInCompatibleWarning(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
-            var arguments = PrepareArguments(GetSampleTestAssembly(), string.Empty, string.Empty, string.Empty);
+            var arguments = PrepareArguments(GetSampleTestAssembly(), string.Empty, string.Empty, string.Empty, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " ", "/tests:PassingTest");
             arguments = string.Concat(arguments, " ", "/Framework:Framework40");
 
@@ -89,6 +97,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 this.StdOutputContains("Following DLL(s) do not match current settings, which are .NETFramework,Version=v4.0 framework and X86 platform.");
                 this.ValidateSummaryStatus(1, 0, 0);
             }
+
+            TryRemoveDirectory(resultsDir);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/LoggerTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/LoggerTests.cs
@@ -8,6 +8,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
     using System.Text;
     using System.IO;
     using System.Xml;
+    using System;
 
     [TestClass]
     public class LoggerTests : AcceptanceTestBase
@@ -18,19 +19,22 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void TrxLoggerWithFriendlyNameShouldProperlyOverwriteFile(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var testResultsDirectory = GetResultsDirectory();
 
-            var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue, testResultsDirectory);
             var trxFileName = "TestResults.trx";
             arguments = string.Concat(arguments, $" /logger:\"trx;LogFileName={trxFileName}\"");
             this.InvokeVsTest(arguments);
 
-            arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue, testResultsDirectory);
             arguments = string.Concat(arguments, $" /logger:\"trx;LogFileName={trxFileName}\"");
             arguments = string.Concat(arguments, " /testcasefilter:Name~Pass");
             this.InvokeVsTest(arguments);
 
-            var trxLogFilePath = Path.Combine(Directory.GetCurrentDirectory(), "TestResults",  trxFileName);
-            Assert.IsTrue(IsValidXml(trxLogFilePath), "Invalid content in Trx log file");
+            var trxFilePath = Path.Combine(testResultsDirectory, trxFileName);
+            Assert.IsTrue(IsValidXml(trxFilePath), "Invalid content in Trx log file");
+
+            TryRemoveDirectory(testResultsDirectory);
         }
 
         [TestMethod]
@@ -39,19 +43,22 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void HtmlLoggerWithFriendlyNameShouldProperlyOverwriteFile(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var testResultsDirectory = GetResultsDirectory();
 
-            var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue, testResultsDirectory);
             var htmlFileName = "TestResults.html";
             arguments = string.Concat(arguments, $" /logger:\"html;LogFileName={htmlFileName}\"");
             this.InvokeVsTest(arguments);
 
-            arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue, testResultsDirectory);
             arguments = string.Concat(arguments, $" /logger:\"html;LogFileName={htmlFileName}\"");
             arguments = string.Concat(arguments, " /testcasefilter:Name~Pass");
             this.InvokeVsTest(arguments);
 
-            var htmlLogFilePath = Path.Combine(Directory.GetCurrentDirectory(), "TestResults", htmlFileName);
+            var htmlLogFilePath = Path.Combine(testResultsDirectory, htmlFileName);
             IsFileAndContentEqual(htmlLogFilePath);
+
+            TryRemoveDirectory(testResultsDirectory);
         }
 
         [TestMethod]
@@ -59,19 +66,22 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void TrxLoggerWithExecutorUriShouldProperlyOverwriteFile(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var testResultsDirectory = GetResultsDirectory();
 
-            var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue, testResultsDirectory);
             var trxFileName = "TestResults.trx";
-            arguments = string.Concat(arguments, $" /logger:\"logger://Microsoft/TestPlatform/TrxLogger/v1;LogFileName{trxFileName}\"");
+            arguments = string.Concat(arguments, $" /logger:\"logger://Microsoft/TestPlatform/TrxLogger/v1;LogFileName={trxFileName}\"");
             this.InvokeVsTest(arguments);
 
-            arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue, testResultsDirectory);
             arguments = string.Concat(arguments, $" /logger:\"logger://Microsoft/TestPlatform/TrxLogger/v1;LogFileName={trxFileName}\"");
             arguments = string.Concat(arguments, " /testcasefilter:Name~Pass");
             this.InvokeVsTest(arguments);
 
-            var trxLogFilePath = Path.Combine(Directory.GetCurrentDirectory(), "TestResults", trxFileName);
+            var trxLogFilePath = Path.Combine(testResultsDirectory, trxFileName);
             Assert.IsTrue(IsValidXml(trxLogFilePath), "Invalid content in Trx log file");
+
+            TryRemoveDirectory(testResultsDirectory);
         }
 
         [TestMethod]
@@ -80,20 +90,22 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void TrxLoggerWithLogFilePrefixShouldGenerateMultipleTrx(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var testResultsDirectory = GetResultsDirectory();
             var trxFileNamePattern = "TestResults";
 
-            var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue, testResultsDirectory);
             arguments = string.Concat(arguments, $" /logger:\"logger://Microsoft/TestPlatform/TrxLogger/v1;LogFilePrefix={trxFileNamePattern}\"");
             this.InvokeVsTest(arguments);
 
-            arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue, testResultsDirectory);
             arguments = string.Concat(arguments, $" /logger:\"logger://Microsoft/TestPlatform/TrxLogger/v1;LogFilePrefix={trxFileNamePattern}\"");
             arguments = string.Concat(arguments, " /testcasefilter:Name~Pass");
             this.InvokeVsTest(arguments);
 
-            var trxFilePaths = Directory.EnumerateFiles(Path.Combine(Directory.GetCurrentDirectory(), "TestResults"), trxFileNamePattern + "_net*.trx");
+            var trxFilePaths = Directory.EnumerateFiles(testResultsDirectory, trxFileNamePattern + "_net*.trx");
             Assert.IsTrue(trxFilePaths.Count() > 1);
 
+            TryRemoveDirectory(testResultsDirectory);
         }
 
         [TestMethod]
@@ -101,30 +113,37 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void HtmlLoggerWithExecutorUriShouldProperlyOverwriteFile(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var testResultsDirectory = GetResultsDirectory();
 
-            var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue, testResultsDirectory);
             var htmlFileName = "TestResults.html";
             arguments = string.Concat(arguments, $" /logger:\"logger://Microsoft/TestPlatform/htmlLogger/v1;LogFileName{htmlFileName}\"");
             this.InvokeVsTest(arguments);
 
-            arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue, testResultsDirectory);
             arguments = string.Concat(arguments, $" /logger:\"logger://Microsoft/TestPlatform/htmlLogger/v1;LogFileName={htmlFileName}\"");
             arguments = string.Concat(arguments, " /testcasefilter:Name~Pass");
             this.InvokeVsTest(arguments);
 
-            var htmlLogFilePath = Path.Combine(Directory.GetCurrentDirectory(), "TestResults", htmlFileName);
+            var htmlLogFilePath = Path.Combine(testResultsDirectory, htmlFileName);
             IsFileAndContentEqual(htmlLogFilePath);
+
+            TryRemoveDirectory(testResultsDirectory);
         }
 
         private bool IsValidXml(string xmlFilePath)
         {
-            var reader = System.Xml.XmlReader.Create(File.OpenRead(xmlFilePath));
             try
             {
-                while (reader.Read())
+                using (var file = File.OpenRead(xmlFilePath))
+                using (var reader = XmlReader.Create(file))
                 {
+                    while (reader.Read())
+                    {
+                    }
+
+                    return true;
                 }
-                return true;
             }
             catch (XmlException)
             {
@@ -139,6 +158,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             {
                 sb.Append(sr.ReadToEnd());
             }
+
             string filePathContent = sb.ToString();
             string[] divs = { "Total tests", "Passed", "Failed", "Skipped", "Run duration", "Pass percentage", "SampleUnitTestProject.UnitTest1.PassingTest" };
             foreach (string str in divs)

--- a/test/Microsoft.TestPlatform.AcceptanceTests/MultitargetingTestHostTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/MultitargetingTestHostTests.cs
@@ -4,7 +4,9 @@
 namespace Microsoft.TestPlatform.AcceptanceTests
 {
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     using System;
+
     using static AcceptanceTestBase;
 
     [TestClass]
@@ -19,12 +21,14 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void RunningTestWithAFailingDebugAssertDoesNotCrashTheHostingProcess(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var assemblyPath = this.BuildMultipleAssemblyPath("MultitargetedNetFrameworkProject.dll").Trim('\"');
-            var arguments = PrepareArguments(assemblyPath, null, null, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            var arguments = PrepareArguments(assemblyPath, null, null, this.FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             this.InvokeVsTest(arguments);
 
             this.ValidateSummaryStatus(passedTestsCount: 1, failedTestsCount: 0, 0);
+            TryRemoveDirectory(resultsDir);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/OrderedTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/OrderedTests.cs
@@ -21,6 +21,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void OlderOrderedTestsShouldWorkFine(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
+
             if (runnerInfo.RunnerFramework.StartsWith("netcoreapp"))
             {
                 Assert.Inconclusive(" Ordered tests are not supported with .Netcore runner.");
@@ -42,7 +44,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 orderedTestFileAbsolutePath,
                 this.GetTestAdapterPath(),
                 string.Empty, this.FrameworkArgValue,
-                runnerInfo.InIsolationValue);
+                runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
 
             this.InvokeVsTest(arguments);
             this.ValidatePassedTests("PassingTest1");
@@ -51,6 +53,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             this.ValidateSkippedTests("FailingTest2");
             // Parent test result should fail as inner results contain failing test.
             this.ValidateSummaryStatus(2, 1, 1);
+            TryRemoveDirectory(resultsDir);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/PlatformTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/PlatformTests.cs
@@ -50,11 +50,13 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
         private void RunTestExecutionWithPlatform(string platformArg, string testhostProcessName, int expectedNumOfProcessCreated)
         {
+            var resultsDir = GetResultsDirectory();
+
             var arguments = PrepareArguments(
                 this.GetSampleTestAssembly(),
                 this.GetTestAdapterPath(),
                 string.Empty, this.FrameworkArgValue,
-                this.testEnvironment.InIsolationValue);
+                this.testEnvironment.InIsolationValue, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, platformArg);
 
             var cts = new CancellationTokenSource();
@@ -71,6 +73,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 numOfProcessCreatedTask.Result.Count,
                 $"Number of {testhostProcessName} process created, expected: {expectedNumOfProcessCreated} actual: {numOfProcessCreatedTask.Result.Count} ({ string.Join(", ", numOfProcessCreatedTask.Result) }) args: {arguments} runner path: {this.GetConsoleRunnerPath()}");
             this.ValidateSummaryStatus(1, 1, 1);
+            TryRemoveDirectory(resultsDir);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/ResultsDirectoryTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/ResultsDirectoryTests.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.TestPlatform.AcceptanceTests
 {
     using System.IO;
+
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -15,19 +16,21 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void TrxFileShouldBeCreatedInResultsDirectory(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+
             var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, this.FrameworkArgValue, runnerInfo.InIsolationValue);
             var trxFileName = "TestResults.trx";
-            var resultsDir = Path.GetTempPath();
+            var resultsDir = GetResultsDirectory();
             var trxFilePath = Path.Combine(resultsDir, trxFileName);
             arguments = string.Concat(arguments, $" /logger:\"trx;LogFileName={trxFileName}\"");
             arguments = string.Concat(arguments, $" /ResultsDirectory:{resultsDir}");
 
             // Delete if already exists
-            File.Delete(trxFilePath);
+            TryRemoveDirectory(resultsDir);
 
             this.InvokeVsTest(arguments);
 
             Assert.IsTrue(File.Exists(trxFilePath), $"Expected Trx file: {trxFilePath} not created in results directory");
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -42,7 +45,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             var relativeDirectory = @"relative\directory";
             var resultsDirectory = Path.Combine(Directory.GetCurrentDirectory(), relativeDirectory);
 
-            var trxFilePath = Path.Combine(resultsDirectory , trxFileName);
+            var trxFilePath = Path.Combine(resultsDirectory, trxFileName);
             arguments = string.Concat(arguments, $" /logger:\"trx;LogFileName={trxFileName}\"");
             arguments = string.Concat(arguments, $" /ResultsDirectory:{relativeDirectory}");
 
@@ -54,6 +57,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             this.InvokeVsTest(arguments);
 
             Assert.IsTrue(File.Exists(trxFilePath), $"Expected Trx file: {trxFilePath} not created in results directory");
+            TryRemoveDirectory(resultsDirectory);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/RunsettingsTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/RunsettingsTests.cs
@@ -237,6 +237,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void RunSettingsWithInvalidValueShouldLogError(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var runConfigurationDictionary = new Dictionary<string, string>
                                                  {
@@ -247,9 +248,10 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 this.GetSampleTestAssembly(),
                 string.Empty,
                 runsettingsFilePath, this.FrameworkArgValue,
-                runnerInfo.InIsolationValue);
+                runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             this.InvokeVsTest(arguments);
             this.StdErrorContains(@"Settings file provided does not conform to required format. An error occurred while loading the settings. Error: Invalid setting 'RunConfiguration'. Invalid value '123' specified for 'TargetPlatform'.");
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -258,6 +260,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void TestAdapterPathFromRunSettings(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var runConfigurationDictionary = new Dictionary<string, string>
                                                  {
@@ -268,9 +271,10 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 this.GetSampleTestAssembly(),
                 string.Empty,
                 runsettingsFilePath, this.FrameworkArgValue,
-                runnerInfo.InIsolationValue);
+                runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 1, 1);
+            TryRemoveDirectory(resultsDir);
         }
 
         #region LegacySettings Tests
@@ -281,6 +285,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void LegacySettingsWithPlatform(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var testAssemblyPath = this.GetAssetFullPath("LegacySettingsUnitTestProject.dll");
             var testAssemblyDirectory = Path.GetDirectoryName(testAssemblyPath);
@@ -300,9 +305,10 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             var arguments = PrepareArguments(
                testAssemblyPath,
                string.Empty,
-               this.runsettingsPath, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+               this.runsettingsPath, this.FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(0, 0, 0);
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -311,6 +317,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void LegacySettingsWithScripts(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var testAssemblyPath = this.GetAssetFullPath("LegacySettingsUnitTestProject.dll");
             var testAssemblyDirectory = Path.GetDirectoryName(testAssemblyPath);
@@ -342,18 +349,19 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             var arguments = PrepareArguments(
                testAssemblyPath,
                string.Empty,
-               this.runsettingsPath, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+               this.runsettingsPath, this.FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " /testcasefilter:Name=ScriptsTest");
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 0, 0);
 
             // Validate cleanup script ran
-            var scriptPath = Path.Combine(Path.GetTempPath() + "ScriptTestingFile.txt");
+            var scriptPath = Path.Combine(Path.GetTempPath(), "ScriptTestingFile.txt");
             Assert.IsFalse(File.Exists(scriptPath));
 
             // Cleanup script files
             File.Delete(setupScriptPath);
             File.Delete(cleanupScriptPath);
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -362,6 +370,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void LegacySettingsWithDeploymentItem(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var testAssemblyPath = this.GetAssetFullPath("LegacySettingsUnitTestProject.dll");
             var testAssemblyDirectory = Path.GetDirectoryName(testAssemblyPath);
@@ -385,10 +394,11 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             var arguments = PrepareArguments(
                testAssemblyPath,
                string.Empty,
-               this.runsettingsPath, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+               this.runsettingsPath, this.FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " /testcasefilter:Name=DeploymentItemTest");
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 0, 0);
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -397,6 +407,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void LegacySettingsTestTimeout(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
+
             var testAssemblyPath = this.GetAssetFullPath("LegacySettingsUnitTestProject.dll");
             var runsettingsXml = @"<RunSettings>
                                     <MSTest>
@@ -408,12 +420,13 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                                     </LegacySettings>
                                    </RunSettings>";
             File.WriteAllText(this.runsettingsPath, runsettingsXml);
-            var arguments = PrepareArguments(testAssemblyPath, string.Empty, this.runsettingsPath, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            var arguments = PrepareArguments(testAssemblyPath, string.Empty, this.runsettingsPath, this.FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " /testcasefilter:Name~TimeTest");
 
             this.InvokeVsTest(arguments);
 
             this.ValidateSummaryStatus(1, 1, 0);
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -422,6 +435,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void LegacySettingsAssemblyResolution(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
+
             var testAssemblyPath = this.GetAssetFullPath("LegacySettingsUnitTestProject.dll");
             var runsettingsFormat = @"<RunSettings>
                                     <MSTest><ForcedLegacyMode>true</ForcedLegacyMode></MSTest>
@@ -445,12 +460,13 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             var runsettingsXml = string.Format(runsettingsFormat, testAssemblyDirectory);
 
             File.WriteAllText(this.runsettingsPath, runsettingsXml);
-            var arguments = PrepareArguments(testAssemblyPath, string.Empty, this.runsettingsPath, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            var arguments = PrepareArguments(testAssemblyPath, string.Empty, this.runsettingsPath, this.FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " /testcasefilter:Name=DependencyTest");
 
             this.InvokeVsTest(arguments);
 
             this.ValidateSummaryStatus(1, 0, 0);
+            TryRemoveDirectory(resultsDir);
         }
 
         #endregion
@@ -463,6 +479,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void EnvironmentVariablesSettingsShouldSetEnvironmentVariables(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var testAssemblyPath = this.GetAssetFullPath("EnvironmentVariablesTestProject.dll");
 
@@ -479,9 +496,10 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             var arguments = PrepareArguments(
                testAssemblyPath,
                string.Empty,
-               this.runsettingsPath, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+               this.runsettingsPath, this.FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 0, 0);
+            TryRemoveDirectory(resultsDir);
         }
 
         #endregion
@@ -531,6 +549,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         private void RunTestWithRunSettings(Dictionary<string, string> runConfigurationDictionary,
             string runSettingsArgs, string additionalArgs, IEnumerable<string> testhostProcessNames, int expectedNumOfProcessCreated)
         {
+            var resultsDir = GetResultsDirectory();
+
             var assemblyPaths =
                 this.BuildMultipleAssemblyPath("SimpleTestProject.dll", "SimpleTestProject2.dll").Trim('\"');
 
@@ -541,7 +561,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 runsettingsPath = this.GetRunsettingsFilePath(runConfigurationDictionary);
             }
 
-            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), runsettingsPath, this.FrameworkArgValue, this.testEnvironment.InIsolationValue);
+            var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), runsettingsPath, this.FrameworkArgValue, this.testEnvironment.InIsolationValue, resultsDirectory: resultsDir);
 
             if (!string.IsNullOrWhiteSpace(additionalArgs))
             {
@@ -574,6 +594,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             {
                 File.Delete(runsettingsPath);
             }
+            TryRemoveDirectory(resultsDir);
         }
 
         private int GetExpectedNumOfProcessCreatedForWithoutParallel()
@@ -583,7 +604,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                 // we create just testhost.exe
                 return 1;
             }
-          
+
             if (this.IsDesktopRunner() && !this.IsDesktopTargetFramework())
             {
                 // we create dotnet testhost and testhost.exe

--- a/test/Microsoft.TestPlatform.AcceptanceTests/SelfContainedAppTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/SelfContainedAppTests.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.TestPlatform.AcceptanceTests
 {
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     using System.IO;
 
     [TestClass]
@@ -21,13 +22,15 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             // that will fail if we run the testhost.exe from the .nuget location, but will work when we run it from the output folder
             // see https://github.com/dotnet/runtime/issues/3569#issuecomment-595820524 and below for description of how it works
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             // the app is published to win10-x64 because of the runtime identifier in the project
             var assemblyPath = this.BuildMultipleAssemblyPath($@"win10-x64{Path.DirectorySeparatorChar}SelfContainedAppTestProject.dll").Trim('\"');
-            var arguments = PrepareArguments(assemblyPath, null, null, this.FrameworkArgValue, runnerInfo.InIsolationValue);
+            var arguments = PrepareArguments(assemblyPath, null, null, this.FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             this.InvokeVsTest(arguments);
 
             this.ValidateSummaryStatus(passedTestsCount: 1, 0, 0);
+            TryRemoveDirectory(resultsDir);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TestCaseFilterTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TestCaseFilterTests.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.TestPlatform.AcceptanceTests
 {
     using System.IO;
+
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -15,15 +16,17 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void RunSelectedTestsWithAndOperatorTrait(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var arguments = PrepareArguments(
                 this.GetSampleTestAssembly(),
                 this.GetTestAdapterPath(),
                 string.Empty, this.FrameworkArgValue,
-                runnerInfo.InIsolationValue);
+                runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " /TestCaseFilter:\"(TestCategory=CategoryA&Priority=3)\"");
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(0, 1, 0);
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -32,15 +35,17 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void RunSelectedTestsWithCategoryTraitInMixCase(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var arguments = PrepareArguments(
                 this.GetSampleTestAssembly(),
                 this.GetTestAdapterPath(),
                 string.Empty, this.FrameworkArgValue,
-                runnerInfo.InIsolationValue);
+                runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " /TestCaseFilter:\"TestCategory=Categorya\"");
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(0, 1, 0);
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -49,15 +54,17 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void RunSelectedTestsWithClassNameTrait(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var arguments = PrepareArguments(
                 this.GetSampleTestAssembly(),
                 this.GetTestAdapterPath(),
                 string.Empty, this.FrameworkArgValue,
-                runnerInfo.InIsolationValue);
+                runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " /TestCaseFilter:\"ClassName=SampleUnitTestProject.UnitTest1\"");
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 1, 1);
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -66,17 +73,19 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void RunSelectedTestsWithFullyQualifiedNameTrait(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var arguments = PrepareArguments(
                 this.GetSampleTestAssembly(),
                 this.GetTestAdapterPath(),
                 string.Empty, this.FrameworkArgValue,
-                runnerInfo.InIsolationValue);
+                runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             arguments = string.Concat(
                 arguments,
                 " /TestCaseFilter:\"FullyQualifiedName=SampleUnitTestProject.UnitTest1.FailingTest\"");
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(0, 1, 0);
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -85,15 +94,17 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void RunSelectedTestsWithNameTrait(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var arguments = PrepareArguments(
                 this.GetSampleTestAssembly(),
                 this.GetTestAdapterPath(),
                 string.Empty, this.FrameworkArgValue,
-                runnerInfo.InIsolationValue);
+                runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " /TestCaseFilter:\"Name=PassingTest\"");
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 0, 0);
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -102,15 +113,17 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void RunSelectedTestsWithOrOperatorTrait(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var arguments = PrepareArguments(
                 this.GetSampleTestAssembly(),
                 this.GetTestAdapterPath(),
                 string.Empty, this.FrameworkArgValue,
-                runnerInfo.InIsolationValue);
+                runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " /TestCaseFilter:\"(TestCategory=CategoryA|Priority=2)\"");
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 1, 0);
+            TryRemoveDirectory(resultsDir);
         }
 
         [TestMethod]
@@ -119,15 +132,17 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void RunSelectedTestsWithPriorityTrait(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var arguments = PrepareArguments(
                 this.GetSampleTestAssembly(),
                 this.GetTestAdapterPath(),
                 string.Empty, this.FrameworkArgValue,
-                runnerInfo.InIsolationValue);
+                runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " /TestCaseFilter:\"Priority=2\"");
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 0, 0);
+            TryRemoveDirectory(resultsDir);
         }
 
         /// <summary>
@@ -140,15 +155,17 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         public void TestCaseFilterShouldWorkIfOnlyPropertyValueGivenInExpression(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var arguments = PrepareArguments(
                 this.testEnvironment.GetTestAsset("SimpleTestProject2.dll"),
                 this.GetTestAdapterPath(),
                 string.Empty, this.FrameworkArgValue,
-                runnerInfo.InIsolationValue);
+                runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " /TestCaseFilter:UnitTest1");
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 1, 1);
+            TryRemoveDirectory(resultsDir);
         }
 
         /// <summary>
@@ -166,20 +183,22 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             }
 
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             var arguments = PrepareArguments(
                 this.testEnvironment.GetTestAsset("MstestV1UnitTestProject.dll"),
                 this.GetTestAdapterPath(),
                 string.Empty, this.FrameworkArgValue,
-                runnerInfo.InIsolationValue);
+                runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " /listtests /TestCaseFilter:\"(TestCategory!=CategoryA&Priority!=3)\"");
 
             this.InvokeVsTest(arguments);
             var listOfTests = new string[] {"MstestV1UnitTestProject.UnitTest1.PassingTest1", "MstestV1UnitTestProject.UnitTest1.PassingTest2",
                 "MstestV1UnitTestProject.UnitTest1.FailingTest2", "MstestV1UnitTestProject.UnitTest1.SkippingTest" };
-            var listOfNotDiscoveredTests = new string[] {"MstestV1UnitTestProject.UnitTest1.FailingTest1" };
+            var listOfNotDiscoveredTests = new string[] { "MstestV1UnitTestProject.UnitTest1.FailingTest1" };
             this.ValidateDiscoveredTests(listOfTests);
             this.ValidateTestsNotDiscovered(listOfNotDiscoveredTests);
+            TryRemoveDirectory(resultsDir);
         }
 
         /// <summary>
@@ -197,21 +216,23 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             }
 
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
+            var resultsDir = GetResultsDirectory();
 
             string testAssemblyPath = this.testEnvironment.GetTestAsset("MstestV1UnitTestProject.dll");
             var arguments = PrepareArguments(
                 testAssemblyPath,
                 this.GetTestAdapterPath(),
                 string.Empty, this.FrameworkArgValue,
-                runnerInfo.InIsolationValue);
+                runnerInfo.InIsolationValue, resultsDirectory: resultsDir);
             string testSettingsPath = Path.Combine(Path.GetDirectoryName(testAssemblyPath), "MstestV1UnitTestProjectTestSettings.testsettings");
             arguments = string.Concat(arguments, " /listtests /TestCaseFilter:PassingTest /settings:", testSettingsPath);
 
             this.InvokeVsTest(arguments);
-            var listOfTests = new string[] {"MstestV1UnitTestProject.UnitTest1.PassingTest1", "MstestV1UnitTestProject.UnitTest1.PassingTest2" };
-            var listOfNotDiscoveredTests = new string[] {"MstestV1UnitTestProject.UnitTest1.FailingTest1", "MstestV1UnitTestProject.UnitTest1.FailingTest2", "MstestV1UnitTestProject.UnitTest1.SkippingTest" };
+            var listOfTests = new string[] { "MstestV1UnitTestProject.UnitTest1.PassingTest1", "MstestV1UnitTestProject.UnitTest1.PassingTest2" };
+            var listOfNotDiscoveredTests = new string[] { "MstestV1UnitTestProject.UnitTest1.FailingTest1", "MstestV1UnitTestProject.UnitTest1.FailingTest2", "MstestV1UnitTestProject.UnitTest1.SkippingTest" };
             this.ValidateDiscoveredTests(listOfTests);
             this.ValidateTestsNotDiscovered(listOfNotDiscoveredTests);
+            TryRemoveDirectory(resultsDir);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TestPlatformNugetPackageTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TestPlatformNugetPackageTests.cs
@@ -45,13 +45,13 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         [TestInitialize]
         public void SetUp()
         {
-            this.resultsDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            this.resultsDirectory = GetResultsDirectory();
         }
 
         [TestCleanup]
         public void CleanUp()
         {
-            Directory.Delete(resultsDirectory, true);
+            TryRemoveDirectory(resultsDirectory);
         }
 
         [TestMethod]
@@ -95,9 +95,9 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             string diagFileName = Path.Combine(this.resultsDirectory, "diaglog.txt");
 
             var arguments = PrepareArguments(assemblyPaths, this.GetTestAdapterPath(), string.Empty,
-                this.FrameworkArgValue, runnerInfo.InIsolationValue);
+                this.FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: resultsDirectory);
 
-            arguments = string.Concat(arguments, $" /ResultsDirectory:{resultsDirectory}", $" /Diag:{diagFileName}", $" /EnableCodeCoverage");
+            arguments = string.Concat(arguments, $" /Diag:{diagFileName}", $" /EnableCodeCoverage");
 
             trxFilePath = Path.Combine(this.resultsDirectory, Guid.NewGuid() + ".trx");
             arguments = string.Concat(arguments, " /logger:trx;logfilename=" + trxFilePath);

--- a/test/Microsoft.TestPlatform.SmokeTests/DataCollectorTests.Coverlet.cs
+++ b/test/Microsoft.TestPlatform.SmokeTests/DataCollectorTests.Coverlet.cs
@@ -25,13 +25,14 @@ namespace Microsoft.TestPlatform.SmokeTests
             // We use netcoreapp runner 
             // "...\vstest\tools\dotnet\dotnet.exe "...\vstest\artifacts\Debug\netcoreapp2.1\vstest.console.dll" --collect:"XPlat Code Coverage" ...
             this.testEnvironment.RunnerFramework = CoreRunnerFramework;
+            var resultsDir = GetResultsDirectory();
 
             string coverletAdapterPath = Path.GetDirectoryName(Directory.GetFiles(this.testEnvironment.GetNugetPackage("coverlet.collector"), "coverlet.collector.dll", SearchOption.AllDirectories).Single());
             string logId = Guid.NewGuid().ToString("N");
             string assemblyPath = this.BuildMultipleAssemblyPath("CoverletCoverageTestProject.dll").Trim('\"');
             string logPath = Path.Combine(Path.GetDirectoryName(assemblyPath), $"coverletcoverage.{logId}.log");
             string logPathDirectory = Path.GetDirectoryName(logPath);
-            string argument = $"--collect:{"XPlat Code Coverage".AddDoubleQuote()} {PrepareArguments(assemblyPath, coverletAdapterPath, "", ".NETCoreApp,Version=v2.1")} --diag:{logPath.AddDoubleQuote()}";
+            string argument = $"--collect:{"XPlat Code Coverage".AddDoubleQuote()} {PrepareArguments(assemblyPath, coverletAdapterPath, "", ".NETCoreApp,Version=v2.1", resultsDirectory: resultsDir)} --diag:{logPath.AddDoubleQuote()}";
             this.InvokeVsTest(argument);
 
             // Verify vstest.console.dll CollectArgumentProcessor fix codeBase for coverlet package
@@ -50,6 +51,7 @@ namespace Microsoft.TestPlatform.SmokeTests
 
             // Verify default coverage file is generated
             this.StdOutputContains("coverage.cobertura.xml");
+            TryRemoveDirectory(resultsDir);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.SmokeTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.SmokeTests/ExecutionTests.cs
@@ -23,11 +23,13 @@ namespace Microsoft.TestPlatform.SmokeTests
         [TestMethod]
         public void RunSelectedTests()
         {
-            var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, ".NETFramework,Version=v4.5.1");
+            var resultsDir = GetResultsDirectory();
+            var arguments = PrepareArguments(this.GetSampleTestAssembly(), this.GetTestAdapterPath(), string.Empty, ".NETFramework,Version=v4.5.1", resultsDirectory: resultsDir);
             arguments = string.Concat(arguments, " /Tests:PassingTest");
             this.InvokeVsTest(arguments);
             this.ValidateSummaryStatus(1, 0, 0);
             this.ValidatePassedTests("SampleUnitTestProject.UnitTest1.PassingTest");
+            TryRemoveDirectory(resultsDir);
         }
     }
 }


### PR DESCRIPTION
## Description
Modified the integration tests to use a temporary folder to store test results and `.trx` logs, so when we report test results to the CI pipeline, they wouldn't falsely be reported.