### PR TITLE
Prevent unecessary using warnings

### DIFF
--- a/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !NETSTANDARD1_0
+
 using System;
 using System.Collections.Generic;
 
-#if !NETSTANDARD1_0
-
 namespace Microsoft.VisualStudio.TestPlatform.Utilities;
+
 // !!! FEATURES MUST BE KEPT IN SYNC WITH https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/commands/dotnet-test/VSTestFeatureFlag.cs !!!
 internal partial class FeatureFlag : IFeatureFlag
 {

--- a/src/Microsoft.TestPlatform.CoreUtilities/Helpers/EnvironmentVariableHelper.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Helpers/EnvironmentVariableHelper.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !NETSTANDARD1_0
+
 using System;
 
 using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
-
-#if !NETSTANDARD1_0
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.CoreUtilities/Helpers/FileHelper.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Helpers/FileHelper.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !NETSTANDARD1_0
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -8,8 +10,6 @@ using System.IO;
 using System.Linq;
 
 using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
-
-#if !NETSTANDARD1_0
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.CoreUtilities/Output/ConsoleOutput.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Output/ConsoleOutput.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !NETSTANDARD1_0 && !WINDOWS_UWP
+
 using System;
 using System.IO;
-
-#if !NETSTANDARD1_0 && !WINDOWS_UWP
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.CoreUtilities/Output/OutputExtensions.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Output/OutputExtensions.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !NETSTANDARD1_0 && !WINDOWS_UWP
+
 using System;
 using System.Globalization;
 
 using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Resources;
-
-#if !NETSTANDARD1_0 && !WINDOWS_UWP
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestRunSummary.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestRunSummary.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Xml;
 

--- a/src/Microsoft.TestPlatform.ObjectModel/DataCollector/Common/FileHelper.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/DataCollector/Common/FileHelper.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;

--- a/src/Microsoft.TestPlatform.ObjectModel/DataCollector/InProcDataCollector/TestSessionStartArgs.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/DataCollector/InProcDataCollector/TestSessionStartArgs.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 
 #nullable disable

--- a/src/Microsoft.TestPlatform.ObjectModel/RegistryFreeActivationContext.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RegistryFreeActivationContext.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK
+
 using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-
-#if NETFRAMEWORK
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/IO/PlatformStream.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/IO/PlatformStream.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || NETCOREAPP || NETSTANDARD2_0
+
 using System.IO;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if NETFRAMEWORK || NETCOREAPP || NETSTANDARD2_0
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || NETCOREAPP ||  NETSTANDARD2_0
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -10,8 +12,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if NETFRAMEWORK || NETCOREAPP ||  NETSTANDARD2_0
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/PlatformEqtTrace.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/PlatformEqtTrace.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || NETCOREAPP || NETSTANDARD2_0
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Threading;
-
-#if NETFRAMEWORK || NETCOREAPP || NETSTANDARD2_0
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/RollingFileTraceListener.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/RollingFileTraceListener.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || NETCOREAPP || NETSTANDARD2_0
+
 using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
-
-#if NETFRAMEWORK || NETCOREAPP || NETSTANDARD2_0
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Interfaces/Tracing/IPlatformEqtTrace.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Interfaces/Tracing/IPlatformEqtTrace.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK
+
 using System;
 using System.Diagnostics;
-
-#if NETFRAMEWORK
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Runtime/PlatformAssemblyExtensions.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Runtime/PlatformAssemblyExtensions.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Reflection;
-
 #if NETFRAMEWORK || NETSTANDARD2_0
+
+using System.Reflection;
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Runtime/PlatformAssemblyLoadContext.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Runtime/PlatformAssemblyLoadContext.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || NETSTANDARD2_0
+
 using System.Reflection;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if NETFRAMEWORK || NETSTANDARD2_0
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Runtime/PlatformAssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Runtime/PlatformAssemblyResolver.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || NETSTANDARD2_0
+
 using System;
 using System.Reflection;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if NETFRAMEWORK || NETSTANDARD2_0
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/PlatformEnvironment.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/PlatformEnvironment.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || NETSTANDARD2_0
+
 using System;
 using System.Threading;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if NETFRAMEWORK || NETSTANDARD2_0
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/PlatformThread.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/PlatformThread.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || NETSTANDARD2_0
+
 using System;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if NETFRAMEWORK || NETSTANDARD2_0
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/ProcessHelper.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK || NETSTANDARD2_0
+
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -9,8 +11,6 @@ using System.Runtime.InteropServices;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if NETFRAMEWORK || NETSTANDARD2_0
 
 #nullable disable
 
@@ -75,7 +75,7 @@ public partial class ProcessHelper : IProcessHelper
         using BinaryReader reader = new(fs);
 
         // https://docs.microsoft.com/windows/win32/debug/pe-format#ms-dos-stub-image-only
-        // At location 0x3c, the stub has the file offset to the PE signature. 
+        // At location 0x3c, the stub has the file offset to the PE signature.
         fs.Position = 0x3C;
         var peHeader = reader.ReadUInt32();
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/ProcessStartInfoExtensions.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/System/ProcessStartInfoExtensions.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
-
 #if NETFRAMEWORK || NETSTANDARD2_0
+
+using System.Diagnostics;
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Tracing/PlatformEqtTrace.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Tracing/PlatformEqtTrace.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK
+
 using System;
 using System.Diagnostics;
-
-#if NETFRAMEWORK
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Tracing/RemoteEqtTrace.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net451/Tracing/RemoteEqtTrace.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK
+
 using System;
 using System.Diagnostics;
-
-#if NETFRAMEWORK
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/Runtime/PlatformAssemblyExtensions.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/Runtime/PlatformAssemblyExtensions.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Reflection;
-
 #if NETCOREAPP
+
+using System.Reflection;
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformEnvironment.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformEnvironment.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETCOREAPP
+
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if NETCOREAPP
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformThread.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformThread.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETCOREAPP
+
 using System;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if NETCOREAPP
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETCOREAPP
+
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -8,8 +10,6 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if NETCOREAPP
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessStartInfoExtensions.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessStartInfoExtensions.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
-
 #if NETCOREAPP
+
+using System.Diagnostics;
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/IO/PlatformStream.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/IO/PlatformStream.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETSTANDARD && !NETSTANDARD2_0
+
 using System;
 using System.IO;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if NETSTANDARD && !NETSTANDARD2_0
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/Runtime/PlatformAssemblyExtensions.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/Runtime/PlatformAssemblyExtensions.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETSTANDARD && !NETSTANDARD2_0
+
 using System;
 using System.Reflection;
-
-#if NETSTANDARD && !NETSTANDARD2_0
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/Runtime/PlatformAssemblyLoadContext.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/Runtime/PlatformAssemblyLoadContext.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETSTANDARD && !NETSTANDARD2_0
+
 using System.Reflection;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if NETSTANDARD && !NETSTANDARD2_0
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/Runtime/PlatformAssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/Runtime/PlatformAssemblyResolver.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETSTANDARD && !NETSTANDARD2_0
+
 using System;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if NETSTANDARD && !NETSTANDARD2_0
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/System/PlatformEnvironment.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/System/PlatformEnvironment.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETSTANDARD && !NETSTANDARD2_0
+
 using System;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if NETSTANDARD && !NETSTANDARD2_0
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/System/PlatformThread.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/System/PlatformThread.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETSTANDARD && !NETSTANDARD2_0
+
 using System;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if NETSTANDARD && !NETSTANDARD2_0
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/System/ProcessHelper.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETSTANDARD && !NETSTANDARD2_0
+
 using System;
 using System.Collections.Generic;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if NETSTANDARD && !NETSTANDARD2_0
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/Tracing/PlatformEqtTrace.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netstandard/Tracing/PlatformEqtTrace.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETSTANDARD && !NETSTANDARD2_0
+
 using System;
 using System.Diagnostics;
-
-#if NETSTANDARD && !NETSTANDARD2_0
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/IO/PlatformStream.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/IO/PlatformStream.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if WINDOWS_UWP
+
 using System.IO;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if WINDOWS_UWP
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Runtime/PlatformAssemblyExtensions.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Runtime/PlatformAssemblyExtensions.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if WINDOWS_UWP
+
 using System.IO;
 using System.Reflection;
-
-#if WINDOWS_UWP
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Runtime/PlatformAssemblyLoadContext.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Runtime/PlatformAssemblyLoadContext.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if WINDOWS_UWP
+
 using System.IO;
 using System.Reflection;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if WINDOWS_UWP
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Runtime/PlatformAssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/Runtime/PlatformAssemblyResolver.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
 #if WINDOWS_UWP
+
+using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/PlatformEnvironment.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/PlatformEnvironment.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if WINDOWS_UWP
+
 using System;
 using System.Runtime.InteropServices;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if WINDOWS_UWP
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/PlatformThread.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/PlatformThread.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if WINDOWS_UWP
+
 using System;
 using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if WINDOWS_UWP
 
 #nullable disable
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/uap10.0/System/ProcessHelper.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if WINDOWS_UWP
+
 using System;
 using System.Collections.Generic;
 using System.IO;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-
-#if WINDOWS_UWP
 
 #nullable disable
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DotnetArchitectureSwitchTests.Windows.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DotnetArchitectureSwitchTests.Windows.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !NET451
+
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,8 +11,6 @@ using Microsoft.TestPlatform.TestUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Newtonsoft.Json.Linq;
-
-#if !NET451
 
 #nullable disable
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DotnetArchitectureSwitchTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DotnetArchitectureSwitchTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !NET451
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -9,8 +11,6 @@ using System.Text.RegularExpressions;
 
 using Microsoft.TestPlatform.TestUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-#if !NET451
 
 #nullable disable
 

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Utilities/AssemblyHelperTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Utilities/AssemblyHelperTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETFRAMEWORK
+
 using System;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
@@ -8,8 +10,6 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
-
-#if NETFRAMEWORK
 
 #nullable disable
 

--- a/test/vstest.console.UnitTests/Processors/EnvironmentArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnvironmentArgumentProcessorTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Linq;
 using System.Xml.Linq;
 


### PR DESCRIPTION
## Description

When running code analysis on solution we have multiple warnings showing up about unecessary warnings that for some reason don't show up in build.
