### PR TITLE
Adjust SettingsMigrator and build.sh for source-build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -247,7 +247,7 @@ function restore_package()
         $dotnet restore $TP_ROOT_DIR/src/package/external/external.csproj --packages $TP_PACKAGES_DIR -v:minimal -warnaserror -p:Version=$TPB_Version || failed=true
     else
         log ".. .. Restore: Source: $TP_ROOT_DIR/src/package/external/external_BuildFromSource.csproj"
-        $dotnet restore $TP_ROOT_DIR/src/package/external/external.csproj /bl:restore.binlog --packages $TP_PACKAGES_DIR -v:minimal -warnaserror -p:Version=$TPB_Version -p:DotNetBuildFromSource=true || failed=true
+        $dotnet restore $TP_ROOT_DIR/src/package/external/external.csproj /bl:restore_external.binlog --packages $TP_PACKAGES_DIR -v:minimal -warnaserror -p:Version=$TPB_Version -p:DotNetBuildFromSource=true || failed=true
     fi
 
     if [ "$failed" = true ]; then
@@ -274,7 +274,7 @@ function invoke_build()
         if [[ $TP_USE_REPO_API = 0 ]]; then
             $dotnet build $TPB_Solution --configuration $TPB_Configuration -v:minimal -p:Version=$TPB_Version -p:CIBuild=$TPB_CIBuild -p:LocalizedBuild=$TPB_LocalizedBuild -bl:TestPlatform.binlog || failed=true
         else
-            $dotnet build $TPB_Build_From_Source_Solution /bl:build.binlog --configuration $TPB_Configuration -v:minimal -p:Version=$TPB_Version -p:CIBuild=$TPB_CIBuild -p:LocalizedBuild=$TPB_LocalizedBuild -p:DotNetBuildFromSource=true -bl:TestPlatform.binlog || failed=true
+            $dotnet build $TPB_Build_From_Source_Solution --configuration $TPB_Configuration -v:minimal -p:Version=$TPB_Version -p:CIBuild=$TPB_CIBuild -p:LocalizedBuild=$TPB_LocalizedBuild -p:DotNetBuildFromSource=true -bl:TestPlatform.binlog || failed=true
        fi
     else
         find . -name "$PROJECT_NAME_PATTERNS" | xargs -L 1 $dotnet build --configuration $TPB_Configuration -v:minimal -p:Version=$TPB_Version -p:CIBuild=$TPB_CIBuild -p:LocalizedBuild=$TPB_LocalizedBuild

--- a/src/SettingsMigrator/SettingsMigrator.csproj
+++ b/src/SettingsMigrator/SettingsMigrator.csproj
@@ -14,7 +14,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net451'">
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
SettingsMigrator failed to build in the offical source-build builds because it was targetting a windows RID.  This type of issue will get caught in the vstest repo's source-build leg when prebuilt detection is enabled (the source-build team will be enabling this soon).  To fix this, I added a condition to the RID.

I also made a couple tweaks to the binlog parameters within build script.


