### PR TITLE
fix same file access exception

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
@@ -309,11 +309,10 @@ public class HtmlLogger : ITestLoggerWithParameters
                 _xmlSerializer.WriteObject(xmlStream, TestRunDetails);
             }
 
-            HtmlFilePath = GenerateUniqueFilePath(
-                string.IsNullOrEmpty(HtmlFilePath)
-                    ? fileName
-                    : Path.GetFileNameWithoutExtension(HtmlFilePath),
-                HtmlLoggerConstants.HtmlFileExtension);
+            if (string.IsNullOrEmpty(HtmlFilePath))
+            {
+                HtmlFilePath = GenerateUniqueFilePath(fileName, HtmlLoggerConstants.HtmlFileExtension);
+            }
 
             _htmlTransformer.Transform(XmlFilePath, HtmlFilePath);
         }
@@ -348,7 +347,7 @@ public class HtmlLogger : ITestLoggerWithParameters
             {
                 if (!File.Exists(fullFilePath))
                 {
-                    File.Create(fullFilePath);
+                    using var _ = File.Create(fullFilePath);
                     return fullFilePath;
                 }
             }

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
@@ -311,9 +311,7 @@ public class HtmlLogger : ITestLoggerWithParameters
 
             HtmlFilePath = string.IsNullOrEmpty(HtmlFilePath)
                 ? GetFilePathAndCreateFile(HtmlLoggerConstants.HtmlFileExtension, fileName)
-                : GetFilePathAndCreateFile(HtmlLoggerConstants.HtmlFileExtension, Path.GetFileNameWithoutExtension(HtmlFilePath));
-
-            HtmlFilePath = GetFilePathAndCreateFile(HtmlLoggerConstants.HtmlFileExtension, Path.GetFileNameWithoutExtension(HtmlFilePath));
+                : HtmlFilePath;
 
             _htmlTransformer.Transform(XmlFilePath, HtmlFilePath);
         }

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
@@ -36,7 +36,7 @@ public class HtmlLogger : ITestLoggerWithParameters
     private readonly IFileHelper _fileHelper;
     private readonly XmlObjectSerializer _xmlSerializer;
     private readonly IHtmlTransformer _htmlTransformer;
-    private static readonly object LockObject = new();
+    private static readonly object FileCreateLockObject = new();
     private Dictionary<string, string> _parametersDictionary;
 
     public HtmlLogger()
