### PR TITLE
Code analysis with static analysers based on microsoft rules

### DIFF
--- a/src/DataCollectors/Microsoft.TestPlatform.Extensions.EventLogCollector/EventLogDataCollector.cs
+++ b/src/DataCollectors/Microsoft.TestPlatform.Extensions.EventLogCollector/EventLogDataCollector.cs
@@ -371,7 +371,6 @@ namespace Microsoft.TestPlatform.Extensions.EventLogCollector
 
             // Delete all the temp event log directories
             this.RemoveTempEventLogDirs(this.eventLogDirectories);
-            GC.SuppressFinalize(this);
         }
 
         #endregion

--- a/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/ManagedNameHelper.Reflection.cs
+++ b/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/ManagedNameHelper.Reflection.cs
@@ -24,12 +24,12 @@ namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities
         /// A <see cref="MethodBase" /> instance to get fully qualified managed type and method name.
         /// </param>
         /// <param name="managedTypeName">
-        /// When this method returns, contains the fully qualified managed type name of the <paramref name="method"/>. 
+        /// When this method returns, contains the fully qualified managed type name of the <paramref name="method"/>.
         /// This parameter is passed uninitialized; any value originally supplied in result will be overwritten.
         /// The format is defined in <see href="https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md#managedtype-property">the RFC</see>.
         /// </param>
         /// <param name="managedMethodName">
-        /// When this method returns, contains the fully qualified managed method name of the <paramref name="method"/>. 
+        /// When this method returns, contains the fully qualified managed method name of the <paramref name="method"/>.
         /// This parameter is passed uninitialized; any value originally supplied in result will be overwritten.
         /// The format is defined in <see href="https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md#managedmethod-property">the RFC</see>.
         /// </param>
@@ -43,7 +43,7 @@ namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities
         /// Required functionality on <paramref name="method"/> is missing on the current platform.
         /// </exception>
         /// <remarks>
-        /// More information about <paramref name="managedTypeName"/> and <paramref name="managedMethodName"/> can be found in 
+        /// More information about <paramref name="managedTypeName"/> and <paramref name="managedMethodName"/> can be found in
         /// <see href="https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md">the RFC</see>.
         /// </remarks>
         public static void GetManagedName(MethodBase method, out string managedTypeName, out string managedMethodName)
@@ -65,7 +65,7 @@ namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities
                 // sure we are working with the open form of the generic type.
                 semanticType = semanticType.GetGenericTypeDefinition();
 
-                // The method might have some of its parameters specified by the original closed type 
+                // The method might have some of its parameters specified by the original closed type
                 // declaration. Here we use the method handle (basically metadata token) to create
                 // a new method reference using the open form of the reflected type. The intent is
                 // to strip all generic type parameters.
@@ -114,7 +114,7 @@ namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities
         }
 
         /// <summary>
-        /// Gets the <see cref="MethodBase"/> object with the specified <paramref name="managedTypeName"/> 
+        /// Gets the <see cref="MethodBase"/> object with the specified <paramref name="managedTypeName"/>
         /// and <paramref name="managedMethodName"/> in the <paramref name="assembly"/> instance.
         /// </summary>
         /// <param name="assembly">
@@ -132,11 +132,11 @@ namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities
         /// A <see cref="MethodBase" /> object that represents specified parameters, throws if null.
         /// </returns>
         /// <exception cref="InvalidManagedNameException">
-        /// Values specified with <paramref name="managedTypeName"/> and <paramref name="managedMethodName"/> 
+        /// Values specified with <paramref name="managedTypeName"/> and <paramref name="managedMethodName"/>
         /// does not correspond to a method in the <paramref name="assembly"/> instance, or malformed.
         /// </exception>
         /// <remarks>
-        /// More information about <paramref name="managedTypeName"/> and <paramref name="managedMethodName"/> can be found in 
+        /// More information about <paramref name="managedTypeName"/> and <paramref name="managedMethodName"/> can be found in
         /// <see href="https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md">the RFC</see>.
         /// </remarks>
         public static MethodBase GetMethod(Assembly assembly, string managedTypeName, string managedMethodName)
@@ -335,7 +335,7 @@ namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities
 
         private static void NormalizeAndAppendString(StringBuilder b, string name)
         {
-            b.Append("'");
+            b.Append('\'');
             for (int i = 0; i < name.Length; i++)
             {
                 char c = name[i];
@@ -348,7 +348,7 @@ namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities
                         // b.Append('0', 4 - encoded.Length);
                         // b.Append(encoded);
 
-                        b.Append("\\");
+                        b.Append('\\');
                         b.Append(c);
                         continue;
                     }
@@ -356,7 +356,7 @@ namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities
 
                 b.Append(c);
             }
-            b.Append("'");
+            b.Append('\'');
         }
 
         private static int AppendNestedTypeName(StringBuilder b, Type type)
