### PR TITLE
Mark early testhost startup APIs as internal for TP 16.10 (#2768)

### DIFF
--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/ITestSession.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/ITestSession.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.TestPlatform.VsTestConsole.TranslationLayer.Int
     /// Defines a test session that can be used to make calls to the vstest.console
     /// process.
     /// </summary>
-    public interface ITestSession : ITestSessionAsync
+    internal interface ITestSession : ITestSessionAsync
     {
         /// <summary>
         /// Starts test discovery.

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/ITestSessionAsync.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/ITestSessionAsync.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.TestPlatform.VsTestConsole.TranslationLayer.Int
     /// Defines a test session that can be used to make async calls to the vstest.console
     /// process.
     /// </summary>
-    public interface ITestSessionAsync
+    internal interface ITestSessionAsync
     {
         /// <summary>
         /// Starts test discovery.

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IVsTestConsoleWrapper.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IVsTestConsoleWrapper.cs
@@ -53,21 +53,21 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces
             TestPlatformOptions options,
             ITestDiscoveryEventsHandler2 discoveryEventsHandler);
 
-        /// <summary>
-        /// Starts test discovery.
-        /// </summary>
-        /// 
-        /// <param name="sources">The list of source assemblies for the discovery.</param>
-        /// <param name="discoverySettings">The run settings for the discovery.</param>
-        /// <param name="options">The test platform options.</param>
-        /// <param name="testSessionInfo">The test session info object.</param>
-        /// <param name="discoveryEventsHandler">The discovery event handler.</param>
-        void DiscoverTests(
-            IEnumerable<string> sources,
-            string discoverySettings,
-            TestPlatformOptions options,
-            TestSessionInfo testSessionInfo,
-            ITestDiscoveryEventsHandler2 discoveryEventsHandler);
+        // <summary>
+        // Starts test discovery.
+        // </summary>
+        // 
+        // <param name="sources">The list of source assemblies for the discovery.</param>
+        // <param name="discoverySettings">The run settings for the discovery.</param>
+        // <param name="options">The test platform options.</param>
+        // <param name="testSessionInfo">The test session info object.</param>
+        // <param name="discoveryEventsHandler">The discovery event handler.</param>
+        // void DiscoverTests(
+        //     IEnumerable<string> sources,
+        //     string discoverySettings,
+        //     TestPlatformOptions options,
+        //     TestSessionInfo testSessionInfo,
+        //     ITestDiscoveryEventsHandler2 discoveryEventsHandler);
 
         /// <summary>
         /// Cancels the last discovery request.
@@ -100,21 +100,21 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces
             TestPlatformOptions options,
             ITestRunEventsHandler testRunEventsHandler);
 
-        /// <summary>
-        /// Starts a test run.
-        /// </summary>
-        /// 
-        /// <param name="sources">The list of source assemblies for the test run.</param>
-        /// <param name="runSettings">The run settings for the run.</param>
-        /// <param name="options">The test platform options.</param>
-        /// <param name="testSessionInfo">The test session info object.</param>
-        /// <param name="testRunEventsHandler">The run event handler.</param>
-        void RunTests(
-            IEnumerable<string> sources,
-            string runSettings,
-            TestPlatformOptions options,
-            TestSessionInfo testSessionInfo,
-            ITestRunEventsHandler testRunEventsHandler);
+        // <summary>
+        // Starts a test run.
+        // </summary>
+        // 
+        // <param name="sources">The list of source assemblies for the test run.</param>
+        // <param name="runSettings">The run settings for the run.</param>
+        // <param name="options">The test platform options.</param>
+        // <param name="testSessionInfo">The test session info object.</param>
+        // <param name="testRunEventsHandler">The run event handler.</param>
+        // void RunTests(
+        //     IEnumerable<string> sources,
+        //     string runSettings,
+        //     TestPlatformOptions options,
+        //     TestSessionInfo testSessionInfo,
+        //     ITestRunEventsHandler testRunEventsHandler);
 
         /// <summary>
         /// Starts a test run.
@@ -142,21 +142,21 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces
             TestPlatformOptions options,
             ITestRunEventsHandler testRunEventsHandler);
 
