### PR TITLE
Improve AttachVS gem output

### DIFF
--- a/src/AttachVS/AttachVs.cs
+++ b/src/AttachVS/AttachVs.cs
@@ -15,13 +15,13 @@ namespace Microsoft.TestPlatform.AttachVS
         {
             try
             {
-                Trace($"Starting with pid '{pid}', and vsPid '{vsPid}'");
                 if (pid == null)
                 {
                     Trace($"FAIL: Pid is null.");
                     return false;
                 }
                 var process = Process.GetProcessById(pid.Value);
+                Trace($"Starting with pid '{pid}({process?.ProcessName})', and vsPid '{vsPid}'");
                 Trace($"Using pid: {pid} to get parent VS.");
                 var vs = GetVsFromPid(Process.GetProcessById(vsPid ?? process.Id));
 
@@ -266,7 +266,7 @@ namespace Microsoft.TestPlatform.AttachVS
 
         private static void Trace(string message, [CallerMemberName] string methodName = null)
         {
-            System.Diagnostics.Trace.WriteLine($"{methodName}: {message}");
+            System.Diagnostics.Trace.WriteLine($"[AttachVS]{methodName}: {message}");
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/AttachVS/Program.cs
+++ b/src/AttachVS/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Microsoft.TestPlatform.AttachVS
@@ -7,6 +8,8 @@ namespace Microsoft.TestPlatform.AttachVS
     {
         static void Main(string[] args)
         {
+            Trace.Listeners.Add(new ConsoleTraceListener());
+
             int? pid = ParsePid(args, position: 0);
             int? vsPid = ParsePid(args, position: 1);
 


### PR DESCRIPTION
I found useful have some output to understand if everything is good.

Let me know @nohwnd 

We could ship this gem as nuget+source file with `DebuggerHelper.AttachVisualStudioDebugger(string environmentVariable)`, inner loop for a project that spawns processes would be straightforward to debug(easier than https://devblogs.microsoft.com/devops/introducing-the-child-process-debugging-power-tool/ here we can jump into new repo/vs instance), I'm using it also with TE(I will propose `AttachVisualStudioDebugger` also there for our stuff) and it's a bit "magic" put bp on datacollector process and that's all 💘 💘 💘 

<img width="616" alt="image" src="https://user-images.githubusercontent.com/7894084/147383830-5e5f3ea4-553c-4177-ac39-0cc27d24ffda.png">
