### PR TITLE
Abort when init and run messages fail to process

### DIFF
--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginCache.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginCache.cs
@@ -529,7 +529,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
             {
                 try
                 {
-                    EqtTrace.Verbose("CurrentDomain_AssemblyResolve: Resolving assembly '{0}'.", args.Name);
+                    EqtTrace.Verbose("CurrentDomainAssemblyResolve: Resolving assembly '{0}'.", args.Name);
 
                     if (this.resolvedAssemblies.TryGetValue(args.Name, out assembly))
                     {

--- a/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs
@@ -106,6 +106,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
 
             if (this.searchDirectories == null || this.searchDirectories.Count == 0)
             {
+                EqtTrace.Info("AssemblyResolver.OnResolve: {0}: There are no search directories, returning.", args.Name);
                 return null;
             }
 
@@ -146,6 +147,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
                         continue;
                     }
 
+                    EqtTrace.Info("AssemblyResolver.OnResolve: {0}: Searching in: '{1}'.", args.Name, dir);
+
                     foreach (var extension in SupportedFileExtensions)
                     {
                         var assemblyPath = Path.Combine(dir, requestedName.Name + extension);
@@ -153,6 +156,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
                         {
                             if (!File.Exists(assemblyPath))
                             {
+                                EqtTrace.Info("AssemblyResolver.OnResolve: {0}: Assembly path does not exist: '{1}', returning.", args.Name, assemblyPath);
+
                                 continue;
                             }
 
@@ -160,9 +165,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
 
                             if (!this.RequestedAssemblyNameMatchesFound(requestedName, foundName))
                             {
+                                EqtTrace.Info("AssemblyResolver.OnResolve: {0}: File exists but version/public key is wrong. Try next extension.", args.Name);
                                 continue;   // File exists but version/public key is wrong. Try next extension.
                             }
 
+                            EqtTrace.Info("AssemblyResolver.OnResolve: {0}: Loading assembly '{1}'.", args.Name, assemblyPath);
+                            
                             assembly = this.platformAssemblyLoadContext.LoadAssemblyFromPath(assemblyPath);
                             this.resolvedAssemblies[args.Name] = assembly;
 
@@ -172,7 +180,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
                         }
                         catch (FileLoadException ex)
                         {
-                            EqtTrace.Info("AssemblyResolver.OnResolve: {0}: Failed to load assembly. Reason:{1} ", args.Name, ex);
+                            EqtTrace.Error("AssemblyResolver.OnResolve: {0}: Failed to load assembly. Reason:{1} ", args.Name, ex);
 
                             // Re-throw FileLoadException, because this exception means that the assembly
                             // was found, but could not be loaded. This will allow us to report a more

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
@@ -168,6 +168,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 ICollection<AttachmentSet> runContextAttachments,
                 ICollection<string> executorUris)
         {
+            // When we abort the run we might have saved the error before we gave the handler the chance to abort
+            // if the handler does not return with any new error we report the original one.
             if (testRunCompleteArgs.IsAborted && testRunCompleteArgs.Error == null && this.messageProcessingUnrecoverableError != null)
             {
                 var curentArgs = testRunCompleteArgs;
@@ -388,11 +390,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                             this.testHostManagerFactoryReady.Wait();
                             var testInitializeEventsHandler = new TestInitializeEventsHandler(this);
                             var pathToAdditionalExtensions = this.dataSerializer.DeserializePayload<IEnumerable<string>>(message);
-                            var a = true;
-                            if (a)
-                            {
-                                throw new InvalidOperationException("fffffaaaail!");
-                            }
                             Action job = () =>
                             {
                                 EqtTrace.Info("TestRequestHandler.OnMessageReceived: Running job '{0}'.", message.MessageType);

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -788,7 +788,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
                         sourceName,
                         frameworkString);
 
-                    
+
                     ConsoleColor? color = null;
                     if (sourceOutcome == TestOutcome.Failed)
                     {
@@ -831,7 +831,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
                 }
                 else if (e.IsAborted)
                 {
-                    Output.Error(false, CommandLineResources.TestRunAborted);
+                    if (e.Error == null)
+                    {
+                        Output.Error(false, CommandLineResources.TestRunAborted);
+                    }
+                    else
+                    {
+                        Output.Error(false, CommandLineResources.TestRunAbortedWithError, e.Error);
+                    }
                 }
 
                 return;
@@ -843,7 +850,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal
             }
             else if (e.IsAborted)
             {
-                Output.Error(false, CommandLineResources.TestRunAborted);
+                if (e.Error == null)
+                {
+                    Output.Error(false, CommandLineResources.TestRunAborted);
+                }
+                else
+                {
+                    Output.Error(false, CommandLineResources.TestRunAbortedWithError, e.Error);
+                }
             }
             else if (failedTests > 0 || this.testRunHasErrorMessages)
             {

--- a/src/vstest.console/Resources/Resources.Designer.cs
+++ b/src/vstest.console/Resources/Resources.Designer.cs
@@ -1575,6 +1575,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Test Run Aborted with error: {0}..
+        /// </summary>
+        internal static string TestRunAbortedWithError {
+            get {
+                return ResourceManager.GetString("TestRunAbortedWithError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Test Run Canceled..
         /// </summary>
         internal static string TestRunCanceled {

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -763,4 +763,7 @@
   <data name="EnvironmentVariableXIsOverriden" xml:space="preserve">
     <value>Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</value>
   </data>
+  <data name="TestRunAbortedWithError" xml:space="preserve">
+    <value>Test Run Aborted with error {0}.</value>
+  </data>
 </root>


### PR DESCRIPTION
## Description

Failing to deserialize incoming request will be logged into log, but won't kill testhost. Vstest console won't know that testhost failed to process and will wait for it indefinitely, or till the whole run times out. The deserialization error happens from time to time (investigating why), and this will prevent the hang if it happens by aborting the run and passing back the error.