-        /// <summary>
-        /// Starts a test run.
-        /// </summary>
-        /// 
-        /// <param name="testCases">The list of test cases for the test run.</param>
-        /// <param name="runSettings">The run settings for the run.</param>
-        /// <param name="options">The test platform options.</param>
-        /// <param name="testSessionInfo">The test session info object.</param>
-        /// <param name="testRunEventsHandler">The run event handler.</param>
-        void RunTests(
-            IEnumerable<TestCase> testCases,
-            string runSettings,
-            TestPlatformOptions options,
-            TestSessionInfo testSessionInfo,
-            ITestRunEventsHandler testRunEventsHandler);
+        // <summary>
+        // Starts a test run.
+        // </summary>
+        // 
+        // <param name="testCases">The list of test cases for the test run.</param>
+        // <param name="runSettings">The run settings for the run.</param>
+        // <param name="options">The test platform options.</param>
+        // <param name="testSessionInfo">The test session info object.</param>
+        // <param name="testRunEventsHandler">The run event handler.</param>
+        // void RunTests(
+        //     IEnumerable<TestCase> testCases,
+        //     string runSettings,
+        //     TestPlatformOptions options,
+        //     TestSessionInfo testSessionInfo,
+        //     ITestRunEventsHandler testRunEventsHandler);
 
         /// <summary>
         /// Starts a test run.
@@ -188,23 +188,23 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces
             ITestRunEventsHandler testRunEventsHandler,
             ITestHostLauncher customTestHostLauncher);
 
-        /// <summary>
-        /// Starts a test run.
-        /// </summary>
-        /// 
-        /// <param name="sources">The list of source assemblies for the test run.</param>
-        /// <param name="runSettings">The run settings for the run.</param>
-        /// <param name="options">The test platform options.</param>
-        /// <param name="testSessionInfo">The test session info object.</param>
-        /// <param name="testRunEventsHandler">The run event handler.</param>
-        /// <param name="customTestHostLauncher">The custom host launcher.</param>
-        void RunTestsWithCustomTestHost(
-            IEnumerable<string> sources,
-            string runSettings,
-            TestPlatformOptions options,
-            TestSessionInfo testSessionInfo,
-            ITestRunEventsHandler testRunEventsHandler,
-            ITestHostLauncher customTestHostLauncher);
+        // <summary>
+        // Starts a test run.
+        // </summary>
+        // 
+        // <param name="sources">The list of source assemblies for the test run.</param>
+        // <param name="runSettings">The run settings for the run.</param>
+        // <param name="options">The test platform options.</param>
+        // <param name="testSessionInfo">The test session info object.</param>
+        // <param name="testRunEventsHandler">The run event handler.</param>
+        // <param name="customTestHostLauncher">The custom host launcher.</param>
+        // void RunTestsWithCustomTestHost(
+        //     IEnumerable<string> sources,
+        //     string runSettings,
+        //     TestPlatformOptions options,
+        //     TestSessionInfo testSessionInfo,
+        //     ITestRunEventsHandler testRunEventsHandler,
+        //     ITestHostLauncher customTestHostLauncher);
 
         /// <summary>
         /// Starts a test run.
@@ -236,83 +236,83 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces
             ITestRunEventsHandler testRunEventsHandler,
             ITestHostLauncher customTestHostLauncher);
 
-        /// <summary>
-        /// Starts a test run.
-        /// </summary>
-        /// 
-        /// <param name="testCases">The list of test cases for the test run.</param>
-        /// <param name="runSettings">The run settings for the run.</param>
-        /// <param name="options">The test platform options.</param>
-        /// <param name="testSessionInfo">The test session info object.</param>
-        /// <param name="testRunEventsHandler">The run event handler.</param>
-        /// <param name="customTestHostLauncher">The custom host launcher.</param>
-        void RunTestsWithCustomTestHost(
-            IEnumerable<TestCase> testCases,
-            string runSettings,
-            TestPlatformOptions options,
-            TestSessionInfo testSessionInfo,
-            ITestRunEventsHandler testRunEventsHandler,
-            ITestHostLauncher customTestHostLauncher);
+        // <summary>
+        // Starts a test run.
+        // </summary>
+        // 
+        // <param name="testCases">The list of test cases for the test run.</param>
+        // <param name="runSettings">The run settings for the run.</param>
+        // <param name="options">The test platform options.</param>
+        // <param name="testSessionInfo">The test session info object.</param>
+        // <param name="testRunEventsHandler">The run event handler.</param>
+        // <param name="customTestHostLauncher">The custom host launcher.</param>
+        // void RunTestsWithCustomTestHost(
+        //     IEnumerable<TestCase> testCases,
+        //     string runSettings,
+        //     TestPlatformOptions options,
+        //     TestSessionInfo testSessionInfo,
+        //     ITestRunEventsHandler testRunEventsHandler,
+        //     ITestHostLauncher customTestHostLauncher);
 
