### PR TITLE
Remove formatting changes from git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Apply modern code styles (#3264)
+commit 065f4d042e2ac8f1bd28deeabca38adf2c14b52a


### PR DESCRIPTION
## Description
Remove formatting changes from git blame by using, `git blame --ignore-revs-file .git-blame-ignore-revs`. Using the de-facto standard naming, so this will be picked up by GitHub once they support it.
