### PR TITLE
Abort when init and run messages fail to process

### DIFF
--- a/Localize/lcl/cs/src/vstest.console/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/cs/src/vstest.console/Resources/xlf/Resources.xlf.lcl
@@ -1447,6 +1447,15 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
+      <Item ItemId=";TestRunAbortedWithError" ItemType="0" PsrId="308" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Test Run Aborted with error {0}.]]></Val>
+          <Tgt Cat="Text" Stat="Loc" Orig="New">
+            <Val><![CDATA[Testovací běh se přerušil s chybou {0}.]]></Val>
+          </Tgt>
+        </Str>
+        <Disp Icon="Str" />
+      </Item>
       <Item ItemId=";TestRunCanceled" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Test Run Canceled.]]></Val>

--- a/Localize/lcl/de/src/vstest.console/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/de/src/vstest.console/Resources/xlf/Resources.xlf.lcl
@@ -1447,6 +1447,15 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
+      <Item ItemId=";TestRunAbortedWithError" ItemType="0" PsrId="308" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Test Run Aborted with error {0}.]]></Val>
+          <Tgt Cat="Text" Stat="Loc" Orig="New">
+            <Val><![CDATA[Der Testlauf wurde mit dem Fehler {0} abgebrochen.]]></Val>
+          </Tgt>
+        </Str>
+        <Disp Icon="Str" />
+      </Item>
       <Item ItemId=";TestRunCanceled" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Test Run Canceled.]]></Val>

--- a/Localize/lcl/es/src/vstest.console/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/es/src/vstest.console/Resources/xlf/Resources.xlf.lcl
@@ -1447,6 +1447,15 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
+      <Item ItemId=";TestRunAbortedWithError" ItemType="0" PsrId="308" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Test Run Aborted with error {0}.]]></Val>
+          <Tgt Cat="Text" Stat="Loc" Orig="New">
+            <Val><![CDATA[La serie de pruebas se ha anulado con el error {0}.]]></Val>
+          </Tgt>
+        </Str>
+        <Disp Icon="Str" />
+      </Item>
       <Item ItemId=";TestRunCanceled" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Test Run Canceled.]]></Val>

--- a/Localize/lcl/fr/src/vstest.console/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/fr/src/vstest.console/Resources/xlf/Resources.xlf.lcl
@@ -1447,6 +1447,15 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
+      <Item ItemId=";TestRunAbortedWithError" ItemType="0" PsrId="308" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Test Run Aborted with error {0}.]]></Val>
+          <Tgt Cat="Text" Stat="Loc" Orig="New">
+            <Val><![CDATA[Désolé... Nous n’avons pas pu procéder à la série de tests, car nous avons rencontré l’erreur suivante : {0}.]]></Val>
+          </Tgt>
+        </Str>
+        <Disp Icon="Str" />
+      </Item>
       <Item ItemId=";TestRunCanceled" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Test Run Canceled.]]></Val>

--- a/Localize/lcl/it/src/vstest.console/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/it/src/vstest.console/Resources/xlf/Resources.xlf.lcl
@@ -1447,6 +1447,15 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
+      <Item ItemId=";TestRunAbortedWithError" ItemType="0" PsrId="308" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Test Run Aborted with error {0}.]]></Val>
+          <Tgt Cat="Text" Stat="Loc" Orig="New">
+            <Val><![CDATA[Esecuzione dei test interrotta con errore {0}.]]></Val>
+          </Tgt>
+        </Str>
+        <Disp Icon="Str" />
+      </Item>
       <Item ItemId=";TestRunCanceled" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Test Run Canceled.]]></Val>

--- a/Localize/lcl/ja/src/vstest.console/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/ja/src/vstest.console/Resources/xlf/Resources.xlf.lcl
@@ -1447,6 +1447,15 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
+      <Item ItemId=";TestRunAbortedWithError" ItemType="0" PsrId="308" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Test Run Aborted with error {0}.]]></Val>
+          <Tgt Cat="Text" Stat="Loc" Orig="New">
+            <Val><![CDATA[テストの実行がエラー {0} により中止されました。]]></Val>
+          </Tgt>
+        </Str>
+        <Disp Icon="Str" />
+      </Item>
       <Item ItemId=";TestRunCanceled" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Test Run Canceled.]]></Val>

