### PR TITLE
Use reported adapters for telemetry

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -505,10 +505,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
                     {
                         // Executors can hide other executors in them. Such as MSTestV1 internally delegating to MSTestV0
                         // when calculating the metrics take the actual URIs reported by testcases, not the ones from DefaultExecutorUri.
-                        foreach (var pair in this.TestRunCache.TestsPerAdapter)
+                        foreach (var pair in this.TestRunCache.TestsPerAdapter.ToList())
                         {
                             this.executorUrisThatRanTests.Add(pair.Key);
                             this.requestData.MetricsCollection.Add(string.Format("{0}.{1}", TelemetryDataConstants.TotalTestsRanByAdapter, pair.Key), pair.Value.Count);
+                            this.requestData.MetricsCollection.Add(string.Format("{0}.{1}", TelemetryDataConstants.TimeTakenToRunTestsByAnAdapter, pair.Key), pair.Value.Duration.TotalSeconds);
+                            this.TestRunCache.TestsPerAdapter.Remove(pair.Key);
                         }
 
                         if (!CrossPlatEngine.Constants.DefaultAdapters.Contains(executor.Metadata.ExtensionUri, StringComparer.OrdinalIgnoreCase))
@@ -528,15 +530,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
                             executor.Metadata.ExtensionUri);
                     }
 
-                    // Collecting Time Taken by each executor Uri
-                    // Executors can hide other executors in them. Such as MSTestV1 internally delegating to MSTestV0
-                    // when calculating the metrics take the actual URIs reported by testcases, not the ones from DefaultExecutorUri.
-                    foreach (var pair in this.TestRunCache.TestsPerAdapter)
-                    {
-                        this.requestData.MetricsCollection.Add(string.Format("{0}.{1}", TelemetryDataConstants.TimeTakenToRunTestsByAnAdapter, pair.Key), pair.Value.Duration.TotalSeconds);
-                    }
-
-                    
                     totalTimeTakenByAdapters += totalTimeTaken.TotalSeconds;
                 }
                 catch (Exception e)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/TestRunCache.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/TestRunCache.cs
@@ -35,6 +35,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
         /// </summary>
         private long totalExecutedTests;
 
+        private Dictionary<string, TestResultMetric> totalExecutedTestsPerAdapter = new Dictionary<string, TestResultMetric>();
+
         /// <summary>
         /// Callback used when cache is ready to report some test results/case.
         /// </summary>
@@ -163,6 +165,17 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
             }
         }
 
+        public Dictionary<string, TestResultMetric> TestsPerAdapter
+        {
+            get
+            {
+                lock (this.syncObject)
+                {
+                    return this.totalExecutedTestsPerAdapter;
+                }
+            }
+        }
+
         /// <summary>
         /// Gets the test run stats
         /// </summary>
@@ -220,6 +233,18 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
             lock (this.syncObject)
             {
                 this.totalExecutedTests++;
+                var executor = testResult.TestCase.ExecutorUri.AbsoluteUri;
+                if (totalExecutedTestsPerAdapter.ContainsKey(executor))
+                {
+                    var metric = totalExecutedTestsPerAdapter[executor];
+                    metric.Count++;
+                    metric.Duration += testResult.Duration;
+                }
+                else
+                {
+                    totalExecutedTestsPerAdapter.Add(executor, new TestResultMetric(testResult.Duration));
+                }
+
                 this.testResults.Add(testResult);
 
                 long count;

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Interfaces/ITestRunCache.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Interfaces/ITestRunCache.cs
@@ -19,7 +19,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
         ICollection<TestResult> TestResults { get; }
 
         ICollection<TestCase> InProgressTests { get; }
+
         long TotalExecutedTests { get; }
+
+        Dictionary<string, TestResultMetric> TestsPerAdapter { get; }
 
         TestRunStatistics TestRunStatistics { get; }
 
@@ -36,5 +39,18 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
         ICollection<TestResult> GetLastChunk();
 
         #endregion
+    }
+
+    internal class TestResultMetric
+    {
+        internal TestResultMetric(TimeSpan duration)
+        {
+            Count = 1;
+            this.Duration = duration;
+        }
+
+        internal long Count { get; set; }
+
+        internal TimeSpan Duration { get; set; }
     }
 }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestableImplementations/TestableTestRunCache.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestableImplementations/TestableTestRunCache.cs
@@ -9,7 +9,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.TestableImplementations
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 
-    public class TestableTestRunCache : ITestRunCache
+    internal class TestableTestRunCache : ITestRunCache
     {
         public TestableTestRunCache()
         {
@@ -34,6 +34,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.TestableImplementations
         public TestRunStatistics TestRunStatistics { get; set; }
 
         public long TotalExecutedTests { get; set; }
+
+        public Dictionary<string, TestResultMetric> TestsPerAdapter => new Dictionary<string, TestResultMetric>();
 
         public ICollection<TestResult> GetLastChunk()
         {


### PR DESCRIPTION
## Description
Count the actual reported adapters in the telemetry instead of the adapter that is the default for the assembly. This is useful for adapters that are delegating the work to other adapters, such as when MSTest v1 actually uses MSTest v0 to execute the tests when the conditions are right. In this case we will now see v0 in the telemetry, instead of v1.

## Related issue

