### PR TITLE
nugets should be developmentdependency

### DIFF
--- a/src/package/nuspec/Microsoft.CodeCoverage.nuspec
+++ b/src/package/nuspec/Microsoft.CodeCoverage.nuspec
@@ -18,7 +18,8 @@
                 url="https://github.com/microsoft/vstest" 
                 branch="$BranchName$" 
                 commit="$CommitId$" />
-                
+    <developmentdependency>true</developmentdependency>
+
     <dependencies>
       <group targetFramework="net45"></group>
       <group targetFramework="netcoreapp1.0"></group>

--- a/src/package/nuspec/Microsoft.NET.Test.Sdk.nuspec
+++ b/src/package/nuspec/Microsoft.NET.Test.Sdk.nuspec
@@ -18,6 +18,7 @@
                 url="https://github.com/microsoft/vstest" 
                 branch="$BranchName$" 
                 commit="$CommitId$" />
+    <developmentdependency>true</developmentdependency>
     <dependencies>
       <group targetFramework="uap10.0">
         <dependency id="System.ComponentModel.Primitives" version="[4.1.0, )" />

--- a/src/package/nuspec/Microsoft.TestPlatform.AdapterUtilities.nuspec
+++ b/src/package/nuspec/Microsoft.TestPlatform.AdapterUtilities.nuspec
@@ -20,6 +20,7 @@
                     url="https://github.com/microsoft/vstest" 
                     branch="$BranchName$" 
                     commit="$CommitId$" />
+        <developmentdependency>true</developmentdependency>
 
         <dependencies>
             <group targetFramework="netstandard1.0">

--- a/src/package/nuspec/Microsoft.TestPlatform.Portable.nuspec
+++ b/src/package/nuspec/Microsoft.TestPlatform.Portable.nuspec
@@ -19,6 +19,7 @@
                 url="https://github.com/microsoft/vstest"
                 branch="$BranchName$"
                 commit="$CommitId$" />
+    <developmentdependency>true</developmentdependency>
   </metadata>
   <files>
     <file src="Icon.png" target="" />

--- a/src/package/nuspec/Microsoft.TestPlatform.nuspec
+++ b/src/package/nuspec/Microsoft.TestPlatform.nuspec
@@ -16,6 +16,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>vstest visual-studio unittest testplatform mstest microsoft test testing</tags>
     <repository type="git" url="https://github.com/microsoft/vstest" branch="$BranchName$" commit="$CommitId$" />
+    <developmentdependency>true</developmentdependency>
   </metadata>
   <files>
     <file src="Icon.png" target="" />

--- a/src/package/nuspec/TestPlatform.Build.nuspec
+++ b/src/package/nuspec/TestPlatform.Build.nuspec
@@ -18,7 +18,8 @@
                 url="https://github.com/microsoft/vstest" 
                 branch="$BranchName$" 
                 commit="$CommitId$" />
-                
+    <developmentdependency>true</developmentdependency>
+
     <dependencies>
       <group targetFramework="netstandard2.0"></group>
     </dependencies>

--- a/src/package/nuspec/TestPlatform.CLI.nuspec
+++ b/src/package/nuspec/TestPlatform.CLI.nuspec
@@ -18,7 +18,8 @@
                 url="https://github.com/microsoft/vstest" 
                 branch="$BranchName$" 
                 commit="$CommitId$" />
-                
+    <developmentdependency>true</developmentdependency>
+
     <contentFiles>
       <files include="**/*.*" copyToOutput="true" flatten="false" buildAction="None" />
     </contentFiles>

--- a/src/package/nuspec/TestPlatform.Extensions.TrxLogger.nuspec
+++ b/src/package/nuspec/TestPlatform.Extensions.TrxLogger.nuspec
@@ -18,7 +18,8 @@
                 url="https://github.com/microsoft/vstest" 
                 branch="$BranchName$" 
                 commit="$CommitId$" />
