### PR TITLE
Favor async/await pattern over .Result for acceptance tests

### DIFF
--- a/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/ExecutionTests.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
     using System;
     using System.IO;
     using System.Threading;
-
+    using System.Threading.Tasks;
     using global::TestPlatform.TestUtilities;
 
     using Microsoft.TestPlatform.TestUtilities;
@@ -56,7 +56,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         [NetFullTargetFrameworkDataSource]
         [NetCoreTargetFrameworkDataSource]
         [DoNotParallelize]
-        public void RunMultipleTestAssembliesInParallel(RunnerInfo runnerInfo)
+        public async Task RunMultipleTestAssembliesInParallel(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
             var resultsDir = GetResultsDirectory();
@@ -74,7 +74,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             var testhostProcessNames = new[] { "testhost.x86", "dotnet" };
 
             var cts = new CancellationTokenSource();
-            var numOfProcessCreatedTask = NumberOfProcessLaunchedUtility.NumberOfProcessCreated(
+            var numOfProcessCreatedTask = await NumberOfProcessLaunchedUtility.NumberOfProcessCreated(
                 cts,
                 testhostProcessNames);
 
@@ -83,8 +83,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             cts.Cancel();
             Assert.AreEqual(
                 expectedNumOfProcessCreated,
-                numOfProcessCreatedTask.Result.Count,
-                $"Number of {testhostProcessName} process created, expected: {expectedNumOfProcessCreated} actual: {numOfProcessCreatedTask.Result.Count} ({ string.Join(", ", numOfProcessCreatedTask.Result) })");
+                numOfProcessCreatedTask.Count,
+                $"Number of {testhostProcessName} process created, expected: {expectedNumOfProcessCreated} actual: {numOfProcessCreatedTask.Count} ({ string.Join(", ", numOfProcessCreatedTask) })");
             this.ValidateSummaryStatus(2, 2, 2);
             this.ExitCodeEquals(1); // failing tests
             TryRemoveDirectory(resultsDir);

--- a/test/Microsoft.TestPlatform.AcceptanceTests/PlatformTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/PlatformTests.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.TestPlatform.AcceptanceTests
 {
     using System.Threading;
-
+    using System.Threading.Tasks;
     using global::TestPlatform.TestUtilities;
 
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -20,12 +20,12 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         [TestMethod]
         [NetFullTargetFrameworkDataSource]
         [NetCoreTargetFrameworkDataSource]
-        public void RunTestExecutionWithPlatformx64(RunnerInfo runnerInfo)
+        public async Task RunTestExecutionWithPlatformx64(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
 
             var platformArg = " /Platform:x64";
-            this.RunTestExecutionWithPlatform(platformArg, "testhost", 1);
+            await RunTestExecutionWithPlatform(platformArg, "testhost", 1);
         }
 
         /// <summary>
@@ -34,12 +34,12 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         [TestMethod]
         [NetFullTargetFrameworkDataSource]
         [NetCoreTargetFrameworkDataSource]
-        public void RunTestExecutionWithPlatformx86(RunnerInfo runnerInfo)
+        public async Task RunTestExecutionWithPlatformx86(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
 
             var platformArg = " /Platform:x86";
-            this.RunTestExecutionWithPlatform(platformArg, "testhost.x86", 1);
+            await RunTestExecutionWithPlatform(platformArg, "testhost.x86", 1);
         }
 
         private void SetExpectedParams(ref int expectedNumOfProcessCreated, ref string testhostProcessName, string desktopHostProcessName)
@@ -48,7 +48,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             expectedNumOfProcessCreated = 1;
         }
 
-        private void RunTestExecutionWithPlatform(string platformArg, string testhostProcessName, int expectedNumOfProcessCreated)
+        private async Task RunTestExecutionWithPlatform(string platformArg, string testhostProcessName, int expectedNumOfProcessCreated)
         {
             var resultsDir = GetResultsDirectory();
 
@@ -60,7 +60,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             arguments = string.Concat(arguments, platformArg);
 
             var cts = new CancellationTokenSource();
-            var numOfProcessCreatedTask = NumberOfProcessLaunchedUtility.NumberOfProcessCreated(
+            var numOfProcessCreatedTask = await NumberOfProcessLaunchedUtility.NumberOfProcessCreated(
                 cts,
                 testhostProcessName);
 
@@ -70,8 +70,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests
 
             Assert.AreEqual(
                 expectedNumOfProcessCreated,
-                numOfProcessCreatedTask.Result.Count,
-                $"Number of {testhostProcessName} process created, expected: {expectedNumOfProcessCreated} actual: {numOfProcessCreatedTask.Result.Count} ({ string.Join(", ", numOfProcessCreatedTask.Result) }) args: {arguments} runner path: {this.GetConsoleRunnerPath()}");
+                numOfProcessCreatedTask.Count,
+                $"Number of {testhostProcessName} process created, expected: {expectedNumOfProcessCreated} actual: {numOfProcessCreatedTask.Count} ({ string.Join(", ", numOfProcessCreatedTask) }) args: {arguments} runner path: {this.GetConsoleRunnerPath()}");
             this.ValidateSummaryStatus(1, 1, 1);
             TryRemoveDirectory(resultsDir);
         }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/RunsettingsTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/RunsettingsTests.cs
@@ -7,7 +7,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
     using System.Collections.Generic;
     using System.IO;
     using System.Threading;
-
+    using System.Threading.Tasks;
     using global::TestPlatform.TestUtilities;
 
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -35,7 +35,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         [TestMethod]
         [NetFullTargetFrameworkDataSource]
         [NetCoreTargetFrameworkDataSource]
-        public void CommandLineRunSettingsShouldWinAmongAllOptions(RunnerInfo runnerInfo)
+        public async Task CommandLineRunSettingsShouldWinAmongAllOptions(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
 
@@ -63,16 +63,16 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                         string.Concat("RunConfiguration.TestAdaptersPaths=" , this.GetTestAdapterPath())
                     });
 
