### PR TITLE
Fix acceptance tests

### DIFF
--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs
@@ -190,7 +190,8 @@ internal class TestPluginDiscoverer
 
             if (e.Types?.Length > 0)
             {
-                types.AddRange(e.Types.Where(type => type.GetTypeInfo().IsClass && !type.GetTypeInfo().IsAbstract));
+                // Unloaded types on e.Types are null, make sure we skip them.
+                types.AddRange(e.Types.Where(type => type != null && type.GetTypeInfo().IsClass && !type.GetTypeInfo().IsAbstract));
             }
 
             if (e.LoaderExceptions != null)

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DotnetTestTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DotnetTestTests.cs
@@ -14,7 +14,7 @@ public class DotnetTestTests : AcceptanceTestBase
     [TestMethod]
     // patched dotnet is not published on non-windows systems
     [TestCategory("Windows-Review")]
-    [NetCoreTargetFrameworkDataSource]
+    [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
     public void RunDotnetTestWithCsproj(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
@@ -31,7 +31,7 @@ public class DotnetTestTests : AcceptanceTestBase
     [TestMethod]
     // patched dotnet is not published on non-windows systems
     [TestCategory("Windows-Review")]
-    [NetCoreTargetFrameworkDataSource]
+    [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
     public void RunDotnetTestWithDll(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
@@ -48,7 +48,7 @@ public class DotnetTestTests : AcceptanceTestBase
     [TestMethod]
     // patched dotnet is not published on non-windows systems
     [TestCategory("Windows-Review")]
-    [NetCoreTargetFrameworkDataSource]
+    [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
     public void RunDotnetTestWithCsprojPassInlineSettings(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
@@ -63,7 +63,7 @@ public class DotnetTestTests : AcceptanceTestBase
     [TestMethod]
     // patched dotnet is not published on non-windows systems
     [TestCategory("Windows-Review")]
-    [NetCoreTargetFrameworkDataSource]
+    [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
     public void RunDotnetTestWithDllPassInlineSettings(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);

--- a/test/Microsoft.TestPlatform.AcceptanceTests/RunsettingsTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/RunsettingsTests.cs
@@ -500,8 +500,8 @@ public class RunsettingsTests : AcceptanceTestBase
     [TestMethod]
     // patched dotnet is not published on non-windows systems
     [TestCategory("Windows-Review")]
-    [NetFullTargetFrameworkDataSource]
-    [NetCoreTargetFrameworkDataSource]
+    [NetFullTargetFrameworkDataSource(useDesktopRunner: false)]
+    [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
     public void RunSettingsAreLoadedFromProject(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);

--- a/test/Microsoft.TestPlatform.TestUtilities/BannedSymbols.txt
+++ b/test/Microsoft.TestPlatform.TestUtilities/BannedSymbols.txt
@@ -1,0 +1,3 @@
+﻿M:System.IO.Path.GetTempPath(); Use 'IntegrationTestBase.GetTempPath()' instead
+M:System.Environment.SetEnvironmentVariable(System.String,System.String); Use one of the overload accepting a dictionary of environment variables instead
+M:System.Environment.SetEnvironmentVariable(System.String,System.String,System.EnvironmentVariableTarget); Use one of the overload accepting a dictionary of environment variables instead

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -170,6 +170,7 @@ public class IntegrationTestBase
     /// <param name="arguments">Arguments provided to <c>vstest.console</c>.exe</param>
     public void InvokeDotnetTest(string arguments, Dictionary<string, string> environmentVariables = null)
     {
+<<<<<<< Updated upstream
         var vstestConsolePath = Path.Combine(IntegrationTestEnvironment.TestPlatformRootDirectory, "artifacts", IntegrationTestEnvironment.BuildConfiguration, "netcoreapp2.1", "vstest.console.dll");
         var env = "VSTEST_CONSOLE_PATH";
         var originalVstestConsolePath = Environment.GetEnvironmentVariable(env);
@@ -186,9 +187,17 @@ public class IntegrationTestBase
             FormatStandardOutCome();
         }
         finally
+=======
+        var vstestConsolePath = GetDotnetRunnerPath();
+        
+        if (arguments.Contains(".csproj"))
+>>>>>>> Stashed changes
         {
-            Environment.SetEnvironmentVariable(env, originalVstestConsolePath);
+            arguments = $@"-p:VsTestConsolePath=""{vstestConsolePath}"" " + arguments;
         }
+
+        ExecutePatchedDotnet("test", arguments, out _standardTestOutput, out _standardTestError, out _runnerExitCode, environmentVariables);
+        FormatStandardOutCome();
     }
 
     /// <summary>
@@ -205,7 +214,48 @@ public class IntegrationTestBase
         Dictionary<string, string> environmentVariables = null)
     {
         var arguments = PrepareArguments(testAssembly, testAdapterPath, runSettings, framework, _testEnvironment.InIsolationValue, resultsDirectory: TempDirectory.Path);
+<<<<<<< Updated upstream
         InvokeVsTest(arguments, environmentVariables);
+=======
+        InvokeVsTest(arguments, AddDebugEnvVariables(environmentVariables));
+    }
+
+    private Dictionary<string, string> AddDebugEnvVariables(Dictionary<string, string> environmentVariables)
+    {
+        var debugVariables = new Dictionary<string, string>();
+        if (environmentVariables != null)
+        {
+            foreach (var pair in environmentVariables)
+            {
+                debugVariables.Add(pair.Key, pair.Value);
+            }
+        }
+
+        if (_testEnvironment.DebugInfo != null)
+        {
+            if (_testEnvironment.DebugInfo.DebugVSTestConsole)
+            {
+                debugVariables.Add("VSTEST_RUNNER_DEBUG_ATTACHVS", "1");
+            }
+
+            if (_testEnvironment.DebugInfo.DebugTestHost)
+            {
+                debugVariables.Add("VSTEST_HOST_DEBUG_ATTACHVS", "1");
+            }
+
+            if (_testEnvironment.DebugInfo.DebugDataCollector)
+            {
+                debugVariables.Add("VSTEST_DATACOLLECTOR_DEBUG_ATTACHVS", "1");
+            }
+
+            if (_testEnvironment.DebugInfo.NoDefaultBreakpoints)
+            {
+                debugVariables.Add("VSTEST_DEBUG_NOBP", "1");
+            }
+        }
+
+        return debugVariables;
+>>>>>>> Stashed changes
     }
 
     /// <summary>
@@ -567,7 +617,53 @@ public class IntegrationTestBase
             throw new FileNotFoundException($"File '{dotnetPath}' was not found.");
         }
 
+<<<<<<< Updated upstream
         var vstestConsoleWrapper = new VsTestConsoleWrapper(consoleRunnerPath, dotnetPath, new ConsoleParameters() { LogFilePath = logFilePath });
+=======
+        if (!File.Exists(consoleRunnerPath))
+        {
+            throw new FileNotFoundException($"File '{consoleRunnerPath}' was not found.");
+        }
+
+        Console.WriteLine($"Console runner path: {consoleRunnerPath}");
+
+        VsTestConsoleWrapper vstestConsoleWrapper;
+        if (_testEnvironment.DebugInfo != null
+            && (_testEnvironment.DebugInfo.DebugVSTestConsole
+                || _testEnvironment.DebugInfo.DebugTestHost
+                || _testEnvironment.DebugInfo.DebugDataCollector))
+        {
+            var environmentVariables = new Dictionary<string, string>();
+            Environment.GetEnvironmentVariables().OfType<DictionaryEntry>().ToList().ForEach(e => environmentVariables.Add(e.Key.ToString(), e.Value.ToString()));
+
+            if (_testEnvironment.DebugInfo.DebugVSTestConsole)
+            {
+                environmentVariables.Add("VSTEST_RUNNER_DEBUG_ATTACHVS", "1");
+            }
+
+            if (_testEnvironment.DebugInfo.DebugTestHost)
+            {
+                environmentVariables.Add("VSTEST_HOST_DEBUG_ATTACHVS", "1");
+            }
+
+            if (_testEnvironment.DebugInfo.DebugDataCollector)
+            {
+                environmentVariables.Add("VSTEST_DATACOLLECTOR_DEBUG_ATTACHVS", "1");
+            }
+
+            if (_testEnvironment.DebugInfo.NoDefaultBreakpoints)
+            {
+                environmentVariables.Add("VSTEST_DEBUG_NOBP", "1");
+            }
+
+            // This clears all variables
+            vstestConsoleWrapper = new VsTestConsoleWrapper(consoleRunnerPath, dotnetPath, new ConsoleParameters() { LogFilePath = logFilePath, EnvironmentVariables = environmentVariables });
+        }
+        else
+        {
+            vstestConsoleWrapper = new VsTestConsoleWrapper(consoleRunnerPath, dotnetPath, new ConsoleParameters() { LogFilePath = logFilePath });
+        }
+>>>>>>> Stashed changes
         vstestConsoleWrapper.StartSession();
 
         return vstestConsoleWrapper;
@@ -770,6 +866,7 @@ public class IntegrationTestBase
 
     protected string BuildMultipleAssemblyPath(params string[] assetNames)
     {
+<<<<<<< Updated upstream
         var assertFullPaths = new string[assetNames.Length];
         for (var i = 0; i < assetNames.Length; i++)
         {
@@ -777,6 +874,9 @@ public class IntegrationTestBase
         }
 
         return string.Join(" ", assertFullPaths);
+=======
+        return @$"""{string.Join(@""" """, GetTestDlls(assetNames))}""";
+>>>>>>> Stashed changes
     }
 
     protected static string GetDiagArg(string rootDir)

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -170,31 +170,18 @@ public class IntegrationTestBase
     /// <param name="arguments">Arguments provided to <c>vstest.console</c>.exe</param>
     public void InvokeDotnetTest(string arguments, Dictionary<string, string> environmentVariables = null)
     {
-<<<<<<< Updated upstream
-        var vstestConsolePath = Path.Combine(IntegrationTestEnvironment.TestPlatformRootDirectory, "artifacts", IntegrationTestEnvironment.BuildConfiguration, "netcoreapp2.1", "vstest.console.dll");
-        var env = "VSTEST_CONSOLE_PATH";
-        var originalVstestConsolePath = Environment.GetEnvironmentVariable(env);
+        environmentVariables ??= new Dictionary<string, string>();
 
-        try
-        {
-            Environment.SetEnvironmentVariable(env, vstestConsolePath);
-            if (arguments.Contains(".csproj"))
-            {
-                arguments = $@"-p:VsTestConsolePath=""{vstestConsolePath}"" " + arguments;
-            }
-
-            ExecutePatchedDotnet("test", arguments, out _standardTestOutput, out _standardTestError, out _runnerExitCode, environmentVariables);
-            FormatStandardOutCome();
-        }
-        finally
-=======
         var vstestConsolePath = GetDotnetRunnerPath();
-        
+
         if (arguments.Contains(".csproj"))
->>>>>>> Stashed changes
         {
             arguments = $@"-p:VsTestConsolePath=""{vstestConsolePath}"" " + arguments;
         }
+
+        // This is used in dotnet/sdk to determine path to vstest.console:
+        // https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/commands/dotnet-test/VSTestForwardingApp.cs#L30-L39
+        environmentVariables["VSTEST_CONSOLE_PATH"] = vstestConsolePath;
 
         ExecutePatchedDotnet("test", arguments, out _standardTestOutput, out _standardTestError, out _runnerExitCode, environmentVariables);
         FormatStandardOutCome();
@@ -214,48 +201,8 @@ public class IntegrationTestBase
         Dictionary<string, string> environmentVariables = null)
     {
         var arguments = PrepareArguments(testAssembly, testAdapterPath, runSettings, framework, _testEnvironment.InIsolationValue, resultsDirectory: TempDirectory.Path);
-<<<<<<< Updated upstream
+
         InvokeVsTest(arguments, environmentVariables);
-=======
-        InvokeVsTest(arguments, AddDebugEnvVariables(environmentVariables));
-    }
-
-    private Dictionary<string, string> AddDebugEnvVariables(Dictionary<string, string> environmentVariables)
-    {
-        var debugVariables = new Dictionary<string, string>();
-        if (environmentVariables != null)
-        {
-            foreach (var pair in environmentVariables)
-            {
-                debugVariables.Add(pair.Key, pair.Value);
-            }
-        }
-
-        if (_testEnvironment.DebugInfo != null)
-        {
-            if (_testEnvironment.DebugInfo.DebugVSTestConsole)
-            {
-                debugVariables.Add("VSTEST_RUNNER_DEBUG_ATTACHVS", "1");
-            }
-
-            if (_testEnvironment.DebugInfo.DebugTestHost)
-            {
-                debugVariables.Add("VSTEST_HOST_DEBUG_ATTACHVS", "1");
-            }
-
-            if (_testEnvironment.DebugInfo.DebugDataCollector)
-            {
-                debugVariables.Add("VSTEST_DATACOLLECTOR_DEBUG_ATTACHVS", "1");
-            }
-
-            if (_testEnvironment.DebugInfo.NoDefaultBreakpoints)
-            {
-                debugVariables.Add("VSTEST_DEBUG_NOBP", "1");
-            }
-        }
-
-        return debugVariables;
->>>>>>> Stashed changes
     }
 
     /// <summary>
@@ -435,7 +382,7 @@ public class IntegrationTestBase
                        || _standardTestOutput.Contains(GetTestMethodName(test));
             Assert.IsTrue(flag, $"Test {test} does not appear in discovered tests list." +
                                 $"{Environment.NewLine}Std Output: {_standardTestOutput}" +
-                                $"{Environment.NewLine}Std Error: { _standardTestError}");
+                                $"{Environment.NewLine}Std Error: {_standardTestError}");
         }
     }
 
@@ -451,7 +398,7 @@ public class IntegrationTestBase
                        || _standardTestOutput.Contains(GetTestMethodName(test));
             Assert.IsFalse(flag, $"Test {test} should not appear in discovered tests list." +
                                 $"{Environment.NewLine}Std Output: {_standardTestOutput}" +
-                                $"{Environment.NewLine}Std Error: { _standardTestError}");
+                                $"{Environment.NewLine}Std Error: {_standardTestError}");
         }
     }
 
