### PR TITLE
Make RunnerInfo serializable to fix discovery serialization

### DIFF
--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs
@@ -181,7 +181,7 @@ internal class TestPluginDiscoverer
 
             if (!types.Any())
             {
-                types.AddRange(assembly.GetTypes().Where(type => type.GetTypeInfo().IsClass && !type.GetTypeInfo().IsAbstract));
+                types.AddRange(assembly.GetTypes().Where(type => type.GetTypeInfo() is { } typeInfo && typeInfo.IsClass && !typeInfo.IsAbstract));
             }
         }
         catch (ReflectionTypeLoadException e)

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DifferentTestFrameworkSimpleTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DifferentTestFrameworkSimpleTests.cs
@@ -20,9 +20,11 @@ public class DifferentTestFrameworkSimpleTests : AcceptanceTestBase
     public void ChutzpahRunAllTestExecution(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
-        var testJSFileAbsolutePath = Path.Combine(_testEnvironment.TestAssetsPath, "test.js");
-        var arguments = PrepareArguments(testJSFileAbsolutePath, GetTestAdapterPath(UnitTestFramework.Chutzpah), string.Empty, FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
-
+        string fileName = "test.js";
+        var testJSFileAbsolutePath = Path.Combine(_testEnvironment.TestAssetsPath, fileName);
+        string tempPath = Path.Combine(TempDirectory.Path, fileName);
+        File.Copy(testJSFileAbsolutePath, tempPath);
+        var arguments = PrepareArguments(tempPath, GetTestAdapterPath(UnitTestFramework.Chutzpah), string.Empty, FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
         InvokeVsTest(arguments);
         ValidateSummaryStatus(1, 1, 0);
     }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DotnetTestTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DotnetTestTests.cs
@@ -21,7 +21,7 @@ public class DotnetTestTests : AcceptanceTestBase
         var projectName = "SimpleTestProject.csproj";
         var projectPath = GetProjectFullPath(projectName);
 
-        InvokeDotnetTest($@"{projectPath} --logger:""Console;Verbosity=normal""");
+        InvokeDotnetTest($@"{projectPath} --no-build -- --logger:""Console;Verbosity=normal""");
 
         // ensure our dev version is used
         StdOutputContains("-dev");
@@ -57,7 +57,7 @@ public class DotnetTestTests : AcceptanceTestBase
 
         var projectName = "ParametrizedTestProject.csproj";
         var projectPath = GetProjectFullPath(projectName);
-        InvokeDotnetTest($@"{projectPath} --logger:""Console;Verbosity=normal"" -- TestRunParameters.Parameter(name =\""weburl\"", value=\""http://localhost//def\"")");
+        InvokeDotnetTest($@"{projectPath} --no-build --logger:""Console;Verbosity=normal"" -- TestRunParameters.Parameter(name =\""weburl\"", value=\""http://localhost//def\"")");
         ValidateSummaryStatus(1, 0, 0);
         ExitCodeEquals(0);
     }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DotnetTestTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DotnetTestTests.cs
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
 
-#nullable disable
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
@@ -18,17 +19,14 @@ public class DotnetTestTests : AcceptanceTestBase
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        var projectName = "SimpleTestProject.csproj";
-        var projectPath = GetProjectFullPath(projectName);
-
-        InvokeDotnetTest($@"{projectPath} --no-build -- --logger:""Console;Verbosity=normal""");
+        var projectPath = GetIsolatedTestAsset("SimpleTestProject.csproj");
+        InvokeDotnetTest($@"{projectPath} --logger:""Console;Verbosity=normal""");
 
         // ensure our dev version is used
         StdOutputContains("-dev");
         ValidateSummaryStatus(1, 1, 1);
         ExitCodeEquals(1);
     }
-
 
     [TestMethod]
     // patched dotnet is not published on non-windows systems
@@ -38,7 +36,7 @@ public class DotnetTestTests : AcceptanceTestBase
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        var assemblyPath = BuildMultipleAssemblyPath("SimpleTestProject.dll").Trim('\"');
+        var assemblyPath = GetAssetFullPath("SimpleTestProject.dll");
         InvokeDotnetTest($@"{assemblyPath} --logger:""Console;Verbosity=normal""");
 
         // ensure our dev version is used
@@ -51,13 +49,13 @@ public class DotnetTestTests : AcceptanceTestBase
     // patched dotnet is not published on non-windows systems
     [TestCategory("Windows-Review")]
     [NetCoreTargetFrameworkDataSource]
-    public void PassInlineSettings(RunnerInfo runnerInfo)
+    public void RunDotnetTestWithCsprojPassInlineSettings(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        var projectName = "ParametrizedTestProject.csproj";
-        var projectPath = GetProjectFullPath(projectName);
-        InvokeDotnetTest($@"{projectPath} --no-build --logger:""Console;Verbosity=normal"" -- TestRunParameters.Parameter(name =\""weburl\"", value=\""http://localhost//def\"")");
+        var projectPath = GetIsolatedTestAsset("ParametrizedTestProject.csproj");
+        InvokeDotnetTest($@"{projectPath} --logger:""Console;Verbosity=normal"" -- TestRunParameters.Parameter(name =\""weburl\"", value=\""http://localhost//def\"")");
+
         ValidateSummaryStatus(1, 0, 0);
         ExitCodeEquals(0);
     }
@@ -66,14 +64,54 @@ public class DotnetTestTests : AcceptanceTestBase
     // patched dotnet is not published on non-windows systems
     [TestCategory("Windows-Review")]
     [NetCoreTargetFrameworkDataSource]
-    public void PassInlineSettingsToDll(RunnerInfo runnerInfo)
+    public void RunDotnetTestWithDllPassInlineSettings(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        var assemblyPath = BuildMultipleAssemblyPath("ParametrizedTestProject.dll").Trim('\"');
+        var assemblyPath = GetAssetFullPath("ParametrizedTestProject.dll");
         InvokeDotnetTest($@"{assemblyPath} --logger:""Console;Verbosity=normal"" -- TestRunParameters.Parameter(name=\""weburl\"", value=\""http://localhost//def\"")");
 
         ValidateSummaryStatus(1, 0, 0);
         ExitCodeEquals(0);
+    }
+
+    private string GetIsolatedTestAsset(string assetName)
+    {
+        var projectPath = GetProjectFullPath(assetName);
+
+        foreach (var file in new FileInfo(projectPath).Directory!.EnumerateFiles())
+        {
+            var newFilePath = Path.Combine(TempDirectory.Path, file.Name);
+
+            if (file.Extension.Equals(".csproj", StringComparison.OrdinalIgnoreCase))
+            {
+                const string testAssetsProps = "TestAssets.props";
+                const string relativePathToRoot = @"..\..\..";
+                const string relativePathToBuild = relativePathToRoot + @"\scripts\build\";
+                const string testAssetsPropsFullPath = relativePathToBuild + testAssetsProps;
+
+                // Copy csproj and edit path to TestAssets.props
+                var content = File.ReadAllText(file.FullName).Replace(testAssetsPropsFullPath, testAssetsProps);
+                File.WriteAllText(newFilePath, content);
+
+                // Copy TestAssets.props and update path to TestPlatform.Dependencies.props
+                const string tpDependenciesPropsFileName = "TestPlatform.Dependencies.props";
+                var assetPropsContent = File.ReadAllText(Path.Combine(file.DirectoryName!, testAssetsPropsFullPath))
+                    .Replace("$(MSBuildThisFileDirectory)" + tpDependenciesPropsFileName, Path.Combine(file.DirectoryName!, relativePathToBuild, tpDependenciesPropsFileName));
+                File.WriteAllText(Path.Combine(TempDirectory.Path, testAssetsProps), assetPropsContent);
+
+                // Copy nuget.config and make packages folder point to vstest packages folder
+                const string nugetFileName = "NuGet.config";
+                var nugetContent = File.ReadAllText(Path.Combine(file.DirectoryName!, relativePathToRoot, nugetFileName))
+                    .Replace("\"packages\"", "\"" + Path.Combine(file.DirectoryName!, relativePathToRoot, "packages") + "\"");
+                File.WriteAllText(Path.Combine(TempDirectory.Path, nugetFileName), nugetContent);
+            }
+            else
+            {
+                File.Copy(file.FullName, newFilePath);
+            }
+        }
+
+        return Path.Combine(TempDirectory.Path, assetName);
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/Extension/RunnnerInfo.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/Extension/RunnnerInfo.cs
@@ -11,7 +11,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 /// <param name="RunnerFramework"></param>
 /// <param name="TargetFramework"></param>
 /// <param name="InIsolationValue">Supported value = <c>/InIsolation</c>.</param>
-public record RunnerInfo(string RunnerFramework, string TargetFramework, string InIsolationValue = "")
+public record struct RunnerInfo(string RunnerFramework, string TargetFramework, string InIsolationValue = "")
 {
     /// <summary>
     /// Is running via .NET "Core" vstest.console?

--- a/test/Microsoft.TestPlatform.AcceptanceTests/Extension/RunnnerInfo.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/Extension/RunnnerInfo.cs
@@ -11,7 +11,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 /// <param name="RunnerFramework"></param>
 /// <param name="TargetFramework"></param>
 /// <param name="InIsolationValue">Supported value = <c>/InIsolation</c>.</param>
-public record struct RunnerInfo(string RunnerFramework, string TargetFramework, string InIsolationValue = "")
+[Serializable] // Type should be serializable to allow the tree-view behavior of test discovery in Test Explorer
+public record RunnerInfo(string RunnerFramework, string TargetFramework, string InIsolationValue = "")
 {
     /// <summary>
     /// Is running via .NET "Core" vstest.console?

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -168,7 +168,7 @@ public class IntegrationTestBase
     /// Invokes our local copy of dotnet that is patched with artifacts from the build with specified arguments.
     /// </summary>
     /// <param name="arguments">Arguments provided to <c>vstest.console</c>.exe</param>
-    public void InvokeDotnetTest(string arguments)
+    public void InvokeDotnetTest(string arguments, Dictionary<string, string> environmentVariables = null)
     {
         var vstestConsolePath = Path.Combine(IntegrationTestEnvironment.TestPlatformRootDirectory, "artifacts", IntegrationTestEnvironment.BuildConfiguration, "netcoreapp2.1", "vstest.console.dll");
         var env = "VSTEST_CONSOLE_PATH";
@@ -182,7 +182,7 @@ public class IntegrationTestBase
                 arguments = $@"-p:VsTestConsolePath=""{vstestConsolePath}"" " + arguments;
             }
 
-            ExecutePatchedDotnet("test", arguments, out _standardTestOutput, out _standardTestError, out _runnerExitCode);
+            ExecutePatchedDotnet("test", arguments, out _standardTestOutput, out _standardTestError, out _runnerExitCode, environmentVariables);
             FormatStandardOutCome();
         }
         finally
@@ -612,12 +612,14 @@ public class IntegrationTestBase
     /// <param name="stdOut"></param>
     /// <param name="stdError"></param>
     /// <param name="exitCode"></param>
-    private void ExecutePatchedDotnet(string command, string args, out string stdOut, out string stdError, out int exitCode)
+    private void ExecutePatchedDotnet(string command, string args, out string stdOut, out string stdError, out int exitCode, Dictionary<string, string> environmentVariables = null)
     {
-        var environmentVariables = new Dictionary<string, string>
+        if (environmentVariables is null)
         {
-            ["DOTNET_MULTILEVEL_LOOKUP"] = "0"
-        };
+            environmentVariables = new Dictionary<string, string>();
+        }
+
+        environmentVariables["DOTNET_MULTILEVEL_LOOKUP"] = "0";
 
         var executablePath = IsWindows ? @"dotnet\dotnet.exe" : @"dotnet-linux/dotnet";
         var patchedDotnetPath = Path.Combine(_testEnvironment.TestArtifactsDirectory, executablePath);


### PR DESCRIPTION
## Description

Relates to #3452. It seems that record was not enough for the serialization to behave properly. Working solutions are either `record struct` or adding `SerializableAttribute`, I went with the `struct`.

cc @nohwnd 
