### PR TITLE
Add .NET 6.0 TestHost for HotReload support in TestWindow

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -80,6 +80,7 @@ $TPB_TargetFramework451 = "net451"
 $TPB_TargetFramework472 = "net472"
 $TPB_TargetFrameworkCore10 = "netcoreapp1.0"
 $TPB_TargetFrameworkCore20 = "netcoreapp2.1"
+$TPB_TargetFrameworkCore60 = "net6.0"
 $TPB_TargetFrameworkUap100 = "uap10.0"
 $TPB_TargetFrameworkNS10 = "netstandard1.0"
 $TPB_TargetFrameworkNS13 = "netstandard1.3"
@@ -208,7 +209,13 @@ function Publish-Package
     $testhostCore10PackageX86Dir = $(Join-Path $env:TP_OUT_DIR "$TPB_Configuration\Microsoft.TestPlatform.TestHost\$TPB_TargetFrameworkCore10\$TPB_X86_Runtime")
     $testhostCore10PackageTempX64Dir = $(Join-Path $env:TP_OUT_DIR "$TPB_Configuration\publishTemp\Microsoft.TestPlatform.TestHost\$TPB_TargetFrameworkCore10\$TPB_X64_Runtime")
     $testhostCore10PackageTempX86Dir = $(Join-Path $env:TP_OUT_DIR "$TPB_Configuration\publishTemp\Microsoft.TestPlatform.TestHost\$TPB_TargetFrameworkCore10\$TPB_X86_Runtime")
-    
+
+    $testhostCore60PackageDir = $(Join-Path $env:TP_OUT_DIR "$TPB_Configuration\Microsoft.TestPlatform.TestHost\$TPB_TargetFrameworkCore60")
+    $testhostCore60PackageX64Dir = $(Join-Path $env:TP_OUT_DIR "$TPB_Configuration\Microsoft.TestPlatform.TestHost\$TPB_TargetFrameworkCore60\$TPB_X64_Runtime")
+    $testhostCore60PackageX86Dir = $(Join-Path $env:TP_OUT_DIR "$TPB_Configuration\Microsoft.TestPlatform.TestHost\$TPB_TargetFrameworkCore60\$TPB_X86_Runtime")
+    $testhostCore60PackageTempX64Dir = $(Join-Path $env:TP_OUT_DIR "$TPB_Configuration\publishTemp\Microsoft.TestPlatform.TestHost\$TPB_TargetFrameworkCore60\$TPB_X64_Runtime")
+    $testhostCore60PackageTempX86Dir = $(Join-Path $env:TP_OUT_DIR "$TPB_Configuration\publishTemp\Microsoft.TestPlatform.TestHost\$TPB_TargetFrameworkCore60\$TPB_X86_Runtime")
+
     $testhostUapPackageDir = $(Join-Path $env:TP_OUT_DIR "$TPB_Configuration\Microsoft.TestPlatform.TestHost\$TPB_TargetFrameworkUap100")
     $vstestConsoleProject = Join-Path $env:TP_ROOT_DIR "src\vstest.console\vstest.console.csproj"
     $settingsMigratorProject = Join-Path $env:TP_ROOT_DIR "src\SettingsMigrator\SettingsMigrator.csproj"
@@ -238,14 +245,17 @@ function Publish-Package
     Publish-PackageInternal $testHostProject $TPB_TargetFramework451 $testhostFullPackageDir
     Publish-PackageInternal $testHostProject $TPB_TargetFrameworkCore20 $testhostCore20PackageDir
     Publish-PackageInternal $testHostProject $TPB_TargetFrameworkCore10 $testhostCore10PackageDir
+    Publish-PackageInternal $testHostProject $TPB_TargetFrameworkCore60 $testhostCore60PackageDir
     Publish-PackageInternal $testHostProject $TPB_TargetFrameworkCore20 $testhostUapPackageDir
     Publish-PackageWithRuntimeInternal $testHostProject $TPB_TargetFrameworkCore20 $TPB_X64_Runtime false $testhostCore20PackageTempX64Dir
     Publish-PackageWithRuntimeInternal $testHostProject $TPB_TargetFrameworkCore10 $TPB_X64_Runtime true $testhostCore10PackageTempX64Dir