-            this.RunTestWithRunSettings(runConfigurationDictionary, runSettingsArgs, additionalArgs, testhostProcessName, expectedNumOfProcessCreated);
+            await this.RunTestWithRunSettings(runConfigurationDictionary, runSettingsArgs, additionalArgs, testhostProcessName, expectedNumOfProcessCreated);
         }
 
         /// <summary>
-        /// Command line run settings should have high precedence btween cli runsettings and cli switches.
+        /// Command line run settings should have high precedence between cli runsettings and cli switches.
         /// </summary>
         [TestMethod]
         [NetFullTargetFrameworkDataSource]
         [NetCoreTargetFrameworkDataSource]
-        public void CLIRunsettingsShouldWinBetweenCLISwitchesAndCLIRunsettings(RunnerInfo runnerInfo)
+        public async Task CLIRunsettingsShouldWinBetweenCLISwitchesAndCLIRunsettings(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
 
@@ -94,7 +94,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                         string.Concat("RunConfiguration.TestAdaptersPaths=" , this.GetTestAdapterPath())
                     });
 
-            this.RunTestWithRunSettings(null, runSettingsArgs, additionalArgs, testhostProcessName, expectedNumOfProcessCreated);
+            await this.RunTestWithRunSettings(null, runSettingsArgs, additionalArgs, testhostProcessName, expectedNumOfProcessCreated);
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         [TestMethod]
         [NetFullTargetFrameworkDataSource]
         [NetCoreTargetFrameworkDataSource]
-        public void CommandLineSwitchesShouldWinBetweenSettingsFileAndCommandLineSwitches(RunnerInfo runnerInfo)
+        public async Task CommandLineSwitchesShouldWinBetweenSettingsFileAndCommandLineSwitches(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
 
@@ -123,7 +123,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                                                  };
             var additionalArgs = "/Platform:x86";
 
