### PR TITLE
Use newer VS UX for data source tests

### DIFF
--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -13,8 +13,8 @@
     from a build parameter would not be available, so I am writing this version from the build.ps1 script to keep it in sync -->
     <NETTestSdkVersion>17.2.0-dev</NETTestSdkVersion>
 
-    <MSTestFrameworkVersion>2.1.0</MSTestFrameworkVersion>
-    <MSTestAdapterVersion>2.1.0</MSTestAdapterVersion>
+    <MSTestFrameworkVersion>2.2.8</MSTestFrameworkVersion>
+    <MSTestAdapterVersion>$(MSTestFrameworkVersion)</MSTestAdapterVersion>
     <MSTestAssertExtensionVersion>1.0.3-preview</MSTestAssertExtensionVersion>
 
     <XUnitFrameworkVersion>2.3.1</XUnitFrameworkVersion>

--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -14,7 +14,7 @@
     <NETTestSdkVersion>17.2.0-dev</NETTestSdkVersion>
 
     <MSTestFrameworkVersion>2.2.8</MSTestFrameworkVersion>
-    <MSTestAdapterVersion>$(MSTestFrameworkVersion)</MSTestAdapterVersion>
+    <MSTestAdapterVersion>2.2.8</MSTestAdapterVersion>
     <MSTestAssertExtensionVersion>1.0.3-preview</MSTestAssertExtensionVersion>
 
     <XUnitFrameworkVersion>2.3.1</XUnitFrameworkVersion>