+    Publish-PackageWithRuntimeInternal $testHostProject $TPB_TargetFrameworkCore60 $TPB_X64_Runtime false $testhostCore60PackageTempX64Dir
     
     Write-Log "Package: Publish testhost.x86\testhost.x86.csproj"
     Publish-PackageInternal $testHostx86Project $TPB_TargetFramework451 $testhostFullPackageDir
     Publish-PackageWithRuntimeInternal $testHostx86Project $TPB_TargetFrameworkCore20 $TPB_X86_Runtime false $testhostCore20PackageTempX86Dir
     Publish-PackageWithRuntimeInternal $testHostx86Project $TPB_TargetFrameworkCore10 $TPB_X86_Runtime true $testhostCore10PackageTempX86Dir
+    Publish-PackageWithRuntimeInternal $testHostx86Project $TPB_TargetFrameworkCore60 $TPB_X86_Runtime false $testhostCore60PackageTempX86Dir
     
     # Copy the .NET multitarget testhost exes to destination folder (except for net451 which is the default)
     foreach ($tfm in "net452;net46;net461;net462;net47;net471;net472;net48" -split ";") {
@@ -277,6 +287,14 @@ function Publish-Package
     New-Item -ItemType directory -Path $testhostCore10PackageX86Dir -Force | Out-Null
     Copy-Item $testhostCore10PackageTempX86Dir\testhost.x86* $testhostCore10PackageX86Dir -Force -Recurse
     Copy-Item $testhostCore10PackageTempX86Dir\Microsoft.TestPlatform.PlatformAbstractions.dll $testhostCore10PackageX86Dir -Force
+
+    New-Item -ItemType directory -Path $testhostCore60PackageX64Dir -Force | Out-Null
+    Copy-Item $testhostCore60PackageTempX64Dir\testhost* $testhostCore60PackageX64Dir -Force -Recurse
+    Copy-Item $testhostCore60PackageTempX64Dir\Microsoft.TestPlatform.PlatformAbstractions.dll $testhostCore60PackageX64Dir -Force
+
+    New-Item -ItemType directory -Path $testhostCore60PackageX86Dir -Force | Out-Null
+    Copy-Item $testhostCore60PackageTempX86Dir\testhost.x86* $testhostCore60PackageX86Dir -Force -Recurse
+    Copy-Item $testhostCore60PackageTempX86Dir\Microsoft.TestPlatform.PlatformAbstractions.dll $testhostCore60PackageX86Dir -Force
     
     # Copy over the Full CLR built testhost package assemblies to the Core CLR and Full CLR package folder.
     $coreCLRFull_Dir = "TestHost"
@@ -350,6 +368,7 @@ function Publish-Package
     $comComponentsDirectory = Join-Path $env:TP_PACKAGES_DIR "Microsoft.Internal.Dia\$testPlatformExternalsVersion\tools\net451"
     Copy-Item -Recurse $comComponentsDirectory\* $testhostCore20PackageDir -Force
     Copy-Item -Recurse $comComponentsDirectory\* $testhostCore10PackageDir -Force
+    Copy-Item -Recurse $comComponentsDirectory\* $testhostCore60PackageDir -Force
     Copy-Item -Recurse $comComponentsDirectory\* $testhostFullPackageDir -Force
     Copy-Item -Recurse $comComponentsDirectory\* $testhostUapPackageDir -Force
     Copy-Item -Recurse $comComponentsDirectory\* $coreCLR20TestHostPackageDir -Force
@@ -744,6 +763,9 @@ function Create-NugetPackages
     Copy-Item $tpNuspecDir\uap\"Microsoft.TestPlatform.TestHost.Uap.props" $testhostUapPackageDir\Microsoft.TestPlatform.TestHost.props -Force
     Copy-Item $tpNuspecDir\uap\"Microsoft.TestPlatform.TestHost.Uap.targets" $testhostUapPackageDir\Microsoft.TestPlatform.TestHost.targets -Force
     
+    $testhostCore60PackageDir = $(Join-Path $env:TP_OUT_DIR "$TPB_Configuration\Microsoft.TestPlatform.TestHost\$TPB_TargetFrameworkCore60")
+    Copy-Item $tpNuspecDir\"Microsoft.TestPlatform.TestHost.NetCore.props" $testhostCore60PackageDir\Microsoft.TestPlatform.TestHost.props -Force
+
     $testhostCore20PackageDir = $(Join-Path $env:TP_OUT_DIR "$TPB_Configuration\Microsoft.TestPlatform.TestHost\$TPB_TargetFrameworkCore20")
     Copy-Item $tpNuspecDir\"Microsoft.TestPlatform.TestHost.NetCore.props" $testhostCore20PackageDir\Microsoft.TestPlatform.TestHost.props -Force
     

--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -58,11 +58,9 @@
 
       <!-- 
         Test projects are not discovered in test window without TestContainer capability.
-        Test projects are marked with TestHotReload to indicate presence of .NET6.0 test host
-        which is needed for hot reloading. 
       -->
       <ItemGroup>
-        <ProjectCapability Include="TestContainer;TestHotReload" />
+        <ProjectCapability Include="TestContainer;" />
       </ItemGroup>
 
       <!-- Test project references -->

--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -60,7 +60,7 @@
         Test projects are not discovered in test window without TestContainer capability.
       -->
       <ItemGroup>
-        <ProjectCapability Include="TestContainer;" />
+        <ProjectCapability Include="TestContainer" />
       </ItemGroup>
 
       <!-- Test project references -->

--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -56,9 +56,13 @@
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
       </PropertyGroup>
 
-      <!-- Test projects are not discovered in test window without test container capability -->
+      <!-- 
+        Test projects are not discovered in test window without TestContainer capability.
+        Test projects are marked with TestHotReload to indicate presence of .NET6.0 test host
+        which is needed for hot reloading. 
+      -->
       <ItemGroup>
-        <ProjectCapability Include="TestContainer" />
+        <ProjectCapability Include="TestContainer;TestHotReload" />
       </ItemGroup>
 
       <!-- Test project references -->

--- a/scripts/verify-nupkgs.ps1
+++ b/scripts/verify-nupkgs.ps1
@@ -16,7 +16,7 @@ function Verify-Nuget-Packages($packageDirectory, $version)
         "Microsoft.NET.Test.Sdk" = 27;
         "Microsoft.TestPlatform" = 493;
         "Microsoft.TestPlatform.Build" = 21;
-        "Microsoft.TestPlatform.CLI" = 381;
+        "Microsoft.TestPlatform.CLI" = 367;
         "Microsoft.TestPlatform.Extensions.TrxLogger" = 35;
         "Microsoft.TestPlatform.ObjectModel" = 238;
         "Microsoft.TestPlatform.AdapterUtilities" = 62;

--- a/scripts/verify-nupkgs.ps1
+++ b/scripts/verify-nupkgs.ps1
@@ -16,12 +16,12 @@ function Verify-Nuget-Packages($packageDirectory, $version)
         "Microsoft.NET.Test.Sdk" = 27;
         "Microsoft.TestPlatform" = 493;
         "Microsoft.TestPlatform.Build" = 21;
-        "Microsoft.TestPlatform.CLI" = 367;
+        "Microsoft.TestPlatform.CLI" = 381;
         "Microsoft.TestPlatform.Extensions.TrxLogger" = 35;
         "Microsoft.TestPlatform.ObjectModel" = 238;
         "Microsoft.TestPlatform.AdapterUtilities" = 62;
         "Microsoft.TestPlatform.Portable" = 596;
-        "Microsoft.TestPlatform.TestHost" = 214;
+        "Microsoft.TestPlatform.TestHost" = 233;
         "Microsoft.TestPlatform.TranslationLayer" = 123;
     }
 