@@ -439,7 +439,7 @@ namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities
             }
 
             if (c == '_'
-              || char.IsLetterOrDigit(c) // Lu, Ll, Lt, Lm, Lo, or Nl 
+              || char.IsLetterOrDigit(c) // Lu, Ll, Lt, Lm, Lo, or Nl
               )
             {
                 return false;

--- a/src/Microsoft.TestPlatform.Build/ArgumentEscaper.cs
+++ b/src/Microsoft.TestPlatform.Build/ArgumentEscaper.cs
@@ -23,7 +23,7 @@ namespace Microsoft.TestPlatform.Build.Utils
 
             if (needsQuotes)
             {
-                sb.Append("\"");
+                sb.Append('\"');
             }
 
             for (int i = 0; i < arg.Length; ++i)
@@ -70,7 +70,7 @@ namespace Microsoft.TestPlatform.Build.Utils
 
             if (needsQuotes)
             {
-                sb.Append("\"");
+                sb.Append('\"');
             }
 
             return sb.ToString();

--- a/src/Microsoft.TestPlatform.Client/Discovery/DiscoveryRequest.cs
+++ b/src/Microsoft.TestPlatform.Client/Discovery/DiscoveryRequest.cs
@@ -267,7 +267,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.Discovery
                     // Raise onDiscoveredTests event if there are some tests in the last chunk.
                     // (We don't want to send the tests in the discovery complete event so that programming on top of
                     // RS client is easier i.e. user does not have to listen on discovery complete event.)
-                    if (lastChunk != null && lastChunk.Count() > 0)
+                    if (lastChunk != null && lastChunk.Any())
                     {
                         var discoveredTestsEvent = new DiscoveredTestsEventArgs(lastChunk);
                         this.LoggerManager.HandleDiscoveredTests(discoveredTestsEvent);

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginManager.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginManager.cs
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
         {
             if (extensionType == null)
             {
-                throw new ArgumentNullException("extensionType");
+                throw new ArgumentNullException(nameof(extensionType));
             }
 
             EqtTrace.Info("TestPluginManager.CreateTestExtension: Attempting to load test extension: " + extensionType);

--- a/src/Microsoft.TestPlatform.Common/Logging/InternalTestLoggerEvents.cs
+++ b/src/Microsoft.TestPlatform.Common/Logging/InternalTestLoggerEvents.cs
@@ -177,7 +177,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Logging
         {
             if (args == null)
             {
-                throw new ArgumentNullException("args");
+                throw new ArgumentNullException(nameof(args));
             }
 
             this.CheckDisposed();

--- a/src/Microsoft.TestPlatform.Common/Logging/TestSessionMessageLogger.cs
+++ b/src/Microsoft.TestPlatform.Common/Logging/TestSessionMessageLogger.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Logging
         {
             if (string.IsNullOrWhiteSpace(message))
             {
-                throw new ArgumentException(ObjectModelCommonResources.CannotBeNullOrEmpty, "message");
+                throw new ArgumentException(ObjectModelCommonResources.CannotBeNullOrEmpty, nameof(message));
             }
 
             if (this.TreatTestAdapterErrorsAsWarnings

--- a/src/Microsoft.TestPlatform.Common/RunSettings.cs
+++ b/src/Microsoft.TestPlatform.Common/RunSettings.cs
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common
         {
             if (StringUtilities.IsNullOrWhiteSpace(settingsName))
             {
-                throw new ArgumentException(ObjectModelCommonResources.CannotBeNullOrEmpty, "settingsName");
+                throw new ArgumentException(ObjectModelCommonResources.CannotBeNullOrEmpty, nameof(settingsName));
             }
 
             // Try and lookup the settings provider.

--- a/src/Microsoft.TestPlatform.Common/SettingsProvider/SettingsProviderExtensionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/SettingsProvider/SettingsProviderExtensionManager.cs
@@ -181,7 +181,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.SettingsProvider
         {
             if (string.IsNullOrWhiteSpace(settingsName))
             {
-                throw new ArgumentException(ObjectModelCommonResources.CannotBeNullOrEmpty, "settingsName");
+                throw new ArgumentException(ObjectModelCommonResources.CannotBeNullOrEmpty, nameof(settingsName));
             }
 
             this.SettingsProvidersMap.TryGetValue(settingsName, out LazyExtension<ISettingsProvider, ISettingsProviderCapabilities> settingsProvider);

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/LengthPrefixCommunicationChannel.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/LengthPrefixCommunicationChannel.cs
@@ -81,6 +81,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             EqtTrace.Verbose("LengthPrefixCommunicationChannel.Dispose: Dispose reader and writer.");
             this.reader.Dispose();
             this.writer.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestObjectConverter.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestObjectConverter.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Serializati
             if (objectType != typeof(List<KeyValuePair<TestProperty, object>>))
             {
                 // Support only deserialization of KeyValuePair list
-                throw new ArgumentException(nameof(objectType));
+                throw new ArgumentException("the objectType was not a KeyValuePair list", nameof(objectType));
             }
 
             var propertyList = new List<KeyValuePair<TestProperty, object>>();

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -470,6 +470,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
             }
 
             this.communicationEndpoint.Stop();
+            GC.SuppressFinalize(this);
         }
 
         private void OnExecutionMessageReceived(object sender, MessageReceivedEventArgs messageReceived, ITestRunEventsHandler testRunEventsHandler)

--- a/src/Microsoft.TestPlatform.CoreUtilities/Helpers/FileHelper.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Helpers/FileHelper.cs
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities.Helpers
             try
             {
                 if (Directory.Exists(dirPath)
-                    && Directory.EnumerateFileSystemEntries(dirPath).Count() == 0)
+                    && !Directory.EnumerateFileSystemEntries(dirPath).Any())
                 {
                     Directory.Delete(dirPath, true);
                 }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionTestRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionTestRunEventsHandler.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
         /// The proxy Data Collection Manager.
         /// </param>
         public DataCollectionTestRunEventsHandler(ITestRunEventsHandler baseTestRunEventsHandler, IProxyDataCollectionManager proxyDataCollectionManager, CancellationToken cancellationToken)
-            : this(baseTestRunEventsHandler, proxyDataCollectionManager, cancellationToken, JsonDataSerializer.Instance)
+            : this(baseTestRunEventsHandler, proxyDataCollectionManager, JsonDataSerializer.Instance, cancellationToken)
         {
         }
 
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
         /// <param name="dataSerializer">
         /// The data Serializer.
         /// </param>
-        public DataCollectionTestRunEventsHandler(ITestRunEventsHandler baseTestRunEventsHandler, IProxyDataCollectionManager proxyDataCollectionManager, CancellationToken cancellationToken, IDataSerializer dataSerializer)
+        public DataCollectionTestRunEventsHandler(ITestRunEventsHandler baseTestRunEventsHandler, IProxyDataCollectionManager proxyDataCollectionManager, IDataSerializer dataSerializer, CancellationToken cancellationToken)
         {
             this.proxyDataCollectionManager = proxyDataCollectionManager;
             this.testRunEventsHandler = baseTestRunEventsHandler;
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
         /// </param>
         public void HandleRawMessage(string rawMessage)
         {
-            // In case of data collection, data collection attachments should be attached to raw message for ExecutionComplete 
+            // In case of data collection, data collection attachments should be attached to raw message for ExecutionComplete
             var message = this.dataSerializer.DeserializeMessage(rawMessage);
 
             if (string.Equals(MessageType.ExecutionComplete, message.MessageType))

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionTestRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionTestRunEventsHandler.cs
@@ -178,12 +178,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
         /// </returns>
         internal static ICollection<AttachmentSet> GetCombinedAttachmentSets(Collection<AttachmentSet> originalAttachmentSets, ICollection<AttachmentSet> newAttachments)
         {
-            if (null == newAttachments || newAttachments.Count == 0)
+            if (newAttachments == null || newAttachments.Count == 0)
             {
                 return originalAttachmentSets;
             }
 
-            if (null == originalAttachmentSets)
+            if (originalAttachmentSets == null)
             {
                 return new Collection<AttachmentSet>(newAttachments.ToList());
             }
@@ -191,7 +191,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection
             foreach (var attachmentSet in newAttachments)
             {
                 var attSet = originalAttachmentSets.FirstOrDefault(item => Uri.Equals(item.Uri, attachmentSet.Uri));
-                if (null == attSet)
+                if (attSet == null)
                 {
                     originalAttachmentSets.Add(attachmentSet);
                 }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscovererEnumerator.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscovererEnumerator.cs
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Discovery
             try
             {
                 // Collecting Total Number of Adapters Discovered in Machine
-                this.requestData.MetricsCollection.Add(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringDiscovery, discovererToSourcesMap.Keys.Count());
+                this.requestData.MetricsCollection.Add(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringDiscovery, discovererToSourcesMap.Keys.Count);
 
                 var context = new DiscoveryContext { RunSettings = settings };
                 context.FilterExpressionWrapper = !string.IsNullOrEmpty(testCaseFilter) ? new FilterExpressionWrapper(testCaseFilter) : null;

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -645,7 +645,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
                 this.requestData.MetricsCollection.Add(TelemetryDataConstants.RunState, canceled ? "Canceled" : (aborted ? "Aborted" : "Completed"));
 
                 // Collecting Number of Adapters Used to run tests.
-                this.requestData.MetricsCollection.Add(TelemetryDataConstants.NumberOfAdapterUsedToRunTests, this.ExecutorUrisThatRanTests.Count());
+                this.requestData.MetricsCollection.Add(TelemetryDataConstants.NumberOfAdapterUsedToRunTests, this.ExecutorUrisThatRanTests.Count);
 
                 if (lastChunkTestResults.Any() && this.IsTestSourceIsPackage())
                 {

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameLogger.cs
@@ -107,7 +107,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
 
             // Gets the faulty test cases if test aborted
             var testCaseNames = this.GetFaultyTestCaseNames(e);
-            if (testCaseNames.Count() == 0)
+            if (!testCaseNames.Any())
             {
                 return;
             }

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/InactivityTimer.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/InactivityTimer.cs
@@ -30,6 +30,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
         public void Dispose()
         {
             this.timer.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
@@ -336,6 +336,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger
                 EqtTrace.Error("HtmlLogger : Failed to populate html file. Exception : {0}",
                     ex.ToString());
                 ConsoleOutput.Instance.Error(false, string.Concat(HtmlResource.HtmlLoggerError), ex.Message);
+                return;
             }
             finally
             {

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
@@ -242,7 +242,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger
 
             Results.TryAdd(executionId, testResult);
 
-            // Check for parent execution id to store the test results in hierarchical way 
+            // Check for parent execution id to store the test results in hierarchical way
             if (parentExecutionId == Guid.Empty)
             {
                 if (e.Result.Outcome == TestOutcome.Failed)
@@ -336,7 +336,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger
                 EqtTrace.Error("HtmlLogger : Failed to populate html file. Exception : {0}",
                     ex.ToString());
                 ConsoleOutput.Instance.Error(false, string.Concat(HtmlResource.HtmlLoggerError), ex.Message);
-                return;
             }
             finally
             {

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestId.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestId.cs
@@ -227,7 +227,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         {
             if (other == null)
             {
-                throw new ArgumentNullException("other");
+                throw new ArgumentNullException(nameof(other));
             }
 
             return this.id.CompareTo(other.id);

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestType.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestType.cs
@@ -19,7 +19,7 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel
         {
             if (id == Guid.Empty)
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
 
             this.typeId = id;

--- a/src/Microsoft.TestPlatform.ObjectModel/Adapter/TestPlatformFormatException.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Adapter/TestPlatformFormatException.cs
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter
         {
             if (info == null)
             {
-                throw new ArgumentNullException("info");
+                throw new ArgumentNullException(nameof(info));
             }
 
             base.GetObjectData(info, context);

--- a/src/Microsoft.TestPlatform.ObjectModel/DataCollector/Common/RequestId.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/DataCollector/Common/RequestId.cs
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection
             RequestId other = obj as RequestId;
             if (other == null)
             {
-                throw new ArgumentException(string.Format(Resources.Common_ObjectMustBeOfType, new object[] { typeof(RequestId).Name }), "obj");
+                throw new ArgumentException(string.Format(Resources.Common_ObjectMustBeOfType, new object[] { typeof(RequestId).Name }), nameof(obj));
             }
 
             return Id.CompareTo(other.Id);

--- a/src/Microsoft.TestPlatform.ObjectModel/DefaultExecutorUriAttribute.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/DefaultExecutorUriAttribute.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         {
             if (string.IsNullOrWhiteSpace(executorUri))
             {
-                throw new ArgumentException(CommonResources.CannotBeNullOrEmpty, "executorUri");
+                throw new ArgumentException(CommonResources.CannotBeNullOrEmpty, nameof(executorUri));
             }
 
             ExecutorUri = executorUri;

--- a/src/Microsoft.TestPlatform.ObjectModel/ExtensionUriAttribute.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/ExtensionUriAttribute.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         {
             if (string.IsNullOrWhiteSpace(extensionUri))
             {
-                throw new ArgumentException(CommonResources.CannotBeNullOrEmpty, "extensionUri");
+                throw new ArgumentException(CommonResources.CannotBeNullOrEmpty, nameof(extensionUri));
             }
 
             ExtensionUri = extensionUri;

--- a/src/Microsoft.TestPlatform.ObjectModel/FileExtensionAttribute.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/FileExtensionAttribute.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         {
             if (string.IsNullOrWhiteSpace(fileExtension))
             {
-                throw new ArgumentException(CommonResources.CannotBeNullOrEmpty, "fileExtension");
+                throw new ArgumentException(CommonResources.CannotBeNullOrEmpty, nameof(fileExtension));
             }
 
             FileExtension = fileExtension;

--- a/src/Microsoft.TestPlatform.ObjectModel/FriendlyNameAttribute.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/FriendlyNameAttribute.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         {
             if (string.IsNullOrWhiteSpace(friendlyName))
             {
-                throw new ArgumentException(CommonResources.CannotBeNullOrEmpty, "friendlyName");
+                throw new ArgumentException(CommonResources.CannotBeNullOrEmpty, nameof(friendlyName));
             }
 
             FriendlyName = friendlyName;

--- a/src/Microsoft.TestPlatform.ObjectModel/Logging/Events/TestRunMessageEventArgs.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Logging/Events/TestRunMessageEventArgs.cs
@@ -25,12 +25,12 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging
         {
             if (string.IsNullOrWhiteSpace(message))
             {
-                throw new ArgumentException(CommonResources.CannotBeNullOrEmpty, "message");
+                throw new ArgumentException(CommonResources.CannotBeNullOrEmpty, nameof(message));
             }
 
             if (level < TestMessageLevel.Informational || level > TestMessageLevel.Error)
             {
-                throw new ArgumentOutOfRangeException("level");
+                throw new ArgumentOutOfRangeException(nameof(level));
             }
 
             Level = level;

--- a/src/Microsoft.TestPlatform.ObjectModel/RunSettings/SettingsNameAttribute.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RunSettings/SettingsNameAttribute.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         {
             if (string.IsNullOrWhiteSpace(settingsName))
             {
-                throw new ArgumentException(CommonResources.CannotBeNullOrEmpty, "settingsName");
+                throw new ArgumentException(CommonResources.CannotBeNullOrEmpty, nameof(settingsName));
             }
 
             SettingsName = settingsName;

--- a/src/Microsoft.TestPlatform.ObjectModel/TestOutcomeHelper.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TestOutcomeHelper.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
                     result = Resources.Resources.TestOutcomeNotFound;
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException("outcome");
+                    throw new ArgumentOutOfRangeException(nameof(outcome));
             }
 
             return result;

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/RollingFileTraceListener.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/RollingFileTraceListener.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
         {
             if (string.IsNullOrWhiteSpace(fileName))
             {
-                throw new ArgumentException(nameof(fileName));
+                throw new ArgumentException("fileName was null or whitespace", nameof(fileName));
             }
 
             if (rollSizeKB <= 0)

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/RollingFileTraceListener.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/RollingFileTraceListener.cs
@@ -281,7 +281,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
                 catch (IOException)
                 {
                     // catch errors and attempt move to a new file with a GUID
-                    archiveFileName = archiveFileName + Guid.NewGuid().ToString();
+                    archiveFileName += Guid.NewGuid().ToString();
 
                     try
                     {

--- a/src/Microsoft.TestPlatform.Utilities/ClientUtilities.cs
+++ b/src/Microsoft.TestPlatform.Utilities/ClientUtilities.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         {
             if (xmlDocument == null)
             {
-                throw new ArgumentNullException("xPathNavigator");
+                throw new ArgumentNullException(nameof(xmlDocument));
             }
 
             if (string.IsNullOrEmpty(path))

--- a/src/Microsoft.TestPlatform.Utilities/CodeCoverageRunSettingsProcessor.cs
+++ b/src/Microsoft.TestPlatform.Utilities/CodeCoverageRunSettingsProcessor.cs
@@ -28,11 +28,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         /// <summary>
         /// Constructs an <see cref="CodeCoverageRunSettingsProcessor"/> object.
         /// </summary>
-        /// 
+        ///
         /// <param name="defaultSettingsRootNode">The default settings root node.</param>
         public CodeCoverageRunSettingsProcessor(XmlNode defaultSettingsRootNode)
         {
-            this.defaultSettingsRootNode = defaultSettingsRootNode ?? throw new ArgumentNullException("Default settings root node is null.");
+            this.defaultSettingsRootNode = defaultSettingsRootNode ?? throw new ArgumentNullException(nameof(defaultSettingsRootNode), "Default settings root node is null.");
         }
         #endregion
 
@@ -40,9 +40,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         /// <summary>
         /// Processes the current settings for the code coverage data collector.
         /// </summary>
-        /// 
+        ///
         /// <param name="currentSettings">The code coverage settings.</param>
-        /// 
+        ///
         /// <returns>An updated version of the current run settings.</returns>
         public XmlNode Process(string currentSettings)
         {
@@ -61,11 +61,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         /// <summary>
         /// Processes the current settings for the code coverage data collector.
         /// </summary>
-        /// 
+        ///
         /// <param name="currentSettingsDocument">
         /// The code coverage settings document.
         /// </param>
-        /// 
+        ///
         /// <returns>An updated version of the current run settings.</returns>
         public XmlNode Process(XmlDocument currentSettingsDocument)
         {
@@ -80,9 +80,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         /// <summary>
         /// Processes the current settings for the code coverage data collector.
         /// </summary>
-        /// 
+        ///
         /// <param name="currentSettingsRootNode">The code coverage root element.</param>
-        /// 
+        ///
         /// <returns>An updated version of the current run settings.</returns>
         public XmlNode Process(XmlNode currentSettingsRootNode)
         {
@@ -159,7 +159,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         /// <see cref="XPathNavigator"/> style path. If unable to select the requested node it adds
         /// default settings along the path.
         /// </summary>
-        /// 
+        ///
         /// <param name="currentRootNode">
         /// The root node from the current settings document for the extraction.
         /// </param>
@@ -167,7 +167,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         /// The corresponding root node from the default settings document.
         /// </param>
         /// <param name="pathComponents">The path components.</param>
-        /// 
+        ///
         /// <returns>The requested node if successful, <see cref="null"/> otherwise.</returns>
         private XmlNode SelectNodeOrAddDefaults(
             XmlNode currentRootNode,
@@ -176,8 +176,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         {
             var currentNode = currentRootNode;
             var partialPath = new StringBuilder();
-            
-            partialPath.Append(".");
+
+            partialPath.Append('.');
 
             foreach (var component in pathComponents)
             {
@@ -220,9 +220,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         /// <summary>
         /// Checks if we should process the current exclusion node.
         /// </summary>
-        /// 
+        ///
         /// <param name="node">The current exclusion node.</param>
-        /// 
+        ///
         /// <returns>
         /// <see cref="true"/> if the node should be processed, <see cref="false"/> otherwise.
         /// </returns>
@@ -248,7 +248,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         /// <summary>
         /// Assembles a relative path from the path given as components.
         /// </summary>
-        /// 
+        ///
         /// <returns>A relative path built from path components.</returns>
         private string BuildPath(IList<string> pathComponents)
         {
@@ -258,10 +258,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         /// <summary>
         /// Extracts the node specified by the current path using the provided node as root.
         /// </summary>
-        /// 
+        ///
         /// <param name="node">The root to be used for extraction.</param>
         /// <param name="path">The path used to specify the requested node.</param>
-        /// 
+        ///
         /// <returns>The extracted node if successful, <see cref="null"/> otherwise.</returns>
         private XmlNode ExtractNode(XmlNode node, string path)
         {
@@ -282,7 +282,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
         /// <summary>
         /// Merges the current settings rules with the default settings rules.
         /// </summary>
-        /// 
+        ///
         /// <param name="currentNode">The current settings root node.</param>
         /// <param name="defaultNode">The default settings root node.</param>
         private void MergeNodes(XmlNode currentNode, XmlNode defaultNode)

--- a/src/vstest.console/CommandLine/CommandArgumentPair.cs
+++ b/src/vstest.console/CommandLine/CommandArgumentPair.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine
         {
             if (String.IsNullOrWhiteSpace(input))
             {
-                throw new ArgumentException(CommandLineResources.CannotBeNullOrEmpty, "input");
+                throw new ArgumentException(CommandLineResources.CannotBeNullOrEmpty, nameof(input));
             }
             Contract.Ensures(!String.IsNullOrWhiteSpace(Command));
 
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine
         {
             if (String.IsNullOrWhiteSpace(command))
             {
-                throw new ArgumentException(CommandLineResources.CannotBeNullOrEmpty, "command");
+                throw new ArgumentException(CommandLineResources.CannotBeNullOrEmpty, nameof(command));
             }
 
             Contract.Ensures(Command == command);

--- a/src/vstest.console/Processors/EnableBlameArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnableBlameArgumentProcessor.cs
@@ -208,7 +208,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             // Add default run settings if required.
             if (this.runSettingsManager.ActiveRunSettings?.SettingsXml == null)
             {
-                this.runSettingsManager.AddDefaultRunSettings(); ;
+                this.runSettingsManager.AddDefaultRunSettings();
             }
             var settings = this.runSettingsManager.ActiveRunSettings?.SettingsXml;
 
@@ -260,7 +260,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
                 {
                     hangDumpParameters.Add("HangDumpType", "Full");
                 }
-                
+
                 AddCollectHangDumpNode(hangDumpParameters, XmlDocument, outernode);
             }
 

--- a/src/vstest.console/Processors/ListFullyQualifiedTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ListFullyQualifiedTestsArgumentProcessor.cs
@@ -203,7 +203,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             Contract.Assert(this.commandLineOptions != null);
             Contract.Assert(!string.IsNullOrWhiteSpace(this.runSettingsManager?.ActiveRunSettings?.SettingsXml));
 
-            if (this.commandLineOptions.Sources.Count() <= 0)
+            if (!this.commandLineOptions.Sources.Any())
             {
                 throw new CommandLineException(string.Format(CultureInfo.CurrentUICulture, CommandLineResources.MissingTestSourceFile));
             }

--- a/src/vstest.console/Processors/ListTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ListTestsArgumentProcessor.cs
@@ -201,7 +201,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             Contract.Assert(this.commandLineOptions != null);
             Contract.Assert(!string.IsNullOrWhiteSpace(this.runSettingsManager?.ActiveRunSettings?.SettingsXml));
 
-            if (this.commandLineOptions.Sources.Count() <= 0)
+            if (!this.commandLineOptions.Sources.Any())
             {
                 throw new CommandLineException(string.Format(CultureInfo.CurrentUICulture, CommandLineResources.MissingTestSourceFile));
             }

--- a/src/vstest.console/Processors/RunSpecificTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunSpecificTestsArgumentProcessor.cs
@@ -256,7 +256,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
         {
             if (this.selectedTestCases.Count > 0)
             {
-                if (this.undiscoveredFilters.Count() != 0)
+                if (this.undiscoveredFilters.Count != 0)
                 {
                     string missingFilters = string.Join(", ", this.undiscoveredFilters);
                     string warningMessage = string.Format(CultureInfo.CurrentCulture, CommandLineResources.SomeTestsUnavailableAfterFiltering, this.discoveredTestCount, missingFilters);

--- a/test/Microsoft.TestPlatform.AcceptanceTests/FilePatternParserTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/FilePatternParserTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
             var resultsDir = GetResultsDirectory();
 
-            var testAssembly = this.BuildMultipleAssemblyPath("SimpleTestProject.dll", "SimpleTestProject2.dll").Trim('\"'); ;
+            var testAssembly = this.BuildMultipleAssemblyPath("SimpleTestProject.dll", "SimpleTestProject2.dll").Trim('\"');
             testAssembly = testAssembly.Replace("SimpleTestProject.dll", "*TestProj*.dll");
             testAssembly = testAssembly.Replace("SimpleTestProject2.dll", "*TestProj*.dll");
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/EventHandler/DiscoveryEventHandler.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/EventHandler/DiscoveryEventHandler.cs
@@ -158,7 +158,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
 
         public void HandleDiscoveredTests(IEnumerable<TestCase> discoveredTestCases)
         {
-            if (discoveredTestCases != null & discoveredTestCases.Count() != 0)
+            if (discoveredTestCases != null & discoveredTestCases.Any())
             {
                 this.DiscoveredTestCases.AddRange(discoveredTestCases);
                 this.BatchSize = discoveredTestCases.Count();

--- a/test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/ManagedNameUtilities/ManagedNameParserTests.cs
+++ b/test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/ManagedNameUtilities/ManagedNameParserTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities.UnitTests
             {
                 ManagedNameParser.ParseManagedTypeName(managedTypeName, out var namespaceName, out var typeName);
                 return (namespaceName, typeName);
-            };
+            }
 
             Assert.AreEqual(("NS", "Class"), Parse("NS.Class"));
             Assert.AreEqual(("NS.NS", "Class"), Parse("NS.NS.Class"));

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestDiscoveryExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestDiscoveryExtensionManagerTests.cs
@@ -29,7 +29,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             var extensionManager = TestDiscoveryExtensionManager.Create();
 
             Assert.IsNotNull(extensionManager.Discoverers);
-            Assert.IsTrue(extensionManager.Discoverers.Count() > 0);
+            Assert.IsTrue(extensionManager.Discoverers.Any());
         }
 
         [TestMethod]
@@ -41,7 +41,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             TestDiscoveryExtensionManager.Create();
 
             Assert.IsNotNull(extensionManager.Discoverers);
-            Assert.IsTrue(extensionManager.Discoverers.Count() > 0);
+            Assert.IsTrue(extensionManager.Discoverers.Any());
         }
 
         [TestMethod]
@@ -52,7 +52,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
                     typeof(TestDiscoveryExtensionManagerTests).GetTypeInfo().Assembly.Location);
 
             Assert.IsNotNull(extensionManager.Discoverers);
-            Assert.IsTrue(extensionManager.Discoverers.Count() > 0);
+            Assert.IsTrue(extensionManager.Discoverers.Any());
         }
 
         #region LoadAndInitialize tests

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestExecutorExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestExecutorExtensionManagerTests.cs
@@ -27,7 +27,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             var extensionManager = TestExecutorExtensionManager.Create();
 
             Assert.IsNotNull(extensionManager.TestExtensions);
-            Assert.IsTrue(extensionManager.TestExtensions.Count() > 0);
+            Assert.IsTrue(extensionManager.TestExtensions.Any());
         }
 
         [TestMethod]
@@ -39,7 +39,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
             TestExecutorExtensionManager.Create();
 
             Assert.IsNotNull(extensionManager.TestExtensions);
-            Assert.IsTrue(extensionManager.TestExtensions.Count() > 0);
+            Assert.IsTrue(extensionManager.TestExtensions.Any());
         }
 
         [TestMethod]
@@ -50,7 +50,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
                     typeof(TestExecutorExtensionManagerTests).GetTypeInfo().Assembly.Location);
 
             Assert.IsNotNull(extensionManager.TestExtensions);
-            Assert.IsTrue(extensionManager.TestExtensions.Count() > 0);
+            Assert.IsTrue(extensionManager.TestExtensions.Any());
         }
 
         #region LoadAndInitialize tests

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginManagerTests.cs
@@ -78,7 +78,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
 
             Assert.IsNotNull(unfilteredTestExtensions);
             Assert.IsNotNull(testExtensions);
-            Assert.IsTrue(testExtensions.Count() > 0);
+            Assert.IsTrue(testExtensions.Any());
         }
 
         [TestMethod]
@@ -115,7 +115,7 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework
                     out var testExtensions);
 
             Assert.IsNotNull(testExtensions);
-            Assert.IsTrue(testExtensions.Count() > 0);
+            Assert.IsTrue(testExtensions.Any());
         }
 
         #region Implementations

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Utilities/FakesUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Utilities/FakesUtilitiesTests.cs
@@ -118,7 +118,7 @@ namespace TestPlatform.Common.UnitTests.Utilities
             FakesUtilities.InsertOrReplaceFakesDataCollectorNode(doc, dataCollectorNode2);
             Assert.IsTrue(XmlRunSettingsUtilities.ContainsDataCollector(doc, FakesUtilities.FakesMetadata.DataCollectorUriV2));
             XmlNodeList nodes = doc.SelectNodes("//RunSettings/RunConfiguration/TargetFrameworkVersion");
-            Assert.AreEqual(nodes[0].InnerText, "FrameworkCore10");
+            Assert.AreEqual("FrameworkCore10", nodes[0].InnerText);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.PlatformTests/SocketClientTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.PlatformTests/SocketClientTests.cs
@@ -38,12 +38,11 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.PlatformTests
 #if NETFRAMEWORK
             // tcpClient.Close() calls tcpClient.Dispose().
             this.tcpClient?.Close();
-            GC.SuppressFinalize(this);
 #else
             // tcpClient.Close() not available for netcoreapp1.0
             this.tcpClient?.Dispose();
-            GC.SuppressFinalize(this);
 #endif
+            GC.SuppressFinalize(this);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.PlatformTests/SocketClientTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.PlatformTests/SocketClientTests.cs
@@ -38,9 +38,11 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.PlatformTests
 #if NETFRAMEWORK
             // tcpClient.Close() calls tcpClient.Dispose().
             this.tcpClient?.Close();
+            GC.SuppressFinalize(this);
 #else
             // tcpClient.Close() not available for netcoreapp1.0
             this.tcpClient?.Dispose();
+            GC.SuppressFinalize(this);
 #endif
         }
 

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.PlatformTests/SocketCommunicationManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.PlatformTests/SocketCommunicationManagerTests.cs
@@ -45,7 +45,6 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.PlatformTests
 #if NETFRAMEWORK
             // tcpClient.Close() calls tcpClient.Dispose().
             this.tcpClient?.Close();
-            GC.SuppressFinalize(this);
 #else
             // tcpClient.Close() not available for netcoreapp1.0
             this.tcpClient?.Dispose();

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.PlatformTests/SocketCommunicationManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.PlatformTests/SocketCommunicationManagerTests.cs
@@ -45,12 +45,14 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.PlatformTests
 #if NETFRAMEWORK
             // tcpClient.Close() calls tcpClient.Dispose().
             this.tcpClient?.Close();
+            GC.SuppressFinalize(this);
 #else
             // tcpClient.Close() not available for netcoreapp1.0
             this.tcpClient?.Dispose();
 #endif
             this.communicationManager.StopServer();
             this.communicationManager.StopClient();
+            GC.SuppressFinalize(this);
         }
 
         #region Server tests

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.PlatformTests/SocketServerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.PlatformTests/SocketServerTests.cs
@@ -35,12 +35,11 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.PlatformTests
 #if NETFRAMEWORK
             // tcpClient.Close() calls tcpClient.Dispose().
             this.tcpClient?.Close();
-            GC.SuppressFinalize(this);
 #else
             // tcpClient.Close() not available for netcoreapp1.0
             this.tcpClient?.Dispose();
-            GC.SuppressFinalize(this);
 #endif
+            GC.SuppressFinalize(this);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.PlatformTests/SocketServerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.PlatformTests/SocketServerTests.cs
@@ -35,9 +35,11 @@ namespace Microsoft.TestPlatform.CommunicationUtilities.PlatformTests
 #if NETFRAMEWORK
             // tcpClient.Close() calls tcpClient.Dispose().
             this.tcpClient?.Close();
+            GC.SuppressFinalize(this);
 #else
             // tcpClient.Close() not available for netcoreapp1.0
             this.tcpClient?.Dispose();
+            GC.SuppressFinalize(this);
 #endif
         }
 

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/LengthPrefixCommunicationChannelTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/LengthPrefixCommunicationChannelTests.cs
@@ -38,6 +38,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.UnitTests
 
             this.reader.Dispose();
             this.writer.Dispose();
+            GC.SuppressFinalize(this);
         }
 
         [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/DataCollectionTestRunEventsHandlerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/DataCollectionTestRunEventsHandlerTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.TestPlatform.CrossPlatEngine.UnitTests.DataCollection
             this.baseTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
             this.proxyDataCollectionManager = new Mock<IProxyDataCollectionManager>();
             this.mockDataSerializer = new Mock<IDataSerializer>();
-            this.testRunEventHandler = new DataCollectionTestRunEventsHandler(this.baseTestRunEventsHandler.Object, this.proxyDataCollectionManager.Object, CancellationToken.None, this.mockDataSerializer.Object);
+            this.testRunEventHandler = new DataCollectionTestRunEventsHandler(this.baseTestRunEventsHandler.Object, this.proxyDataCollectionManager.Object, this.mockDataSerializer.Object, CancellationToken.None);
         }
 
         [TestMethod]
@@ -76,7 +76,7 @@ namespace Microsoft.TestPlatform.CrossPlatEngine.UnitTests.DataCollection
                 .Returns(new TestRunCompletePayload() { TestRunCompleteArgs = testRunCompleteEventArgs });
 
             var cancellationTokenSource = new CancellationTokenSource();
-            testRunEventHandler = new DataCollectionTestRunEventsHandler(this.baseTestRunEventsHandler.Object, this.proxyDataCollectionManager.Object, cancellationTokenSource.Token, this.mockDataSerializer.Object);
+            testRunEventHandler = new DataCollectionTestRunEventsHandler(this.baseTestRunEventsHandler.Object, this.proxyDataCollectionManager.Object, this.mockDataSerializer.Object, cancellationTokenSource.Token);
 
             testRunEventHandler.HandleRawMessage(string.Empty);
 
@@ -95,7 +95,7 @@ namespace Microsoft.TestPlatform.CrossPlatEngine.UnitTests.DataCollection
                 .Returns(new TestRunCompletePayload() { TestRunCompleteArgs = testRunCompleteEventArgs });
 
             var cancellationTokenSource = new CancellationTokenSource();
-            testRunEventHandler = new DataCollectionTestRunEventsHandler(this.baseTestRunEventsHandler.Object, this.proxyDataCollectionManager.Object, cancellationTokenSource.Token, this.mockDataSerializer.Object);
+            testRunEventHandler = new DataCollectionTestRunEventsHandler(this.baseTestRunEventsHandler.Object, this.proxyDataCollectionManager.Object, this.mockDataSerializer.Object, cancellationTokenSource.Token);
             cancellationTokenSource.Cancel();
 
             testRunEventHandler.HandleRawMessage(string.Empty);

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Discovery/DiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Discovery/DiscoveryManagerTests.cs
@@ -64,7 +64,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
             var allDiscoverers = TestDiscoveryExtensionManager.Create().Discoverers;
 
             Assert.IsNotNull(allDiscoverers);
-            Assert.IsTrue(allDiscoverers.Count() > 0);
+            Assert.IsTrue(allDiscoverers.Any());
         }
 
         #endregion

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/BaseRunTestsTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/BaseRunTestsTests.cs
@@ -535,8 +535,8 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
             Assert.IsNotNull(receivedRunStatusArgs);
             Assert.AreEqual(this.runTestsInstance.GetTestRunCache.TestRunStatistics.ExecutedTests, receivedRunStatusArgs.TestRunStatistics.ExecutedTests);
             Assert.IsNotNull(receivedRunStatusArgs.NewTestResults);
-            Assert.IsTrue(receivedRunStatusArgs.NewTestResults.Count() > 0);
-            Assert.IsTrue(receivedRunStatusArgs.ActiveTests == null || receivedRunStatusArgs.ActiveTests.Count() == 0);
+            Assert.IsTrue(receivedRunStatusArgs.NewTestResults.Any());
+            Assert.IsTrue(receivedRunStatusArgs.ActiveTests == null || !receivedRunStatusArgs.ActiveTests.Any());
 
             // Attachments
             Assert.IsNotNull(receivedattachments);
@@ -568,7 +568,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution
 
             // Test run changed event assertions
             Assert.IsNotNull(receivedRunStatusArgs.NewTestResults);
-            Assert.IsTrue(receivedRunStatusArgs.NewTestResults.Count() > 0);
+            Assert.IsTrue(receivedRunStatusArgs.NewTestResults.Any());
 
             // verify TC.Source is updated with package
             foreach (var tr in receivedRunStatusArgs.NewTestResults)

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/CodeCoverageRunSettingsProcessorTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/CodeCoverageRunSettingsProcessorTests.cs
@@ -277,7 +277,7 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
                 set.Remove(child.OuterXml);
             }
 
-            Assert.AreEqual(set.Count, 0);
+            Assert.AreEqual(0, set.Count);
         }
         #endregion
     }

--- a/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
         {
             RunSpecificTestsArgumentProcessorCapabilities capabilities = new RunSpecificTestsArgumentProcessorCapabilities();
             Assert.AreEqual("/Tests", capabilities.CommandName);
-            StringAssert.Contains(capabilities.HelpContentResourceName.NormalizeLineEndings(), 
+            StringAssert.Contains(capabilities.HelpContentResourceName.NormalizeLineEndings(),
                 "/Tests:<Test Names>\r\n      Run tests with names that match the provided values.".NormalizeLineEndings());
 
             Assert.AreEqual(HelpContentPriority.RunSpecificTestsArgumentProcessorHelpPriority, capabilities.HelpPriority);
@@ -193,7 +193,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             mockTestPlatform.Setup(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockTestRunRequest.Object);
             mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockDiscoveryRequest.Object);
 
-            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);;
+            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);
             var executor = GetExecutor(testRequestManager);
 
             CommandLineOptions.Instance.TestCaseFilterValue = "Filter";
@@ -218,7 +218,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockDiscoveryRequest.Object);
 
             this.ResetAndAddSourceToCommandLineOptions();
-            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);;
+            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);
             var executor = GetExecutor(testRequestManager);
 
             Assert.ThrowsException<TestPlatformException>(() => executor.Execute());
@@ -236,7 +236,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockDiscoveryRequest.Object);
 
             this.ResetAndAddSourceToCommandLineOptions();
-            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);;
+            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);
             var executor = GetExecutor(testRequestManager);
 
             Assert.ThrowsException<InvalidOperationException>(() => executor.Execute());
@@ -254,7 +254,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockDiscoveryRequest.Object);
 
             this.ResetAndAddSourceToCommandLineOptions();
-            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);;
+            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);
             var executor = GetExecutor(testRequestManager);
 
             Assert.ThrowsException<SettingsException>(() => executor.Execute());
@@ -277,7 +277,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockDiscoveryRequest.Object);
 
             this.ResetAndAddSourceToCommandLineOptions();
-            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);;
+            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);
             var executor = GetExecutor(testRequestManager);
 
             executor.Initialize("Test1");
@@ -302,7 +302,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockDiscoveryRequest.Object);
 
             this.ResetAndAddSourceToCommandLineOptions();
-            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);;
+            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);
             var executor = GetExecutor(testRequestManager);
 
             executor.Initialize("Test1");
@@ -328,7 +328,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
 
             this.ResetAndAddSourceToCommandLineOptions();
 
-            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);;
+            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);
             var executor = GetExecutor(testRequestManager);
 
             executor.Initialize("Test1");
@@ -349,7 +349,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
 
             mockDiscoveryRequest.Setup(dr => dr.DiscoverAsync()).Raises(dr => dr.OnDiscoveredTests += null, new DiscoveredTestsEventArgs(new List<TestCase>()));
             mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockDiscoveryRequest.Object);
-            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);;
+            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);
             var executor = GetExecutor(testRequestManager);
 
             executor.Initialize("Test1");
