### PR TITLE
Support reading embedded pdbs

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/Navigation/DiaSession.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Navigation/DiaSession.cs
@@ -101,12 +101,21 @@ public class DiaSession : INavigationSession
         // For remote scenario, also look for pdb in current directory, (esp for UWP)
         // The alternate search path should be an input from Adapters, but since it is not so currently adding a HACK
         pdbFilePath = !File.Exists(pdbFilePath) ? Path.Combine(Directory.GetCurrentDirectory(), Path.GetFileName(pdbFilePath)) : pdbFilePath;
-        using var stream = new FileHelper().GetStream(pdbFilePath, FileMode.Open, FileAccess.Read);
-        if (PortablePdbReader.IsPortable(stream))
+
+        if (File.Exists(pdbFilePath))
         {
+            using var stream = new FileHelper().GetStream(pdbFilePath, FileMode.Open, FileAccess.Read);
+            if (PortablePdbReader.IsPortable(stream))
+            {
+                return new PortableSymbolReader();
+            }
+
+            return new FullSymbolReader();
+        }
+        else
+        {
+            // If we cannot find the pdb file, it might be embedded in the dll.
             return new PortableSymbolReader();
         }
-
-        return new FullSymbolReader();
     }
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/Navigation/PortablePdbReader.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Navigation/PortablePdbReader.cs
@@ -55,6 +55,17 @@ internal class PortablePdbReader : IDisposable
     }
 
     /// <summary>
+    /// Reads the pdb using a provided metadata reader, when the pdb is embedded in the dll, or found by
+    /// path that is in the dll metadata.
+    /// </summary>
+    /// <param name="metadataReaderProvider"></param>
+    public PortablePdbReader(MetadataReaderProvider metadataReaderProvider!!)
+    {
+        _provider = metadataReaderProvider;
+        _reader = _provider.GetMetadataReader();
+    }
+
+    /// <summary>
     /// Dispose Metadata reader
     /// </summary>
     public void Dispose()

--- a/src/Microsoft.TestPlatform.ObjectModel/Navigation/PortableSymbolReader.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Navigation/PortableSymbolReader.cs
@@ -163,11 +163,10 @@ internal class PortableSymbolReader : ISymbolReader
     /// <exception cref="InvalidOperationException"></exception>
     private static PortablePdbReader CreatePortablePdbReaderFromPEData(string binaryPath)
     {
-        var peReader = new PEReader(new FileStream(binaryPath, FileMode.Open, FileAccess.Read));
+        using var dllStream = new FileStream(binaryPath, FileMode.Open, FileAccess.Read);
+        using var peReader = new PEReader(dllStream);
 
-        // (_) => null is stream reader factory for the pdb. We don't need that stream.
-        // out _ is the path to the found pdb, we also don't need that.
-        var hasPdb = peReader.TryOpenAssociatedPortablePdb(binaryPath, (_) => null, out MetadataReaderProvider mp, out _);
+        var hasPdb = peReader.TryOpenAssociatedPortablePdb(binaryPath, pdbPath => new FileStream(pdbPath, FileMode.Open, FileAccess.Read), out MetadataReaderProvider mp, pdbPath: out _);
 
         // The out parameters don't give additional info about the pdbFile in case it is not found. So we have few reasons to fail:
         if (!hasPdb)


### PR DESCRIPTION
## Description
Building with `<DebugType>embedded</DebugType>` embeds portable pdb into the dll. This change either takes the pdb that is next to the file, or falls back to trying to read the pdb information from the executable.

## Related issue
Fix #1908

Fixes 1. and 2. from https://github.com/microsoft/vstest/issues/1908#issuecomment-548164376 comment, but not 3. which is a perf improvement). Also keeps the current functionality of looking up the file next to the source in place for backwards compatibility.

If only I saw that comment before I went on to implement this. It spells out exactly what I ended up doing, minus 2 hours spent trying to find the right class and method that can read the embedded pdbs.