--- a/src/package/nuspec/Microsoft.NET.Test.Sdk.props
+++ b/src/package/nuspec/Microsoft.NET.Test.Sdk.props
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectCapability Include="TestContainer" />
+    <ProjectCapability Include="TestContainer;TestHotReload" />
   </ItemGroup>  
  
 </Project>

--- a/src/package/nuspec/Microsoft.NET.Test.Sdk.props
+++ b/src/package/nuspec/Microsoft.NET.Test.Sdk.props
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectCapability Include="TestContainer;TestHotReload" />
+    <ProjectCapability Include="TestContainer;HotReloadForTest" />
   </ItemGroup>  
  
 </Project>

--- a/src/package/nuspec/TestPlatform.TestHost.nuspec
+++ b/src/package/nuspec/TestPlatform.TestHost.nuspec
@@ -38,6 +38,11 @@
         <dependency id="Newtonsoft.Json" version="$JsonNetVersion$"/>
       </group>
 
+      <group targetFramework="net6.0">
+        <dependency id="Microsoft.TestPlatform.ObjectModel" version="$Version$"/>
+        <dependency id="Newtonsoft.Json" version="$JsonNetVersion$"/>
+      </group>
+
       <group targetFramework="uap10.0">
         <dependency id="Microsoft.TestPlatform.ObjectModel" version="$Version$"/>
         <dependency id="Newtonsoft.Json" version="$JsonNetVersion$"/>
