### PR TITLE
Generating cc attachments with correct uri (#2750)

### DIFF
--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionAttachmentManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionAttachmentManager.cs
@@ -328,11 +328,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollector
                     {
                         if (t.Exception == null)
                         {
-                            // Uri doesn't recognize file paths in unix. See https://github.com/dotnet/corefx/issues/1745
-                            var attachmentUri = new UriBuilder() { Scheme = "file", Host = "", Path = localFilePath }.Uri;
                             lock (attachmentTaskLock)
                             {
-                                this.AttachmentSets[fileTransferInfo.Context][uri].Attachments.Add(new UriDataAttachment(attachmentUri, fileTransferInfo.Description));
+                                this.AttachmentSets[fileTransferInfo.Context][uri].Attachments.Add(UriDataAttachment.CreateFrom(localFilePath, fileTransferInfo.Description));
                             }
                         }
 

--- a/src/Microsoft.TestPlatform.ObjectModel/AttachmentSet.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/AttachmentSet.cs
@@ -77,5 +77,11 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         {
             return $"{nameof(Uri)}: {Uri.AbsoluteUri}, {nameof(Description)}: {Description}";
         }
+
+        public static UriDataAttachment CreateFrom(string localFilePath, string description)
+        {
+            var uri = new UriBuilder() { Scheme = "file", Host = "", Path = localFilePath }.Uri;
+            return new UriDataAttachment(uri, description);
+        }
     }
 }

--- a/src/Microsoft.TestPlatform.Utilities/CodeCoverageDataAttachmentsHandler.cs
+++ b/src/Microsoft.TestPlatform.Utilities/CodeCoverageDataAttachmentsHandler.cs
@@ -59,11 +59,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
                     if (!string.IsNullOrEmpty(mergedCoverageReportFilePath))
                     {
                         var resultAttachmentSet = new AttachmentSet(CodeCoverageDataCollectorUri, CoverageFriendlyName);
-                        resultAttachmentSet.Attachments.Add(new UriDataAttachment(new Uri(mergedCoverageReportFilePath), CoverageFriendlyName));
+                        resultAttachmentSet.Attachments.Add(UriDataAttachment.CreateFrom(mergedCoverageReportFilePath, CoverageFriendlyName));
 
                         foreach (var coverageOtherFilePath in coverageOtherFilePaths)
                         {
-                            resultAttachmentSet.Attachments.Add(new UriDataAttachment(new Uri(coverageOtherFilePath), string.Empty));
+                            resultAttachmentSet.Attachments.Add(UriDataAttachment.CreateFrom(coverageOtherFilePath, string.Empty));
                         }
 
                         return new Collection<AttachmentSet> { resultAttachmentSet };


### PR DESCRIPTION
* Generating cc attachments with correct uri

* Remove constructor

Co-authored-by: Jakub Chocholowicz <jachocho@microsoft.com>

## Description
Please add a meaningful description for this change.
Ensure the PR has required unit tests.

## Related issue
Kindly link any related issues. E.g. Fixes #xyz.
