### PR TITLE
Blame fixes

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
@@ -222,11 +222,13 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                 this.processDumpUtility.DetachFromTargetProcess(this.testHostProcessId);
             }
 
+            var hangDumpSuccess = false;
             try
             {
                 Action<string> logWarning = m => this.logger.LogWarning(this.context.SessionDataCollectionContext, m);
                 var dumpDirectory = this.GetDumpDirectory();
                 this.processDumpUtility.StartHangBasedProcessDump(this.testHostProcessId, dumpDirectory, this.processFullDumpEnabled, this.targetFramework, logWarning);
+                hangDumpSuccess = true;
             }
             catch (Exception ex)
             {
@@ -237,7 +239,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
             {
                 try
                 {
-                    var dumpFiles = this.processDumpUtility.GetDumpFiles(false, true);
+                    var dumpFiles = this.processDumpUtility.GetDumpFiles(true, /* if we killed it by hang dumper, we already have our dump, otherwise it might have crashed, and we want all dumps */ !hangDumpSuccess);
                     foreach (var dumpFile in dumpFiles)
                     {
                         try

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/CrashDumperFactory.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/CrashDumperFactory.cs
@@ -6,6 +6,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
     using System;
     using System.Runtime.InteropServices;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+    using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
     using NuGet.Frameworks;
 
     internal class CrashDumperFactory : ICrashDumperFactory
@@ -52,13 +53,13 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                 }
 
                 EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework}, returning the .NETClient dumper which uses env variables to collect crashdumps of testhost and any child process.");
-                return new NetClientCrashDumper();
+                return new NetClientCrashDumper(new FileHelper());
             }
 
             if (isNet50OrNewer)
             {
                 EqtTrace.Info($"CrashDumperFactory: This is {RuntimeInformation.OSDescription} on {targetFramework} .NETClient dumper which uses env variables to collect crashdumps of testhost and any child process.");
-                return new NetClientCrashDumper();
+                return new NetClientCrashDumper(new FileHelper());
             }
 
             throw new PlatformNotSupportedException($"Unsupported operating system: {RuntimeInformation.OSDescription}, and framework: {targetFramework}.");

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/CrashDumperFactory.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/CrashDumperFactory.cs
@@ -35,7 +35,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                 if (!isNet50OrNewer)
                 {
                     EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework} which is not net5.0 or newer, returning ProcDumpCrashDumper that uses ProcDump utility.");
-                    return new ProcDumpCrashDumper();
+                    return new ProcDumpDumper();
                 }
 
                 // On net5.0 we don't have the capability to crash dump on exit, which is useful in rare cases
@@ -49,7 +49,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                 if (forceUsingProcdump)
                 {
                     EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework}. Forcing the use of ProcDumpCrashDumper that uses ProcDump utility, via VSTEST_DUMP_FORCEPROCDUMP={procdumpOverride}.");
-                    return new ProcDumpCrashDumper();
+                    return new ProcDumpDumper();
                 }
 
                 EqtTrace.Info($"CrashDumperFactory: This is Windows on {targetFramework}, returning the .NETClient dumper which uses env variables to collect crashdumps of testhost and any child process.");

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ICrashDumper.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ICrashDumper.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
 {
+    using System.Collections.Generic;
+
     public interface ICrashDumper
     {
         void AttachToTargetProcess(int processId, string outputDirectory, DumpTypeOption dumpType, bool collectAlways);
@@ -10,5 +12,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
         void WaitForDumpToFinish();
 
         void DetachFromTargetProcess(int processId);
+
+        IEnumerable<string> GetDumpFiles(bool processCrashed);
     }
 }

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Interfaces/IProcDumpArgsBuilder.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Interfaces/IProcDumpArgsBuilder.cs
@@ -22,11 +22,8 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
         /// <param name="isFullDump">
         /// Is full dump enabled
         /// </param>
-        /// <param name="collectAlways">
-        /// Collects the dump on process exit even when there is no exception
-        /// </param>
         /// <returns>Arguments</returns>