@@ -466,7 +413,7 @@ public class IntegrationTestBase
                        || fileOutput.Contains(GetTestMethodName(test));
             Assert.IsTrue(flag, $"Test {test} does not appear in discovered tests list." +
                                 $"{Environment.NewLine}Std Output: {_standardTestOutput}" +
-                                $"{Environment.NewLine}Std Error: { _standardTestError}");
+                                $"{Environment.NewLine}Std Error: {_standardTestError}");
         }
     }
 
@@ -617,53 +564,7 @@ public class IntegrationTestBase
             throw new FileNotFoundException($"File '{dotnetPath}' was not found.");
         }
 
-<<<<<<< Updated upstream
         var vstestConsoleWrapper = new VsTestConsoleWrapper(consoleRunnerPath, dotnetPath, new ConsoleParameters() { LogFilePath = logFilePath });
-=======
-        if (!File.Exists(consoleRunnerPath))
-        {
-            throw new FileNotFoundException($"File '{consoleRunnerPath}' was not found.");
-        }
-
-        Console.WriteLine($"Console runner path: {consoleRunnerPath}");
-
-        VsTestConsoleWrapper vstestConsoleWrapper;
-        if (_testEnvironment.DebugInfo != null
-            && (_testEnvironment.DebugInfo.DebugVSTestConsole
-                || _testEnvironment.DebugInfo.DebugTestHost
-                || _testEnvironment.DebugInfo.DebugDataCollector))
-        {
-            var environmentVariables = new Dictionary<string, string>();
-            Environment.GetEnvironmentVariables().OfType<DictionaryEntry>().ToList().ForEach(e => environmentVariables.Add(e.Key.ToString(), e.Value.ToString()));
-
-            if (_testEnvironment.DebugInfo.DebugVSTestConsole)
-            {
-                environmentVariables.Add("VSTEST_RUNNER_DEBUG_ATTACHVS", "1");
-            }
-
-            if (_testEnvironment.DebugInfo.DebugTestHost)
-            {
-                environmentVariables.Add("VSTEST_HOST_DEBUG_ATTACHVS", "1");
-            }
-
-            if (_testEnvironment.DebugInfo.DebugDataCollector)
-            {
-                environmentVariables.Add("VSTEST_DATACOLLECTOR_DEBUG_ATTACHVS", "1");
-            }
-
-            if (_testEnvironment.DebugInfo.NoDefaultBreakpoints)
-            {
-                environmentVariables.Add("VSTEST_DEBUG_NOBP", "1");
-            }
-
-            // This clears all variables
-            vstestConsoleWrapper = new VsTestConsoleWrapper(consoleRunnerPath, dotnetPath, new ConsoleParameters() { LogFilePath = logFilePath, EnvironmentVariables = environmentVariables });
-        }
-        else
-        {
-            vstestConsoleWrapper = new VsTestConsoleWrapper(consoleRunnerPath, dotnetPath, new ConsoleParameters() { LogFilePath = logFilePath });
-        }
->>>>>>> Stashed changes
         vstestConsoleWrapper.StartSession();
 
         return vstestConsoleWrapper;
