### PR TITLE
Add Architecture.S390x

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/Architecture.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Architecture.cs
@@ -11,4 +11,5 @@ public enum Architecture
     ARM,
     AnyCPU,
     ARM64,
+    S390x
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
@@ -106,6 +106,7 @@ Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter.TestPlatformFormatExcept
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter.TestPlatformFormatException.TestPlatformFormatException(string message, string filterValue) -> void
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter.TestPlatformFormatException.TestPlatformFormatException(string message, System.Exception innerException) -> void
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
+Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.S390x = 6 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.ARM64 = 5 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.AnyCPU = 4 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.ARM = 3 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -624,7 +624,7 @@ internal class TestRequestManager : ITestRequestManager
                 // We want to find 64-bit SDK because it is more likely to be installed.
                 defaultArchitecture = Environment.Is64BitOperatingSystem ? Architecture.X64 : Architecture.X86;
 #endif
-                EqtTrace.Verbose($"Default architecture: {defaultArchitecture} IsDefaultTargetArchitecture: {RunSettingsHelper.Instance.IsDefaultTargetArchitecture}, Current process architecture: {_processHelper.GetCurrentProcessArchitecture()}.");
+                EqtTrace.Verbose($"TestRequestManager.UpdateRunSettingsIfRequired: Default architecture: {defaultArchitecture} IsDefaultTargetArchitecture: {RunSettingsHelper.Instance.IsDefaultTargetArchitecture}, Current process architecture: {_processHelper.GetCurrentProcessArchitecture()}.");
             }
 
             settingsUpdated |= UpdatePlatform(
@@ -667,6 +667,7 @@ internal class TestRequestManager : ITestRequestManager
                 case PlatformArchitecture.S390x:
                     return Architecture.S390x;
                 default:
+                    EqtTrace.Error($"TestRequestManager.TranslateToArchitecture: Unhandled architecture '{targetArchitecture}'.");
                     break;
             }
 

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -664,11 +664,13 @@ internal class TestRequestManager : ITestRequestManager
                     return Architecture.ARM;
                 case PlatformArchitecture.ARM64:
                     return Architecture.ARM64;
+                case PlatformArchitecture.S390x:
+                    return Architecture.S390x;
                 default:
                     break;
             }
 
-            throw new TestPlatformException($"Invalid target architecture '{targetArchitecture}'");
+            return Architecture.Default;
         }
 #endif
     }

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -624,7 +624,7 @@ internal class TestRequestManager : ITestRequestManager
                 // We want to find 64-bit SDK because it is more likely to be installed.
                 defaultArchitecture = Environment.Is64BitOperatingSystem ? Architecture.X64 : Architecture.X86;
 #endif
-                EqtTrace.Verbose($"Default architecture: {defaultArchitecture} IsDefaultTargetArchitecture: {RunSettingsHelper.Instance.IsDefaultTargetArchitecture} Current process architecture: {_processHelper.GetCurrentProcessArchitecture()}");
+                EqtTrace.Verbose($"Default architecture: {defaultArchitecture} IsDefaultTargetArchitecture: {RunSettingsHelper.Instance.IsDefaultTargetArchitecture}, Current process architecture: {_processHelper.GetCurrentProcessArchitecture()}.");
             }
 
             settingsUpdated |= UpdatePlatform(

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -671,7 +671,7 @@ internal class TestRequestManager : ITestRequestManager
             }
 
             // We prefer to not throw in case of unhandled architecture but return Default,
-            // it should be handled in correct way by the callers.
+            // it should be handled in a correct way by the callers.
             return Architecture.Default;
         }
 #endif

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -670,6 +670,8 @@ internal class TestRequestManager : ITestRequestManager
                     break;
             }
 
+            // We prefer to not throw in case of unhandled architecture but return Default,
+            // it should be handled in correct way by the callers.
             return Architecture.Default;
         }
 #endif

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -624,7 +624,7 @@ internal class TestRequestManager : ITestRequestManager
                 // We want to find 64-bit SDK because it is more likely to be installed.
                 defaultArchitecture = Environment.Is64BitOperatingSystem ? Architecture.X64 : Architecture.X86;
 #endif
-                EqtTrace.Verbose($"Default architecture: {defaultArchitecture} IsDefaultTargetArchitecture: {RunSettingsHelper.Instance.IsDefaultTargetArchitecture}");
+                EqtTrace.Verbose($"Default architecture: {defaultArchitecture} IsDefaultTargetArchitecture: {RunSettingsHelper.Instance.IsDefaultTargetArchitecture} Current process architecture: {_processHelper.GetCurrentProcessArchitecture()}");
             }
 
             settingsUpdated |= UpdatePlatform(

--- a/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
@@ -86,7 +86,7 @@ public class PlatformArgumentProcessorTests
     {
         ExceptionUtilities.ThrowsException<CommandLineException>(
             () => _executor.Initialize("foo"),
-            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64.",
+            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x.",
             "foo");
     }
 
@@ -95,7 +95,7 @@ public class PlatformArgumentProcessorTests
     {
         ExceptionUtilities.ThrowsException<CommandLineException>(
             () => _executor.Initialize("AnyCPU"),
-            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64.",
+            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x.",
             "AnyCPU");
     }
 


### PR DESCRIPTION
Align Architecture to PlatformArchitecture.
Return Default instead of throw in case of missing mapping.