### PR TITLE
Allow attachVS env variables in release build

### DIFF
--- a/src/Microsoft.TestPlatform.Execution.Shared/DebuggerBreakpoint.cs
+++ b/src/Microsoft.TestPlatform.Execution.Shared/DebuggerBreakpoint.cs
@@ -22,7 +22,7 @@ internal static class DebuggerBreakpoint
 {
     internal static void AttachVisualStudioDebugger(string environmentVariable)
     {
-#if NETCOREAPP1_0 || !DEBUG
+#if NETCOREAPP1_0
         return;
 #else
         if (string.IsNullOrWhiteSpace(environmentVariable))
@@ -62,7 +62,7 @@ internal static class DebuggerBreakpoint
 
     private static bool AttachVs(Process process, int? vsPid)
     {
-#if NETCOREAPP1_0 || !DEBUG
+#if NETCOREAPP1_0
         return false;
 #else
         // The way we attach VS is not compatible with .NET Core 2.1 and .NET Core 3.1, but works in .NET Framework and .NET.
@@ -93,7 +93,7 @@ internal static class DebuggerBreakpoint
 
     private static string FindAttachVs()
     {
-#if NETCOREAPP1_0 || !DEBUG
+#if NETCOREAPP1_0
         return null;
 #else
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("755996fa-672a-4272-9776-7f707a520058")]
 
-// Enable IAP at method level with as many threads as possible based on CPU and core count.
-[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+// Enable IAP at class level with as many threads as possible based on CPU and core count.
+[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.ClassLevel)]


### PR DESCRIPTION
Allow lookup of AttachVS tool in Release build, but not ship the tool with the build.