@@ -866,7 +767,6 @@ public class IntegrationTestBase
 
     protected string BuildMultipleAssemblyPath(params string[] assetNames)
     {
-<<<<<<< Updated upstream
         var assertFullPaths = new string[assetNames.Length];
         for (var i = 0; i < assetNames.Length; i++)
         {
@@ -874,9 +774,6 @@ public class IntegrationTestBase
         }
 
         return string.Join(" ", assertFullPaths);
-=======
-        return @$"""{string.Join(@""" """, GetTestDlls(assetNames))}""";
->>>>>>> Stashed changes
     }
 
     protected static string GetDiagArg(string rootDir)

--- a/test/Microsoft.TestPlatform.TestUtilities/Microsoft.TestPlatform.TestUtilities.csproj
+++ b/test/Microsoft.TestPlatform.TestUtilities/Microsoft.TestPlatform.TestUtilities.csproj
@@ -11,6 +11,12 @@
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="BannedSymbols.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="BannedSymbols.txt" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.Common\Microsoft.TestPlatform.Common.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.ObjectModel\Microsoft.TestPlatform.ObjectModel.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.CoreUtilities\Microsoft.TestPlatform.CoreUtilities.csproj">
@@ -21,6 +27,10 @@
   <ItemGroup>
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="MSTest.TestFramework" Version="$(MSTestFrameworkVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.41" />