@@ -343,7 +343,7 @@ public class HtmlLogger : ITestLoggerWithParameters
         {
             var fileNameWithIter = i == 0 ? fileName : Path.GetFileNameWithoutExtension(fileName) + $"[{i}]";
             fullFilePath = Path.Combine(TestResultsDirPath, $"TestResult_{fileNameWithIter}.{fileExtension}");
-            lock (LockObject)
+            lock (FileCreateLockObject)
             {
                 if (!File.Exists(fullFilePath))
                 {

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
@@ -36,8 +36,8 @@ public class HtmlLogger : ITestLoggerWithParameters
     private readonly IFileHelper _fileHelper;
     private readonly XmlObjectSerializer _xmlSerializer;
     private readonly IHtmlTransformer _htmlTransformer;
-    private Dictionary<string, string> _parametersDictionary;
     private static readonly object LockObject = new();
+    private Dictionary<string, string> _parametersDictionary;
 
     public HtmlLogger()
         : this(new FileHelper(), new HtmlTransformer(), new DataContractSerializer(typeof(TestRunDetails)))
@@ -302,16 +302,16 @@ public class HtmlLogger : ITestLoggerWithParameters
                 Environment.GetEnvironmentVariable("UserName"), Environment.MachineName,
                 FormatDateTimeForRunName(DateTime.Now));
 
-            XmlFilePath = _parametersDictionary.TryGetValue(HtmlLoggerConstants.LogFileNameKey, out var string logFileNameValue) && !string.IsNullOrWhiteSpace(logFileNameValue)
-            ? GetFilePath(HtmlLoggerConstants.XmlFileExtension, fileName)
-            : GenerateUniqueFile(HtmlLoggerConstants.XmlFileExtension, fileName);
+            XmlFilePath = _parametersDictionary.TryGetValue(HtmlLoggerConstants.LogFileNameKey, out var logFileNameValue) && !string.IsNullOrWhiteSpace(logFileNameValue)
+                ? GetFilePath(HtmlLoggerConstants.XmlFileExtension, fileName)
+                : GenerateUniqueFile(HtmlLoggerConstants.XmlFileExtension, fileName);
 
             using (var xmlStream = _fileHelper.GetStream(XmlFilePath, FileMode.OpenOrCreate))
             {
                 _xmlSerializer.WriteObject(xmlStream, TestRunDetails);
             }
 
-            HtmlFilePath = _parametersDictionary.TryGetValue(HtmlLoggerConstants.LogFileNameKey, out var string logFileNameValue) && !string.IsNullOrWhiteSpace(logFileNameValue)
+            HtmlFilePath = _parametersDictionary.TryGetValue(HtmlLoggerConstants.LogFileNameKey, out logFileNameValue) && !string.IsNullOrWhiteSpace(logFileNameValue)
                 ? HtmlFilePath
                 : GenerateUniqueFile(HtmlLoggerConstants.HtmlFileExtension, fileName);
 
@@ -319,7 +319,7 @@ public class HtmlLogger : ITestLoggerWithParameters
         }
         catch (Exception ex)
         {
-            EqtTrace.Error("HtmlLogger : Failed to populate html file. Exception : {0}",
+            EqtTrace.Error("HtmlLogger: Failed to populate html file. Exception: {0}",
                 ex.ToString());
             ConsoleOutput.Instance.Error(false, string.Concat(HtmlResource.HtmlLoggerError), ex.Message);
             return;
@@ -339,7 +339,7 @@ public class HtmlLogger : ITestLoggerWithParameters
 
     private string GetFilePath(string fileExtension, string fileName)
     {
-        return Path.Combine(TestResultsDirPath, string.Concat("TestResult_", fileName, $".{fileExtension}"));
+        return Path.Combine(TestResultsDirPath, $"TestResult_{fileName}.{fileExtension}");
     }
 
     private string GenerateUniqueFile(string fileExtension, string fileName)
@@ -359,17 +359,15 @@ public class HtmlLogger : ITestLoggerWithParameters
             }
         }
 
-        throw new Exception($"Cannot generate unique filename for: {fileName} on path: {TestResultsDirPath}");
+        throw new InvalidOperationException($"Cannot generate a unique filename for '{fileName}' on path '{TestResultsDirPath}'.");
+
+        static string GetNextIterationFile(string baseName, short iteration)
+            => Path.GetFileNameWithoutExtension(baseName) + $"[{iteration}]";
     }
 
     private string FormatDateTimeForRunName(DateTime timeStamp)
     {
         return timeStamp.ToString("yyyyMMdd_HHmmss", DateTimeFormatInfo.InvariantInfo);
-    }
-
-    private string GetNextIterationFile(string baseName, short iteration)
-    {
-        return Path.GetFileNameWithoutExtension(baseName) + $"[{iteration}]";
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -57,6 +57,15 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger.Resources {
             }
             set {
                 resourceCulture = value;
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot generate a unique file name for name &apos;{0}&apos; on path &apos;{1}&apos;..
+        /// </summary>
+        internal static string CannotGenerateUniqueFilePath {
+            get {
+                return ResourceManager.GetString("CannotGenerateUniqueFilePath", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CannotGenerateUniqueFilePath" xml:space="preserve">
+    <value>Cannot generate a unique file name for name '{0}' on path '{1}'.</value>
+  </data>
   <data name="HtmlFilePath" xml:space="preserve">
     <value>Html test results file : {0}</value>
   </data>

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.cs.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Parametry LogFileName a LogFilePrefix nelze uvést společně.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CannotGenerateUniqueFilePath">
+        <source>Cannot generate a unique file name for name '{0}' on path '{1}'.</source>
+        <target state="new">Cannot generate a unique file name for name '{0}' on path '{1}'.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.de.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Die Parameter "LogFileName" und "LogFilePrefix" können nicht zusammen angegeben werden. </target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CannotGenerateUniqueFilePath">
+        <source>Cannot generate a unique file name for name '{0}' on path '{1}'.</source>
+        <target state="new">Cannot generate a unique file name for name '{0}' on path '{1}'.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.es.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Los parámetros LogFileName y LogFilePrefix no se pueden proporcionar juntos.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CannotGenerateUniqueFilePath">
+        <source>Cannot generate a unique file name for name '{0}' on path '{1}'.</source>
+        <target state="new">Cannot generate a unique file name for name '{0}' on path '{1}'.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.fr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Les paramètres LogFileName et LogFilePrefix ne peuvent pas être donnés ensemble. </target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CannotGenerateUniqueFilePath">
+        <source>Cannot generate a unique file name for name '{0}' on path '{1}'.</source>
+        <target state="new">Cannot generate a unique file name for name '{0}' on path '{1}'.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.it.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Non è possibile specificare insieme i parametri LogFileName e LogFilePrefix.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CannotGenerateUniqueFilePath">
+        <source>Cannot generate a unique file name for name '{0}' on path '{1}'.</source>
+        <target state="new">Cannot generate a unique file name for name '{0}' on path '{1}'.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.ja.xlf
@@ -17,6 +17,11 @@
         <target state="translated">パラメーター LogFileName と LogFilePrefix を同時に指定することはできません。</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CannotGenerateUniqueFilePath">
+        <source>Cannot generate a unique file name for name '{0}' on path '{1}'.</source>
+        <target state="new">Cannot generate a unique file name for name '{0}' on path '{1}'.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.ko.xlf
@@ -17,6 +17,11 @@
         <target state="translated">LogFileName 및 LogFilePrefix 매개 변수는 함께 제공할 수 없습니다.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CannotGenerateUniqueFilePath">
+        <source>Cannot generate a unique file name for name '{0}' on path '{1}'.</source>
+        <target state="new">Cannot generate a unique file name for name '{0}' on path '{1}'.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.pl.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Parametry LogFileName i LogFilePrefix nie mogą być podawane razem. </target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CannotGenerateUniqueFilePath">
+        <source>Cannot generate a unique file name for name '{0}' on path '{1}'.</source>
+        <target state="new">Cannot generate a unique file name for name '{0}' on path '{1}'.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Os parâmetros LogFileName e LogFilePrefix não podem ser usados juntos.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CannotGenerateUniqueFilePath">
+        <source>Cannot generate a unique file name for name '{0}' on path '{1}'.</source>
+        <target state="new">Cannot generate a unique file name for name '{0}' on path '{1}'.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.ru.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Параметры LogFileName и LogFilePrefix не могут использоваться вместе.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CannotGenerateUniqueFilePath">
+        <source>Cannot generate a unique file name for name '{0}' on path '{1}'.</source>
+        <target state="new">Cannot generate a unique file name for name '{0}' on path '{1}'.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.tr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">LogFileName ve LogFilePrefix parametreleri birlikte kullanılamaz. </target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CannotGenerateUniqueFilePath">
+        <source>Cannot generate a unique file name for name '{0}' on path '{1}'.</source>
+        <target state="new">Cannot generate a unique file name for name '{0}' on path '{1}'.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.xlf
@@ -17,6 +17,11 @@
         <target state="new">The parameters LogFileName and LogFilePrefix cannot be given together.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CannotGenerateUniqueFilePath">
+        <source>Cannot generate a unique file name for name '{0}' on path '{1}'.</source>
+        <target state="new">Cannot generate a unique file name for name '{0}' on path '{1}'.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="translated">参数 LogFileName 和 LogFilePrefix 不能一起使用。</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CannotGenerateUniqueFilePath">
+        <source>Cannot generate a unique file name for name '{0}' on path '{1}'.</source>
+        <target state="new">Cannot generate a unique file name for name '{0}' on path '{1}'.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/Resources/xlf/Resources.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="translated">不能同時指定參數 LogFileName 和 LogFilePrefix。</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="CannotGenerateUniqueFilePath">
+        <source>Cannot generate a unique file name for name '{0}' on path '{1}'.</source>
+        <target state="new">Cannot generate a unique file name for name '{0}' on path '{1}'.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/test/Microsoft.TestPlatform.AcceptanceTests/LoggerTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/LoggerTests.cs
@@ -107,7 +107,7 @@ public class LoggerTests : AcceptanceTestBase
 
         var arguments = PrepareArguments(GetSampleTestAssembly(), GetTestAdapterPath(), string.Empty, FrameworkArgValue, runnerInfo.InIsolationValue, TempDirectory.Path);
         var htmlFileName = "TestResults.html";
-        arguments = string.Concat(arguments, $" /logger:\"logger://Microsoft/TestPlatform/htmlLogger/v1;LogFileName{htmlFileName}\"");
+        arguments = string.Concat(arguments, $" /logger:\"logger://Microsoft/TestPlatform/htmlLogger/v1;LogFileName={htmlFileName}\"");
         InvokeVsTest(arguments);
 
         arguments = PrepareArguments(GetSampleTestAssembly(), GetTestAdapterPath(), string.Empty, FrameworkArgValue, runnerInfo.InIsolationValue, TempDirectory.Path);

--- a/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
@@ -396,7 +396,7 @@ public class HtmlLoggerTests
     }
 
     [TestMethod]
-    public void TestCompleteHandlerShouldCreateCustumHtmlFileNamewithLogFileNameKey()
+    public void TestCompleteHandlerShouldCreateCustomHtmlFileNamewithLogFileNameKey()
     {
         var parameters = new Dictionary<string, string?>
         {
@@ -415,7 +415,7 @@ public class HtmlLoggerTests
     }
 
     [TestMethod]
-    public void TestCompleteHandlerShouldCreateCustumHtmlFileNameWithLogPrefix()
+    public void TestCompleteHandlerShouldCreateCustomHtmlFileNameWithLogPrefix()
     {
         var parameters = new Dictionary<string, string>
         {
@@ -435,7 +435,7 @@ public class HtmlLoggerTests
     }
 
     [TestMethod]
-    public void TestCompleteHandlerShouldCreateCustumHtmlFileNameWithLogPrefixIfTargetFrameworkIsNull()
+    public void TestCompleteHandlerShouldCreateCustomHtmlFileNameWithLogPrefixIfTargetFrameworkIsNull()
     {
         var parameters = new Dictionary<string, string>
         {
@@ -455,7 +455,7 @@ public class HtmlLoggerTests
     }
 
     [TestMethod]
-    public void TestCompleteHandlerShouldCreateCustumHtmlFileNameWithLogPrefixNull()
+    public void TestCompleteHandlerShouldCreateCustomHtmlFileNameWithLogPrefixNull()
     {
         var parameters = new Dictionary<string, string?>
         {

--- a/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
@@ -468,14 +468,14 @@ public class HtmlLoggerTests
         var result1 = new ObjectModel.TestResult(testCase1) { Outcome = TestOutcome.Failed };
         var resultEventArg1 = new Mock<TestResultEventArgs>(result1);
 
-        _mockFileHelper.Setup(x => x.GetStream(It.IsAny<string>(), FileMode.Create, FileAccess.ReadWrite)).Callback<string, FileMode, FileAccess>((x, y, z) =>
+        _mockFileHelper.Setup(x => x.GetStream(It.IsAny<string>(), FileMode.OpenOrCreate, FileAccess.ReadWrite)).Callback<string, FileMode, FileAccess>((x, y, z) =>
         {
         }).Returns(new Mock<Stream>().Object);
 
         _htmlLogger.TestResultHandler(new object(), resultEventArg1.Object);
         _htmlLogger.TestRunCompleteHandler(new object(), new TestRunCompleteEventArgs(null, false, true, null, null, null, TimeSpan.Zero));
 
-        _mockFileHelper.Verify(x => x.GetStream(It.IsAny<string>(), FileMode.Create, FileAccess.ReadWrite), Times.Once);
+        _mockFileHelper.Verify(x => x.GetStream(It.IsAny<string>(), FileMode.OpenOrCreate, FileAccess.ReadWrite), Times.Once);
     }
 
     [TestMethod]
@@ -514,14 +514,14 @@ public class HtmlLoggerTests
         var result1 = new ObjectModel.TestResult(testCase1) { Outcome = TestOutcome.Failed };
         var resultEventArg1 = new Mock<TestResultEventArgs>(result1);
 
-        _mockFileHelper.Setup(x => x.GetStream(It.IsAny<string>(), FileMode.Create, FileAccess.ReadWrite)).Callback<string, FileMode, FileAccess>((x, y, z) =>
+        _mockFileHelper.Setup(x => x.GetStream(It.IsAny<string>(), FileMode.OpenOrCreate, FileAccess.ReadWrite)).Callback<string, FileMode, FileAccess>((x, y, z) =>
         {
         }).Returns(new Mock<Stream>().Object);
 
         _htmlLogger.TestResultHandler(new object(), resultEventArg1.Object);
         _htmlLogger.TestRunCompleteHandler(new object(), new TestRunCompleteEventArgs(null, false, true, null, null, null, TimeSpan.Zero));
 
-        _mockFileHelper.Verify(x => x.GetStream(It.IsAny<string>(), FileMode.Create, FileAccess.ReadWrite), Times.Once);
+        _mockFileHelper.Verify(x => x.GetStream(It.IsAny<string>(), FileMode.OpenOrCreate, FileAccess.ReadWrite), Times.Once);
     }
 
     [TestMethod]
@@ -548,7 +548,7 @@ public class HtmlLoggerTests
         var result1 = new ObjectModel.TestResult(testCase1) { Outcome = TestOutcome.Failed };
         var resultEventArg1 = new Mock<TestResultEventArgs>(result1);
 
-        _mockFileHelper.Setup(x => x.GetStream(It.IsAny<string>(), FileMode.Create, FileAccess.ReadWrite)).Callback<string, FileMode, FileAccess>((x, y, z) =>
+        _mockFileHelper.Setup(x => x.GetStream(It.IsAny<string>(), FileMode.OpenOrCreate, FileAccess.ReadWrite)).Callback<string, FileMode, FileAccess>((x, y, z) =>
         {
         }).Returns(new Mock<Stream>().Object);
 
@@ -564,7 +564,7 @@ public class HtmlLoggerTests
         var testCase1 = CreateTestCase("TestCase1") ?? throw new ArgumentNullException($"CreateTestCase(\"TestCase1\")");
         var result1 = new ObjectModel.TestResult(testCase1) { Outcome = TestOutcome.Failed };
         var resultEventArg1 = new Mock<TestResultEventArgs>(result1);
-        _mockFileHelper.Setup(x => x.GetStream(It.IsAny<string>(), FileMode.Create, FileAccess.ReadWrite)).Callback<string, FileMode, FileAccess>((x, y, z) =>
+        _mockFileHelper.Setup(x => x.GetStream(It.IsAny<string>(), FileMode.OpenOrCreate, FileAccess.ReadWrite)).Callback<string, FileMode, FileAccess>((x, y, z) =>
         {
         }).Returns(new Mock<Stream>().Object);
 
@@ -579,7 +579,7 @@ public class HtmlLoggerTests
     [TestMethod]
     public void TestCompleteHandlerShouldNotDivideByZeroWhenThereAre0TestResults()
     {
-        _mockFileHelper.Setup(x => x.GetStream(It.IsAny<string>(), FileMode.Create, FileAccess.ReadWrite)).Callback<string, FileMode, FileAccess>((x, y, z) =>
+        _mockFileHelper.Setup(x => x.GetStream(It.IsAny<string>(), FileMode.OpenOrCreate, FileAccess.ReadWrite)).Callback<string, FileMode, FileAccess>((x, y, z) =>
         {
         }).Returns(new Mock<Stream>().Object);
 


### PR DESCRIPTION
The current pull request fixes the following error: `Html Logger Error : The process cannot access the file 'C:\xxxxxxx\TestResult_XXXXXXXXXX_20220215_084850.xml' because it is being used by another process.`, while running tests for multiple projects on the same solution.
