### PR TITLE
Fix change done in commit a223146b8c3d5dbbf7bae49149aed762560434c4

### DIFF
--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -55,7 +55,7 @@
   -->
   <Choose>
     <!-- Use relative path between the project and the root to avoid including the analyzer if the path above the root contains 'src' (e.g. C:\src\vstest). -->
-    <When Condition="$([MSBuild]::MakeRelative($(TestPlatformRoot), $(MSBuildProjectFullPath)).Contains('/src/')) OR $([MSBuild]::MakeRelative($(TestPlatformRoot), $(MSBuildProjectFullPath)).Contains('\src\'))">
+    <When Condition="$([MSBuild]::MakeRelative($(TestPlatformRoot), $(MSBuildProjectFullPath)).StartsWith('src/')) OR $([MSBuild]::MakeRelative($(TestPlatformRoot), $(MSBuildProjectFullPath)).StartsWith('src\'))">
       <ItemGroup>
         <!-- We normally don't build against net6.0, so the public api analyzer errors would only appear in CI pipeline. -->
         <PackageReference Condition=" '$(DotNetBuildFromSource)' != 'true' " Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(RoslynPublicApiAnalyzersVersion)">


### PR DESCRIPTION
## Description

For some reason, the analyzer was still shown in VS while the condition was broken... The relative path gives us a path that doesn't starts with '/' or '\'  so the condition looking for '/src' or '\src' was always false. I removed the first '/' or '\' and updated the condition to be starts with instead of contains as we are now sure to always look from the root folder of the repo.