@@ -370,7 +370,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
 
             mockDiscoveryRequest.Setup(dr => dr.DiscoverAsync()).Raises(dr => dr.OnDiscoveredTests += null, new DiscoveredTestsEventArgs(new List<TestCase>()));
             mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockDiscoveryRequest.Object);
-            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);;
+            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);
             var executor = GetExecutor(testRequestManager);
 
             executor.Initialize("Test1");
@@ -397,7 +397,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             mockTestPlatform.Setup(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockTestRunRequest.Object);
             mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockDiscoveryRequest.Object);
 
-            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);;
+            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);
             var executor = GetExecutor(testRequestManager);
 
             executor.Initialize("Test1");
@@ -423,7 +423,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             mockTestPlatform.Setup(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockTestRunRequest.Object);
             mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockDiscoveryRequest.Object);
 
-            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);;
+            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);
             var executor = GetExecutor(testRequestManager);
 
             executor.Initialize("Test1, Test2");
@@ -450,7 +450,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             mockTestPlatform.Setup(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockTestRunRequest.Object);
             mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockDiscoveryRequest.Object);
 
-            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);;
+            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);
             var executor = GetExecutor(testRequestManager);
 
             executor.Initialize("Test1");
@@ -476,7 +476,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             mockTestPlatform.Setup(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockTestRunRequest.Object);
             mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockDiscoveryRequest.Object);
 
