### PR TITLE
Rename to main

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,7 +15,7 @@
 > What is the behavior observed?
 
 ## Diagnostic logs
-> Please share test platform diagnostics logs. Instructions to collect logs are [here](https://github.com/Microsoft/vstest-docs/blob/master/docs/diagnose.md#test-platform-diagnostics).  
+> Please share test platform diagnostics logs. Instructions to collect logs are [here](https://github.com/Microsoft/vstest-docs/blob/main/docs/diagnose.md#test-platform-diagnostics).  
 > The logs may contain test assembly paths, kindly review and mask those before sharing.
 
 ## Environment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,13 @@
 Welcome, and thank you for your interest in contributing. There are many ways to contribute:
 - [Submit issues](https://github.com/Microsoft/vstest/issues) and help verify fixes as they are checked in.
 - Review the [source code changes](https://github.com/Microsoft/vstest/pulls).
-- [Contribute features and fixes](https://github.com/Microsoft/vstest-docs/blob/master/docs/contribute.md).
+- [Contribute features and fixes](https://github.com/Microsoft/vstest-docs/blob/main/docs/contribute.md).
 - Contribute to the [documentation](https://github.com/Microsoft/vstest-docs).
 
 ### Building
 If you want to understand how **vstest** works or want to debug an issue, you'll want to get the source, build it, and run the tool locally. **vstest** can be built from within Visual Studio or from the CLI.
-- [Building with Visual Studio](https://github.com/Microsoft/vstest-docs/blob/master/docs/contribute.md#building-with-visual-studio)
-- [Building with CLI, CI, Editors](https://github.com/Microsoft/vstest-docs/blob/master/docs/contribute.md#building-with-cli-ci-editors)
+- [Building with Visual Studio](https://github.com/Microsoft/vstest-docs/blob/main/docs/contribute.md#building-with-visual-studio)
+- [Building with CLI, CI, Editors](https://github.com/Microsoft/vstest-docs/blob/main/docs/contribute.md#building-with-cli-ci-editors)
 
 ### Thank You!
 Your contributions to open source, large or small, make projects like this possible. Thank you for taking the time to contribute.

--- a/Localize/lcl/cs/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/cs/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
@@ -39,9 +39,9 @@
       </Item>
       <Item ItemId=";DeprecatedAdapterPath" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
+          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Mění se vyhledávání adaptéru. Další informace najdete tady: https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.]]></Val>
+            <Val><![CDATA[Mění se vyhledávání adaptéru. Další informace najdete tady: https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/Localize/lcl/de/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/de/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
@@ -39,9 +39,9 @@
       </Item>
       <Item ItemId=";DeprecatedAdapterPath" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
+          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Die Adaptersuche wird gerade geändert. Weitere Informationen finden Sie unter https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.]]></Val>
+            <Val><![CDATA[Die Adaptersuche wird gerade geändert. Weitere Informationen finden Sie unter https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/Localize/lcl/es/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/es/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
@@ -39,9 +39,9 @@
       </Item>
       <Item ItemId=";DeprecatedAdapterPath" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
+          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Se está cambiando la búsqueda de adaptador. Siga https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap para obtener más detalles.]]></Val>
+            <Val><![CDATA[Se está cambiando la búsqueda de adaptador. Siga https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap para obtener más detalles.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/Localize/lcl/fr/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/fr/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
@@ -39,9 +39,9 @@
       </Item>
       <Item ItemId=";DeprecatedAdapterPath" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
+          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[La fonctionnalité de recherche d’adaptateur fait actuellement l’objet de modifications. Pour plus d’informations, consultez https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.]]></Val>
+            <Val><![CDATA[La fonctionnalité de recherche d’adaptateur fait actuellement l’objet de modifications. Pour plus d’informations, consultez https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/Localize/lcl/it/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/it/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
@@ -39,9 +39,9 @@
       </Item>
       <Item ItemId=";DeprecatedAdapterPath" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
+          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[La ricerca degli adattatori verrà modificata a breve. Per maggiori dettagli, vedere https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.]]></Val>
+            <Val><![CDATA[La ricerca degli adattatori verrà modificata a breve. Per maggiori dettagli, vedere https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/Localize/lcl/ja/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/ja/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
@@ -39,9 +39,9 @@
       </Item>
       <Item ItemId=";DeprecatedAdapterPath" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
+          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[アダプター検索は変更中です。詳細については、https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap をご覧ください。]]></Val>
+            <Val><![CDATA[アダプター検索は変更中です。詳細については、https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap をご覧ください。]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/Localize/lcl/ko/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/ko/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
@@ -39,9 +39,9 @@
       </Item>
       <Item ItemId=";DeprecatedAdapterPath" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
+          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[어댑터 조회가 변경됩니다. 자세한 내용은 https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap을 참조하세요.]]></Val>
+            <Val><![CDATA[어댑터 조회가 변경됩니다. 자세한 내용은 https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap을 참조하세요.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/Localize/lcl/pl/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/pl/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
@@ -39,9 +39,9 @@
       </Item>
       <Item ItemId=";DeprecatedAdapterPath" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
+          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Wyszukiwanie adaptera jest zmieniane, zobacz https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap w celu uzyskania dalszych szczegółów.]]></Val>
+            <Val><![CDATA[Wyszukiwanie adaptera jest zmieniane, zobacz https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap w celu uzyskania dalszych szczegółów.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/Localize/lcl/pt-BR/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/pt-BR/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
@@ -39,9 +39,9 @@
       </Item>
       <Item ItemId=";DeprecatedAdapterPath" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
+          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[A pesquisa do adaptador está sendo alterada, siga https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap para obter mais detalhes.]]></Val>
+            <Val><![CDATA[A pesquisa do adaptador está sendo alterada, siga https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap para obter mais detalhes.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/Localize/lcl/ru/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/ru/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
@@ -39,9 +39,9 @@
       </Item>
       <Item ItemId=";DeprecatedAdapterPath" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
+          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Изменяется поиск адаптеров. Дополнительные сведения: https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.]]></Val>
+            <Val><![CDATA[Изменяется поиск адаптеров. Дополнительные сведения: https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/Localize/lcl/tr/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/tr/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
@@ -39,9 +39,9 @@
       </Item>
       <Item ItemId=";DeprecatedAdapterPath" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
+          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Bağdaştırıcı arama değiştiriliyor. Ayrıntılar için lütfen https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap sayfasını takip edin.]]></Val>
+            <Val><![CDATA[Bağdaştırıcı arama değiştiriliyor. Ayrıntılar için lütfen https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap sayfasını takip edin.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/Localize/lcl/zh-Hans/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/zh-Hans/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
@@ -39,9 +39,9 @@
       </Item>
       <Item ItemId=";DeprecatedAdapterPath" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
+          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[适配器查找发生了变化，请转到 https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap，了解详细信息。]]></Val>
+            <Val><![CDATA[适配器查找发生了变化，请转到 https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap，了解详细信息。]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/Localize/lcl/zh-Hant/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
+++ b/Localize/lcl/zh-Hant/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf.lcl
@@ -39,9 +39,9 @@
       </Item>
       <Item ItemId=";DeprecatedAdapterPath" ItemType="0" PsrId="308" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
+          <Val><![CDATA[Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[目前正在變更配接器查閱，請遵循 https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap，以取得詳細資料。]]></Val>
+            <Val><![CDATA[目前正在變更配接器查閱，請遵循 https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap，以取得詳細資料。]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/README.md
+++ b/README.md
@@ -4,54 +4,54 @@ The Visual Studio Test Platform is an open and extensible test platform that ena
 The Test Platform currently ships as part Visual Studio 2019, and in the .NET Core Tools Preview 3.
 
 ### Build status
-[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/vstest/microsoft.vstest.ci?branchName=master)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=935&branchName=master)
+[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/vstest/microsoft.vstest.ci?branchName=main)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=935&branchName=main)
 
 ### Contributing
 There are many ways to contribute to VSTest
 - [Submit issues](https://github.com/Microsoft/vstest/issues) and help verify fixes as they are checked in.
 - Review the [source code changes](https://github.com/Microsoft/vstest/pulls).
-- [Contribute features and fixes](https://github.com/Microsoft/vstest-docs/blob/master/docs/contribute.md).
+- [Contribute features and fixes](https://github.com/Microsoft/vstest-docs/blob/main/docs/contribute.md).
 - Contribute to the [documentation](https://github.com/Microsoft/vstest-docs).
 
 ### Documentation
-- [Test Platform Architecture](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0001-Test-Platform-Architecture.md)
-- [Test Discovery Protocol](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0002-Test-Discovery-Protocol.md)
-- [Test Execution Protocol](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0003-Test-Execution-Protocol.md)
-- [Adapter Extensibility](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0004-Adapter-Extensibility.md)
-- [Test Platform SDK](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0005-Test-Platform-SDK.md)
-- [Editors API Specification](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0007-Editors-API-Specification.md)
-- [Data collection Protocol](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0006-DataCollection-Protocol.md)
-- [Translation Layer](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0008-TranslationLayer.md)
-- [Editors API Revision Update](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0009-Editors-API-RevisionUpdate.md)
-- [TranslationLayer](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0008-TranslationLayer.md)
-- [Source Information For Discovered Tests](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0010-Source-Information-For-Discovered-Tests.md)
-- [Test Session Timeout](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0011-Test-Session-Timeout.md)
-- [Test Adapter Lookup](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0013-Test-Adapter-Lookup.md)
-- [Packaging](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0014-Packaging.md)
-- [Telemetry](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0015-Telemetry.md)
-- [Loggers Information From RunSettings](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0016-Loggers-Information-From-RunSettings.md)
-- [Properties for TestCases in Managed Code](https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md)
-- [Skip Default Adapters](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0018-Skip-Default-Adapters.md)
-- [Disable Appdomain While Running Tests](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0019-Disable-Appdomain-While-Running-Tests.md)
-- [Improving Logic To Pass Sources To Adapters](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0020-Improving-Logic-To-Pass-Sources-To-Adapters.md)
-- [Code Coverage for .Net Core](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0021-CodeCoverageForNetCore.md)
-- [User Specified TestAdapter Lookup](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md)
-- [TestSettings Deprecation](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0023-TestSettings-Deprecation.md)
-- [Blame Collector Options](https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0024-Blame-Collector-Options.md)
+- [Test Platform Architecture](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0001-Test-Platform-Architecture.md)
+- [Test Discovery Protocol](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0002-Test-Discovery-Protocol.md)
+- [Test Execution Protocol](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0003-Test-Execution-Protocol.md)
+- [Adapter Extensibility](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0004-Adapter-Extensibility.md)
+- [Test Platform SDK](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0005-Test-Platform-SDK.md)
+- [Editors API Specification](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0007-Editors-API-Specification.md)
+- [Data collection Protocol](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0006-DataCollection-Protocol.md)
+- [Translation Layer](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0008-TranslationLayer.md)
+- [Editors API Revision Update](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0009-Editors-API-RevisionUpdate.md)
+- [TranslationLayer](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0008-TranslationLayer.md)
+- [Source Information For Discovered Tests](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0010-Source-Information-For-Discovered-Tests.md)
+- [Test Session Timeout](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0011-Test-Session-Timeout.md)
+- [Test Adapter Lookup](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0013-Test-Adapter-Lookup.md)
+- [Packaging](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0014-Packaging.md)
+- [Telemetry](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0015-Telemetry.md)
+- [Loggers Information From RunSettings](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0016-Loggers-Information-From-RunSettings.md)
+- [Properties for TestCases in Managed Code](https://github.com/microsoft/vstest-docs/blob/main/RFCs/0017-Managed-TestCase-Properties.md)
+- [Skip Default Adapters](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0018-Skip-Default-Adapters.md)
+- [Disable Appdomain While Running Tests](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0019-Disable-Appdomain-While-Running-Tests.md)
+- [Improving Logic To Pass Sources To Adapters](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0020-Improving-Logic-To-Pass-Sources-To-Adapters.md)
+- [Code Coverage for .Net Core](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0021-CodeCoverageForNetCore.md)
+- [User Specified TestAdapter Lookup](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md)
+- [TestSettings Deprecation](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0023-TestSettings-Deprecation.md)
+- [Blame Collector Options](https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0024-Blame-Collector-Options.md)
 
 ### Building
 VSTest can be built from within Visual Studio or from the CLI.
-- [Building with Visual Studio](https://github.com/Microsoft/vstest-docs/blob/master/docs/contribute.md#building-with-visual-studio)
-- [Building with CLI, CI, Editors](https://github.com/Microsoft/vstest-docs/blob/master/docs/contribute.md#building-with-cli-ci-editors)
+- [Building with Visual Studio](https://github.com/Microsoft/vstest-docs/blob/main/docs/contribute.md#building-with-visual-studio)
+- [Building with CLI, CI, Editors](https://github.com/Microsoft/vstest-docs/blob/main/docs/contribute.md#building-with-cli-ci-editors)
 
 ### Microsoft Open Source Code of Conduct
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 ### License
-VSTest platform is licensed under the [MIT license](https://github.com/Microsoft/vstest/blob/master/LICENSE)
+VSTest platform is licensed under the [MIT license](https://github.com/Microsoft/vstest/blob/main/LICENSE)
 
 ### Issue Tracking
-Please see [issue tracking](https://github.com/Microsoft/vstest-docs/blob/master/issuetracking.md) for a description of the workflow we use to process issues.
+Please see [issue tracking](https://github.com/Microsoft/vstest-docs/blob/main/issuetracking.md) for a description of the workflow we use to process issues.
 
 ### Roadmap
-For more information on shipped and upcoming features/enhancements please refer to our [Releases](https://github.com/Microsoft/vstest-docs/blob/master/docs/releases.md) and [Quarterly Checkin reports](https://github.com/Microsoft/vstest-docs/tree/master/Quarterly%20Checkins)
+For more information on shipped and upcoming features/enhancements please refer to our [Releases](https://github.com/Microsoft/vstest-docs/blob/main/docs/releases.md) and [Quarterly Checkin reports](https://github.com/Microsoft/vstest-docs/tree/main/Quarterly%20Checkins)

--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -9,7 +9,7 @@ function Test-FilesUseTelemetryOutput {
 
     If($filesMissingTelemetry) {
         Write-PipelineTelemetryError -category 'Build' 'One or more eng/common scripts do not use telemetry categorization.'
-        Write-Host "See https://github.com/dotnet/arcade/blob/master/Documentation/Projects/DevOps/CI/Telemetry-Guidance.md"
+        Write-Host "See https://github.com/dotnet/arcade/blob/main/Documentation/Projects/DevOps/CI/Telemetry-Guidance.md"
         Write-Host "The following ps1 files do not include telemetry categorization output:"
         ForEach($file In $filesMissingTelemetry) {
             Write-Host $file

--- a/eng/configure-toolset.sh
+++ b/eng/configure-toolset.sh
@@ -24,7 +24,7 @@ function Test-FilesUseTelemetryOutput {
 
     if [[ -n "${file_list//[[:space:]]/}" ]]; then 
         Write-PipelineTelemetryError -force -category 'Build' 'One or more eng/common scripts do not use telemetry categorization.'
-        echo "https://github.com/dotnet/arcade/blob/master/Documentation/Projects/DevOps/CI/Telemetry-Guidance.md"
+        echo "https://github.com/dotnet/arcade/blob/main/Documentation/Projects/DevOps/CI/Telemetry-Guidance.md"
         echo "The following bash files do not include telemetry categorization output:"
         for file in $file_list
             do echo "'$file'"

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -183,7 +183,7 @@ function Install-DotNetCli
 {
     $timer = Start-Timer
     Write-Log "Install-DotNetCli: Get dotnet-install.ps1 script..."
-    $dotnetInstallRemoteScript = "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1"
+    $dotnetInstallRemoteScript = "https://raw.githubusercontent.com/dotnet/install-scripts/main/src/dotnet-install.ps1"
     $dotnetInstallScript = Join-Path $env:TP_TOOLS_DIR "dotnet-install.ps1"
     if (-not (Test-Path $env:TP_TOOLS_DIR)) {
         New-Item $env:TP_TOOLS_DIR -Type Directory | Out-Null

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -190,7 +190,7 @@ function install_cli()
         $install_script  --runtime dotnet --version "5.0.1" --channel "release/5.0.1" --install-dir "$TP_DOTNET_DIR" --no-path --architecture x64
 
         log "install_cli: Get the latest dotnet cli toolset..."
-        $install_script --install-dir "$TP_DOTNET_DIR" --no-path --channel "master" --version $DOTNET_CLI_VERSION
+        $install_script --install-dir "$TP_DOTNET_DIR" --no-path --channel "main" --version $DOTNET_CLI_VERSION
 
 
         log " ---- dotnet x64"

--- a/scripts/write-release-notes.ps1
+++ b/scripts/write-release-notes.ps1
@@ -97,7 +97,7 @@ $issues = $log | ForEach-Object {
 
 $output = @"
 
-See the release notes [here](https://github.com/microsoft/vstest-docs/blob/master/docs/releases.md#$($v -replace '\.')).
+See the release notes [here](https://github.com/microsoft/vstest-docs/blob/main/docs/releases.md#$($v -replace '\.')).
 
 -------------------------------
 

--- a/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/ManagedNameHelper.Reflection.cs
+++ b/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/ManagedNameHelper.Reflection.cs
@@ -26,12 +26,12 @@ namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities
         /// <param name="managedTypeName">
         /// When this method returns, contains the fully qualified managed type name of the <paramref name="method"/>.
         /// This parameter is passed uninitialized; any value originally supplied in result will be overwritten.
-        /// The format is defined in <see href="https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md#managedtype-property">the RFC</see>.
+        /// The format is defined in <see href="https://github.com/microsoft/vstest-docs/blob/main/RFCs/0017-Managed-TestCase-Properties.md#managedtype-property">the RFC</see>.
         /// </param>
         /// <param name="managedMethodName">
         /// When this method returns, contains the fully qualified managed method name of the <paramref name="method"/>.
         /// This parameter is passed uninitialized; any value originally supplied in result will be overwritten.
-        /// The format is defined in <see href="https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md#managedmethod-property">the RFC</see>.
+        /// The format is defined in <see href="https://github.com/microsoft/vstest-docs/blob/main/RFCs/0017-Managed-TestCase-Properties.md#managedmethod-property">the RFC</see>.
         /// </param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="method"/> is null.
@@ -44,7 +44,7 @@ namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities
         /// </exception>
         /// <remarks>
         /// More information about <paramref name="managedTypeName"/> and <paramref name="managedMethodName"/> can be found in
-        /// <see href="https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md">the RFC</see>.
+        /// <see href="https://github.com/microsoft/vstest-docs/blob/main/RFCs/0017-Managed-TestCase-Properties.md">the RFC</see>.
         /// </remarks>
         public static void GetManagedName(MethodBase method, out string managedTypeName, out string managedMethodName)
             => GetManagedName(method, out managedTypeName, out managedMethodName, out _);
@@ -58,12 +58,12 @@ namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities
         /// <param name="managedTypeName">
         /// When this method returns, contains the fully qualified managed type name of the <paramref name="method"/>.
         /// This parameter is passed uninitialized; any value originally supplied in result will be overwritten.
-        /// The format is defined in <see href="https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md#managedtype-property">the RFC</see>.
+        /// The format is defined in <see href="https://github.com/microsoft/vstest-docs/blob/main/RFCs/0017-Managed-TestCase-Properties.md#managedtype-property">the RFC</see>.
         /// </param>
         /// <param name="managedMethodName">
         /// When this method returns, contains the fully qualified managed method name of the <paramref name="method"/>.
         /// This parameter is passed uninitialized; any value originally supplied in result will be overwritten.
-        /// The format is defined in <see href="https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md#managedmethod-property">the RFC</see>.
+        /// The format is defined in <see href="https://github.com/microsoft/vstest-docs/blob/main/RFCs/0017-Managed-TestCase-Properties.md#managedmethod-property">the RFC</see>.
         /// </param>
         /// <param name="hierarchyValues">
         /// When this method returns, contains the default test hierarchy values of the <paramref name="method"/>.
@@ -80,7 +80,7 @@ namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities
         /// </exception>
         /// <remarks>
         /// More information about <paramref name="managedTypeName"/> and <paramref name="managedMethodName"/> can be found in
-        /// <see href="https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md">the RFC</see>.
+        /// <see href="https://github.com/microsoft/vstest-docs/blob/main/RFCs/0017-Managed-TestCase-Properties.md">the RFC</see>.
         /// </remarks>
         public static void GetManagedName(MethodBase method, out string managedTypeName, out string managedMethodName, out string[] hierarchyValues)
         {
@@ -162,11 +162,11 @@ namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities
         /// </param>
         /// <param name="managedTypeName">
         /// The fully qualified managed name of the type.
-        /// The format is defined in <see href="https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md#managedtype-property">the RFC</see>.
+        /// The format is defined in <see href="https://github.com/microsoft/vstest-docs/blob/main/RFCs/0017-Managed-TestCase-Properties.md#managedtype-property">the RFC</see>.
         /// </param>
         /// <param name="managedMethodName">
         /// The fully qualified managed name of the method.
-        /// The format is defined in <see href="https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md#managedmethod-property">the RFC</see>.
+        /// The format is defined in <see href="https://github.com/microsoft/vstest-docs/blob/main/RFCs/0017-Managed-TestCase-Properties.md#managedmethod-property">the RFC</see>.
         /// </param>
         /// <returns>
         /// A <see cref="MethodBase" /> object that represents specified parameters, throws if null.
@@ -177,7 +177,7 @@ namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities
         /// </exception>
         /// <remarks>
         /// More information about <paramref name="managedTypeName"/> and <paramref name="managedMethodName"/> can be found in
-        /// <see href="https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md">the RFC</see>.
+        /// <see href="https://github.com/microsoft/vstest-docs/blob/main/RFCs/0017-Managed-TestCase-Properties.md">the RFC</see>.
         /// </remarks>
         public static MethodBase GetMethod(Assembly assembly, string managedTypeName, string managedMethodName)
         {

--- a/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/ManagedNameParser.cs
+++ b/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/ManagedNameParser.cs
@@ -17,7 +17,7 @@ namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities
         /// </summary>
         /// <param name="managedTypeName">
         /// The fully qualified managed type name to parse.
-        /// The format is defined in <see href="https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md#managedtype-property">the RFC</see>.
+        /// The format is defined in <see href="https://github.com/microsoft/vstest-docs/blob/main/RFCs/0017-Managed-TestCase-Properties.md#managedtype-property">the RFC</see>.
         /// </param>
         /// <param name="namespaceName">
         /// When this method returns, contains the parsed namespace name of the <paramref name="managedTypeName"/>.
@@ -47,7 +47,7 @@ namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities
         /// </summary>
         /// <param name="managedMethodName">
         /// The fully qualified managed method name to parse.
-        /// The format is defined in <see href="https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md#managedmethod-property">the RFC</see>.
+        /// The format is defined in <see href="https://github.com/microsoft/vstest-docs/blob/main/RFCs/0017-Managed-TestCase-Properties.md#managedmethod-property">the RFC</see>.
         /// </param>
         /// <param name="methodName">
         /// When this method returns, contains the parsed method name of the <paramref name="managedMethodName"/>.

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.Designer.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details..
+        ///   Looks up a localized string similar to Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details..
         /// </summary>
         internal static string DeprecatedAdapterPath {
             get {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/Resources.resx
@@ -190,7 +190,7 @@
     <value>Could not find extensions: {0}</value>
   </data>
   <data name="DeprecatedAdapterPath" xml:space="preserve">
-    <value>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</value>
+    <value>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</value>
   </data>
   <data name="NoTestsAvailableForGivenTestCaseFilter" xml:space="preserve">
     <value>No test matches the given testcase filter `{0}` in {1}</value>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.cs.xlf
@@ -118,8 +118,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="DeprecatedAdapterPath">
-        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
-        <target state="translated">Mění se vyhledávání adaptéru. Další informace najdete tady: https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.</target>
+        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
+        <target state="translated">Mění se vyhledávání adaptéru. Další informace najdete tady: https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.de.xlf
@@ -118,8 +118,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="DeprecatedAdapterPath">
-        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
-        <target state="translated">Die Adaptersuche wird gerade geändert. Weitere Informationen finden Sie unter https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.</target>
+        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
+        <target state="translated">Die Adaptersuche wird gerade geändert. Weitere Informationen finden Sie unter https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.es.xlf
@@ -118,8 +118,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="DeprecatedAdapterPath">
-        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
-        <target state="translated">Se está cambiando la búsqueda de adaptador. Siga https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap para obtener más detalles.</target>
+        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
+        <target state="translated">Se está cambiando la búsqueda de adaptador. Siga https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap para obtener más detalles.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.fr.xlf
@@ -118,8 +118,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="DeprecatedAdapterPath">
-        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
-        <target state="translated">La fonctionnalité de recherche d’adaptateur fait actuellement l’objet de modifications. Pour plus d’informations, consultez https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.</target>
+        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
+        <target state="translated">La fonctionnalité de recherche d’adaptateur fait actuellement l’objet de modifications. Pour plus d’informations, consultez https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.it.xlf
@@ -118,8 +118,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="DeprecatedAdapterPath">
-        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
-        <target state="translated">La ricerca degli adattatori verrà modificata a breve. Per maggiori dettagli, vedere https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.</target>
+        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
+        <target state="translated">La ricerca degli adattatori verrà modificata a breve. Per maggiori dettagli, vedere https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ja.xlf
@@ -118,8 +118,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="DeprecatedAdapterPath">
-        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
-        <target state="translated">アダプター検索は変更中です。詳細については、https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap をご覧ください。</target>
+        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
+        <target state="translated">アダプター検索は変更中です。詳細については、https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap をご覧ください。</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ko.xlf
@@ -118,8 +118,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="DeprecatedAdapterPath">
-        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
-        <target state="translated">어댑터 조회가 변경됩니다. 자세한 내용은 https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap을 참조하세요.</target>
+        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
+        <target state="translated">어댑터 조회가 변경됩니다. 자세한 내용은 https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap을 참조하세요.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pl.xlf
@@ -118,8 +118,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="DeprecatedAdapterPath">
-        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
-        <target state="translated">Wyszukiwanie adaptera jest zmieniane, zobacz https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap w celu uzyskania dalszych szczegółów.</target>
+        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
+        <target state="translated">Wyszukiwanie adaptera jest zmieniane, zobacz https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap w celu uzyskania dalszych szczegółów.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.pt-BR.xlf
@@ -118,8 +118,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="DeprecatedAdapterPath">
-        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
-        <target state="translated">A pesquisa do adaptador está sendo alterada, siga https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap para obter mais detalhes.</target>
+        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
+        <target state="translated">A pesquisa do adaptador está sendo alterada, siga https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap para obter mais detalhes.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.ru.xlf
@@ -118,8 +118,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="DeprecatedAdapterPath">
-        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
-        <target state="translated">Изменяется поиск адаптеров. Дополнительные сведения: https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.</target>
+        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
+        <target state="translated">Изменяется поиск адаптеров. Дополнительные сведения: https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.tr.xlf
@@ -118,8 +118,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="DeprecatedAdapterPath">
-        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
-        <target state="translated">Bağdaştırıcı arama değiştiriliyor. Ayrıntılar için lütfen https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap sayfasını takip edin.</target>
+        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
+        <target state="translated">Bağdaştırıcı arama değiştiriliyor. Ayrıntılar için lütfen https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap sayfasını takip edin.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.xlf
@@ -104,8 +104,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="DeprecatedAdapterPath">
-        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
-        <target state="new">Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</target>
+        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
+        <target state="new">Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hans.xlf
@@ -118,8 +118,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="DeprecatedAdapterPath">
-        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
-        <target state="translated">适配器查找发生了变化，请转到 https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap，了解详细信息。</target>
+        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
+        <target state="translated">适配器查找发生了变化，请转到 https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap，了解详细信息。</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Resources/xlf/Resources.zh-Hant.xlf
@@ -118,8 +118,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="DeprecatedAdapterPath">
-        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
-        <target state="translated">目前正在變更配接器查閱，請遵循 https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap，以取得詳細資料。</target>
+        <source>Adapter lookup is being changed, please follow https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap for more details.</source>
+        <target state="translated">目前正在變更配接器查閱，請遵循 https://github.com/Microsoft/vstest-docs/blob/main/RFCs/0022-User-Specified-TestAdapter-Lookup.md#roadmap，以取得詳細資料。</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoTestsAvailableForGivenTestCaseFilter">

--- a/src/vstest.console/app.config
+++ b/src/vstest.console/app.config
@@ -32,7 +32,7 @@
           1. Uncomment below system.diagnostics element content.
           2. Replace "c:\tmp\log.txt" with valid filename. Make sure "c:\tmp" folder exists. log.txt file will be created by vstest.console if does not exists.
           3. Restart vstest.console or it's client(VS, any other IDE).
-        More details: https://github.com/Microsoft/vstest-docs/blob/master/docs/diagnose.md#collect-trace-using-config-file
+        More details: https://github.com/Microsoft/vstest-docs/blob/main/docs/diagnose.md#collect-trace-using-config-file
   -->
 
   <!-- <system.diagnostics>


### PR DESCRIPTION
## Description
Rename our links to use main instead of master.

## Related issue
Unifying names across microsoft repos.


