### PR TITLE
Fixed manifest generation

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -975,8 +975,9 @@ function Generate-Manifest
 {
     Write-Log "Generate-Manifest: Started."
 
-    $sdkTaskPath = Join-Path $env:TP_ROOT_DIR "eng\common\sdk-task.ps1"
-    & $sdkTaskPath -restore -task GenerateBuildManifest /p:PackagesToPublishPattern=$TPB_PackageOutDir\*.nupkg /p:AssetManifestFilePath=$TPB_PackageOutDir\manifest\manifest.xml /p:ManifestBuildData="Location=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" /p:BUILD_BUILDNUMBER=$BuildNumber
+    $generateManifestPath = Join-Path $env:TP_ROOT_DIR "scripts\build\GenerateManifest.proj"
+    $msbuildPath = Locate-MSBuildPath
+    & $msbuildPath $generateManifestPath /t:PublishToBuildAssetRegistry /p:PackagesToPublishPattern=$TPB_PackageOutDir\*.nupkg /p:BUILD_BUILDNUMBER=$BuildNumber /p:Configuration=$TPB_Configuration /bl:"$env:TP_OUT_DIR\log\$Configuration\manifest-generation.binlog"
 
     Write-Log "Generate-Manifest: Completed."
 }
@@ -1075,6 +1076,9 @@ if ($Force -or $Steps -contains "Publish") {
     Publish-Package
     Create-VsixPackage
     Create-NugetPackages
+}
+
+if ($Force -or $Steps -contains "Publish" -or $Steps -contains "Manifest") {
     Generate-Manifest
     Copy-PackageIntoStaticDirectory
 }

--- a/scripts/build/GenerateManifest.proj
+++ b/scripts/build/GenerateManifest.proj
@@ -1,0 +1,43 @@
+<Project>
+    <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+    <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+
+    <PropertyGroup>
+        <TargetFramework>net472</TargetFramework>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <NETCORE_ENGINEERING_TELEMETRY>Publish</NETCORE_ENGINEERING_TELEMETRY>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <MicrosoftDotNetBuildTasksFeedFilePath Condition=" '$(MicrosoftDotNetBuildTasksFeedFilePath)' == '' ">$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\tools\$(TargetFramework)\Microsoft.DotNet.Build.Tasks.Feed.dll</MicrosoftDotNetBuildTasksFeedFilePath>
+        <PackagesPath Condition=" '$(PackagesPath)' == '' ">$(ArtifactsDir)\$(Configuration)\packages\</PackagesPath>
+        <AssetManifestFilePath Condition=" '$(AssetManifestFilePath)' == '' ">$(PackagesPath)manifest\manifest.xml</AssetManifestFilePath>
+        <PackagesToPublishPattern Condition=" '$(PackagesToPublishPattern)' == '' ">$(PackagesPath)*.nupkg</PackagesToPublishPattern>
+        <FeedUrl Condition=" '$(FeedUrl)' == '' ">https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json</FeedUrl>
+    </PropertyGroup>
+    
+    <ItemGroup Condition="'$(PackagesToPublishPattern)' != ''">
+        <ItemsToPush Remove="@(ItemsToPush)" />
+        <ItemsToPush Include="$(PackagesToPublishPattern)" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ManifestBuildData Include="Location=$(FeedUrl)" />
+    </ItemGroup>
+
+    <UsingTask TaskName="GenerateBuildManifest" AssemblyFile="$(MicrosoftDotNetBuildTasksFeedFilePath)" />
+
+    <Target Name="PublishToBuildAssetRegistry">
+        <GenerateBuildManifest Artifacts="@(ItemsToPush)"
+            ItemsToSign="@(ItemsToSignPostBuild)"
+            StrongNameSignInfo="@(StrongNameSignInfo)"
+            FileSignInfo="@(FileSignInfo)"
+            FileExtensionSignInfo="@(FileExtensionSignInfo)"
+            OutputPath="$(AssetManifestFilePath)"
+            BuildId="$(BUILD_BUILDNUMBER)"
+            BuildData="@(ManifestBuildData)"
+            RepoUri="$(BUILD_REPOSITORY_URI)"
+            RepoBranch="$(BUILD_SOURCEBRANCH)"
+            RepoCommit="$(BUILD_SOURCEVERSION)" />
+    </Target>
+</Project>

--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -16,7 +16,7 @@
     <MSTestFrameworkVersion>2.1.0</MSTestFrameworkVersion>
     <MSTestAdapterVersion>2.1.0</MSTestAdapterVersion>
     <MSTestAssertExtensionVersion>1.0.3-preview</MSTestAssertExtensionVersion>
-    
+
     <XUnitFrameworkVersion>2.3.1</XUnitFrameworkVersion>
     <XUnitAdapterVersion>2.3.1</XUnitAdapterVersion>
     <XUnitConsoleRunnerVersion>2.3.1</XUnitConsoleRunnerVersion>
@@ -30,7 +30,7 @@
     <NuGetFrameworksVersion>5.0.0</NuGetFrameworksVersion>
     <ILAsmPackageVersion>5.0.0</ILAsmPackageVersion>
     <JsonNetVersion>9.0.1</JsonNetVersion>
