### PR TITLE
Added support for WinUI3 appxrecipe.

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
         private ITestRunEventsHandler testRunEventsHandler;
         private ITestEventsPublisher testEventsPublisher;
         private ITestRunCache testRunCache;
-        private string package;
+        private protected string package;
         private IRequestData requestData;
 
         /// <summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/RunTestsWithSources.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/RunTestsWithSources.cs
@@ -150,7 +150,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution
             // Validate the sources 
             foreach (var kvp in this.adapterSourceMap)
             {
-                var verifiedSources = DiscoveryManager.GetValidSources(kvp.Value, logger);
+                var verifiedSources = DiscoveryManager.GetValidSources(kvp.Value, logger, package);
                 if (verifiedSources.Any())
                 {
                     verifiedExtensionSourceMap.Add(kvp.Key, kvp.Value);

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Discovery/DiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Discovery/DiscoveryManagerTests.cs
@@ -89,6 +89,29 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Discovery
         }
 
         [TestMethod]
+        public void DiscoverTestsShouldLogIfTheSourceDoesNotExistIfItHasAPackage()
+        {
+            var criteria = new DiscoveryCriteria(new List<string> { "imaginary.exe" }, 100, null);
+
+            var packageName = "recipe.AppxRecipe";
+
+            var fakeDirectory = Directory.GetDirectoryRoot(typeof(DiscoveryManagerTests).GetTypeInfo().Assembly.Location);
+
+            criteria.Package = Path.Combine(fakeDirectory, Path.Combine(packageName));
+            var mockLogger = new Mock<ITestDiscoveryEventsHandler2>();
+
+            this.discoveryManager.DiscoverTests(criteria, mockLogger.Object);
+
+            var errorMessage = string.Format(CultureInfo.CurrentCulture, "Could not find file {0}.", Path.Combine(fakeDirectory, "imaginary.exe"));
+            mockLogger.Verify(
+                l =>
+                l.HandleLogMessage(
+                    Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging.TestMessageLevel.Warning,
+                    errorMessage),
+                Times.Once);
+        }
+
+        [TestMethod]
         public void DiscoverTestsShouldLogIfThereAreNoValidSources()
         {
             var sources = new List<string> { "imaginary.dll" };


### PR DESCRIPTION
## Description
WinUI3 builds appxrecipe files, but there was a fundamental change in how the appx behaves.
The source is still valid if the file exists in the same path as the appxrecipe file. This change, paired with another PR in testfx (adding a net5-windows tfm for the adapters), allows UnitTests to be executed for tests that exists inside a WAPProject.