### PR TITLE
Fix path.combine

### DIFF
--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -696,7 +696,12 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
     private string GetTestHostPath(string runtimeConfigDevPath, string depsFilePath, string sourceDirectory)
     {
         string testHostPackageName = "microsoft.testplatform.testhost";
-        string testHostPath = null;
+        // This must be empty string, otherwise the Path.Combine below
+        // will fail if a very specific setup is used where you add our dlls
+        // as assemblies directly, but you have no RuntimeAssemblyGroups in deps.json
+        // because you don't add our nuget package. In such case we just want to move on
+        // to the next fallback.
+        string testHostPath = string.Empty;
 
         if (_fileHelper.Exists(depsFilePath))
         {


### PR DESCRIPTION
## Description
When a test project is setup in very specific way, where the references to our package
are in the output folder and mentioned in deps.json, but there is no runtime reference
then we fail with null ref in Path.Combine.
