### PR TITLE
Temporary disable full post processing in design mode

### DIFF
--- a/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
@@ -20,6 +20,7 @@ internal partial class FeatureFlag : IFeatureFlag
     {
         FeatureFlags.Add(ARTIFACTS_POSTPROCESSING, true);
         FeatureFlags.Add(ARTIFACTS_POSTPROCESSING_SDK_KEEP_OLD_UX, false);
+        FeatureFlags.Add(FORCE_DATACOLLECTORS_ATTACHMENTPROCESSORS, false);
     }
 
     // Added for artifact porst-processing, it enable/disable the post processing.
@@ -30,6 +31,9 @@ internal partial class FeatureFlag : IFeatureFlag
     // It can be useful if we need to restore old UX in case users are parsing the console output.
     // Added in 17.2-preview 7.0-preview
     public static string ARTIFACTS_POSTPROCESSING_SDK_KEEP_OLD_UX = VSTEST_FEATURE + "_" + "ARTIFACTS_POSTPROCESSING_SDK_KEEP_OLD_UX";
+
+    // Temporary used to allow tests to work
+    public static string FORCE_DATACOLLECTORS_ATTACHMENTPROCESSORS = VSTEST_FEATURE + "_" + "FORCE_DATACOLLECTORS_ATTACHMENTPROCESSORS";
 
     // For now we're checking env var.
     // We could add it also to some section inside the runsettings.

--- a/src/Microsoft.TestPlatform.CoreUtilities/Helpers/Interfaces/IRunsettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Helpers/Interfaces/IRunsettingsHelper.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 
 internal interface IRunSettingsHelper
 {
     bool IsDefaultTargetArchitecture { get; set; }
+
+    bool IsDesignMode { get; set; }
 }

--- a/src/Microsoft.TestPlatform.CoreUtilities/Helpers/RunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Helpers/RunSettingsHelper.cs
@@ -21,4 +21,10 @@ internal class RunSettingsHelper : IRunSettingsHelper
     /// --arch or runsettings file or -- RunConfiguration.TargetPlatform=arch
     /// </summary>
     public bool IsDefaultTargetArchitecture { get; set; } = true;
+
+    /// <summary>
+    /// True indicates the test run is started from an Editor or IDE.
+    /// Defaults to false.
+    /// </summary>
+    public bool IsDesignMode { get; set; }
 }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/DataCollectorAttachmentsProcessorsFactory.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/DataCollectorAttachmentsProcessorsFactory.cs
