### PR TITLE
Fix OperationCanceledException handling for the TestRunAttachmentsProcessingManager

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/TestRunAttachmentsProcessingManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/TestRunAttachmentsProcessingManager.cs
@@ -166,7 +166,8 @@ internal class TestRunAttachmentsProcessingManager : ITestRunAttachmentsProcessi
                     }
                 }
             }
-            catch (Exception e)
+            // If it's OperationCanceledException of our cancellationToken we let the exception bubble up.
+            catch (Exception e) when ((e is OperationCanceledException operationCanceled && operationCanceled.CancellationToken == cancellationToken) == false)
             {
                 EqtTrace.Error("TestRunAttachmentsProcessingManager: Exception in ProcessAttachmentsAsync: " + e);
                 logger.SendMessage(TestMessageLevel.Error, e.ToString());

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/TestRunAttachmentsProcessingManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/TestRunAttachmentsProcessingManager.cs
@@ -169,13 +169,14 @@ internal class TestRunAttachmentsProcessingManager : ITestRunAttachmentsProcessi
             catch (Exception e)
             {
                 EqtTrace.Error("TestRunAttachmentsProcessingManager: Exception in ProcessAttachmentsAsync: " + e);
-                logger.SendMessage(TestMessageLevel.Error, e.ToString());
 
                 // If it's OperationCanceledException of our cancellationToken we let the exception bubble up.
                 if (e is OperationCanceledException operationCanceled && operationCanceled.CancellationToken == cancellationToken)
                 {
                     throw;
                 }
+
+                logger.SendMessage(TestMessageLevel.Error, e.ToString());
 
                 // Restore the attachment sets for the others attachment processors.
                 attachments = attachmentsBackup;

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/TestRunAttachmentsProcessingManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/TestRunAttachmentsProcessingManager.cs
@@ -166,11 +166,16 @@ internal class TestRunAttachmentsProcessingManager : ITestRunAttachmentsProcessi
                     }
                 }
             }
-            // If it's OperationCanceledException of our cancellationToken we let the exception bubble up.
-            catch (Exception e) when ((e is OperationCanceledException operationCanceled && operationCanceled.CancellationToken == cancellationToken) == false)
+            catch (Exception e)
             {
                 EqtTrace.Error("TestRunAttachmentsProcessingManager: Exception in ProcessAttachmentsAsync: " + e);
                 logger.SendMessage(TestMessageLevel.Error, e.ToString());
+
+                // If it's OperationCanceledException of our cancellationToken we let the exception bubble up.
+                if (e is OperationCanceledException operationCanceled && operationCanceled.CancellationToken == cancellationToken)
+                {
+                    throw;
+                }
 
                 // Restore the attachment sets for the others attachment processors.
                 attachments = attachmentsBackup;


### PR DESCRIPTION
Fix OperationCanceledException handling for the TestRunAttachmentsProcessingManager.