-        /// <summary>
-        /// Starts a new test session.
-        /// </summary>
-        /// 
-        /// <param name="sources">The list of source assemblies for the test run.</param>
-        /// <param name="runSettings">The run settings for the run.</param>
-        /// <param name="eventsHandler">The session event handler.</param>
-        /// 
-        /// <returns>A test session info object.</returns>
-        ITestSession StartTestSession(
-            IList<string> sources,
-            string runSettings,
-            ITestSessionEventsHandler eventsHandler);
+        // <summary>
+        // Starts a new test session.
+        // </summary>
+        // 
+        // <param name="sources">The list of source assemblies for the test run.</param>
+        // <param name="runSettings">The run settings for the run.</param>
+        // <param name="eventsHandler">The session event handler.</param>
+        // 
+        // <returns>A test session info object.</returns>
+        // ITestSession StartTestSession(
+        //     IList<string> sources,
+        //     string runSettings,
+        //     ITestSessionEventsHandler eventsHandler);
 
-        /// <summary>
-        /// Starts a new test session.
-        /// </summary>
-        /// 
-        /// <param name="sources">The list of source assemblies for the test run.</param>
-        /// <param name="runSettings">The run settings for the run.</param>
-        /// <param name="options">The test platform options.</param>
-        /// <param name="eventsHandler">The session event handler.</param>
-        /// 
-        /// <returns>A test session info object.</returns>
-        ITestSession StartTestSession(
-            IList<string> sources,
-            string runSettings,
-            TestPlatformOptions options,
-            ITestSessionEventsHandler eventsHandler);
+        // <summary>
+        // Starts a new test session.
+        // </summary>
+        // 
+        // <param name="sources">The list of source assemblies for the test run.</param>
+        // <param name="runSettings">The run settings for the run.</param>
+        // <param name="options">The test platform options.</param>
+        // <param name="eventsHandler">The session event handler.</param>
+        // 
+        // <returns>A test session info object.</returns>
+        // ITestSession StartTestSession(
+        //     IList<string> sources,
+        //     string runSettings,
+        //     TestPlatformOptions options,
+        //     ITestSessionEventsHandler eventsHandler);
 
-        /// <summary>
-        /// Starts a new test session.
-        /// </summary>
-        /// 
-        /// <param name="sources">The list of source assemblies for the test run.</param>
-        /// <param name="runSettings">The run settings for the run.</param>
-        /// <param name="options">The test platform options.</param>
-        /// <param name="eventsHandler">The session event handler.</param>
-        /// <param name="testHostLauncher">The custom host launcher.</param>
-        /// 
-        /// <returns>A test session info object.</returns>
-        ITestSession StartTestSession(
-            IList<string> sources,
-            string runSettings,
-            TestPlatformOptions options,
-            ITestSessionEventsHandler eventsHandler,
-            ITestHostLauncher testHostLauncher);
+        // <summary>
+        // Starts a new test session.
+        // </summary>
+        // 
+        // <param name="sources">The list of source assemblies for the test run.</param>
+        // <param name="runSettings">The run settings for the run.</param>
+        // <param name="options">The test platform options.</param>
+        // <param name="eventsHandler">The session event handler.</param>
+        // <param name="testHostLauncher">The custom host launcher.</param>
+        // 
+        // <returns>A test session info object.</returns>
+        // ITestSession StartTestSession(
+        //     IList<string> sources,
+        //     string runSettings,
+        //     TestPlatformOptions options,
+        //     ITestSessionEventsHandler eventsHandler,
+        //     ITestHostLauncher testHostLauncher);
 
