### PR TITLE
[ArPow] Use --work-tree with git apply

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <Exec
-      Command="git apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
+      Command="git --work-tree=$(InnerSourceBuildRepoRoot) apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
       WorkingDirectory="$(InnerSourceBuildRepoRoot)"
       Condition="'@(SourceBuildPatchFile)' != ''" />
   </Target>


### PR DESCRIPTION
## Description

This makes things work better in a source-tarball build, where there may be a .git directory somewhere in our parent directories but it's for a different repo than vstest. In a situation like that a plain `git apply` will (silently!) ignore patches because they wont apply to the unrelated repository. That will (eventually) make the source-build fail. `--work-tree` makes git directly use the directory that we care about.

## Related issue

See https://github.com/dotnet/source-build/issues/2445 for more details.