-            this.RunTestWithRunSettings(runConfigurationDictionary, null, additionalArgs, testhostProcessName, expectedNumOfProcessCreated);
+            await this.RunTestWithRunSettings(runConfigurationDictionary, null, additionalArgs, testhostProcessName, expectedNumOfProcessCreated);
         }
 
         #endregion
@@ -131,7 +131,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
         [TestMethod]
         [NetFullTargetFrameworkDataSource]
         [NetCoreTargetFrameworkDataSource]
-        public void RunSettingsWithoutParallelAndPlatformX86(RunnerInfo runnerInfo)
+        public async Task RunSettingsWithoutParallelAndPlatformX86(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
 
@@ -146,13 +146,13 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                                                          { "TargetFrameworkVersion", this.GetTargetFramworkForRunsettings() },
                                                          { "TestAdaptersPaths", this.GetTestAdapterPath() }
                                                  };
-            this.RunTestWithRunSettings(runConfigurationDictionary, null, null, testhostProcessNames, expectedNumOfProcessCreated);
+            await this.RunTestWithRunSettings(runConfigurationDictionary, null, null, testhostProcessNames, expectedNumOfProcessCreated);
         }
 
         [TestMethod]
         [NetFullTargetFrameworkDataSource]
         [NetCoreTargetFrameworkDataSource]
-        public void RunSettingsParamsAsArguments(RunnerInfo runnerInfo)
+        public async Task RunSettingsParamsAsArguments(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
 
@@ -170,13 +170,13 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                         string.Concat("RunConfiguration.TestAdaptersPaths=" , this.GetTestAdapterPath())
                     });
 
-            this.RunTestWithRunSettings(null, runSettingsArgs, null, testhostProcessName, expectedNumOfProcessCreated);
+            await this.RunTestWithRunSettings(null, runSettingsArgs, null, testhostProcessName, expectedNumOfProcessCreated);
         }
 
         [TestMethod]
         [NetFullTargetFrameworkDataSource]
         [NetCoreTargetFrameworkDataSource]
-        public void RunSettingsAndRunSettingsParamsAsArguments(RunnerInfo runnerInfo)
+        public async Task RunSettingsAndRunSettingsParamsAsArguments(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
 
@@ -201,13 +201,13 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                         string.Concat("RunConfiguration.TestAdaptersPaths=" , this.GetTestAdapterPath())
                     });
 
-            this.RunTestWithRunSettings(runConfigurationDictionary, runSettingsArgs, null, testhostProcessName, expectedNumOfProcessCreated);
+            await this.RunTestWithRunSettings(runConfigurationDictionary, runSettingsArgs, null, testhostProcessName, expectedNumOfProcessCreated);
         }
 
         [TestMethod]
         [NetFullTargetFrameworkDataSource]
         [NetCoreTargetFrameworkDataSource]
-        public void RunSettingsWithParallelAndPlatformX64(RunnerInfo runnerInfo)
+        public async Task RunSettingsWithParallelAndPlatformX64(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
 
@@ -228,7 +228,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
                                                          { "TargetFrameworkVersion", this.GetTargetFramworkForRunsettings()},
                                                          { "TestAdaptersPaths", this.GetTestAdapterPath() }
                                                  };
-            this.RunTestWithRunSettings(runConfigurationDictionary, null, null, testhostProcessName, expectedProcessCreated);
+            await this.RunTestWithRunSettings(runConfigurationDictionary, null, null, testhostProcessName, expectedProcessCreated);
         }
 
         [TestMethod]
@@ -546,7 +546,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             return runsettingsPath;
         }
 