-                
+    <developmentdependency>true</developmentdependency>
+
     <dependencies>
       <group targetFramework="net451">
         <dependency id="Newtonsoft.Json" version="$JsonNetVersion$"/>

--- a/src/package/nuspec/TestPlatform.Internal.Uwp.nuspec
+++ b/src/package/nuspec/TestPlatform.Internal.Uwp.nuspec
@@ -15,6 +15,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>vstest visual-studio unittest testplatform mstest microsoft test testing</tags>
     <repository type="git" url="https://github.com/microsoft/vstest" branch="$BranchName$" commit="$CommitId$" />
+    <developmentdependency>true</developmentdependency>
 
   </metadata>
   <files>

--- a/src/package/nuspec/TestPlatform.ObjectModel.nuspec
+++ b/src/package/nuspec/TestPlatform.ObjectModel.nuspec
@@ -18,7 +18,8 @@
                 url="https://github.com/microsoft/vstest" 
                 branch="$BranchName$" 
                 commit="$CommitId$" />
-                
+    <developmentdependency>true</developmentdependency>
+
     <dependencies>
       <group targetFramework="net45">
         <dependency id="System.Reflection.Metadata" version="[1.6.0, )" />

--- a/src/package/nuspec/TestPlatform.TestHost.nuspec
+++ b/src/package/nuspec/TestPlatform.TestHost.nuspec
@@ -18,7 +18,8 @@
                 url="https://github.com/microsoft/vstest" 
                 branch="$BranchName$" 
                 commit="$CommitId$" />
-                
+    <developmentdependency>true</developmentdependency>
+
     <dependencies>
       <group targetFramework="netcoreapp1.0">
         <dependency id="Microsoft.TestPlatform.ObjectModel" version="$Version$"/>

--- a/src/package/nuspec/TestPlatform.TranslationLayer.nuspec
+++ b/src/package/nuspec/TestPlatform.TranslationLayer.nuspec
@@ -18,6 +18,7 @@
                 url="https://github.com/microsoft/vstest" 
                 branch="$BranchName$" 
                 commit="$CommitId$" />
+    <developmentdependency>true</developmentdependency>
 
     <dependencies>
       <group targetFramework="net451">

--- a/test/TestAssets/CPPSimpleTestProject/Microsoft.TestPlatform.Asset.NativeCPP.nuspec
+++ b/test/TestAssets/CPPSimpleTestProject/Microsoft.TestPlatform.Asset.NativeCPP.nuspec
@@ -15,6 +15,7 @@
       <!-- Include Assets as Content -->
       <files include="**/*.*" buildAction="None" copyToOutput="true" flatten="false" />
     </contentFiles>
+    <developmentdependency>true</developmentdependency>
   </metadata>
   <files>
     <file src="package\licenses\LICENSE_NET.txt" target="" />

--- a/test/TestAssets/QualityToolsAssets/Microsoft.TestPlatform.QTools.Assets.nuspec
+++ b/test/TestAssets/QualityToolsAssets/Microsoft.TestPlatform.QTools.Assets.nuspec
@@ -15,6 +15,7 @@
       <!-- Include Assets as Content -->
       <files include="**/*.*" buildAction="None" copyToOutput="true" flatten="false" />
     </contentFiles>
+    <developmentdependency>true</developmentdependency>
   </metadata>
   <files>
     <file src="package\licenses\LICENSE_NET.txt" target="" />


### PR DESCRIPTION
Currently pulling in `Microsoft.NET.Test.Sdk` pulls in `Microsoft.TestPlatform.TestHost` which pulls in `Newtonsoft.Json` version 9.0.1

note that v9 is 5+ years old and 4 majors behind.

This pollutes intellisense can can cause type/assembly loading issue when most projects are referencing a newer major version of Newtonsoft.Json.

So shouldnt the nuspecs for Microsoft.NET.Test.Sdk (and transitive) all be developmentdependency so they do not pollute the compile/run time of the test project consuming them?