-        string BuildTriggerBasedProcDumpArgs(int processId, string filename, IEnumerable<string> procDumpExceptionsList, bool isFullDump, bool collectAlways);
+        string BuildTriggerBasedProcDumpArgs(int processId, string filename, IEnumerable<string> procDumpExceptionsList, bool isFullDump);
 
         /// <summary>
         /// Arguments for procdump.exe for getting a dump in case of a testhost hang

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Interfaces/IProcessDumpUtility.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Interfaces/IProcessDumpUtility.cs
@@ -12,10 +12,11 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
         /// Get generated dump files
         /// </summary>
         /// <param name="warnOnNoDumpFiles">Writes warning when no dump file is found.</param>
+        /// <param name="processCrashed">Process might have crashed. If true it crashed for sure. If false we don't know.</param>
         /// <returns>
         /// Path of dump file
         /// </returns>
-        IEnumerable<string> GetDumpFiles(bool warnOnNoDumpFiles = true);
+        IEnumerable<string> GetDumpFiles(bool warnOnNoDumpFiles, bool processCrashed);
 
         /// <summary>
         /// Launch proc dump process

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/NetClientCrashDumper.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/NetClientCrashDumper.cs
@@ -3,17 +3,37 @@
 
 namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
 {
+    using System.Collections.Generic;
+    using System.IO;
+    using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
+
     internal class NetClientCrashDumper : ICrashDumper
     {
+        private string outputDirectory;
+        private IFileHelper fileHelper;
+
+        public NetClientCrashDumper(IFileHelper fileHelper)
+        {
+            this.fileHelper = fileHelper;
+        }
+
         public void AttachToTargetProcess(int processId, string outputDirectory, DumpTypeOption dumpType, bool collectAlways)
         {
             // we don't need to do anything directly here, we setup the env variables
             // in the dumper configuration, including the path
+            this.outputDirectory = outputDirectory;
         }
 
         public void DetachFromTargetProcess(int processId)
         {
             // here we might consider renaming the files to have timestamp
+        }
+
+        public IEnumerable<string> GetDumpFiles(bool processCrashed)
+        {
+            return this.fileHelper.DirectoryExists(this.outputDirectory)
+               ? this.fileHelper.EnumerateFiles(this.outputDirectory, SearchOption.AllDirectories, new[] { ".dmp" })
+               : new List<string>();
         }
 
         public void WaitForDumpToFinish()

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/NetClientCrashDumper.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/NetClientCrashDumper.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
@@ -32,8 +33,8 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
         public IEnumerable<string> GetDumpFiles(bool processCrashed)
         {
             return this.fileHelper.DirectoryExists(this.outputDirectory)
-               ? this.fileHelper.EnumerateFiles(this.outputDirectory, SearchOption.AllDirectories, new[] { ".dmp" })
-               : new List<string>();
+               ? this.fileHelper.GetFiles(this.outputDirectory, "*_crashdump*.dmp", SearchOption.AllDirectories)
+               : Array.Empty<string>();
         }
 
         public void WaitForDumpToFinish()

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcDumpArgsBuilder.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcDumpArgsBuilder.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
 {
+    using System;
     using System.Collections.Generic;
     using System.Text;
 
@@ -23,7 +24,13 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
             // -ma: Full dump argument.
             // -f: Filter the exceptions.
             // Filter the first chance exceptions only to those that are most likely to kill the whole process.
-            StringBuilder procDumpArgument = new StringBuilder($"-accepteula -e 1 -g -t ");
+
+            // Fully override parameters to procdump
+            var procdumpArgumentsFromEnv = Environment.GetEnvironmentVariable("VSTEST_DUMP_PROCDUMPARGUMENTS")?.Trim();
+
+            // Useful additional arguments are -n 100, to collect all dumps that you can, or -o to overwrite dump, or -f EXCEPTION_NAME to add exception to filter list
+            var procdumpAdditonalArgumentsFromEnv = Environment.GetEnvironmentVariable("VSTEST_DUMP_PROCDUMPADDITIONALARGUMENTS")?.Trim();
+            StringBuilder procDumpArgument = new StringBuilder($"-accepteula -e 1 -g -t {procdumpAdditonalArgumentsFromEnv}");
             if (isFullDump)
             {
                 procDumpArgument.Append("-ma ");
@@ -35,7 +42,11 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
             }
 
             procDumpArgument.Append($"{processId} {filename}.dmp");
-            var argument = procDumpArgument.ToString();
+            var argument = string.IsNullOrWhiteSpace(procdumpArgumentsFromEnv) ? procDumpArgument.ToString() : procdumpArgumentsFromEnv;
+            if (!argument.ToUpperInvariant().Contains("-accepteula".ToUpperInvariant()))
+            {
+                argument = $"-accepteula {argument}";
+            }
 
             return argument;
         }

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcessDumpUtility.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcessDumpUtility.cs
@@ -58,16 +58,14 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
                 this.crashDumper.WaitForDumpToFinish();
             }
 
-            if (this.crashDumpDirectory == this.hangDumpDirectory)
-            {
-                throw new InvalidOperationException("Crash dump directory and hang dump directory should not be the same.");
-            }
-
-            IEnumerable<string> crashDumps = this.crashDumper.GetDumpFiles(processCrashed);
+            // If the process was hang dumped we killed it ourselves, so it crashed when executing tests,
+            // but we already have the hang dump, and should not also collect the exit dump that we got
+            // from killing the process by the hang dumper.
+            IEnumerable<string> crashDumps = this.crashDumper?.GetDumpFiles(!this.wasHangDumped && processCrashed) ?? new List<string>();
 
             IEnumerable<string> hangDumps = this.fileHelper.DirectoryExists(this.hangDumpDirectory)
-                ? this.fileHelper.EnumerateFiles(this.hangDumpDirectory, SearchOption.TopDirectoryOnly, new[] { ".dmp" })
-                : new List<string>();
+                ? this.fileHelper.GetFiles(this.hangDumpDirectory, "*_hangdump*.dmp", SearchOption.TopDirectoryOnly)
+                : Array.Empty<string>();
 
             var foundDumps = new List<string>();
             foreach (var dumpPath in crashDumps.Concat(hangDumps))

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcessDumpUtility.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcessDumpUtility.cs
@@ -51,16 +51,19 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
         };
 
         /// <inheritdoc/>
