### PR TITLE
Fix ignore blame revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,8 +1,8 @@
 # Apply modern code styles (#3264)
-commit 065f4d042e2ac8f1bd28deeabca38adf2c14b52a
+065f4d042e2ac8f1bd28deeabca38adf2c14b52a
 
 # Reformat projects and script files (#3290)
-commit 5e425f80cb9b1de3be823b83c718c9a057df857a
+5e425f80cb9b1de3be823b83c718c9a057df857a
 
 # Run dotnet format whitespace (#3307)
-commit cf2bd925e3e11a76bcbd965f5d337b2c8f4dbab1
+cf2bd925e3e11a76bcbd965f5d337b2c8f4dbab1


### PR DESCRIPTION
Fix the format in blame revs file because github complaints that it is incorrect, so I guess it is finally supported.
