### PR TITLE
Remove architecture validation

### DIFF
--- a/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
@@ -182,9 +182,6 @@ public class InferRunSettingsHelper
 
         EqtTrace.Verbose("Using effective platform:{0} effective framework:{1}", architecture, framework);
 
-        // check if platform is compatible with current system architecture.
-        VerifyCompatibilityWithOsArchitecture(architecture);
-
         // Check if inputRunSettings has results directory configured.
         var hasResultsDirectory = runSettingsDocument.SelectSingleNode(ResultsDirectoryNodePath) != null;
 
@@ -557,27 +554,6 @@ public class InferRunSettingsHelper
                             TargetFrameworkNodeName)));
             }
         }
-    }
-
-    /// <summary>
-    /// Throws SettingsException if platform is incompatible with system architecture.
-    /// </summary>
-    /// <param name="architecture"></param>
-    private static void VerifyCompatibilityWithOsArchitecture(Architecture architecture)
-    {
-        var osArchitecture = XmlRunSettingsUtilities.OSArchitecture;
-
-        if (architecture == Architecture.X86 && osArchitecture == Architecture.X64)
-        {
-            return;
-        }
-
-        if (architecture == osArchitecture)
-        {
-            return;
-        }
-
-        throw new SettingsException(string.Format(CultureInfo.CurrentCulture, UtilitiesResources.SystemArchitectureIncompatibleWithTargetPlatform, architecture, osArchitecture));
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.Utilities/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.Utilities/Resources/Resources.Designer.cs
@@ -11,8 +11,8 @@
 namespace Microsoft.VisualStudio.TestPlatform.Utilities.Resources {
     using System;
     using System.Reflection;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -103,15 +103,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities.Resources {
         internal static string RunSettingsParseError {
             get {
                 return ResourceManager.GetString("RunSettingsParseError", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Incompatible Target platform settings &apos;{0}&apos; with system architecture &apos;{1}&apos;..
-        /// </summary>
-        internal static string SystemArchitectureIncompatibleWithTargetPlatform {
-            get {
-                return ResourceManager.GetString("SystemArchitectureIncompatibleWithTargetPlatform", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TestPlatform.Utilities/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.Utilities/Resources/Resources.resx
@@ -132,9 +132,6 @@
   <data name="RunSettingsParseError" xml:space="preserve">
     <value>An error occurred while loading the settings.  Error: {0}.</value>
   </data>
-  <data name="SystemArchitectureIncompatibleWithTargetPlatform" xml:space="preserve">
-    <value>Incompatible Target platform settings '{0}' with system architecture '{1}'.</value>
-  </data>
   <data name="UnExpectedSettingsFile" xml:space="preserve">
     <value>Unexpected settings file specified.</value>
   </data>

--- a/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.cs.xlf
@@ -27,11 +27,6 @@
         <note></note>
         <target state="translated">Při načítání nastavení se stala chyba. Chyba: {0}</target>
       </trans-unit>
-      <trans-unit id="SystemArchitectureIncompatibleWithTargetPlatform">
-        <source>Incompatible Target platform settings '{0}' with system architecture '{1}'.</source>
-        <note></note>
-        <target state="translated">Nastavení cílové platformy {0} není kompatibilní s architekturou systému {1}.</target>
-      </trans-unit>
       <trans-unit id="UnExpectedSettingsFile">
         <source>Unexpected settings file specified.</source>
         <note></note>

--- a/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.de.xlf
@@ -27,11 +27,6 @@
         <note></note>
         <target state="translated">Fehler beim Laden der Einstellungen. Fehler: {0}.</target>
       </trans-unit>
-      <trans-unit id="SystemArchitectureIncompatibleWithTargetPlatform">
-        <source>Incompatible Target platform settings '{0}' with system architecture '{1}'.</source>
-        <note></note>
-        <target state="translated">Inkompatible Zielplattformeinstellungen "{0}" mit der Systemarchitektur "{1}".</target>
-      </trans-unit>
       <trans-unit id="UnExpectedSettingsFile">
         <source>Unexpected settings file specified.</source>
         <note></note>

--- a/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.es.xlf
@@ -27,11 +27,6 @@
         <note></note>
         <target state="translated">Error al cargar la configuración. Error: {0}.</target>
       </trans-unit>
-      <trans-unit id="SystemArchitectureIncompatibleWithTargetPlatform">
-        <source>Incompatible Target platform settings '{0}' with system architecture '{1}'.</source>
-        <note></note>
-        <target state="translated">La configuración de plataforma de destino '{0}' es incompatible con la arquitectura del sistema '{1}'.</target>
-      </trans-unit>
       <trans-unit id="UnExpectedSettingsFile">
         <source>Unexpected settings file specified.</source>
         <note></note>

--- a/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.fr.xlf
@@ -27,11 +27,6 @@
         <note></note>
         <target state="translated">Une erreur s'est produite durant le chargement des paramètres. Erreur : {0}.</target>
       </trans-unit>
-      <trans-unit id="SystemArchitectureIncompatibleWithTargetPlatform">
-        <source>Incompatible Target platform settings '{0}' with system architecture '{1}'.</source>
-        <note></note>
-        <target state="translated">Paramètres de plateforme cible '{0}' incompatibles avec l'architecture système '{1}'.</target>
-      </trans-unit>
       <trans-unit id="UnExpectedSettingsFile">
         <source>Unexpected settings file specified.</source>
         <note></note>

--- a/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.it.xlf
@@ -27,11 +27,6 @@
         <note></note>
         <target state="translated">Si è verificato un errore durante il caricamento delle impostazioni. Errore: {0}.</target>
       </trans-unit>
-      <trans-unit id="SystemArchitectureIncompatibleWithTargetPlatform">
-        <source>Incompatible Target platform settings '{0}' with system architecture '{1}'.</source>
-        <note></note>
-        <target state="translated">Le impostazioni della piattaforma di destinazione '{0}' non sono compatibili con l'architettura di sistema '{1}'.</target>
-      </trans-unit>
       <trans-unit id="UnExpectedSettingsFile">
         <source>Unexpected settings file specified.</source>
         <note></note>

--- a/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.ja.xlf
@@ -27,11 +27,6 @@
         <note></note>
         <target state="translated">設定の読み込み中にエラーが発生しました。エラー: {0}。</target>
       </trans-unit>
-      <trans-unit id="SystemArchitectureIncompatibleWithTargetPlatform">
-        <source>Incompatible Target platform settings '{0}' with system architecture '{1}'.</source>
-        <note></note>
-        <target state="translated">ターゲット プラットフォームの設定 '{0}' はシステム アーキテクチャ '{1}' と互換性がありません。</target>
-      </trans-unit>
       <trans-unit id="UnExpectedSettingsFile">
         <source>Unexpected settings file specified.</source>
         <note></note>

--- a/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.ko.xlf
@@ -27,11 +27,6 @@
         <note></note>
         <target state="translated">설정을 로드하는 동안 오류가 발생했습니다. 오류: {0}.</target>
       </trans-unit>
-      <trans-unit id="SystemArchitectureIncompatibleWithTargetPlatform">
-        <source>Incompatible Target platform settings '{0}' with system architecture '{1}'.</source>
-        <note></note>
-        <target state="translated">대상 플랫폼 설정 '{0}'이(가) 시스템 아키텍처 '{1}'과(와) 호환되지 않습니다.</target>
-      </trans-unit>
       <trans-unit id="UnExpectedSettingsFile">
         <source>Unexpected settings file specified.</source>
         <note></note>

--- a/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.pl.xlf
@@ -27,11 +27,6 @@
         <note></note>
         <target state="translated">Wystąpił błąd podczas ładowania ustawień. Błąd: {0}</target>
       </trans-unit>
-      <trans-unit id="SystemArchitectureIncompatibleWithTargetPlatform">
-        <source>Incompatible Target platform settings '{0}' with system architecture '{1}'.</source>
-        <note></note>
-        <target state="translated">Niezgodne ustawienia platformy docelowej „{0}” z architekturą systemu „{1}”.</target>
-      </trans-unit>
       <trans-unit id="UnExpectedSettingsFile">
         <source>Unexpected settings file specified.</source>
         <note></note>

--- a/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.pt-BR.xlf
@@ -27,11 +27,6 @@
         <note></note>
         <target state="translated">Ocorreu um erro ao carregar as configurações. Erro: {0}.</target>
       </trans-unit>
-      <trans-unit id="SystemArchitectureIncompatibleWithTargetPlatform">
-        <source>Incompatible Target platform settings '{0}' with system architecture '{1}'.</source>
-        <note></note>
-        <target state="translated">Configurações da plataforma de destino '{0}' incompatíveis com a arquitetura do sistema '{1}'.</target>
-      </trans-unit>
       <trans-unit id="UnExpectedSettingsFile">
         <source>Unexpected settings file specified.</source>
         <note></note>

--- a/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.ru.xlf
@@ -27,11 +27,6 @@
         <note></note>
         <target state="translated">Произошла ошибка при загрузке параметров. Ошибка: {0}.</target>
       </trans-unit>
-      <trans-unit id="SystemArchitectureIncompatibleWithTargetPlatform">
-        <source>Incompatible Target platform settings '{0}' with system architecture '{1}'.</source>
-        <note></note>
-        <target state="translated">Параметры целевой платформы "{0}" несовместимы с архитектурой системы "{1}".</target>
-      </trans-unit>
       <trans-unit id="UnExpectedSettingsFile">
         <source>Unexpected settings file specified.</source>
         <note></note>

--- a/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.tr.xlf
@@ -27,11 +27,6 @@
         <note></note>
         <target state="translated">Ayarlar yüklenirken bir hata oluştu. Hata: {0}.</target>
       </trans-unit>
-      <trans-unit id="SystemArchitectureIncompatibleWithTargetPlatform">
-        <source>Incompatible Target platform settings '{0}' with system architecture '{1}'.</source>
-        <note></note>
-        <target state="translated">'{0}' hedef platform ayarları, '{1}' sistem mimarisiyle uyumlu değil.</target>
-      </trans-unit>
       <trans-unit id="UnExpectedSettingsFile">
         <source>Unexpected settings file specified.</source>
         <note></note>

--- a/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.xlf
@@ -22,10 +22,6 @@
         <source>An error occurred while loading the settings.  Error: {0}.</source>
         <note></note>
       </trans-unit>
-      <trans-unit id="SystemArchitectureIncompatibleWithTargetPlatform">
-        <source>Incompatible Target platform settings '{0}' with system architecture '{1}'.</source>
-        <note></note>
-      </trans-unit>
       <trans-unit id="UnExpectedSettingsFile">
         <source>Unexpected settings file specified.</source>
         <note></note>

--- a/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.zh-Hans.xlf
@@ -27,11 +27,6 @@
         <note></note>
         <target state="translated">加载设置时出错。错误: {0}。</target>
       </trans-unit>
-      <trans-unit id="SystemArchitectureIncompatibleWithTargetPlatform">
-        <source>Incompatible Target platform settings '{0}' with system architecture '{1}'.</source>
-        <note></note>
-        <target state="translated">目标平台设置“{0}”与系统体系结构“{1}”不兼容。</target>
-      </trans-unit>
       <trans-unit id="UnExpectedSettingsFile">
         <source>Unexpected settings file specified.</source>
         <note></note>

--- a/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.Utilities/Resources/xlf/Resources.zh-Hant.xlf
@@ -27,11 +27,6 @@
         <note></note>
         <target state="translated">載入設定時發生錯誤。錯誤: {0}。</target>
       </trans-unit>
-      <trans-unit id="SystemArchitectureIncompatibleWithTargetPlatform">
-        <source>Incompatible Target platform settings '{0}' with system architecture '{1}'.</source>
-        <note></note>
-        <target state="translated">目標平台設定 '{0}' 與系統架構 '{1}' 不相容。</target>
-      </trans-unit>
       <trans-unit id="UnExpectedSettingsFile">
         <source>Unexpected settings file specified.</source>
         <note></note>

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/InferRunSettingsHelperTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/InferRunSettingsHelperTests.cs
@@ -10,7 +10,6 @@ using System.Xml;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using OMResources = VisualStudio.TestPlatform.ObjectModel.Resources.CommonResources;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
 using VisualStudio.TestTools.UnitTesting;
 using MSTest.TestFramework.AssertExtensions;
@@ -215,21 +214,6 @@ public class InferRunSettingsHelperTests
         var expectedRunSettings = string.Format("<RunSettings><RunConfiguration><ResultsDirectory>temp</ResultsDirectory><TargetPlatform>X64</TargetPlatform><TargetFrameworkVersion>{0}</TargetFrameworkVersion></RunConfiguration></RunSettings>", Framework.DefaultFramework.Name);
 
         Assert.AreEqual(expectedRunSettings, xml);
-    }
-
-    [TestMethod]
-    public void UpdateRunSettingsShouldThrowIfArchitectureSetIsIncompatibleWithCurrentSystemArchitecture()
-    {
-        var settings = @"<RunSettings></RunSettings>";
-        var xmlDocument = GetXmlDocument(settings);
-
-        Action action = () => InferRunSettingsHelper.UpdateRunSettingsWithUserProvidedSwitches(xmlDocument, Architecture.ARM, Framework.DefaultFramework, "temp");
-
-        Assert.That.Throws<SettingsException>(action)
-            .WithMessage(string.Format(
-                "Incompatible Target platform settings '{0}' with system architecture '{1}'.",
-                "ARM",
-                XmlRunSettingsUtilities.OSArchitecture.ToString()));
     }
 
     [TestMethod]


### PR DESCRIPTION
## Description
With multiple architectures being added, we are being too strict with this validation. Right now it blocks run of .NET tests on arm64 when vstest.console is emulated to x86. 

## Related issue
Fix #3354 