-        /// <summary>
-        /// Stops the test session.
-        /// </summary>
-        /// 
-        /// <param name="testSessionInfo">The test session info object.</param>
-        /// <param name="eventsHandler">The session event handler.</param>
-        /// 
-        /// <returns>True if the session was successfuly stopped, false otherwise.</returns>
-        bool StopTestSession(
-            TestSessionInfo testSessionInfo,
-            ITestSessionEventsHandler eventsHandler);
+        // <summary>
+        // Stops the test session.
+        // </summary>
+        // 
+        // <param name="testSessionInfo">The test session info object.</param>
+        // <param name="eventsHandler">The session event handler.</param>
+        // 
+        // <returns>True if the session was successfuly stopped, false otherwise.</returns>
+        // bool StopTestSession(
+        //     TestSessionInfo testSessionInfo,
+        //     ITestSessionEventsHandler eventsHandler);
 
         /// <summary>
         /// Cancels the last test run.

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IVsTestConsoleWrapperAsync.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IVsTestConsoleWrapperAsync.cs
@@ -55,21 +55,21 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces
             TestPlatformOptions options,
             ITestDiscoveryEventsHandler2 discoveryEventsHandler);
 
-        /// <summary>
-        /// Asynchronous equivalent of <see cref="
-        /// IVsTestConsoleWrapper.DiscoverTests(
-        ///     IEnumerable{string},
-        ///     string,
-        ///     TestPlatformOptions,
-        ///     TestSessionInfo,
-        ///     ITestDiscoveryEventsHandler2)"/>.
-        /// </summary>
-        Task DiscoverTestsAsync(
-            IEnumerable<string> sources,
-            string discoverySettings,
-            TestPlatformOptions options,
-            TestSessionInfo testSessionInfo,
-            ITestDiscoveryEventsHandler2 discoveryEventsHandler);
+        // <summary>
+        // Asynchronous equivalent of <see cref="
+        // IVsTestConsoleWrapper.DiscoverTests(
+        //     IEnumerable{string},
+        //     string,
+        //     TestPlatformOptions,
+        //     TestSessionInfo,
+        //     ITestDiscoveryEventsHandler2)"/>.
+        // </summary>
+        // Task DiscoverTestsAsync(
+        //     IEnumerable<string> sources,
+        //     string discoverySettings,
+        //     TestPlatformOptions options,
+        //     TestSessionInfo testSessionInfo,
+        //     ITestDiscoveryEventsHandler2 discoveryEventsHandler);
 
         /// <summary>
         /// See <see cref="IVsTestConsoleWrapper.CancelDiscovery"/>.
@@ -102,21 +102,21 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces
             TestPlatformOptions options,
             ITestRunEventsHandler testRunEventsHandler);
 
-        /// <summary>
-        /// Asynchronous equivalent of <see cref="
-        /// IVsTestConsoleWrapper.RunTests(
-        ///     IEnumerable{string},
-        ///     string,
-        ///     TestPlatformOptions,
-        ///     TestSessionInfo,
-        ///     ITestRunEventsHandler)"/>.
-        /// </summary>
-        Task RunTestsAsync(
-            IEnumerable<string> sources,
-            string runSettings,
-            TestPlatformOptions options,
-            TestSessionInfo testSessionInfo,
-            ITestRunEventsHandler testRunEventsHandler);
+        // <summary>
+        // Asynchronous equivalent of <see cref="
+        // IVsTestConsoleWrapper.RunTests(
+        //     IEnumerable{string},
+        //     string,
+        //     TestPlatformOptions,
+        //     TestSessionInfo,
+        //     ITestRunEventsHandler)"/>.
+        // </summary>
+        // Task RunTestsAsync(
+        //     IEnumerable<string> sources,
+        //     string runSettings,
+        //     TestPlatformOptions options,
+        //     TestSessionInfo testSessionInfo,
+        //     ITestRunEventsHandler testRunEventsHandler);
 
         /// <summary>
         /// Asynchronous equivalent of <see cref="
@@ -144,21 +144,21 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces
             TestPlatformOptions options,
             ITestRunEventsHandler testRunEventsHandler);
 
-        /// <summary>
-        /// Asynchronous equivalent of <see cref="
-        ///     IVsTestConsoleWrapper.RunTests(
-        ///     IEnumerable{TestCase},
-        ///     string,
-        ///     TestPlatformOptions,
-        ///     TestSessionInfo,
-        ///     ITestRunEventsHandler)"/>.
-        /// </summary>
-        Task RunTestsAsync(
-            IEnumerable<TestCase> testCases,
-            string runSettings,
-            TestPlatformOptions options,
-            TestSessionInfo testSessionInfo,
-            ITestRunEventsHandler testRunEventsHandler);
+        // <summary>
+        // Asynchronous equivalent of <see cref="
+        //     IVsTestConsoleWrapper.RunTests(
+        //     IEnumerable{TestCase},
+        //     string,
+        //     TestPlatformOptions,
+        //     TestSessionInfo,
+        //     ITestRunEventsHandler)"/>.
+        // </summary>
+        // Task RunTestsAsync(
+        //     IEnumerable<TestCase> testCases,
+        //     string runSettings,
+        //     TestPlatformOptions options,
+        //     TestSessionInfo testSessionInfo,
+        //     ITestRunEventsHandler testRunEventsHandler);
 
         /// <summary>
         /// Asynchronous equivalent of <see cref="
