### PR TITLE
Fix serialization issue with TestRunSettings

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/RunSettings/TestRunSettings.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RunSettings/TestRunSettings.cs
@@ -12,7 +12,6 @@ using System.Xml;
 /// </summary>
 public abstract class TestRunSettings
 {
-
     #region Constructor
 
     /// <summary>
@@ -37,7 +36,7 @@ public abstract class TestRunSettings
     /// during RunSettings.LoadSection() call
     /// TODO: Communicate to Chutzpah and fix it
     /// </summary>
-    public string Name { get; private set; }
+    public string Name { get; }
 
     #endregion
 
@@ -46,6 +45,7 @@ public abstract class TestRunSettings
     /// Converter the setting to be an XmlElement.
     /// </summary>
     /// <returns>The Xml element for the run settings provided.</returns>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1059:MembersShouldNotExposeCertainConcreteTypes", Justification = "XmlElement is required in the data collector.")]
     public abstract XmlElement ToXml();
 #endif
 }

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunSettingsTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunSettingsTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.TestPlatform.ObjectModel.UnitTests;
+
+using System.IO;
+using System.Xml;
+using System.Xml.Serialization;
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class RunSettingsTests
+{
+    [TestMethod]
+    public void RunSettingsNameSerialization()
+    {
+        var chilRunSettings = new ChildRunSettings();
+        var xml = chilRunSettings.ToXml();
+        Assert.IsNotNull(xml);
+    }
+
+    public class ChildRunSettings : TestRunSettings
+    {
+        public ChildRunSettings() : base("SomeName")
+        {
+        }
+
+        public override XmlElement ToXml()
+        {
+            var document = new XmlDocument();
+            using (XmlWriter writer = document.CreateNavigator().AppendChild())
+            {
+                new XmlSerializer(typeof(ChildRunSettings)).Serialize(writer, this);
+            }
+            return document.DocumentElement;
+        }
+    }
+}


### PR DESCRIPTION
Use auto-property code-fix changed the readonly property into a private setter property which seems to change the behavior of the xml serializer. I have kept a property only but moved to a readonly property.

cc @AbhitejJohn 
