### PR TITLE
Add support for s390x processor architecture

### DIFF
--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/PlatformArchitecture.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/PlatformArchitecture.cs
@@ -11,6 +11,7 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
         X86,
         X64,
         ARM,
-        ARM64
+        ARM64,
+        S390x
     }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformEnvironment.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformEnvironment.cs
@@ -28,6 +28,12 @@ namespace Microsoft.VisualStudio.TestPlatform.PlatformAbstractions
                         return PlatformArchitecture.ARM;
                     case System.Runtime.InteropServices.Architecture.Arm64:
                         return PlatformArchitecture.ARM64;
+
+                    // The symbolic value is only available with .NET 6
+                    // preview 6 or later, so use the numerical value for now.
+                    // case System.Runtime.InteropServices.Architecture.S390x:
+                    case (Architecture)5:
+                        return PlatformArchitecture.S390x;
                     default:
                         throw new NotSupportedException();
                 }


### PR DESCRIPTION
## Description
We have recently added support for the s390x processor architecture to the dotnet runtime, which included adding a new value for the `System.Runtime.InteropServices.Architecture` enum: https://github.com/dotnet/runtime/issues/52909

However, code in `Microsoft.VisualStudio.TestPlatform.PlatformAbstractions` does not recognize this new value, which currently causes any test run on s390x to immediately abort on startup.  To fix this, this patch adds a new value to `Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture` as well, and maps the s390x Architecture value to that new value.

## Related issue
n/a
