### PR TITLE
Update vmImage ci for deprecation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ jobs:
 - job: Windows
   timeoutInMinutes: 120
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
   variables:
     buildConfiguration: 'Release'
   steps:
@@ -50,7 +50,7 @@ jobs:
   dependsOn: Windows
   timeoutInMinutes: 120
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
   variables:
     buildConfiguration: 'Release'
   steps:


### PR DESCRIPTION
windows-2016 will be deprecated soon.

```
##[warning]The windows-2016 environment will be deprecated on November 15, 2021, and removed on March 15, 2022. Migrate to windows-latest instead. For more details see https://github.com/actions/virtual-environments/issues/4312
```

https://github.com/actions/virtual-environments#available-environments