### PR TITLE
Exclude externals when building from source

### DIFF
--- a/src/package/external/external.csproj
+++ b/src/package/external/external.csproj
@@ -29,7 +29,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(DotNetBuildFromSource)' != 'true' ">
     <!-- This csproj restore external tools required for build process -->
     <PackageReference Include="NuGet.CommandLine" Version="5.8.1" PrivateAssets="All" />
     <PackageReference Include="fmdev.xlftool" Version="0.1.3" PrivateAssets="All" />


### PR DESCRIPTION
## Description
Excludes a group of unneeded external package references when building from source.

## Related issue
https://github.com/dotnet/installer/pull/11980