@@ -190,23 +190,23 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces
             ITestRunEventsHandler testRunEventsHandler,
             ITestHostLauncher customTestHostLauncher);
 
-        /// <summary>
-        /// Asynchronous equivalent of <see cref="
-        /// IVsTestConsoleWrapper.RunTestsWithCustomTestHost(
-        ///     IEnumerable{string},
-        ///     string,
-        ///     TestPlatformOptions,
-        ///     TestSessionInfo,
-        ///     ITestRunEventsHandler,
-        ///     ITestHostLauncher)"/>.
-        /// </summary>
-        Task RunTestsWithCustomTestHostAsync(
-            IEnumerable<string> sources,
-            string runSettings,
-            TestPlatformOptions options,
-            TestSessionInfo testSessionInfo,
-            ITestRunEventsHandler testRunEventsHandler,
-            ITestHostLauncher customTestHostLauncher);
+        // <summary>
+        // Asynchronous equivalent of <see cref="
+        // IVsTestConsoleWrapper.RunTestsWithCustomTestHost(
+        //     IEnumerable{string},
+        //     string,
+        //     TestPlatformOptions,
+        //     TestSessionInfo,
+        //     ITestRunEventsHandler,
+        //     ITestHostLauncher)"/>.
+        // </summary>
+        // Task RunTestsWithCustomTestHostAsync(
+        //     IEnumerable<string> sources,
+        //     string runSettings,
+        //     TestPlatformOptions options,
+        //     TestSessionInfo testSessionInfo,
+        //     ITestRunEventsHandler testRunEventsHandler,
+        //     ITestHostLauncher customTestHostLauncher);
 
         /// <summary>
         /// Asynchronous equivalent of <see cref="
@@ -238,75 +238,75 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces
             ITestRunEventsHandler testRunEventsHandler,
             ITestHostLauncher customTestHostLauncher);
 
-        /// <summary>
-        /// Asynchronous equivalent of <see cref="
-        /// IVsTestConsoleWrapper.RunTestsWithCustomTestHost(
-        ///     IEnumerable{TestCase},
-        ///     string,
-        ///     TestPlatformOptions,
-        ///     TestSessionInfo,
-        ///     ITestRunEventsHandler,
-        ///     ITestHostLauncher)"/>.
-        /// </summary>
-        Task RunTestsWithCustomTestHostAsync(
-            IEnumerable<TestCase> testCases,
-            string runSettings,
-            TestPlatformOptions options,
-            TestSessionInfo testSessionInfo,
-            ITestRunEventsHandler testRunEventsHandler,
-            ITestHostLauncher customTestHostLauncher);
+        // <summary>
+        // Asynchronous equivalent of <see cref="
+        // IVsTestConsoleWrapper.RunTestsWithCustomTestHost(
+        //     IEnumerable{TestCase},
+        //     string,
+        //     TestPlatformOptions,
+        //     TestSessionInfo,
+        //     ITestRunEventsHandler,
+        //     ITestHostLauncher)"/>.
+        // </summary>
+        // Task RunTestsWithCustomTestHostAsync(
+        //     IEnumerable<TestCase> testCases,
+        //     string runSettings,
+        //     TestPlatformOptions options,
+        //     TestSessionInfo testSessionInfo,
+        //     ITestRunEventsHandler testRunEventsHandler,
+        //     ITestHostLauncher customTestHostLauncher);
 
