### PR TITLE
Fix run in no isolation to use x64 architecture

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
@@ -380,13 +380,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine
             // Return true if
             // 1) Not running in parallel;
             // 2) Data collector is not enabled;
-            // 3) Target framework is x86 or anyCpu;
+            // 3) Target framework is X64 or anyCpu;
             // 4) DisableAppDomain is false;
             // 5) Not running in design mode;
             // 6) target framework is NETFramework (Desktop test);
             if (!isParallelEnabled &&
                 !isDataCollectorEnabled &&
-                (runConfiguration.TargetPlatform == Architecture.X86 || runConfiguration.TargetPlatform == Architecture.AnyCPU) &&
+                (runConfiguration.TargetPlatform == Architecture.X64 || runConfiguration.TargetPlatform == Architecture.AnyCPU) &&
                 !runConfiguration.DisableAppDomain &&
                 !runConfiguration.DesignMode &&
                 runConfiguration.TargetFramework.Name.IndexOf("netframework", StringComparison.OrdinalIgnoreCase) >= 0)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
@@ -386,7 +386,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine
             // 6) target framework is NETFramework (Desktop test);
             if (!isParallelEnabled &&
                 !isDataCollectorEnabled &&
-                (runConfiguration.TargetPlatform == Architecture.X64 || runConfiguration.TargetPlatform == Architecture.AnyCPU) &&
+                (runConfiguration.TargetPlatform == ObjectModel.Constants.DefaultPlatform || runConfiguration.TargetPlatform == Architecture.AnyCPU) &&
                 !runConfiguration.DisableAppDomain &&
                 !runConfiguration.DesignMode &&
                 runConfiguration.TargetFramework.Name.IndexOf("netframework", StringComparison.OrdinalIgnoreCase) >= 0)

--- a/src/Microsoft.TestPlatform.ObjectModel/Constants.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Constants.cs
@@ -153,7 +153,11 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 
         public const string EmptyRunSettings = @"<RunSettings></RunSettings>";
 
-        public static readonly Architecture DefaultPlatform = XmlRunSettingsUtilities.OSArchitecture == Architecture.ARM ? Architecture.ARM : Architecture.X64;
+        public static readonly Architecture DefaultPlatform = XmlRunSettingsUtilities.OSArchitecture == Architecture.ARM 
+            ? Architecture.ARM :
+                XmlRunSettingsUtilities.OSArchitecture == Architecture.X64
+                    ? Architecture.X64
+                    : Architecture.X86;
 
         /// <summary>
         /// Adding this for compatibility

--- a/src/Microsoft.TestPlatform.ObjectModel/Constants.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Constants.cs
@@ -153,7 +153,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel
 
         public const string EmptyRunSettings = @"<RunSettings></RunSettings>";
 
-        public static readonly Architecture DefaultPlatform = XmlRunSettingsUtilities.OSArchitecture == Architecture.ARM ? Architecture.ARM : Architecture.X86;
+        public static readonly Architecture DefaultPlatform = XmlRunSettingsUtilities.OSArchitecture == Architecture.ARM ? Architecture.ARM : Architecture.X64;
 
         /// <summary>
         /// Adding this for compatibility

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DifferentTestFrameworkSimpleTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DifferentTestFrameworkSimpleTests.cs
@@ -29,9 +29,9 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         }
 
         [TestMethod]
-        // vstest.console is 64-bit now, do not run in process because the 32-bit native dll won't load
+        // vstest.console is x64 now, but x86 run "in process" run should still succeed by being run in x86 testhost
         // skip .NET (Core) tests because the called methods ignores them anyway
-        [NetFullTargetFrameworkDataSource(inIsolation: true, inProcess: false, useCoreRunner: false)]
+        [NetFullTargetFrameworkDataSource(inIsolation: true, inProcess: true, useCoreRunner: false)]
         public void CPPRunAllTestExecution(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestEngineTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestEngineTests.cs
@@ -229,7 +229,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests
             string settingXml =
                 @"<RunSettings>
                     <RunConfiguration>
-                        <TargetPlatform>x86</TargetPlatform>
+                        <TargetPlatform>x64</TargetPlatform>
                         <DisableAppDomain>false</DisableAppDomain>
                         <DesignMode>false</DesignMode>
                         <TargetFrameworkVersion>.NETFramework, Version=v4.5</TargetFrameworkVersion>

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/Properties/launchSettings.json
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "WSL": {
-      "commandName": "WSL2",
-      "distributionName": ""
-    }
-  }
-}

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/Properties/launchSettings.json
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "WSL": {
+      "commandName": "WSL2",
+      "distributionName": ""
+    }
+  }
+}

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -250,9 +250,9 @@ namespace TestPlatform.TestHostProvider.UnitTests.Hosting
         }
 
         [TestMethod]