-        public IEnumerable<string> GetDumpFiles(bool warnOnNoDumpFiles = true)
+        public IEnumerable<string> GetDumpFiles(bool warnOnNoDumpFiles, bool processCrashed)
         {
             if (!this.wasHangDumped)
             {
                 this.crashDumper.WaitForDumpToFinish();
             }
 
-            IEnumerable<string> crashDumps = this.fileHelper.DirectoryExists(this.crashDumpDirectory)
-                ? this.fileHelper.EnumerateFiles(this.crashDumpDirectory, SearchOption.AllDirectories, new[] { ".dmp" })
-                : new List<string>();
+            if (this.crashDumpDirectory == this.hangDumpDirectory)
+            {
+                throw new InvalidOperationException("Crash dump directory and hang dump directory should not be the same.");
+            }
+
+            IEnumerable<string> crashDumps = this.crashDumper.GetDumpFiles(processCrashed);
 
             IEnumerable<string> hangDumps = this.fileHelper.DirectoryExists(this.hangDumpDirectory)
                 ? this.fileHelper.EnumerateFiles(this.hangDumpDirectory, SearchOption.TopDirectoryOnly, new[] { ".dmp" })

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcessDumpUtility.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcessDumpUtility.cs
@@ -61,7 +61,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector
             // If the process was hang dumped we killed it ourselves, so it crashed when executing tests,
             // but we already have the hang dump, and should not also collect the exit dump that we got
             // from killing the process by the hang dumper.
-            IEnumerable<string> crashDumps = this.crashDumper?.GetDumpFiles(!this.wasHangDumped && processCrashed) ?? new List<string>();
+            IEnumerable<string> crashDumps = this.crashDumper?.GetDumpFiles(processCrashed) ?? new List<string>();
 
             IEnumerable<string> hangDumps = this.fileHelper.DirectoryExists(this.hangDumpDirectory)
                 ? this.fileHelper.GetFiles(this.hangDumpDirectory, "*_hangdump*.dmp", SearchOption.TopDirectoryOnly)

--- a/src/vstest.console/Processors/EnableBlameArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnableBlameArgumentProcessor.cs
@@ -233,8 +233,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             if (enableCrashDump)
             {
                 var dumpParameters = collectDumpParameters
-                    .Where(p => new[] { "CollectAlways", "DumpType" }.Contains(p.Key))
-                    .ToDictionary(p => p.Key, p => p.Value);
+                    .Where(p => new[] { "CollectAlways", "DumpType" }.Contains(p.Key, StringComparer.OrdinalIgnoreCase))
+                    .ToDictionary(p => p.Key, p => p.Value, StringComparer.OrdinalIgnoreCase);
 
                 if (!dumpParameters.ContainsKey("DumpType"))
                 {
@@ -248,8 +248,8 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors
             if (enableHangDump)
             {
                 var hangDumpParameters = collectDumpParameters
-                    .Where(p => new[] { "TestTimeout", "HangDumpType" }.Contains(p.Key))
-                    .ToDictionary(p => p.Key, p => p.Value);
+                    .Where(p => new[] { "TestTimeout", "HangDumpType" }.Contains(p.Key, StringComparer.OrdinalIgnoreCase))
+                    .ToDictionary(p => p.Key, p => p.Value, StringComparer.OrdinalIgnoreCase);
 
                 if (!hangDumpParameters.ContainsKey("TestTimeout"))
                 {

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameCollectorTests.cs
@@ -367,7 +367,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 this.context);
 
             // Setup
-            this.mockProcessDumpUtility.Setup(x => x.GetDumpFiles(It.IsAny<bool>(), false)).Returns(new[] { this.filepath });
+            this.mockProcessDumpUtility.Setup(x => x.GetDumpFiles(It.IsAny<bool>(), It.IsAny<bool>())).Returns(new[] { this.filepath });
             this.mockBlameReaderWriter.Setup(x => x.WriteTestSequence(It.IsAny<List<Guid>>(), It.IsAny<Dictionary<Guid, BlameTestObject>>(), It.IsAny<string>()))
                 .Returns(this.filepath);
 
@@ -377,7 +377,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockDataColectionEvents.Raise(x => x.SessionEnd += null, new SessionEndEventArgs(this.dataCollectionContext));
 
             // Verify GetDumpFiles Call
-            this.mockProcessDumpUtility.Verify(x => x.GetDumpFiles(It.IsAny<bool>(), false), Times.Once);
+            this.mockProcessDumpUtility.Verify(x => x.GetDumpFiles(It.IsAny<bool>(), It.IsAny<bool>()), Times.Once);
         }
 
         /// <summary>
@@ -450,7 +450,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             // Setup and raise events
             this.mockBlameReaderWriter.Setup(x => x.WriteTestSequence(It.IsAny<List<Guid>>(), It.IsAny<Dictionary<Guid, BlameTestObject>>(), It.IsAny<string>()))
                 .Returns(this.filepath);
-            this.mockProcessDumpUtility.Setup(x => x.GetDumpFiles(true, false)).Throws(new FileNotFoundException());
+            this.mockProcessDumpUtility.Setup(x => x.GetDumpFiles(true, It.IsAny<bool>())).Throws(new FileNotFoundException());
             this.mockDataColectionEvents.Raise(x => x.TestHostLaunched += null, new TestHostLaunchedEventArgs(this.dataCollectionContext, 1234));
             this.mockDataColectionEvents.Raise(x => x.TestCaseStart += null, new TestCaseStartEventArgs(new TestCase()));
             this.mockDataColectionEvents.Raise(x => x.SessionEnd += null, new SessionEndEventArgs(this.dataCollectionContext));

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameCollectorTests.cs
@@ -173,7 +173,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockFileHelper.Setup(x => x.Exists(It.Is<string>(y => y == "abc_hang.dmp"))).Returns(true);
             this.mockFileHelper.Setup(x => x.GetFullPath(It.Is<string>(y => y == "abc_hang.dmp"))).Returns("abc_hang.dmp");
             this.mockProcessDumpUtility.Setup(x => x.StartHangBasedProcessDump(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<Action<string>>()));
-            this.mockProcessDumpUtility.Setup(x => x.GetDumpFiles(true)).Returns(new[] { dumpFile });
+            this.mockProcessDumpUtility.Setup(x => x.GetDumpFiles(true, false)).Returns(new[] { dumpFile });
             this.mockDataCollectionSink.Setup(x => x.SendFileAsync(It.IsAny<FileTransferInformation>())).Callback(() => hangBasedDumpcollected.Set());
 
             this.blameDataCollector.Initialize(
@@ -185,7 +185,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             hangBasedDumpcollected.Wait(1000);
             this.mockProcessDumpUtility.Verify(x => x.StartHangBasedProcessDump(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<Action<string>>()), Times.Once);
-            this.mockProcessDumpUtility.Verify(x => x.GetDumpFiles(true), Times.Once);
+            this.mockProcessDumpUtility.Verify(x => x.GetDumpFiles(true, false), Times.Once);
             this.mockDataCollectionSink.Verify(x => x.SendFileAsync(It.Is<FileTransferInformation>(y => y.Path == dumpFile)), Times.Once);
         }
 
@@ -207,7 +207,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockFileHelper.Setup(x => x.Exists(It.Is<string>(y => y == "abc_hang.dmp"))).Returns(true);
             this.mockFileHelper.Setup(x => x.GetFullPath(It.Is<string>(y => y == "abc_hang.dmp"))).Returns("abc_hang.dmp");
             this.mockProcessDumpUtility.Setup(x => x.StartHangBasedProcessDump(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<Action<string>>()));
-            this.mockProcessDumpUtility.Setup(x => x.GetDumpFiles(true)).Callback(() => hangBasedDumpcollected.Set()).Throws(new Exception("Some exception"));
+            this.mockProcessDumpUtility.Setup(x => x.GetDumpFiles(true, false)).Callback(() => hangBasedDumpcollected.Set()).Throws(new Exception("Some exception"));
 
             this.blameDataCollector.Initialize(
                 this.GetDumpConfigurationElement(false, false, true, 0),
@@ -218,7 +218,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             hangBasedDumpcollected.Wait(1000);
             this.mockProcessDumpUtility.Verify(x => x.StartHangBasedProcessDump(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<Action<string>>()), Times.Once);
-            this.mockProcessDumpUtility.Verify(x => x.GetDumpFiles(true), Times.Once);
+            this.mockProcessDumpUtility.Verify(x => x.GetDumpFiles(true, false), Times.Once);
         }
 
         /// <summary>
@@ -240,7 +240,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockFileHelper.Setup(x => x.Exists(It.Is<string>(y => y == "abc_hang.dmp"))).Returns(true);
             this.mockFileHelper.Setup(x => x.GetFullPath(It.Is<string>(y => y == "abc_hang.dmp"))).Returns("abc_hang.dmp");
             this.mockProcessDumpUtility.Setup(x => x.StartHangBasedProcessDump(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<Action<string>>()));
-            this.mockProcessDumpUtility.Setup(x => x.GetDumpFiles(true)).Returns(new[] { dumpFile });
+            this.mockProcessDumpUtility.Setup(x => x.GetDumpFiles(true, false)).Returns(new[] { dumpFile });
             this.mockDataCollectionSink.Setup(x => x.SendFileAsync(It.IsAny<FileTransferInformation>())).Callback(() => hangBasedDumpcollected.Set()).Throws(new Exception("Some other exception"));
 
             this.blameDataCollector.Initialize(
@@ -252,7 +252,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             hangBasedDumpcollected.Wait(1000);
             this.mockProcessDumpUtility.Verify(x => x.StartHangBasedProcessDump(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<Action<string>>()), Times.Once);
-            this.mockProcessDumpUtility.Verify(x => x.GetDumpFiles(true), Times.Once);
+            this.mockProcessDumpUtility.Verify(x => x.GetDumpFiles(true, false), Times.Once);
             this.mockDataCollectionSink.Verify(x => x.SendFileAsync(It.Is<FileTransferInformation>(y => y.Path == dumpFile)), Times.Once);
         }
 
@@ -367,7 +367,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 this.context);
 
             // Setup
-            this.mockProcessDumpUtility.Setup(x => x.GetDumpFiles(It.IsAny<bool>())).Returns(new[] { this.filepath });
+            this.mockProcessDumpUtility.Setup(x => x.GetDumpFiles(It.IsAny<bool>(), false)).Returns(new[] { this.filepath });
             this.mockBlameReaderWriter.Setup(x => x.WriteTestSequence(It.IsAny<List<Guid>>(), It.IsAny<Dictionary<Guid, BlameTestObject>>(), It.IsAny<string>()))
                 .Returns(this.filepath);
 
@@ -377,7 +377,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockDataColectionEvents.Raise(x => x.SessionEnd += null, new SessionEndEventArgs(this.dataCollectionContext));
 
             // Verify GetDumpFiles Call
-            this.mockProcessDumpUtility.Verify(x => x.GetDumpFiles(It.IsAny<bool>()), Times.Once);
+            this.mockProcessDumpUtility.Verify(x => x.GetDumpFiles(It.IsAny<bool>(), false), Times.Once);
         }
 
         /// <summary>
@@ -419,7 +419,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
                 this.context);
 
             // Setup