--- a/test/Microsoft.TestPlatform.AcceptanceTests/Extension/RunnnerInfo.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/Extension/RunnnerInfo.cs
@@ -16,20 +16,30 @@ public record RunnerInfo(string RunnerFramework, string TargetFramework, string 
     /// <summary>
     /// Is running via .NET "Core" vstest.console?
     /// </summary>
-    public bool IsNetRunner => RunnerFramework.StartsWith("netcoreapp", StringComparison.InvariantCultureIgnoreCase);
+    public bool IsNetRunner => !IsNetFrameworkRunner;
 
     /// <summary>
     /// Is running via .NET Framework vstest.console?
     /// </summary>
-    public bool IsNetFrameworkRunner => !IsNetRunner;
+    public bool IsNetFrameworkRunner => RunnerFramework.StartsWith("net4", StringComparison.InvariantCultureIgnoreCase);
+
+    /// <summary>
+    /// Is running via .NET "Core" testhost?
+    /// </summary>
+    public bool IsNetTarget => !IsNetFrameworkTarget;
 
     /// <summary>
     /// Is running via .NET Framework testhost?
     /// </summary>
-    public bool IsNetTarget => TargetFramework.StartsWith("netcoreapp", StringComparison.InvariantCultureIgnoreCase);
+    public bool IsNetFrameworkTarget => TargetFramework.StartsWith("net4", StringComparison.InvariantCultureIgnoreCase);
 
-    /// <summary>
-    /// Is running via .NET Framework testhost?
-    /// </summary>
-    public bool IsNetFrameworkTarget => !IsNetTarget;
+    public override string ToString()
+        => string.Join(
+            ",",
+            new[]
+            {
+                "RunnerFramework = " + RunnerFramework,
+                " TargetFramework = " + TargetFramework,
+                string.IsNullOrEmpty(InIsolationValue) ? " InProcess" : " InIsolation",
+            });
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/Extension/RunnnerInfo.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/Extension/RunnnerInfo.cs
@@ -1,90 +1,35 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
-public class RunnerInfo
+/// <summary>
+///
+/// </summary>
+/// <param name="RunnerFramework"></param>
+/// <param name="TargetFramework"></param>
+/// <param name="InIsolationValue">Supported value = <c>/InIsolation</c>.</param>
+public record RunnerInfo(string RunnerFramework, string TargetFramework, string InIsolationValue = "")
 {
-    // Serialization ctor that enables correct tree view for data source tests
-    private RunnerInfo()
-    {
-    }
-
-    public RunnerInfo(string runnerType, string targetFramework)
-        : this(runnerType, targetFramework, "")
-    {
-    }
-
-    public RunnerInfo(string runnerType, string targetFramework, string inIsolation)
-    {
-        RunnerFramework = runnerType;
-        TargetFramework = targetFramework;
-        InIsolationValue = inIsolation;
-        // The value is netcoreapp2.1.
-        IsNetRunner = RunnerFramework.StartsWith("netcoreapp", StringComparison.InvariantCultureIgnoreCase);
-        // The value is net451.
-        IsNetFrameworkRunner = !IsNetRunner;
-        IsNetTarget = TargetFramework.StartsWith("netcoreapp", StringComparison.InvariantCultureIgnoreCase);
-        IsNetFrameworkTarget = !IsNetTarget;
-    }
-
-    /// <summary>
-    /// Gets the target framework.
-    /// </summary>
-    public string TargetFramework
-    {
-        get;
-        set;
-    }
-
-    /// <summary>
-    /// Gets the inIsolation.
-    /// Supported values = <c>/InIsolation</c>.
-    /// </summary>
-    public string InIsolationValue
-    {
-        get; set;
-    }
-
-    /// <summary>
-    /// Gets the application type.
-    /// </summary>
-    public string RunnerFramework
-    {
-        get;
-        set;
-    }
-
-    public override string ToString()
-    {
-        return string.Join(",", new[] { "RunnerFramework = " + RunnerFramework, " TargetFramework = " + TargetFramework, string.IsNullOrEmpty(InIsolationValue) ? " InProcess" : " InIsolation" });
-    }
-
     /// <summary>
     /// Is running via .NET "Core" vstest.console?
     /// </summary>
-    /// <returns></returns>
-    public bool IsNetRunner { get; }
+    public bool IsNetRunner => RunnerFramework.StartsWith("netcoreapp", StringComparison.InvariantCultureIgnoreCase);
 
     /// <summary>
     /// Is running via .NET Framework vstest.console?
     /// </summary>
-    /// <returns></returns>
-    public bool IsNetFrameworkRunner { get; }
-
-    /// <summary>
-    /// Is running via .NET "Core" testhost?
-    /// </summary>
-    /// <returns></returns>
-    public bool IsNetTarget { get; }
+    public bool IsNetFrameworkRunner => !IsNetRunner;
 
     /// <summary>
     /// Is running via .NET Framework testhost?
     /// </summary>
-    /// <returns></returns>
-    public bool IsNetFrameworkTarget { get; }
+    public bool IsNetTarget => TargetFramework.StartsWith("netcoreapp", StringComparison.InvariantCultureIgnoreCase);
+
+    /// <summary>
+    /// Is running via .NET Framework testhost?
+    /// </summary>
+    public bool IsNetFrameworkTarget => !IsNetTarget;
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/Extension/RunnnerInfo.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/Extension/RunnnerInfo.cs
@@ -9,7 +9,13 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 
 public class RunnerInfo
 {
-    public RunnerInfo(string runnerType, string targetFramework) : this(runnerType, targetFramework, "")
+    // Serialization ctor that enables correct tree view for data source tests
+    private RunnerInfo()
+    {
+    }
+
+    public RunnerInfo(string runnerType, string targetFramework)
+        : this(runnerType, targetFramework, "")
     {
     }
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/IsExternalInit.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/IsExternalInit.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !NET5_0_OR_GREATER
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Reserved for use by the compiler for records.
+/// /!\ Do not use directly. /!\
+/// </summary>
+[ExcludeFromCodeCoverage, DebuggerNonUserCode]
+internal static class IsExternalInit
+{
+}
+
+#endif

--- a/test/Microsoft.TestPlatform.AcceptanceTests/LoggerTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/LoggerTests.cs
@@ -183,7 +183,7 @@ public class LoggerTests : AcceptanceTestBase
         }
     }
 
-    private void IsFileAndContentEqual(string filePath)
+    private static void IsFileAndContentEqual(string filePath)
     {
         StringBuilder sb = new();
         using (var sr = new StreamReader(filePath))
@@ -192,7 +192,7 @@ public class LoggerTests : AcceptanceTestBase
         }
 
         string filePathContent = sb.ToString();
-        string[] divs = { "Total tests", "Passed", "Failed", "Skipped", "Run duration", "Pass percentage", "SampleUnitTestProject.UnitTest1.PassingTest" };
+        string[] divs = { "Total tests", "Passed", "Failed", "Skipped", "Run duration", "Pass percentage", "PassingTest" };
         foreach (string str in divs)
         {
             StringAssert.Contains(filePathContent, str);


### PR DESCRIPTION
## Description

Using the newer version of the test fx + adding the private ctor allows us to have children of a test for each configuration rather than having multiple outputs.