@@ -29,7 +29,7 @@ internal class DataCollectorAttachmentsProcessorsFactory : IDataCollectorAttachm
     {
         IDictionary<string, Tuple<string, IDataCollectorAttachmentProcessor>> datacollectorsAttachmentsProcessors = new Dictionary<string, Tuple<string, IDataCollectorAttachmentProcessor>>();
 
-        if (!RunSettingsHelper.Instance.IsDesignMode)
+        if (!RunSettingsHelper.Instance.IsDesignMode || FeatureFlag.Instance.IsEnabled(FeatureFlag.FORCE_DATACOLLECTORS_ATTACHMENTPROCESSORS))
         {
             if (invokedDataCollectors?.Length > 0)
             {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/DataCollectorAttachmentsProcessorsFactory.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/DataCollectorAttachmentsProcessorsFactory.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
 
 #nullable disable
 
@@ -28,50 +29,53 @@ internal class DataCollectorAttachmentsProcessorsFactory : IDataCollectorAttachm
     {
         IDictionary<string, Tuple<string, IDataCollectorAttachmentProcessor>> datacollectorsAttachmentsProcessors = new Dictionary<string, Tuple<string, IDataCollectorAttachmentProcessor>>();
 
-        if (invokedDataCollectors?.Length > 0)
+        if (!RunSettingsHelper.Instance.IsDesignMode)
         {
-            // We order files by filename descending so in case of the same collector from the same nuget but with different versions, we'll run the newer version.
-            // i.e. C:\Users\xxx\.nuget\packages\coverlet.collector
-            // /3.0.2
-            // /3.0.3
-            // /3.1.0
-            foreach (var invokedDataCollector in invokedDataCollectors.OrderByDescending(d => d.FilePath))
+            if (invokedDataCollectors?.Length > 0)
             {
-                // We'll merge using only one AQN in case of more "same processors" in different assembly.
-                if (!invokedDataCollector.HasAttachmentProcessor)
+                // We order files by filename descending so in case of the same collector from the same nuget but with different versions, we'll run the newer version.
+                // i.e. C:\Users\xxx\.nuget\packages\coverlet.collector
+                // /3.0.2
+                // /3.0.3
+                // /3.1.0
+                foreach (var invokedDataCollector in invokedDataCollectors.OrderByDescending(d => d.FilePath))
                 {
-                    continue;
-                }
-
-                EqtTrace.Info($"DataCollectorAttachmentsProcessorsFactory: Analyzing data collector attachment processor Uri: {invokedDataCollector.Uri} AssemblyQualifiedName: {invokedDataCollector.AssemblyQualifiedName} FilePath: {invokedDataCollector.FilePath} HasAttachmentProcessor: {invokedDataCollector.HasAttachmentProcessor}");
-
-                // We cache extension locally by file path
-                var dataCollectorExtensionManager = DataCollectorExtensionManagerCache.GetOrAdd(invokedDataCollector.FilePath, DataCollectorExtensionManager.Create(invokedDataCollector.FilePath, true, TestSessionMessageLogger.Instance));
-                var dataCollectorExtension = dataCollectorExtensionManager.TryGetTestExtension(invokedDataCollector.Uri);
-                if (dataCollectorExtension?.Metadata.HasAttachmentProcessor == true)
-                {
-                    Type attachmentProcessorType = ((DataCollectorConfig)dataCollectorExtension.TestPluginInfo).AttachmentsProcessorType;
-                    IDataCollectorAttachmentProcessor dataCollectorAttachmentProcessorInstance = null;
-                    try
+                    // We'll merge using only one AQN in case of more "same processors" in different assembly.
+                    if (!invokedDataCollector.HasAttachmentProcessor)
                     {
-                        dataCollectorAttachmentProcessorInstance = TestPluginManager.CreateTestExtension<IDataCollectorAttachmentProcessor>(attachmentProcessorType);
-                        EqtTrace.Info($"DataCollectorAttachmentsProcessorsFactory: Creation of collector attachment processor '{attachmentProcessorType.AssemblyQualifiedName}' from file '{invokedDataCollector.FilePath}' succeded");
-                    }
-                    catch (Exception ex)
-                    {
-                        EqtTrace.Error($"DataCollectorAttachmentsProcessorsFactory: Failed during the creation of data collector attachment processor '{attachmentProcessorType.AssemblyQualifiedName}'\n{ex}");
-                        logger?.SendMessage(TestMessageLevel.Error, $"DataCollectorAttachmentsProcessorsFactory: Failed during the creation of data collector attachment processor '{attachmentProcessorType.AssemblyQualifiedName}'\n{ex}");
+                        continue;
                     }
 
-                    if (dataCollectorAttachmentProcessorInstance != null && !datacollectorsAttachmentsProcessors.ContainsKey(attachmentProcessorType.AssemblyQualifiedName))
+                    EqtTrace.Info($"DataCollectorAttachmentsProcessorsFactory: Analyzing data collector attachment processor Uri: {invokedDataCollector.Uri} AssemblyQualifiedName: {invokedDataCollector.AssemblyQualifiedName} FilePath: {invokedDataCollector.FilePath} HasAttachmentProcessor: {invokedDataCollector.HasAttachmentProcessor}");
+
+                    // We cache extension locally by file path
+                    var dataCollectorExtensionManager = DataCollectorExtensionManagerCache.GetOrAdd(invokedDataCollector.FilePath, DataCollectorExtensionManager.Create(invokedDataCollector.FilePath, true, TestSessionMessageLogger.Instance));
+                    var dataCollectorExtension = dataCollectorExtensionManager.TryGetTestExtension(invokedDataCollector.Uri);
+                    if (dataCollectorExtension?.Metadata.HasAttachmentProcessor == true)
                     {
-                        datacollectorsAttachmentsProcessors.Add(attachmentProcessorType.AssemblyQualifiedName, new Tuple<string, IDataCollectorAttachmentProcessor>(dataCollectorExtension.Metadata.FriendlyName, dataCollectorAttachmentProcessorInstance));
-                        EqtTrace.Info($"DataCollectorAttachmentsProcessorsFactory: Collector attachment processor '{attachmentProcessorType.AssemblyQualifiedName}' from file '{invokedDataCollector.FilePath}' added to the 'run list'");
+                        Type attachmentProcessorType = ((DataCollectorConfig)dataCollectorExtension.TestPluginInfo).AttachmentsProcessorType;
+                        IDataCollectorAttachmentProcessor dataCollectorAttachmentProcessorInstance = null;
+                        try
+                        {
+                            dataCollectorAttachmentProcessorInstance = TestPluginManager.CreateTestExtension<IDataCollectorAttachmentProcessor>(attachmentProcessorType);
+                            EqtTrace.Info($"DataCollectorAttachmentsProcessorsFactory: Creation of collector attachment processor '{attachmentProcessorType.AssemblyQualifiedName}' from file '{invokedDataCollector.FilePath}' succeded");
+                        }
+                        catch (Exception ex)
+                        {
+                            EqtTrace.Error($"DataCollectorAttachmentsProcessorsFactory: Failed during the creation of data collector attachment processor '{attachmentProcessorType.AssemblyQualifiedName}'\n{ex}");
+                            logger?.SendMessage(TestMessageLevel.Error, $"DataCollectorAttachmentsProcessorsFactory: Failed during the creation of data collector attachment processor '{attachmentProcessorType.AssemblyQualifiedName}'\n{ex}");
+                        }
+
+                        if (dataCollectorAttachmentProcessorInstance != null && !datacollectorsAttachmentsProcessors.ContainsKey(attachmentProcessorType.AssemblyQualifiedName))
+                        {
+                            datacollectorsAttachmentsProcessors.Add(attachmentProcessorType.AssemblyQualifiedName, new Tuple<string, IDataCollectorAttachmentProcessor>(dataCollectorExtension.Metadata.FriendlyName, dataCollectorAttachmentProcessorInstance));
+                            EqtTrace.Info($"DataCollectorAttachmentsProcessorsFactory: Collector attachment processor '{attachmentProcessorType.AssemblyQualifiedName}' from file '{invokedDataCollector.FilePath}' added to the 'run list'");
+                        }
                     }
-                }
-                else
-                {
-                    EqtTrace.Info($"DataCollectorAttachmentsProcessorsFactory: DataCollectorExtension not found for uri '{invokedDataCollector.Uri}'");
+                    else
+                    {
+                        EqtTrace.Info($"DataCollectorAttachmentsProcessorsFactory: DataCollectorExtension not found for uri '{invokedDataCollector.Uri}'");
+                    }
                 }
             }
         }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/DataCollectorAttachmentsProcessorsFactory.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/DataCollectorAttachmentsProcessorsFactory.cs
@@ -29,6 +29,12 @@ internal class DataCollectorAttachmentsProcessorsFactory : IDataCollectorAttachm
     {
         IDictionary<string, Tuple<string, IDataCollectorAttachmentProcessor>> datacollectorsAttachmentsProcessors = new Dictionary<string, Tuple<string, IDataCollectorAttachmentProcessor>>();
 
+
+        // Temporary disabled in design mode.
+        // We have an issue when the collector is found inside bin folder/subfolder of the user in case of VS.
+        // Usually collector are loaded from nuget package or visual studio special folders, but if a user for some reason run `dotnet publish`
+        // and after run the datacollector with the attachment processor we're loading 'published' version and no more nuget one.
+        // This led to file locking that prevents further `dotnet publish` and maybe build.
         if (!RunSettingsHelper.Instance.IsDesignMode || FeatureFlag.Instance.IsEnabled(FeatureFlag.FORCE_DATACOLLECTORS_ATTACHMENTPROCESSORS))
         {
             if (invokedDataCollectors?.Length > 0)

--- a/src/vstest.console/Processors/PortArgumentProcessor.cs
+++ b/src/vstest.console/Processors/PortArgumentProcessor.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
 
 using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;
 
@@ -143,6 +144,7 @@ internal class PortArgumentExecutor : IArgumentExecutor
 
         _commandLineOptions.Port = portNumber;
         _commandLineOptions.IsDesignMode = true;
+        RunSettingsHelper.Instance.IsDesignMode = true;
         _designModeClient = _designModeInitializer?.Invoke(_commandLineOptions.ParentProcessId, _processHelper);
     }
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/CodeCoverageTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/CodeCoverageTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -31,6 +32,13 @@ public class CodeCoverageTests : CodeCoverageAcceptanceTestBase
     private TempDirectory _tempDirectory;
     private RunEventHandler _runEventHandler;
     private TestRunAttachmentsProcessingEventHandler _testRunAttachmentsProcessingEventHandler;
+
+    static CodeCoverageTests()
+    {
+#pragma warning disable RS0030 // Do not used banned APIs - We need it temporary
+        Environment.SetEnvironmentVariable("VSTEST_FEATURE_FORCE_DATACOLLECTORS_ATTACHMENTPROCESSORS", "1");
+#pragma warning restore RS0030 // Do not used banned APIs - We need it temporary
+    }
 
     private void Setup()
     {


### PR DESCRIPTION
## Description

In VS if for some reason the datacollector is pushed to the bin folder/subfoldersr and not resolved by nuget folders we're loading the `DataCollectorAttachmentsProcessors` extension locking the file blocking build/publish until `vstest.console.exe`  restarts.

We need better strategy.

This PR doesn't have any effect on the CodeCoverage merging, it will continue to work like in the past.