### PR TITLE
Add failed logic for trx logger when TreatNoTestAsError is set to true

### DIFF
--- a/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsUtilities.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsUtilities.cs
@@ -131,20 +131,20 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
             return cpuCount;
         }
         /// <summary>
-        /// Gets the value of FailWhenNoTestsFound parameter from runsettings file
+        /// Gets the value of TreatNoTestsAsError parameter from runsettings file
         /// </summary>
         /// <param name="runSettings">Runsetting string value</param>
-        /// <returns>The value of FailWhenNoTestsFound</returns>
+        /// <returns>The value of TreatNoTestsAsError</returns>
         public static bool GetTreatNoTestsAsError(string runSettings)
         {
-            bool failWhenNoTestFound = false;
+            bool treatNoTestsAsError = false;
 
             if (runSettings != null)
             {
                 try
                 {
                     RunConfiguration runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(runSettings);
-                    failWhenNoTestFound = GetTreatNoTestsAsError(runConfiguration);
+                    treatNoTestsAsError = GetTreatNoTestsAsError(runConfiguration);
                 }
                 catch (SettingsException se)
                 {
@@ -155,7 +155,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
                 }
             }
 
-            return failWhenNoTestFound;
+            return treatNoTestsAsError;
         }
 
         private static bool GetTreatNoTestsAsError(RunConfiguration runConfiguration)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/TestLoggerManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/TestLoggerManager.cs
@@ -666,8 +666,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             loggerParams[DefaultLoggerParameterNames.TargetFramework] = targetFramework;
 
             // Add custom logger parameters
-            // TODO think about constans for TreatNoTestsAsError, do we really need to pu in constants?
-            loggerParams[Constants.TreatNoTestsAsError] = treatNoTestsAsError.ToString();
+            if (treatNoTestsAsError)
+            {
+                loggerParams[Constants.TreatNoTestsAsError] = treatNoTestsAsError.ToString();
+            }
             
             return loggerParams;
         }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/TestLoggerManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/TestLoggerManager.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
     using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
     using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-    using CommonResources = Microsoft.VisualStudio.TestPlatform.Common.Resources.Resources;
+    using CommonResources = Common.Resources.Resources;
 
     /// <summary>
     /// Responsible for managing logger extensions and broadcasting results
@@ -51,6 +51,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         /// Target framework.
         /// </summary>
         private string targetFramework;
+
+        /// <summary>
+        /// TreatNoTestsAsError value;
+        /// </summary>
+        private bool treatNoTestsAsError;
 
         /// <summary>
         /// Test Logger Events instance which will be passed to loggers when they are initialized.
@@ -145,6 +150,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             // Store test run directory. This runsettings is the final runsettings merging CLI args and runsettings.
             this.testRunDirectory = GetResultsDirectory(runSettings);
             this.targetFramework = GetTargetFramework(runSettings)?.Name;
+            this.treatNoTestsAsError = GetTreatNoTestsAsError(runSettings);
 
             var loggers = XmlRunSettingsUtilities.GetLoggerRunSettings(runSettings);
 
@@ -488,6 +494,16 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
         }
 
         /// <summary>
+        /// Get TreatNoTestsAsError value of the test run
+        /// </summary>
+        /// <param name="runSettings"></param>
+        /// <returns></returns>
+        internal bool GetTreatNoTestsAsError(string runSettings)
+        {
+            return RunSettingsUtilities.GetTreatNoTestsAsError(runSettings);
+        }
+
+        /// <summary>
         /// Enables sending of events to the loggers which are registered.
         /// </summary>
         /// <remarks>
@@ -648,6 +664,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
             // Add default logger parameters...
             loggerParams[DefaultLoggerParameterNames.TestRunDirectory] = testRunDirectory;
             loggerParams[DefaultLoggerParameterNames.TargetFramework] = targetFramework;
