### PR TITLE
Treat .msix files the same as .appx

### DIFF
--- a/src/vstest.console/CommandLine/InferHelper.cs
+++ b/src/vstest.console/CommandLine/InferHelper.cs
@@ -139,6 +139,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLineUtilities
                         fx = new FrameworkName(Constants.DotNetFramework40);
                     }
                     else if (extension.Equals(".appx", StringComparison.OrdinalIgnoreCase)
+                        || extension.Equals(".msix", StringComparison.OrdinalIgnoreCase)
                         || extension.Equals(".appxrecipe", StringComparison.OrdinalIgnoreCase))
                     {
                         fx = new FrameworkName(Constants.DotNetFrameworkUap10);

--- a/test/vstest.console.UnitTests/CommandLine/InferHelperTests.cs
+++ b/test/vstest.console.UnitTests/CommandLine/InferHelperTests.cs
@@ -199,6 +199,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.CommandLine
         }
 
         [TestMethod]
+        public void AutoDetectFrameworkShouldReturnFrameworkUap10ForMsixFiles()
+        {
+            var fx = Framework.FromString(Constants.DotNetFrameworkUap10);
+            var assemblyName = "uwp10.msix";
+            SetupAndValidateForSingleAssembly(assemblyName, fx, false);
+        }
+
+        [TestMethod]
         public void AutoDetectFrameworkShouldReturnFrameworkUap10ForAppxrecipeFiles()
         {
             var fx = Framework.FromString(Constants.DotNetFrameworkUap10);


### PR DESCRIPTION
## Description
This change ensures that .msix files are treated exactly the same as .appx files, auto-detecting the UAP framework.

## Related issue
Fixes #2476, #2296