-            this.mockProcessDumpUtility.Setup(x => x.GetDumpFiles(true)).Returns(new[] { this.filepath });
+            this.mockProcessDumpUtility.Setup(x => x.GetDumpFiles(true, false)).Returns(new[] { this.filepath });
             this.mockBlameReaderWriter.Setup(x => x.WriteTestSequence(It.IsAny<List<Guid>>(), It.IsAny<Dictionary<Guid, BlameTestObject>>(), It.IsAny<string>()))
                 .Returns(this.filepath);
 
@@ -428,7 +428,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             this.mockDataColectionEvents.Raise(x => x.SessionEnd += null, new SessionEndEventArgs(this.dataCollectionContext));
 
             // Verify GetDumpFiles Call
-            this.mockProcessDumpUtility.Verify(x => x.GetDumpFiles(true), Times.Once);
+            this.mockProcessDumpUtility.Verify(x => x.GetDumpFiles(true, false), Times.Once);
         }
 
         /// <summary>
@@ -450,7 +450,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
             // Setup and raise events
             this.mockBlameReaderWriter.Setup(x => x.WriteTestSequence(It.IsAny<List<Guid>>(), It.IsAny<Dictionary<Guid, BlameTestObject>>(), It.IsAny<string>()))
                 .Returns(this.filepath);