-        /// <summary>
-        /// Asynchronous equivalent of <see cref="
-        /// IVsTestConsoleWrapper.StartTestSession(
-        ///     IList{string},
-        ///     string,
-        ///     ITestSessionEventsHandler)"/>.
-        /// </summary>
-        Task<ITestSession> StartTestSessionAsync(
-            IList<string> sources,
-            string runSettings,
-            ITestSessionEventsHandler eventsHandler);
+        // <summary>
+        // Asynchronous equivalent of <see cref="
+        // IVsTestConsoleWrapper.StartTestSession(
+        //     IList{string},
+        //     string,
+        //     ITestSessionEventsHandler)"/>.
+        // </summary>
+        // Task<ITestSession> StartTestSessionAsync(
+        //     IList<string> sources,
+        //     string runSettings,
+        //     ITestSessionEventsHandler eventsHandler);
 
-        /// <summary>
-        /// Asynchronous equivalent of <see cref="
-        /// IVsTestConsoleWrapper.StartTestSession(
-        ///     IList{string},
-        ///     string,
-        ///     TestPlatformOptions,
-        ///     ITestSessionEventsHandler)"/>.
-        /// </summary>
-        Task<ITestSession> StartTestSessionAsync(
-            IList<string> sources,
-            string runSettings,
-            TestPlatformOptions options,
-            ITestSessionEventsHandler eventsHandler);
+        // <summary>
+        // Asynchronous equivalent of <see cref="
+        // IVsTestConsoleWrapper.StartTestSession(
+        //     IList{string},
+        //     string,
+        //     TestPlatformOptions,
+        //     ITestSessionEventsHandler)"/>.
+        // </summary>
+        // Task<ITestSession> StartTestSessionAsync(
+        //     IList<string> sources,
+        //     string runSettings,
+        //     TestPlatformOptions options,
+        //     ITestSessionEventsHandler eventsHandler);
 
-        /// <summary>
-        /// Asynchronous equivalent of <see cref="
-        /// IVsTestConsoleWrapper.StartTestSession(
-        ///     IList{string},
-        ///     string,
-        ///     TestPlatformOptions,
-        ///     ITestSessionEventsHandler,
-        ///     ITestHostLauncher)"/>.
-        /// </summary>
-        Task<ITestSession> StartTestSessionAsync(
-            IList<string> sources,
-            string runSettings,
-            TestPlatformOptions options,
-            ITestSessionEventsHandler eventsHandler,
-            ITestHostLauncher testHostLauncher);
+        // <summary>
+        // Asynchronous equivalent of <see cref="
+        // IVsTestConsoleWrapper.StartTestSession(
+        //     IList{string},
+        //     string,
+        //     TestPlatformOptions,
+        //     ITestSessionEventsHandler,
+        //     ITestHostLauncher)"/>.
+        // </summary>
+        // Task<ITestSession> StartTestSessionAsync(
+        //     IList<string> sources,
+        //     string runSettings,
+        //     TestPlatformOptions options,
+        //     ITestSessionEventsHandler eventsHandler,
+        //     ITestHostLauncher testHostLauncher);
 
-        /// <summary>
-        /// Asynchronous equivalent of <see cref="
-        /// IVsTestConsoleWrapper.StopTestSession(
-        ///     TestSessionInfo,
-        ///     ITestSessionEventsHandler)"/>.
-        /// </summary>
-        Task<bool> StopTestSessionAsync(
-            TestSessionInfo testSessionInfo,
-            ITestSessionEventsHandler eventsHandler);
+        // <summary>
+        // Asynchronous equivalent of <see cref="
+        // IVsTestConsoleWrapper.StopTestSession(
+        //     TestSessionInfo,
+        //     ITestSessionEventsHandler)"/>.
+        // </summary>
+        // Task<bool> StopTestSessionAsync(
+        //     TestSessionInfo testSessionInfo,
+        //     ITestSessionEventsHandler eventsHandler);
 
         /// <summary>
         /// See <see cref="IVsTestConsoleWrapper.CancelTestRun"/>.

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/TestSession.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/TestSession.cs
@@ -15,7 +15,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
     /// Defines a test session object that can be used to make calls to the vstest.console
     /// process.
     /// </summary>