+
+            // Add custom logger parameters
+            // TODO think about constans for TreatNoTestsAsError, do we really need to pu in constants?
+            loggerParams[Constants.TreatNoTestsAsError] = treatNoTestsAsError.ToString();
+            
             return loggerParams;
         }
 

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -766,7 +766,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
         private TrxLoggerObjectModel.TestOutcome changeTestOutcomeIfNecessary (TrxLoggerObjectModel.TestOutcome outcome)
         {
             // If no tests discovered/executed and TreatNoTestsAsError was set to True
-            // We will return ResultSummary as Failed and RunInfo as Error
+            // We will return ResultSummary as Failed
             // Note : we only send the value of TreatNoTestsAsError if it is "True"
             if (totalTests == 0 && parametersDictionary.ContainsKey(ObjectModelConstants.TreatNoTestsAsError))
             {

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -235,8 +235,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
 
             RunInfo runMessage;
 
-            e.Level = changeMessageLevelIfNecessary(e.Level);
-
             switch (e.Level)
             {
                 case TestMessageLevel.Informational:
@@ -365,6 +363,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
             {
                 this.testRunOutcome = TrxLoggerObjectModel.TestOutcome.Completed;
             }
+
+            testRunOutcome = changeTestOutcomeIfNecessary(testRunOutcome);
 
             List<string> errorMessages = new List<string>();
             List<CollectorDataEntry> collectorEntries = this.converter.ToCollectionEntries(e.AttachmentSets, this.testRun, this.testResultsDirPath);
@@ -763,16 +763,16 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
             return testEntry;
         }
 
-        private TestMessageLevel changeMessageLevelIfNecessary (TestMessageLevel level)
+        private TrxLoggerObjectModel.TestOutcome changeTestOutcomeIfNecessary (TrxLoggerObjectModel.TestOutcome outcome)
         {
-            // Currently if no tests were discovered/executed in trx logs we get outcome as Warning
-            // If TreatNoTestsAsError was set to True, we want to return ResultSummary as Failed and RunInfo as Error
-            if (level == TestMessageLevel.Warning && parametersDictionary[ObjectModelConstants.TreatNoTestsAsError] == bool.TrueString)
+            // If no tests discovered/executed and TreatNoTestsAsError was set to True
+            // We will return ResultSummary as Failed and RunInfo as Error
+            if (totalTests == 0 && parametersDictionary[ObjectModelConstants.TreatNoTestsAsError] == bool.TrueString)
             {
-                level = TestMessageLevel.Error;
+                outcome = TrxLoggerObjectModel.TestOutcome.Failed;
             }
 
-            return level;
+            return outcome;
         }
 
         #endregion

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -767,7 +767,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger
         {
             // If no tests discovered/executed and TreatNoTestsAsError was set to True
             // We will return ResultSummary as Failed and RunInfo as Error
-            if (totalTests == 0 && parametersDictionary[ObjectModelConstants.TreatNoTestsAsError] == bool.TrueString)
+            // Note : we only send the value of TreatNoTestsAsError if it is "True"
+            if (totalTests == 0 && parametersDictionary.ContainsKey(ObjectModelConstants.TreatNoTestsAsError))
             {
                 outcome = TrxLoggerObjectModel.TestOutcome.Failed;
             }

--- a/src/Microsoft.TestPlatform.ObjectModel/Constants.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Constants.cs
@@ -116,6 +116,11 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         public const string LoggerConfigurationNameLower = "configuration";
 
         /// <summary>
+        /// Name of TreatNoTestsAsError parameter
+        /// </summary>
+        public const string TreatNoTestsAsError = "TreatNoTestsAsError";
+
+        /// <summary>
         /// Name of RunConfiguration settings node in RunSettings.
         /// </summary>
         public const string RunConfigurationSettingsName = "RunConfiguration";

--- a/test/Microsoft.TestPlatform.AcceptanceTests/LoggerTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/LoggerTests.cs
@@ -117,6 +117,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         }
 
         [TestMethod]
+        [TestCategory("Windows-Review")]
         [NetFullTargetFrameworkDataSource]
         public void TrxLoggerResultSummaryOutcomeValueShouldBeFailedIfNoTestsExecutedAndTreatNoTestsAsErrorIsTrue(RunnerInfo runnerInfo)
         {
@@ -140,6 +141,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         }
 
         [TestMethod]
+        [TestCategory("Windows-Review")]
         [NetFullTargetFrameworkDataSource]
         public void TrxLoggerResultSummaryOutcomeValueShouldNotChangeIfNoTestsExecutedAndTreatNoTestsAsErrorIsFalse(RunnerInfo runnerInfo)
         {


### PR DESCRIPTION
## Description
Add logic for trx logger when `TreatNoTestAsError` parameter is set to true to show `ResultSummary` as `Failed`.

## Related issue
Fix : #2707 

Example  of the change : 
```
  <ResultSummary outcome="Failed">
    <Counters total="0" executed="0" passed="0" failed="0" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
    <RunInfos>
      <RunInfo computerName="SAYUZBAS-SFB2" outcome="Warning" timestamp="2021-02-17T18:20:41.7410456+01:00">
        <Text>No test is available in C:\Users\sayuzbas\source\repos\EmptyTestProject\EmptyTestProject\bin\Debug\EmptyTestProject.dll. Make sure that test discoverer &amp; executors are registered and platform &amp; framework version settings are appropriate and try again.</Text>
      </RunInfo>
    </RunInfos>
  </ResultSummary>
```
Note : Changed `ResultSummary outcome="Failed"` previously was `ResultSummary outcome="Completed"` even if no tests ran.

The change only applies for `ResultSummary`. Trying to change `RunInfo outcome` result in having several `RunInfo` line in Xunit and Nunit adapters