### PR TITLE
Add ionide exclusions to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ src/package/sign/sign.nuget.targets
 # diag log files
 # ===========================
 logs/
+
+.fake
+.ionide


### PR DESCRIPTION
## Description

I was opening the project with VSCode and got prompted to add the ionide (F#) exclusions to our `.gitignore`.