-            this.mockProcessDumpUtility.Setup(x => x.GetDumpFiles(true)).Throws(new FileNotFoundException());
+            this.mockProcessDumpUtility.Setup(x => x.GetDumpFiles(true, false)).Throws(new FileNotFoundException());
             this.mockDataColectionEvents.Raise(x => x.TestHostLaunched += null, new TestHostLaunchedEventArgs(this.dataCollectionContext, 1234));
             this.mockDataColectionEvents.Raise(x => x.TestCaseStart += null, new TestCaseStartEventArgs(new TestCase()));
             this.mockDataColectionEvents.Raise(x => x.SessionEnd += null, new SessionEndEventArgs(this.dataCollectionContext));

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/ProcDumpArgsBuilderTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/ProcDumpArgsBuilderTests.cs
@@ -32,23 +32,23 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
         public void BuildTriggerBasedProcDumpArgsShouldCreateCorrectArgString()
         {
             var procDumpArgsBuilder = new ProcDumpArgsBuilder();
-            var argString = procDumpArgsBuilder.BuildTriggerBasedProcDumpArgs(this.defaultProcId, this.defaultDumpFileName, new List<string> { "a", "b" }, false, false);
-            Assert.AreEqual("-accepteula -e 1 -g -f a -f b 1234 dump.dmp", argString);
+            var argString = procDumpArgsBuilder.BuildTriggerBasedProcDumpArgs(this.defaultProcId, this.defaultDumpFileName, new List<string> { "a", "b" }, false);
+            Assert.AreEqual("-accepteula -e 1 -g -t -f a -f b 1234 dump.dmp", argString);
         }
 
         [TestMethod]
         public void BuildTriggerProcDumpArgsWithFullDumpEnabledShouldCreateCorrectArgString()
         {
             var procDumpArgsBuilder = new ProcDumpArgsBuilder();
-            var argString = procDumpArgsBuilder.BuildTriggerBasedProcDumpArgs(this.defaultProcId, this.defaultDumpFileName, new List<string> { "a", "b" }, true, false);
-            Assert.AreEqual("-accepteula -e 1 -g -ma -f a -f b 1234 dump.dmp", argString);
+            var argString = procDumpArgsBuilder.BuildTriggerBasedProcDumpArgs(this.defaultProcId, this.defaultDumpFileName, new List<string> { "a", "b" }, true);
+            Assert.AreEqual("-accepteula -e 1 -g -t -ma -f a -f b 1234 dump.dmp", argString);
         }
 
         [TestMethod]
         public void BuildTriggerProcDumpArgsWithAlwaysCollectShouldCreateCorrectArgString()
         {
             var procDumpArgsBuilder = new ProcDumpArgsBuilder();
-            var argString = procDumpArgsBuilder.BuildTriggerBasedProcDumpArgs(this.defaultProcId, this.defaultDumpFileName, new List<string> { "a", "b" }, true, collectAlways: true);
+            var argString = procDumpArgsBuilder.BuildTriggerBasedProcDumpArgs(this.defaultProcId, this.defaultDumpFileName, new List<string> { "a", "b" }, true);
 
             // adds -t for collect on every process exit
             Assert.AreEqual("-accepteula -e 1 -g -t -ma -f a -f b 1234 dump.dmp", argString);

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/ProcessDumpUtilityTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/ProcessDumpUtilityTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             processDumpUtility.StartTriggerBasedProcessDump(processId, testResultsDirectory, false, ".NETCoreApp,Version=v5.0", false);
 
-            var ex = Assert.ThrowsException<FileNotFoundException>(() => processDumpUtility.GetDumpFiles(false, false));
+            var ex = Assert.ThrowsException<FileNotFoundException>(() => processDumpUtility.GetDumpFiles(true, false));
             Assert.AreEqual(ex.Message, Resources.Resources.DumpFileNotGeneratedErrorMessage);
         }
     }

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/ProcessDumpUtilityTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/ProcessDumpUtilityTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests
 
             processDumpUtility.StartTriggerBasedProcessDump(processId, testResultsDirectory, false, ".NETCoreApp,Version=v5.0", false);
 