--- a/Localize/lcl/ko/src/vstest.console/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/ko/src/vstest.console/Resources/xlf/Resources.xlf.lcl
@@ -1447,6 +1447,15 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
+      <Item ItemId=";TestRunAbortedWithError" ItemType="0" PsrId="308" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Test Run Aborted with error {0}.]]></Val>
+          <Tgt Cat="Text" Stat="Loc" Orig="New">
+            <Val><![CDATA[테스트 실행이 {0} 오류로 인해 중단되었습니다.]]></Val>
+          </Tgt>
+        </Str>
+        <Disp Icon="Str" />
+      </Item>
       <Item ItemId=";TestRunCanceled" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Test Run Canceled.]]></Val>

--- a/Localize/lcl/pl/src/vstest.console/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/pl/src/vstest.console/Resources/xlf/Resources.xlf.lcl
@@ -1447,6 +1447,15 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
+      <Item ItemId=";TestRunAbortedWithError" ItemType="0" PsrId="308" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Test Run Aborted with error {0}.]]></Val>
+          <Tgt Cat="Text" Stat="Loc" Orig="New">
+            <Val><![CDATA[Przebieg testowy został przerwany z powodu błędu {0}.]]></Val>
+          </Tgt>
+        </Str>
+        <Disp Icon="Str" />
+      </Item>
       <Item ItemId=";TestRunCanceled" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Test Run Canceled.]]></Val>

--- a/Localize/lcl/pt-BR/src/vstest.console/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/pt-BR/src/vstest.console/Resources/xlf/Resources.xlf.lcl
@@ -1447,6 +1447,15 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
+      <Item ItemId=";TestRunAbortedWithError" ItemType="0" PsrId="308" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Test Run Aborted with error {0}.]]></Val>
+          <Tgt Cat="Text" Stat="Loc" Orig="New">
+            <Val><![CDATA[Execução de Teste Abortada com Erro {0}.]]></Val>
+          </Tgt>
+        </Str>
+        <Disp Icon="Str" />
+      </Item>
       <Item ItemId=";TestRunCanceled" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Test Run Canceled.]]></Val>

--- a/Localize/lcl/ru/src/vstest.console/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/ru/src/vstest.console/Resources/xlf/Resources.xlf.lcl
@@ -1456,6 +1456,15 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
+      <Item ItemId=";TestRunAbortedWithError" ItemType="0" PsrId="308" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Test Run Aborted with error {0}.]]></Val>
+          <Tgt Cat="Text" Stat="Loc" Orig="New">
+            <Val><![CDATA[Тестовый запуск прерван с ошибкой {0}.]]></Val>
+          </Tgt>
+        </Str>
+        <Disp Icon="Str" />
+      </Item>
       <Item ItemId=";TestRunFailed" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Test Run Failed.]]></Val>

--- a/Localize/lcl/tr/src/vstest.console/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/tr/src/vstest.console/Resources/xlf/Resources.xlf.lcl
@@ -1447,6 +1447,15 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
+      <Item ItemId=";TestRunAbortedWithError" ItemType="0" PsrId="308" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Test Run Aborted with error {0}.]]></Val>
+          <Tgt Cat="Text" Stat="Loc" Orig="New">
+            <Val><![CDATA[Test Çalıştırması {0} hatasıyla durduruldu.]]></Val>
+          </Tgt>
+        </Str>
+        <Disp Icon="Str" />
+      </Item>
       <Item ItemId=";TestRunCanceled" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Test Run Canceled.]]></Val>