-        public void GetTestHostProcessStartInfoShouldUseTestHostX86ExePresentOnWindows()
+        public void GetTestHostProcessStartInfoShouldUseTestHostX64ExePresentOnWindows()
         {
-            var testhostExePath = "testhost.x86.exe";
+            var testhostExePath = "testhost.exe";
             this.mockFileHelper.Setup(ph => ph.Exists(testhostExePath)).Returns(true);
             this.mockFileHelper.Setup(ph => ph.Exists("testhost.dll")).Returns(true);
             this.mockEnvironment.Setup(ev => ev.OperatingSystem).Returns(PlatformOperatingSystem.Windows);

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/InferRunSettingsHelperTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/InferRunSettingsHelperTests.cs
@@ -405,11 +405,11 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
 			sb.AppendLine(GetSourceIncompatibleMessage("x64net47.exe"));
 			sb.AppendLine(GetSourceIncompatibleMessage("x86net45.dll"));
 
-			var expected = string.Format(CultureInfo.CurrentCulture, OMResources.DisplayChosenSettings, frameworkNet47, Constants.DefaultPlatform, sb.ToString(), multiTargettingForwardLink);
+			var expected = string.Format(CultureInfo.CurrentCulture, OMResources.DisplayChosenSettings, frameworkNet45, Constants.DefaultPlatform, sb.ToString(), multiTargettingForwardLink);
 			#endregion
 
 			string warningMessage = string.Empty;
-			var compatibleSources = InferRunSettingsHelper.FilterCompatibleSources(Constants.DefaultPlatform, Constants.DefaultPlatform, frameworkNet47, sourceArchitectures, sourceFrameworks, out warningMessage);
+			var compatibleSources = InferRunSettingsHelper.FilterCompatibleSources(Constants.DefaultPlatform, Constants.DefaultPlatform, frameworkNet45, sourceArchitectures, sourceFrameworks, out warningMessage);
 
 			// None of the DLLs passed are compatible to the chosen settings
 			Assert.AreEqual(0, compatibleSources.Count());
@@ -427,14 +427,14 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
 
 			StringBuilder sb = new StringBuilder();
 			sb.AppendLine();
-			sb.AppendLine(GetSourceIncompatibleMessage("x64net45.exe"));
+			sb.AppendLine(GetSourceIncompatibleMessage("x86net45.dll"));
 
 			var expected = string.Format(CultureInfo.CurrentCulture, OMResources.DisplayChosenSettings, frameworkNet45, Constants.DefaultPlatform, sb.ToString(), multiTargettingForwardLink);
 
 			string warningMessage = string.Empty;
 			var compatibleSources = InferRunSettingsHelper.FilterCompatibleSources(Constants.DefaultPlatform, Constants.DefaultPlatform, frameworkNet45, sourceArchitectures, sourceFrameworks, out warningMessage);
 
-			// only "x86net45.dll" is the compatible source
+			// only "x64net45.exe" is the compatible source
 			Assert.AreEqual(1, compatibleSources.Count());
 			Assert.AreEqual(expected, warningMessage);
 		}
@@ -446,7 +446,7 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
 			sourceFrameworks["x86net45.dll"] = frameworkNet45;
 
 			string warningMessage = string.Empty;
-			var compatibleSources = InferRunSettingsHelper.FilterCompatibleSources(Constants.DefaultPlatform, Constants.DefaultPlatform, frameworkNet45, sourceArchitectures, sourceFrameworks, out warningMessage);
+			var compatibleSources = InferRunSettingsHelper.FilterCompatibleSources(Architecture.X86, Constants.DefaultPlatform, frameworkNet45, sourceArchitectures, sourceFrameworks, out warningMessage);
 
 			// only "x86net45.dll" is the compatible source
 			Assert.AreEqual(1, compatibleSources.Count());
@@ -460,7 +460,7 @@ namespace Microsoft.TestPlatform.Utilities.UnitTests
 			sourceFrameworks["x64net45.exe"] = frameworkNet45;
 
 			string warningMessage = string.Empty;
-			var compatibleSources = InferRunSettingsHelper.FilterCompatibleSources(Architecture.X64, Constants.DefaultPlatform, frameworkNet45, sourceArchitectures, sourceFrameworks, out warningMessage);
+			var compatibleSources = InferRunSettingsHelper.FilterCompatibleSources(Constants.DefaultPlatform, Constants.DefaultPlatform, frameworkNet45, sourceArchitectures, sourceFrameworks, out warningMessage);
 
 			Assert.IsTrue(string.IsNullOrEmpty(warningMessage));
 		}


### PR DESCRIPTION
## Description
Run in no isolation is decided based on the inferred architecture, and if the architecture is not the same it will offload to a host. vstest.console is now a 64-bit executable for the desktop case, so we need to non-x64 bit workloads outside of the executable.

