### PR TITLE
Fix race condition inside DataCollectionAttachmentManager

### DIFF
--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
@@ -768,10 +768,28 @@ internal class DataCollectionManager : IDataCollectionManager
 
     private void LogAttachments(List<AttachmentSet> attachmentSets)
     {
+        if (attachmentSets is null)
+        {
+            EqtTrace.Error("DataCollectionManager.LogAttachments: Unexpected null attachmentSets.");
+            return;
+        }
+
         foreach (var entry in attachmentSets)
         {
+            if (entry is null)
+            {
+                EqtTrace.Error("DataCollectionManager.LogAttachments: Unexpected null entry inside attachmentSets.");
+                continue;
+            }
+
             foreach (var file in entry.Attachments)
             {
+                if (file is null)
+                {
+                    EqtTrace.Error("DataCollectionManager.LogAttachments: Unexpected null file inside entry attachments.");
+                    continue;
+                }
+
                 EqtTrace.Verbose(
                     "Test Attachment Description: Collector:'{0}'  Uri:'{1}'  Description:'{2}' Uri:'{3}' ",
                     entry.DisplayName,

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
@@ -76,7 +76,7 @@ internal class DataCollectionRequestHandler : IDataCollectionRequestHandler, IDi
             new SocketCommunicationManager(),
             messageSink,
             DataCollectionManager.Create(messageSink, requestData),
-            new DataCollectionTestCaseEventHandler(),
+            new DataCollectionTestCaseEventHandler(messageSink),
             JsonDataSerializer.Instance,
             new FileHelper(),
             requestData)
@@ -162,7 +162,7 @@ internal class DataCollectionRequestHandler : IDataCollectionRequestHandler, IDi
                         communicationManager,
                         messageSink,
                         DataCollectionManager.Create(messageSink, requestData),
-                        new DataCollectionTestCaseEventHandler(),
+                        new DataCollectionTestCaseEventHandler(messageSink),
                         JsonDataSerializer.Instance,
                         new FileHelper(),
                         requestData);
@@ -362,7 +362,7 @@ internal class DataCollectionRequestHandler : IDataCollectionRequestHandler, IDi
                     }
                     catch (Exception e)
                     {
-                        EqtTrace.Error("DataCollectionRequestHandler.HandleBeforeTestRunStart : Error occurred during initialization of TestHost : {0}", e);
+                        EqtTrace.Error("DataCollectionRequestHandler.HandleBeforeTestRunStart : Error occurred during test case events handling: {0}.", e);
                     }
                 },
                 _cancellationTokenSource.Token);

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/DataCollectionTestCaseEventHandlerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/DataCollectionTestCaseEventHandlerTests.cs
@@ -27,13 +27,15 @@ public class DataCollectionTestCaseEventHandlerTests
     private readonly Mock<IDataCollectionManager> _mockDataCollectionManager;
     private readonly DataCollectionTestCaseEventHandler _requestHandler;
     private readonly Mock<IDataSerializer> _dataSerializer;
+    private readonly Mock<IMessageSink> _messageSink;
 
     public DataCollectionTestCaseEventHandlerTests()
     {
         _mockCommunicationManager = new Mock<ICommunicationManager>();
         _mockDataCollectionManager = new Mock<IDataCollectionManager>();
         _dataSerializer = new Mock<IDataSerializer>();
-        _requestHandler = new DataCollectionTestCaseEventHandler(_mockCommunicationManager.Object, new Mock<IDataCollectionManager>().Object, _dataSerializer.Object);
+        _messageSink = new Mock<IMessageSink>();
+        _requestHandler = new DataCollectionTestCaseEventHandler(_messageSink.Object, _mockCommunicationManager.Object, new Mock<IDataCollectionManager>().Object, _dataSerializer.Object);
     }
 
     [TestMethod]
@@ -91,7 +93,7 @@ public class DataCollectionTestCaseEventHandlerTests
     [TestMethod]
     public void CloseShouldNotThrowExceptionIfCommunicationManagerIsNull()
     {
-        var requestHandler = new DataCollectionTestCaseEventHandler(null, new Mock<IDataCollectionManager>().Object, _dataSerializer.Object);
+        var requestHandler = new DataCollectionTestCaseEventHandler(_messageSink.Object, null, new Mock<IDataCollectionManager>().Object, _dataSerializer.Object);
 
         requestHandler.Close();
 
@@ -107,7 +109,7 @@ public class DataCollectionTestCaseEventHandlerTests
 
         _mockCommunicationManager.SetupSequence(x => x.ReceiveMessage()).Returns(message).Returns(new Message() { MessageType = MessageType.SessionEnd, Payload = "false" });
 
-        var requestHandler = new DataCollectionTestCaseEventHandler(_mockCommunicationManager.Object, _mockDataCollectionManager.Object, _dataSerializer.Object);
+        var requestHandler = new DataCollectionTestCaseEventHandler(_messageSink.Object, _mockCommunicationManager.Object, _mockDataCollectionManager.Object, _dataSerializer.Object);
 
         requestHandler.ProcessRequests();
 
@@ -124,7 +126,7 @@ public class DataCollectionTestCaseEventHandlerTests
 
         _mockCommunicationManager.SetupSequence(x => x.ReceiveMessage()).Returns(message).Returns(new Message() { MessageType = MessageType.SessionEnd, Payload = "false" });
 
-        var requestHandler = new DataCollectionTestCaseEventHandler(_mockCommunicationManager.Object, _mockDataCollectionManager.Object, _dataSerializer.Object);
+        var requestHandler = new DataCollectionTestCaseEventHandler(_messageSink.Object, _mockCommunicationManager.Object, _mockDataCollectionManager.Object, _dataSerializer.Object);
 
         requestHandler.ProcessRequests();
 


### PR DESCRIPTION
* We're analyzing a strange race condition issue, but if we enable diag logs we're hiding real issue for an NRE inside the logs self.

<img width="868" alt="image" src="https://user-images.githubusercontent.com/7894084/151710580-d787ef0d-93af-4ec8-ac64-e47b28ccac0e.png">



* Update `Dictionary` to `ConcurrentDictionary` to make `DataCollectionAttachmentManager` thread safe, concurrent call to the data collector `TestCaseEnded` will eventually fail.

```cs
 [TestMethod]
    public void ParallelAccess()
    {
        _attachmentManager.Initialize(new SessionId(Guid.NewGuid()), Path.GetTempPath(), _messageSink.Object);
        Task.WaitAll(

        Task.Run(() =>
        {
            try
            {
                while (true)
                {
                    var dc = new DataCollectionContext(new SessionId(Guid.NewGuid()));
                    string path = Path.GetTempFileName();
                    File.WriteAllText(path, "test");
                    _attachmentManager.AddAttachment(new FileTransferInformation(dc, path, true), null, new Uri("//test1"), "test1");
                    var res = _attachmentManager.GetAttachments(dc);
                }
            }
            catch (Exception ex)
            {
                Assert.Fail(ex.ToString());
            }
        }),

        Task.Run(() =>
        {
            try
            {
                while (true)
                {
                    var dc = new DataCollectionContext(new SessionId(Guid.NewGuid()));
                    string path = Path.GetTempFileName();
                    File.WriteAllText(path, "test");
                    _attachmentManager.AddAttachment(new FileTransferInformation(dc, path, true), null, new Uri("//test2"), "test2");
                    var res = _attachmentManager.GetAttachments(dc);
                }
            }
            catch (Exception ex)
            {
                Assert.Fail(ex.ToString());
            }
        })
        );
    }
``` 
* Add try/catch on the events to avoid possible unhandled exception that lead to the test host hang.