### PR TITLE
Enable TreatWarningsAsErrors only on CI

### DIFF
--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -20,7 +20,9 @@
          serialization. This is also defined in build script. -->
     <AssemblyVersion Condition="'$(AssemblyVersion)' == ''">15.0.0</AssemblyVersion>
 
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Treat warnings as errors only on CI to prevent painful development process because of unused usings... -->
+    <TreatWarningsAsErrors Condition="'$(CIBuild)' == 'true'">true</TreatWarningsAsErrors>
+
     <PublicSign Condition="'$(CIBuild)' == '' or '$(CIBuild)' == 'false'">true</PublicSign>
     <DelaySign Condition="'$(CIBuild)' == 'true'">true</DelaySign>
     <!--<GenerateDocumentationFile>true</GenerateDocumentationFile>-->


### PR DESCRIPTION
## Description

We raised the severity of some rules from message to warning to ensure they are followed in the team but because of the `TreatWarningsAsErrors` we end up with some "boring" dev cycles where we are forced to cleanup usings etc while we iterate. The idea is to keep warnings locally to not slow us down but still fail in PRs so that we can keep styling consistency.

cc @nohwnd @MarcoRossignoli 