-            var ex = Assert.ThrowsException<FileNotFoundException>(() => processDumpUtility.GetDumpFiles());
+            var ex = Assert.ThrowsException<FileNotFoundException>(() => processDumpUtility.GetDumpFiles(false, false));
             Assert.AreEqual(ex.Message, Resources.Resources.DumpFileNotGeneratedErrorMessage);
         }
     }


### PR DESCRIPTION
## Description
Fix few issues with Blame collector. 

1) Crash collector was catching FailFast because in the past it was done by always collecting the dump, and only sending it back when user enabled AlwaysCollect. With the new approach where crashes can produce multiple dumps, including dumps from child processes we can't really tell if the process crashed or exited normally. So I am using the test count to determine if the testhost crashed while executing tests. It would definitely be nicer to get a message with the actual exit status after testhost exits, but that would mean extending the IDataCollector interface, which needs to be done with a bit more thinking. 

The native .NET Crash monitor still don't seem to catch FailFast, but there is internal option `VSTEST_DUMP_FORCEPROCDUMP=1` that forces the use of ProcDump even where the built it net dump would be used. 

2) This now also applies the hang dumps, because on some systems the PInvoke I do to not need ProcDump throws AccessViolationException, so this is a way to force that to use ProcDump. 

3) There is also `VSTEST_DUMP_FORCENETDUMP=1` internal option which is forcing the net dumper to be used on Windows so we can test it a bit better.

4) I also added `VSTEST_DUMP_PROCDUMPARGUMENTS` and `VSTEST_DUMP_PROCDUMPADDITIONALARGUMENTS` internal option to fully or partially override what arguments procdump will use, because I found it quite useful when debugging crashes. And there is sadly no way to collect both "managed" and "native" dumps at the same time. So when I can't really see the crash I need to change how proc dump runs a lot.

Not sure how to fix this properly without relying on those internal env variables to set the dumpers. Maybe I could try looking if procdump can be found when on windows and try using that, otherwise try the other dumpers based on the platform. 

## Related issue
Workaround for #3005 by using `VSTEST_DUMP_FORCEPROCDUMP=1`
Workaround for https://github.com/dotnet/sdk/issues/14578#issuecomment-910168503 also by using `VSTEST_DUMP_FORCEPROCDUMP=1`


Easiest way to install procdump is by using this task: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/test/vstest?view=azure-devops
 
Easiest way to deploy latest version of TestPlatform is by using this task: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/vstest-platform-tool-installer?view=azure-devops 
