### PR TITLE
Migrating to 1ES Hosted Pools

### DIFF
--- a/eng/validate-sdk.yml
+++ b/eng/validate-sdk.yml
@@ -19,8 +19,12 @@ jobs:
           name: Logs_ValidateSdk_Windows_NT_Release
     timeoutInMinutes: 90
     pool:
-      name: NetCoreInternal-Pool
-      queue: BuildPool.Windows.10.Amd64.VS2017
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        name: NetCore1ESPool-Public
+        demands: ImageOverride -equals build.windows.10.amd64.vs2019.open
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals build.windows.10.amd64.vs2019
     variables:
     - group: DotNet-Blob-Feed
     - group: Publish-Build-Assets


### PR DESCRIPTION
We will officially be decommissioning the arcade build pools (aka NetCore[Public|Internal]-Pool). This will switch our repo to 1ES hosted pools.