### PR TITLE
Remove TargetPlatform before start test host

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -380,6 +380,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client
                 updatedRunSettingsXml = InferRunSettingsHelper.MakeRunsettingsCompatible(runsettingsXml);
             }
 
+            // We can remove "TargetPlatform" because is not needed, process is already in a "specific" target platform after test host process start,
+            // so the default architecture is always the correct one.
+            // This allow us to support new architecture enumeration without the need to update old test sdk.
+            updatedRunSettingsXml = InferRunSettingsHelper.RemoveTargetPlatformElement(updatedRunSettingsXml);
+
             return updatedRunSettingsXml;
         }
 

--- a/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities
             return MakeRunsettingsCompatible(runsettingsXml, listOfValidRunConfigurationSettings, null);
         }
 
-        internal static string MakeRunsettingsCompatible(string runsettingsXml, HashSet<string> listOfValidRunConfigurationSettings, HashSet<string> listOfInValidRunConfigurationSettings)
+        private static string MakeRunsettingsCompatible(string runsettingsXml, HashSet<string> listOfValidRunConfigurationSettings, HashSet<string> listOfInValidRunConfigurationSettings)
         {
             var updatedRunSettingsXml = runsettingsXml;
 


### PR DESCRIPTION
Remove TargetPlatform before start test host to support dotnet sdk 6.0.2/7.0 with old test sdk(<17.0.1).