### PR TITLE
Fix TargetInvocationException in AttachVS

### DIFF
--- a/src/AttachVS/AttachVs.cs
+++ b/src/AttachVS/AttachVs.cs
@@ -143,6 +143,14 @@ internal class DebuggerUtility
                             Trace($"ComException: Retrying in 250ms.\n{ex}");
                             Thread.Sleep(250);
                         }
+                        catch (TargetInvocationException ex)
+                        {
+                            if (ex.InnerException is not COMException)
+                                throw;
+
+                            Trace($"ComException: Retrying in 250ms.\n{ex}");
+                            Thread.Sleep(250);
+                        }
                     }
                     Marshal.ReleaseComObject(moniker[0]);
 


### PR DESCRIPTION
Not sure why, but sometimes the COM exception is wrapped. This makes AttachVS way more reliable.