-    public class TestSession : ITestSession
+    internal class TestSession : ITestSession
     {
         private TestSessionInfo testSessionInfo;
         private VsTestConsoleWrapper consoleWrapper;

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
@@ -211,7 +211,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         /// <inheritdoc/>
-        public void DiscoverTests(
+        internal void DiscoverTests(
             IEnumerable<string> sources,
             string discoverySettings,
             TestPlatformOptions options,
@@ -263,7 +263,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         /// <inheritdoc/>
-        public void RunTests(
+        internal void RunTests(
             IEnumerable<string> sources,
             string runSettings,
             TestPlatformOptions options,
@@ -315,7 +315,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         /// <inheritdoc/>
-        public void RunTests(
+        internal void RunTests(
             IEnumerable<TestCase> testCases,
             string runSettings,
             TestPlatformOptions options,
@@ -371,7 +371,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         /// <inheritdoc/>
-        public void RunTestsWithCustomTestHost(
+        internal void RunTestsWithCustomTestHost(
             IEnumerable<string> sources,
             string runSettings,
             TestPlatformOptions options,
@@ -429,7 +429,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         /// <inheritdoc/>
-        public void RunTestsWithCustomTestHost(
+        internal void RunTestsWithCustomTestHost(
             IEnumerable<TestCase> testCases,
             string runSettings,
             TestPlatformOptions options,
@@ -455,7 +455,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         /// <inheritdoc/>
-        public ITestSession StartTestSession(
+        internal ITestSession StartTestSession(
             IList<string> sources,
             string runSettings,
             ITestSessionEventsHandler eventsHandler)
@@ -468,7 +468,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         /// <inheritdoc/>
-        public ITestSession StartTestSession(
+        internal ITestSession StartTestSession(
             IList<string> sources,
             string runSettings,
             TestPlatformOptions options,
@@ -483,7 +483,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         /// <inheritdoc/>
-        public ITestSession StartTestSession(
+        internal ITestSession StartTestSession(
             IList<string> sources,
             string runSettings,
             TestPlatformOptions options,
@@ -504,7 +504,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         /// <inheritdoc/>
-        public bool StopTestSession(
+        internal bool StopTestSession(
             TestSessionInfo testSessionInfo,
             ITestSessionEventsHandler eventsHandler)
         {
@@ -612,7 +612,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         /// <inheritdoc/>
-        public async Task DiscoverTestsAsync(
+        internal async Task DiscoverTestsAsync(
             IEnumerable<string> sources,
             string discoverySettings,
             TestPlatformOptions options,
@@ -658,7 +658,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         /// <inheritdoc/>
-        public async Task RunTestsAsync(
+        internal async Task RunTestsAsync(
             IEnumerable<string> sources,
             string runSettings,
             TestPlatformOptions options,
@@ -710,7 +710,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         /// <inheritdoc/>
-        public async Task RunTestsAsync(
+        internal async Task RunTestsAsync(
             IEnumerable<TestCase> testCases,
             string runSettings,
             TestPlatformOptions options,
@@ -766,7 +766,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         /// <inheritdoc/>
-        public async Task RunTestsWithCustomTestHostAsync(
+        internal async Task RunTestsWithCustomTestHostAsync(
             IEnumerable<string> sources,
             string runSettings,
             TestPlatformOptions options,
@@ -824,7 +824,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         /// <inheritdoc/>
-        public async Task RunTestsWithCustomTestHostAsync(
+        internal async Task RunTestsWithCustomTestHostAsync(
             IEnumerable<TestCase> testCases,
             string runSettings,
             TestPlatformOptions options,
@@ -850,7 +850,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         /// <inheritdoc/>
-        public async Task<ITestSession> StartTestSessionAsync(
+        internal async Task<ITestSession> StartTestSessionAsync(
             IList<string> sources,
             string runSettings,
             ITestSessionEventsHandler eventsHandler)
@@ -863,7 +863,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         /// <inheritdoc/>
-        public async Task<ITestSession> StartTestSessionAsync(
+        internal async Task<ITestSession> StartTestSessionAsync(
             IList<string> sources,
             string runSettings,
             TestPlatformOptions options,
@@ -878,7 +878,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         /// <inheritdoc/>
-        public async Task<ITestSession> StartTestSessionAsync(
+        internal async Task<ITestSession> StartTestSessionAsync(
             IList<string> sources,
             string runSettings,
             TestPlatformOptions options,
@@ -899,7 +899,7 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer
         }
 
         /// <inheritdoc/>
-        public async Task<bool> StopTestSessionAsync(
+        internal async Task<bool> StopTestSessionAsync(
             TestSessionInfo testSessionInfo,
             ITestSessionEventsHandler eventsHandler)
         {


### PR DESCRIPTION
* Marked test session APIs as internal

Co-authored-by: Codrin Poienaru <copoiena@microsoft.com>

