### PR TITLE
Update system.net.http to 4.3.4 for uap10

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj
+++ b/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj
@@ -65,6 +65,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'uap10.0'">
 	<PackageReference Include="NETStandard.Library" Version="1.6.0" />
+	<PackageReference Include="System.Net.Http" Version="4.3.4" />
 	<PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
 	<PackageReference Include="System.Xml.XPath" Version="4.0.1" />
 	<PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.0.1" />


### PR DESCRIPTION
## Description

Update system.net.http from 4.1.0 to 4.3.4 when netstandard 1.6 is used

## Related issue