-        private void RunTestWithRunSettings(Dictionary<string, string> runConfigurationDictionary,
+        private async Task RunTestWithRunSettings(Dictionary<string, string> runConfigurationDictionary,
             string runSettingsArgs, string additionalArgs, IEnumerable<string> testhostProcessNames, int expectedNumOfProcessCreated)
         {
             var resultsDir = GetResultsDirectory();
@@ -574,14 +574,14 @@ namespace Microsoft.TestPlatform.AcceptanceTests
             }
 
             var cts = new CancellationTokenSource();
-            var numOfProcessCreatedTask = NumberOfProcessLaunchedUtility.NumberOfProcessCreated(
+            var numOfProcessCreatedTask = await NumberOfProcessLaunchedUtility.NumberOfProcessCreated(
                 cts,
                 testhostProcessNames);
 
             this.InvokeVsTest(arguments);
             cts.Cancel();
 
-            var processesCreated = numOfProcessCreatedTask.Result;
+            var processesCreated = numOfProcessCreatedTask;
             // assert
             Assert.AreEqual(
                 expectedNumOfProcessCreated,

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/RunTestsWithDifferentConfigurationTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/RunTestsWithDifferentConfigurationTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
     using System.Linq;
     using System.Text;
     using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// The Run Tests using VsTestConsoleWrapper API's
@@ -64,7 +65,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
         [TestMethod]
         [NetFullTargetFrameworkDataSource]
         [NetCoreTargetFrameworkDataSource]
-        public void RunTestsWithRunSettingsWithParallel(RunnerInfo runnerInfo)
+        public async Task RunTestsWithRunSettingsWithParallel(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
             this.Setup();
@@ -81,7 +82,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
             int expectedNumOfProcessCreated = 2;
 
             var cts = new CancellationTokenSource();
-            var numOfProcessCreatedTask = NumberOfProcessLaunchedUtility.NumberOfProcessCreated(
+            var numOfProcessCreatedTask = await NumberOfProcessLaunchedUtility.NumberOfProcessCreated(
                 cts,
                 testHostNames);
 
@@ -100,8 +101,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
             Assert.AreEqual(2, this.runEventHandler.TestResults.Count(t => t.Outcome == TestOutcome.Skipped));
             Assert.AreEqual(
                 expectedNumOfProcessCreated,
-                numOfProcessCreatedTask.Result.Count,
-                $"Number of '{ string.Join(", ", testHostNames) }' process created, expected: {expectedNumOfProcessCreated} actual: {numOfProcessCreatedTask.Result.Count} ({ string.Join(", ", numOfProcessCreatedTask.Result) })");
+                numOfProcessCreatedTask.Count,
+                $"Number of '{ string.Join(", ", testHostNames) }' process created, expected: {expectedNumOfProcessCreated} actual: {numOfProcessCreatedTask.Count} ({ string.Join(", ", numOfProcessCreatedTask) })");
         }
 
         [TestMethod]
@@ -140,7 +141,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
         [TestMethod]
         [NetFullTargetFrameworkDataSource]
         [NetCoreTargetFrameworkDataSource]
-        public void RunTestsWithX64Source(RunnerInfo runnerInfo)
+        public async Task RunTestsWithX64Source(RunnerInfo runnerInfo)
         {
             AcceptanceTestBase.SetTestEnvironment(this.testEnvironment, runnerInfo);
             this.Setup();
@@ -155,7 +156,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
             var testhostProcessNames = new[] { "testhost", "dotnet" };
 
             var cts = new CancellationTokenSource();
-            var numOfProcessCreatedTask = NumberOfProcessLaunchedUtility.NumberOfProcessCreated(
+            var numOfProcessCreatedTask = await NumberOfProcessLaunchedUtility.NumberOfProcessCreated(
                 cts, testhostProcessNames);
 
             this.vstestConsoleWrapper.RunTests(
@@ -169,7 +170,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests.TranslationLayerTests
             // Assert
             Assert.AreEqual(1, this.runEventHandler.TestResults.Count);
             Assert.AreEqual(1, this.runEventHandler.TestResults.Count(t => t.Outcome == TestOutcome.Passed));
-            var numberOfProcessCreated = numOfProcessCreatedTask.Result;
+            var numberOfProcessCreated = numOfProcessCreatedTask;
             Assert.AreEqual(
                 expectedNumOfProcessCreated,
                 numberOfProcessCreated.Count,


### PR DESCRIPTION
## Description

Ensure acceptance tests favor async/await pattern over .Result