-            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);;
+            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);
             var executor = GetExecutor(testRequestManager);
 
             executor.Initialize("Test1, Test2");
@@ -503,7 +503,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             mockTestPlatform.Setup(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockTestRunRequest.Object);
             mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockDiscoveryRequest.Object);
 
-            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);;
+            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);
             var executor = GetExecutor(testRequestManager);
 
             executor.Initialize("Test1(a\\,b), Test2(c\\,d)");
@@ -533,7 +533,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockDiscoveryRequest.Object);
 
             this.ResetAndAddSourceToCommandLineOptions();
-            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);;
+            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);
             var executor = GetExecutor(testRequestManager);
 
             executor.Initialize("Test1");
@@ -562,7 +562,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors
             mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>())).Returns(mockDiscoveryRequest.Object);
 
             this.ResetAndAddSourceToCommandLineOptions();
-            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);;
+            var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, this.mockTestPlatformEventSource.Object, this.inferHelper, this.mockMetricsPublisherTask, this.mockProcessHelper.Object, this.mockAttachmentsProcessingManager.Object);
             var executor = GetExecutor(testRequestManager);
 
             executor.Initialize("Test1");


### PR DESCRIPTION
## Description
Provided some code cleanup based on some microsoft rules, 

CA1507 Use nameof in place of string literal
CA1827 Count() is used where Any() could be used instead to improve performance
CA1068 Method should take CancellationToken as the last parameter
CA1834 Use 'StringBuilder.Append(char)' instead of 'StringBuilder.Append(string)' when the input is a constant unit string
CA2208 Replace this argument with one of the method's parameter names. Note that the provided parameter name should have the exact casing as declared on the method.
CA1816 Change .Dispose() to call GC.SuppressFinalize(object). This will prevent derived types that introduce a finalizer from needing to re-implement 'IDisposable' to call it.

S3626 Remove this redundant jump.
S3415 Make sure these 2 arguments are in the correct order: expected value, actual value.
S2971 Use 'Count' property here instead.
S1155 Use '.Any()' to test whether is empty or not.
S1116 Remove this empty statement

## Related issue
Related to #2827