--- a/test/Microsoft.TestPlatform.TestUtilities/TempDirectory.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/TempDirectory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 using IO = System.IO;
@@ -52,6 +53,36 @@ public class TempDirectory : IDisposable
     }
 
     /// <summary>
+    /// Copy given files into the TempDirectory and return the updated paths that are pointing to TempDirectory.
+    /// </summary>
+    /// <param name="filePaths"></param>
+    /// <returns></returns>
+    public string[] CopyFile(params string[] filePaths)
+    {
+        var paths = new List<string>(filePaths.Length);
+        foreach (var filePath in filePaths)
+        {
+            var destination = IO.Path.Combine(Path, IO.Path.GetFileName(filePath));
+            File.Copy(filePath, destination);
+            paths.Add(destination);
+        }
+
+        return paths.ToArray();
+    }
+
+    /// <summary>
+    /// Copy given file into TempDirectory and return the updated path.
+    /// </summary>
+    /// <param name="filePath"></param>
+    /// <returns></returns>
+    public string CopyFile(string filePath)
+    {
+        var destination = IO.Path.Combine(Path, IO.Path.GetFileName(filePath));
+        File.Copy(filePath, destination);
+        return destination; 
+    }
+
+    /// <summary>
     /// Creates an unique temporary directory.
     /// </summary>
     /// <returns>
@@ -71,7 +102,13 @@ public class TempDirectory : IDisposable
         // AGENT_TEMPDIRECTORY is AzureDevops variable, which is set to path
         // that is cleaned up after every job. This is preferable to use over
         // just the normal TEMP, because that is not cleaned up for every run.
-        return Environment.GetEnvironmentVariable("AGENT_TEMPDIRECTORY") ?? IO.Path.GetTempPath();
+        //
+        // System.IO.Path.GetTempPath is banned from the rest of the code. This is the only
+        // place where we are allowed to use it. All other methods should use our GetTempPath (this method).
+#pragma warning disable RS0030 // Do not used banned APIs
+        return Environment.GetEnvironmentVariable("AGENT_TEMPDIRECTORY")
+            ?? IO.Path.GetTempPath();
+#pragma warning restore RS0030 // Do not used banned APIs
     }
 
     public static void TryRemoveDirectory(string directory)


### PR DESCRIPTION
## Description
Fix chutzpah tests. 
Ban SetEnvironment from test utilities. 
Resolve vstest.console.dll based on the target framework, to avoid running the same test 2 or 4 times.

## Related issue
Related https://github.com/mmanela/chutzpah/issues/812