--- a/Localize/lcl/zh-Hans/src/vstest.console/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/zh-Hans/src/vstest.console/Resources/xlf/Resources.xlf.lcl
@@ -1447,6 +1447,15 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
+      <Item ItemId=";TestRunAbortedWithError" ItemType="0" PsrId="308" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Test Run Aborted with error {0}.]]></Val>
+          <Tgt Cat="Text" Stat="Loc" Orig="New">
+            <Val><![CDATA[测试运行已中止，出现错误 {0}。]]></Val>
+          </Tgt>
+        </Str>
+        <Disp Icon="Str" />
+      </Item>
       <Item ItemId=";TestRunCanceled" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Test Run Canceled.]]></Val>

--- a/Localize/lcl/zh-Hant/src/vstest.console/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/zh-Hant/src/vstest.console/Resources/xlf/Resources.xlf.lcl
@@ -1447,6 +1447,15 @@
         </Str>
         <Disp Icon="Str" />
       </Item>
+      <Item ItemId=";TestRunAbortedWithError" ItemType="0" PsrId="308" Leaf="true">
+        <Str Cat="Text">
+          <Val><![CDATA[Test Run Aborted with error {0}.]]></Val>
+          <Tgt Cat="Text" Stat="Loc" Orig="New">
+            <Val><![CDATA[測試執行已中止，錯誤 {0}。]]></Val>
+          </Tgt>
+        </Str>
+        <Disp Icon="Str" />
+      </Item>
       <Item ItemId=";TestRunCanceled" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
           <Val><![CDATA[Test Run Canceled.]]></Val>

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginCache.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginCache.cs
@@ -529,7 +529,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework
             {
                 try
                 {
-                    EqtTrace.Verbose("CurrentDomain_AssemblyResolve: Resolving assembly '{0}'.", args.Name);
+                    EqtTrace.Verbose("CurrentDomainAssemblyResolve: Resolving assembly '{0}'.", args.Name);
 
                     if (this.resolvedAssemblies.TryGetValue(args.Name, out assembly))
                     {

--- a/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs
@@ -106,6 +106,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
 
             if (this.searchDirectories == null || this.searchDirectories.Count == 0)
             {
+                EqtTrace.Info("AssemblyResolver.OnResolve: {0}: There are no search directories, returning.", args.Name);
                 return null;
             }
 
@@ -146,6 +147,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
                         continue;
                     }
 
+                    EqtTrace.Info("AssemblyResolver.OnResolve: {0}: Searching in: '{1}'.", args.Name, dir);
+
                     foreach (var extension in SupportedFileExtensions)
                     {
                         var assemblyPath = Path.Combine(dir, requestedName.Name + extension);
@@ -153,6 +156,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
                         {
                             if (!File.Exists(assemblyPath))
                             {
+                                EqtTrace.Info("AssemblyResolver.OnResolve: {0}: Assembly path does not exist: '{1}', returning.", args.Name, assemblyPath);
+
                                 continue;
                             }
 
@@ -160,8 +165,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
 
                             if (!this.RequestedAssemblyNameMatchesFound(requestedName, foundName))
                             {
+                                EqtTrace.Info("AssemblyResolver.OnResolve: {0}: File exists but version/public key is wrong. Try next extension.", args.Name);
+
                                 continue;   // File exists but version/public key is wrong. Try next extension.
                             }
+
+                            EqtTrace.Info("AssemblyResolver.OnResolve: {0}: Loading assembly '{1}'.", args.Name, assemblyPath);
 
                             assembly = this.platformAssemblyLoadContext.LoadAssemblyFromPath(assemblyPath);
                             this.resolvedAssemblies[args.Name] = assembly;
@@ -172,7 +181,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities
                         }
                         catch (FileLoadException ex)
                         {
-                            EqtTrace.Info("AssemblyResolver.OnResolve: {0}: Failed to load assembly. Reason:{1} ", args.Name, ex);
+                            EqtTrace.Error("AssemblyResolver.OnResolve: {0}: Failed to load assembly. Reason:{1} ", args.Name, ex);
 
                             // Re-throw FileLoadException, because this exception means that the assembly
                             // was found, but could not be loaded. This will allow us to report a more

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
@@ -41,8 +41,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
         private ManualResetEventSlim sessionCompleted;
         private Action<Message> onLaunchAdapterProcessWithDebuggerAttachedAckReceived;
         private Action<Message> onAttachDebuggerAckRecieved;
+        private Exception messageProcessingUnrecoverableError;
 
-        public TestHostConnectionInfo ConnectionInfo { get; set; } 
+        public TestHostConnectionInfo ConnectionInfo { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestRequestHandler" />.
@@ -167,6 +168,19 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                 ICollection<AttachmentSet> runContextAttachments,
                 ICollection<string> executorUris)
         {
+            // When we abort the run we might have saved the error before we gave the handler the chance to abort
+            // if the handler does not return with any new error we report the original one.
+            if (testRunCompleteArgs.IsAborted && testRunCompleteArgs.Error == null && this.messageProcessingUnrecoverableError != null)
+            {
+                var curentArgs = testRunCompleteArgs;
+                testRunCompleteArgs = new TestRunCompleteEventArgs(
+                    curentArgs.TestRunStatistics,
+                    curentArgs.IsCanceled,
+                    curentArgs.IsAborted,
+                    this.messageProcessingUnrecoverableError,
+                    curentArgs.AttachmentSets, curentArgs.ElapsedTimeInRunningTests
+                    );
+            }
             var data = this.dataSerializer.SerializePayload(
                     MessageType.ExecutionComplete,
                     new TestRunCompletePayload
@@ -257,104 +271,152 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
 
             if (EqtTrace.IsInfoEnabled)
             {
-                EqtTrace.Info("TestRequestHandler.ProcessRequests: received message: {0}", message);
+                EqtTrace.Info("TestRequestHandler.OnMessageReceived: received message: {0}", message);
             }
 
             switch (message.MessageType)
             {
                 case MessageType.VersionCheck:
-                    var version = this.dataSerializer.DeserializePayload<int>(message);
-                    // choose the highest version that we both support
-                    var negotiatedVersion = Math.Min(version, highestSupportedVersion);
-                    // BUT don't choose 3, because protocol version 3 has performance problems in 16.7.1-16.8. Those problems are caused
-                    // by choosing payloadSerializer instead of payloadSerializer2 for protocol version 3.
-                    //
-                    // We cannot just update the code to choose the new serializer, because then that change would apply only to testhost.
-                    // Testhost is is delivered by Microsoft.NET.Test.SDK nuget package, and can be used with an older vstest.console.
-                    // An older vstest.console, that supports protocol version 3, would serialize its messages using payloadSerializer,
-                    // but the fixed testhost would serialize it using payloadSerializer2, resulting in incompatible messages.
-                    //
-                    // Instead we must downgrade to protocol version 2 when 3 would be negotiated. Or higher when higher version
-                    // would be negotiated.
-                    if (negotiatedVersion != 3)
+                    try
                     {
-                        this.protocolVersion = negotiatedVersion;
-                    }
-                    else
-                    {
-                        var flag = Environment.GetEnvironmentVariable("VSTEST_DISABLE_PROTOCOL_3_VERSION_DOWNGRADE");
-                        var flagIsEnabled = flag != null && flag != "0";
-                        var dowgradeIsDisabled = flagIsEnabled;
-                        if (dowgradeIsDisabled)
+                        var version = this.dataSerializer.DeserializePayload<int>(message);
+                        // choose the highest version that we both support
+                        var negotiatedVersion = Math.Min(version, highestSupportedVersion);
+                        // BUT don't choose 3, because protocol version 3 has performance problems in 16.7.1-16.8. Those problems are caused
+                        // by choosing payloadSerializer instead of payloadSerializer2 for protocol version 3.
+                        //
+                        // We cannot just update the code to choose the new serializer, because then that change would apply only to testhost.
+                        // Testhost is is delivered by Microsoft.NET.Test.SDK nuget package, and can be used with an older vstest.console.
+                        // An older vstest.console, that supports protocol version 3, would serialize its messages using payloadSerializer,
+                        // but the fixed testhost would serialize it using payloadSerializer2, resulting in incompatible messages.
+                        //
+                        // Instead we must downgrade to protocol version 2 when 3 would be negotiated. Or higher when higher version
+                        // would be negotiated.
+                        if (negotiatedVersion != 3)
                         {
                             this.protocolVersion = negotiatedVersion;
                         }
                         else
                         {
-                            this.protocolVersion = 2;
+                            var flag = Environment.GetEnvironmentVariable("VSTEST_DISABLE_PROTOCOL_3_VERSION_DOWNGRADE");
+                            var flagIsEnabled = flag != null && flag != "0";
+                            var dowgradeIsDisabled = flagIsEnabled;
+                            if (dowgradeIsDisabled)
+                            {
+                                this.protocolVersion = negotiatedVersion;
+                            }
+                            else
+                            {
+                                this.protocolVersion = 2;
+                            }
+                        }
+
+                        // Send the negotiated protocol to request sender
+                        this.channel.Send(this.dataSerializer.SerializePayload(MessageType.VersionCheck, this.protocolVersion));
+
+                        // Can only do this after InitializeCommunication because TestHost cannot "Send Log" unless communications are initialized
+                        if (!string.IsNullOrEmpty(EqtTrace.LogFile))
+                        {
+                            this.SendLog(TestMessageLevel.Informational, string.Format(CrossPlatResources.TesthostDiagLogOutputFile, EqtTrace.LogFile));
+                        }
+                        else if (!string.IsNullOrEmpty(EqtTrace.ErrorOnInitialization))
+                        {
+                            this.SendLog(TestMessageLevel.Warning, EqtTrace.ErrorOnInitialization);
                         }
                     }
-
-                    // Send the negotiated protocol to request sender
-                    this.channel.Send(this.dataSerializer.SerializePayload(MessageType.VersionCheck, this.protocolVersion));
-
-                    // Can only do this after InitializeCommunication because TestHost cannot "Send Log" unless communications are initialized
-                    if (!string.IsNullOrEmpty(EqtTrace.LogFile))
+                    catch (Exception ex)
                     {
-                        this.SendLog(TestMessageLevel.Informational, string.Format(CrossPlatResources.TesthostDiagLogOutputFile, EqtTrace.LogFile));
-                    }
-                    else if (!string.IsNullOrEmpty(EqtTrace.ErrorOnInitialization))
-                    {
-                        this.SendLog(TestMessageLevel.Warning, EqtTrace.ErrorOnInitialization);
+                        this.messageProcessingUnrecoverableError = ex;
+                        EqtTrace.Error("Failed processing message {0}, aborting test run.", message.MessageType);
+                        EqtTrace.Error(ex);
+                        goto case MessageType.AbortTestRun;
                     }
                     break;
 
                 case MessageType.DiscoveryInitialize:
                     {
-                        EqtTrace.Info("Discovery Session Initialize.");
-                        this.testHostManagerFactoryReady.Wait();
-                        var discoveryEventsHandler = new TestDiscoveryEventHandler(this);
-                        var pathToAdditionalExtensions = this.dataSerializer.DeserializePayload<IEnumerable<string>>(message);
-                        jobQueue.QueueJob(
-                                () =>
-                                testHostManagerFactory.GetDiscoveryManager().Initialize(pathToAdditionalExtensions, discoveryEventsHandler), 0);
+                        try
+                        {
+                            this.testHostManagerFactoryReady.Wait();
+                            var discoveryEventsHandler = new TestDiscoveryEventHandler(this);
+                            var pathToAdditionalExtensions = this.dataSerializer.DeserializePayload<IEnumerable<string>>(message);
+                            Action job = () =>
+                            {
+                                EqtTrace.Info("TestRequestHandler.OnMessageReceived: Running job '{0}'.", message.MessageType);
+                                testHostManagerFactory.GetDiscoveryManager().Initialize(pathToAdditionalExtensions, discoveryEventsHandler);
+                            };
+                            jobQueue.QueueJob(job, 0);
+                        }
+                        catch (Exception ex)
+                        {
+                            this.messageProcessingUnrecoverableError = ex;
+                            EqtTrace.Error("Failed processing message {0}, aborting test run.", message.MessageType);
+                            EqtTrace.Error(ex);
+                            goto case MessageType.AbortTestRun;
+                        }
                         break;
                     }
 
                 case MessageType.StartDiscovery:
                     {
-                        EqtTrace.Info("Discovery started.");
-                        this.testHostManagerFactoryReady.Wait();
-                        var discoveryEventsHandler = new TestDiscoveryEventHandler(this);
-                        var discoveryCriteria = this.dataSerializer.DeserializePayload<DiscoveryCriteria>(message);
-                        jobQueue.QueueJob(
-                                () =>
+                        try
+                        {
+                            this.testHostManagerFactoryReady.Wait();
+                            var discoveryEventsHandler = new TestDiscoveryEventHandler(this);
+                            var discoveryCriteria = this.dataSerializer.DeserializePayload<DiscoveryCriteria>(message);
+                            Action job = () =>
+                            {
+                                EqtTrace.Info("TestRequestHandler.OnMessageReceived: Running job '{0}'.", message.MessageType);
                                 testHostManagerFactory.GetDiscoveryManager()
-                                .DiscoverTests(discoveryCriteria, discoveryEventsHandler), 0);
+                                    .DiscoverTests(discoveryCriteria, discoveryEventsHandler);
+                            };
 
+                            jobQueue.QueueJob(job, 0);
+                        }
+                        catch (Exception ex)
+                        {
+                            this.messageProcessingUnrecoverableError = ex;
+                            EqtTrace.Error("Failed processing message {0}, aborting test run.", message.MessageType);
+                            EqtTrace.Error(ex);
+                            goto case MessageType.AbortTestRun;
+                        }
                         break;
                     }
 
                 case MessageType.ExecutionInitialize:
                     {
-                        EqtTrace.Info("Execution Session Initialize.");
-                        this.testHostManagerFactoryReady.Wait();
-                        var testInitializeEventsHandler = new TestInitializeEventsHandler(this);
-                        var pathToAdditionalExtensions = this.dataSerializer.DeserializePayload<IEnumerable<string>>(message);
-                        jobQueue.QueueJob(
-                                () =>
-                                testHostManagerFactory.GetExecutionManager().Initialize(pathToAdditionalExtensions, testInitializeEventsHandler), 0);
+                        try
+                        {
+                            this.testHostManagerFactoryReady.Wait();
+                            var testInitializeEventsHandler = new TestInitializeEventsHandler(this);
+                            var pathToAdditionalExtensions = this.dataSerializer.DeserializePayload<IEnumerable<string>>(message);
+                            Action job = () =>
+                            {
+                                EqtTrace.Info("TestRequestHandler.OnMessageReceived: Running job '{0}'.", message.MessageType);
+                                testHostManagerFactory.GetExecutionManager().Initialize(pathToAdditionalExtensions, testInitializeEventsHandler);
+                            };
+                            jobQueue.QueueJob(job, 0);
+                        }
+                        catch (Exception ex)
+                        {
+                            this.messageProcessingUnrecoverableError = ex;
+                            EqtTrace.Error("Failed processing message {0}, aborting test run.", message.MessageType);
+                            EqtTrace.Error(ex);
+                            goto case MessageType.AbortTestRun;
+                        }
                         break;
                     }
 
                 case MessageType.StartTestExecutionWithSources:
                     {
-                        EqtTrace.Info("Execution started.");
-                        var testRunEventsHandler = new TestRunEventsHandler(this);
-                        this.testHostManagerFactoryReady.Wait();
-                        var testRunCriteriaWithSources = this.dataSerializer.DeserializePayload<TestRunCriteriaWithSources>(message);
-                        jobQueue.QueueJob(
-                                () =>
+                        try
+                        {
+                            var testRunEventsHandler = new TestRunEventsHandler(this);
+                            this.testHostManagerFactoryReady.Wait();
+                            var testRunCriteriaWithSources = this.dataSerializer.DeserializePayload<TestRunCriteriaWithSources>(message);
+                            Action job = () =>
+                            {
+                                EqtTrace.Info("TestRequestHandler.OnMessageReceived: Running job '{0}'.", message.MessageType);
                                 testHostManagerFactory.GetExecutionManager()
                                 .StartTestRun(
                                     testRunCriteriaWithSources.AdapterSourceMap,
@@ -362,22 +424,32 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                                     testRunCriteriaWithSources.RunSettings,
                                     testRunCriteriaWithSources.TestExecutionContext,
                                     this.GetTestCaseEventsHandler(testRunCriteriaWithSources.RunSettings),
-                                    testRunEventsHandler),
-                                0);
-
+                                    testRunEventsHandler);
+                            };
+                            jobQueue.QueueJob(job, 0);
+                        }
+                        catch (Exception ex)
+                        {
+                            this.messageProcessingUnrecoverableError = ex;
+                            EqtTrace.Error("Failed processing message {0}, aborting test run.", message.MessageType);
+                            EqtTrace.Error(ex);
+                            goto case MessageType.AbortTestRun;
+                        }
                         break;
                     }
 
                 case MessageType.StartTestExecutionWithTests:
                     {
-                        EqtTrace.Info("Execution started.");
-                        var testRunEventsHandler = new TestRunEventsHandler(this);
-                        this.testHostManagerFactoryReady.Wait();
-                        var testRunCriteriaWithTests =
-                            this.dataSerializer.DeserializePayload<TestRunCriteriaWithTests>(message);
+                        try
+                        {
+                            var testRunEventsHandler = new TestRunEventsHandler(this);
+                            this.testHostManagerFactoryReady.Wait();
+                            var testRunCriteriaWithTests =
+                                this.dataSerializer.DeserializePayload<TestRunCriteriaWithTests>(message);
 
-                        jobQueue.QueueJob(
-                                () =>
+                            Action job = () =>
+                            {
+                                EqtTrace.Info("TestRequestHandler.OnMessageReceived: Running job '{0}'.", message.MessageType);
                                 testHostManagerFactory.GetExecutionManager()
                                 .StartTestRun(
                                     testRunCriteriaWithTests.Tests,
@@ -385,9 +457,17 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                                     testRunCriteriaWithTests.RunSettings,
                                     testRunCriteriaWithTests.TestExecutionContext,
                                     this.GetTestCaseEventsHandler(testRunCriteriaWithTests.RunSettings),
-                                    testRunEventsHandler),
-                                0);
-
+                                    testRunEventsHandler);
+                            };
+                            jobQueue.QueueJob(job, 0);
+                        }
+                        catch (Exception ex)
+                        {
+                            this.messageProcessingUnrecoverableError = ex;
+                            EqtTrace.Error("Failed processing message {0}, aborting test run.", message.MessageType);
+                            EqtTrace.Error(ex);
+                            goto case MessageType.AbortTestRun;
+                        }
                         break;
                     }
 
@@ -406,9 +486,19 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities
                     break;
 
                 case MessageType.AbortTestRun:
-                    jobQueue.Pause();
-                    this.testHostManagerFactoryReady.Wait();
-                    testHostManagerFactory.GetExecutionManager().Abort(new TestRunEventsHandler(this));
+                    try
+                    {
+                        jobQueue.Pause();
+                        this.testHostManagerFactoryReady.Wait();
+                        testHostManagerFactory.GetExecutionManager().Abort(new TestRunEventsHandler(this));
+                    }
+                    catch (Exception ex)
+                    {
+                        EqtTrace.Error("Failed processing message {0}. Stopping communication.", message.MessageType);
+                        EqtTrace.Error(ex);
+                        sessionCompleted.Set();
+                        this.Close();
+                    }
                     break;
 
                 case MessageType.SessionEnd:

--- a/src/vstest.console/Resources/Resources.Designer.cs
+++ b/src/vstest.console/Resources/Resources.Designer.cs
@@ -1575,6 +1575,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Test Run Aborted with error: {0}..
+        /// </summary>
+        internal static string TestRunAbortedWithError {
+            get {
+                return ResourceManager.GetString("TestRunAbortedWithError", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Test Run Canceled..
         /// </summary>
         internal static string TestRunCanceled {

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -763,4 +763,7 @@
   <data name="EnvironmentVariableXIsOverriden" xml:space="preserve">
     <value>Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</value>
   </data>
+  <data name="TestRunAbortedWithError" xml:space="preserve">
+    <value>Test Run Aborted with error {0}.</value>
+  </data>
 </root>

--- a/src/vstest.console/Resources/xlf/Resources.cs.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.cs.xlf
@@ -1273,6 +1273,11 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="TestRunAbortedWithError">
+        <source>Test Run Aborted with error {0}.</source>
+        <target state="translated">Testovací běh se přerušil s chybou {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.de.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.de.xlf
@@ -1273,6 +1273,11 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="TestRunAbortedWithError">
+        <source>Test Run Aborted with error {0}.</source>
+        <target state="translated">Der Testlauf wurde mit dem Fehler {0} abgebrochen.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.es.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.es.xlf
@@ -1276,6 +1276,11 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="TestRunAbortedWithError">
+        <source>Test Run Aborted with error {0}.</source>
+        <target state="translated">La serie de pruebas se ha anulado con el error {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.fr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.fr.xlf
@@ -1273,6 +1273,11 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="TestRunAbortedWithError">
+        <source>Test Run Aborted with error {0}.</source>
+        <target state="translated">Désolé... Nous n’avons pas pu procéder à la série de tests, car nous avons rencontré l’erreur suivante : {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.it.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.it.xlf
@@ -1273,6 +1273,11 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="TestRunAbortedWithError">
+        <source>Test Run Aborted with error {0}.</source>
+        <target state="translated">Esecuzione dei test interrotta con errore {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.ja.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ja.xlf
@@ -1273,6 +1273,11 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="TestRunAbortedWithError">
+        <source>Test Run Aborted with error {0}.</source>
+        <target state="translated">テストの実行がエラー {0} により中止されました。</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.ko.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ko.xlf
@@ -1273,6 +1273,11 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="TestRunAbortedWithError">
+        <source>Test Run Aborted with error {0}.</source>
+        <target state="translated">테스트 실행이 {0} 오류로 인해 중단되었습니다.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.pl.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pl.xlf
@@ -1273,6 +1273,11 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="TestRunAbortedWithError">
+        <source>Test Run Aborted with error {0}.</source>
+        <target state="translated">Przebieg testowy został przerwany z powodu błędu {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
@@ -1273,6 +1273,11 @@ Altere o prefixo de nível de diagnóstico do agente de console, como mostrado a
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="TestRunAbortedWithError">
+        <source>Test Run Aborted with error {0}.</source>
+        <target state="translated">Execução de Teste Abortada com Erro {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.ru.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ru.xlf
@@ -1273,6 +1273,11 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="TestRunAbortedWithError">
+        <source>Test Run Aborted with error {0}.</source>
+        <target state="translated">Тестовый запуск прерван с ошибкой {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.tr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.tr.xlf
@@ -1273,6 +1273,11 @@ Günlükler için izleme düzeyini aşağıda gösterildiği gibi değiştirin
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="TestRunAbortedWithError">
+        <source>Test Run Aborted with error {0}.</source>
+        <target state="translated">Test Çalıştırması {0} hatasıyla durduruldu.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.xlf
@@ -896,6 +896,11 @@ Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")
         <target state="new">Environment variable '{0}' was already defined, but it's overridden by -Environment argument.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="TestRunAbortedWithError">
+        <source>Test Run Aborted with error {0}.</source>
+        <target state="new">Test Run Aborted with error {0}.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
@@ -1273,6 +1273,11 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="TestRunAbortedWithError">
+        <source>Test Run Aborted with error {0}.</source>
+        <target state="translated">测试运行已中止，出现错误 {0}。</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
@@ -1273,6 +1273,11 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="TestRunAbortedWithError">
+        <source>Test Run Aborted with error {0}.</source>
+        <target state="translated">測試執行已中止，錯誤 {0}。</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
* Abort when init and run messages fail to process, usually on deserialization, to prevent the host from hanging
* Send the message via the abort handler when we abort the run

Cherrypicked from #2857 with an extra sauce of localization.