-    <MoqVersion>4.7.63</MoqVersion>
+    <MoqVersion>4.8.3</MoqVersion>
     <TestPlatformExternalsVersion>16.11.31329.17</TestPlatformExternalsVersion>
     <CodeCoverageExternalsVersion>17.0.0-beta.21314.4</CodeCoverageExternalsVersion>
     <InteropExternalsVersion>17.0.0-preview-2-31223-026</InteropExternalsVersion>
@@ -46,6 +46,7 @@
     <CoverletCoverageVersion>1.2.0</CoverletCoverageVersion>
   </PropertyGroup>
 
+  <Import Project="$(MSBuildThisFileDirectory)..\..\eng\Versions.props" />
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition="'$(DotNetPackageVersionPropsPath)' != ''" />
 
 </Project>

--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <TestPlatformRoot Condition="$(TestPlatformRoot) == ''">$(MSBuildThisFileDirectory)../../</TestPlatformRoot>
+    <TestPlatformRoot>$(MSBuildThisFileDirectory)..\..\</TestPlatformRoot>
     <!-- This version is read by vsts-prebuild.ps1 and is a base for the current version, this should be updated
     at the start of new iteration to the goal number. This is also used to version the local packages. This version needs to be statically
     readable when we read the file as xml, don't move it to a .props file, unless you change the build server process -->

--- a/scripts/build/TestPlatform.targets
+++ b/scripts/build/TestPlatform.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <TestPlatformRoot Condition="$(TestPlatformRoot) == ''">$(MSBuildThisFileDirectory)..\..\</TestPlatformRoot>
+    <TestPlatformRoot>$(MSBuildThisFileDirectory)..\..\</TestPlatformRoot>
 
     <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>

--- a/scripts/common.lib.ps1
+++ b/scripts/common.lib.ps1
@@ -151,7 +151,7 @@ function Restore-Package
     $dotnetExe = Get-DotNetPath
 
     Write-Log ".. .. Restore-Package: Source: $env:TP_ROOT_DIR\src\package\external\external.csproj"
-    & $dotnetExe restore $env:TP_ROOT_DIR\src\package\external\external.csproj --packages $env:TP_PACKAGES_DIR -v:minimal -warnaserror -p:Version=$TPB_Version
+    & $dotnetExe restore $env:TP_ROOT_DIR\src\package\external\external.csproj --packages $env:TP_PACKAGES_DIR -v:minimal -warnaserror -p:Version=$TPB_Version -bl:"$env:TP_OUT_DIR\log\$Configuration\external.binlog"
     Write-Log ".. .. Restore-Package: Complete."
 
     Set-ScriptFailedOnError

--- a/src/package/external/external.csproj
+++ b/src/package/external/external.csproj
@@ -28,6 +28,7 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+
   <ItemGroup>
     <!-- This csproj restore external tools required for build process -->
     <PackageReference Include="NuGet.CommandLine" Version="5.8.1" PrivateAssets="All" />
@@ -57,6 +58,7 @@
     <PackageReference Include="Microsoft.Internal.Intellitrace.Extensions" Version="$(TestPlatformExternalsVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETCore.ILAsm" Version="$(ILAsmPackageVersion)" />
     <PackageReference Include="Microsoft.NETCore.ILDAsm" Version="$(ILAsmPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" PrivateAssets="All" />
 
     <!-- Required for resolution of desktop dependencies in non windows environment.
          We've to set to net472 since the net451 and other packages have assemblies in wrong case.
@@ -65,5 +67,6 @@
   </ItemGroup>
   <Import Project="$(TestPlatformRoot)scripts\build\TestPlatform.targets" />
 
-  <Target Name="CoreCompile" />                               <!-- Prevent Csc from being called -->
+  <!-- Prevent Csc from being called -->
+  <Target Name="CoreCompile" />
 </Project>

--- a/test/Microsoft.TestPlatform.TestUtilities/Microsoft.TestPlatform.TestUtilities.csproj
+++ b/test/Microsoft.TestPlatform.TestUtilities/Microsoft.TestPlatform.TestUtilities.csproj
@@ -18,18 +18,13 @@
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.VsTestConsole.TranslationLayer\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.7.63" />
-    <PackageReference Include="MSTest.TestFramework">
-      <Version>$(MSTestFrameworkVersion)</Version>
-    </PackageReference>
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
+    <PackageReference Include="MSTest.TestFramework" Version="$(MSTestFrameworkVersion)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
-      <Version>1.0.41</Version>
-    </PackageReference>
-    <PackageReference Include="System.Text.RegularExpressions">
-      <Version>4.3.0</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.41" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
+    
     <Reference Include="System" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Text.RegularExpressions" />

--- a/test/TestAssets/CILProject/OrphanMethod.il
+++ b/test/TestAssets/CILProject/OrphanMethod.il
@@ -1,5 +1,6 @@
 ﻿.assembly OrphanMethod {}
 .assembly extern mscorlib {}
+.assembly extern System.Core {}
 
 .method static public int32 Add(int32 x, int32 y) cil managed 
 {


### PR DESCRIPTION
## Description
SdkTask we were using to generation our build manifest was removed by https://github.com/dotnet/arcade/pull/6729. That broke our signed pipelines. This change will fix it.