@@ -93,6 +98,24 @@
 
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp2.1\Microsoft.TestPlatform.TestHost.props" target="build\netcoreapp2.1\" />
     
+    <!-- net6.0 -->
+    <file src="Microsoft.TestPlatform.TestHost\net6.0\Microsoft.VisualStudio.TestPlatform.*.dll" target="lib\net6.0\" />
+    <file src="Microsoft.TestPlatform.TestHost\net6.0\Microsoft.TestPlatform.*.dll" target="lib\net6.0\" />
+    <file src="Microsoft.TestPlatform.TestHost\net6.0\testhost.dll" target="lib\net6.0\" />
+    <file src="Microsoft.TestPlatform.TestHost\net6.0\testhost.deps.json" target="lib\net6.0\" />
+    <file src="Microsoft.TestPlatform.TestHost\net6.0\x86\msdia140.dll" target="lib\net6.0\x86\" />
+    <file src="Microsoft.TestPlatform.TestHost\net6.0\x64\msdia140.dll" target="lib\net6.0\x64\" />
+
+    <file src="Microsoft.TestPlatform.TestHost\net6.0\Microsoft.TestPlatform.PlatformAbstractions.dll" target="build\net6.0\" />
+    <file src="Microsoft.TestPlatform.TestHost\net6.0\win7-x64\testhost.dll" target="build\net6.0\x64\" />
+    <file src="Microsoft.TestPlatform.TestHost\net6.0\win7-x64\testhost.exe" target="build\net6.0\x64\" />
+    <file src="Microsoft.TestPlatform.TestHost\net6.0\win7-x64\Microsoft.TestPlatform.PlatformAbstractions.dll" target="build\net6.0\x64\" />
+    <file src="Microsoft.TestPlatform.TestHost\net6.0\win7-x86\testhost.x86.dll" target="build\net6.0\x86\" />
+    <file src="Microsoft.TestPlatform.TestHost\net6.0\win7-x86\testhost.x86.exe" target="build\net6.0\x86\" />
+    <file src="Microsoft.TestPlatform.TestHost\net6.0\win7-x86\Microsoft.TestPlatform.PlatformAbstractions.dll" target="build\net6.0\x86\" />
+
+    <file src="Microsoft.TestPlatform.TestHost\net6.0\Microsoft.TestPlatform.TestHost.props" target="build\net6.0\" />
+
     <!-- UWP -->
     <file src="Microsoft.TestPlatform.TestHost\uap10.0\testhost.dll" target="lib\uap10.0\" />
     <file src="Microsoft.TestPlatform.TestHost\uap10.0\Microsoft.TestPlatform.*.dll" target="lib\uap10.0\" />

--- a/src/testhost.x86/testhost.x86.csproj
+++ b/src/testhost.x86/testhost.x86.csproj
@@ -8,7 +8,7 @@
   <Import Project="$(TestPlatformRoot)scripts/build/TestPlatform.Settings.targets" />
   <PropertyGroup>
     <AssemblyName>testhost.x86</AssemblyName>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp1.0;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp2.1;netcoreapp1.0;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">net6.0</TargetFrameworks>
     <WarningsAsErrors>true</WarningsAsErrors>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/testhost/testhost.csproj
+++ b/src/testhost/testhost.csproj
@@ -8,7 +8,7 @@
   <Import Project="$(TestPlatformRoot)scripts/build/TestPlatform.Settings.targets" />
   <PropertyGroup>
     <AssemblyName>testhost</AssemblyName>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp1.0;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp2.1;netcoreapp1.0;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>app.manifest</ApplicationManifest>


### PR DESCRIPTION
## Description
1. Add .NET6.0 Test Host 
2. Add `TestHotReload` capability to indicate support


