### PR TITLE
Change target framework for source-build

### DIFF
--- a/src/package/nuspec/Microsoft.TestPlatform.Build.csproj
+++ b/src/package/nuspec/Microsoft.TestPlatform.Build.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework Condition=" '$(DotNetBuildFromSource)' != 'true' ">netcoreapp1.0</TargetFramework>
+    <TargetFramework Condition=" '$(DotNetBuildFromSource)' == 'true' ">net6.0</TargetFramework>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <NuspecFile>TestPlatform.Build.nuspec</NuspecFile>
     <NuspecProperties>version=$(Version)</NuspecProperties>

--- a/src/package/nuspec/Microsoft.TestPlatform.CLI.csproj
+++ b/src/package/nuspec/Microsoft.TestPlatform.CLI.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework Condition=" '$(DotNetBuildFromSource)' != 'true' ">netcoreapp1.0</TargetFramework>
+    <TargetFramework Condition=" '$(DotNetBuildFromSource)' == 'true' ">net6.0</TargetFramework>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <NuspecFile>TestPlatform.CLI.nuspec</NuspecFile>
     <NuspecProperties>version=$(Version)</NuspecProperties>


### PR DESCRIPTION
related to https://github.com/dotnet/source-build/issues/2626

This PR reverts two changes made with https://github.com/microsoft/vstest/pull/3077 which introduces prebuilts into source-build.
