### PR TITLE
Add nullable helpers TPDebug and StringUtils and ban system equivalents

### DIFF
--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -19,7 +19,6 @@
     <MSTestAdapterVersion>2.2.9-preview-20220210-07</MSTestAdapterVersion>
     <MSTestAssertExtensionVersion>1.0.3-preview</MSTestAssertExtensionVersion>
 
-    
     <XUnitFrameworkVersion>2.3.1</XUnitFrameworkVersion>
     <XUnitAdapterVersion>2.3.1</XUnitAdapterVersion>
     <XUnitConsoleRunnerVersion>2.3.1</XUnitConsoleRunnerVersion>
@@ -30,8 +29,8 @@
 
     <ChutzpahAdapterVersion>4.4.12</ChutzpahAdapterVersion>
 
-    <!-- Versions that are used when building projects from TestAssets.sln for compatibility tests. See Invoke-TestAssetsBuild in scripts/build.ps1. 
-    Exact versions are used to avoid Nuget substituting them by closest match, if we make a typo. 
+    <!-- Versions that are used when building projects from TestAssets.sln for compatibility tests. See Invoke-TestAssetsBuild in scripts/build.ps1.
+    Exact versions are used to avoid Nuget substituting them by closest match, if we make a typo.
     These versions need to be "statically" readable because we read this file as xml in our build and tests. -->
     <!-- <MSTestFrameworkLatestVersion></MSTestFrameworkLatestVersion> is not here, because we don't build MSTest locally, so we don't have access to the latest version. -->
     <MSTestFrameworkLatestPreviewVersion>[2.2.9-preview-20220210-07]</MSTestFrameworkLatestPreviewVersion>
@@ -42,8 +41,8 @@
     <MSTestFrameworkLegacyStableVersion>[1.4.0]</MSTestFrameworkLegacyStableVersion>
 
 
-    <!-- Versions that are used to restore previous versions of console, translation layer, and test.sdk for compatibility tests. 
-    See Invoke-TestAssetsBuild in scripts/build.ps1. Exact versions are used to avoid Nuget substituting them by closest match, if we make a typo. 
+    <!-- Versions that are used to restore previous versions of console, translation layer, and test.sdk for compatibility tests.
+    See Invoke-TestAssetsBuild in scripts/build.ps1. Exact versions are used to avoid Nuget substituting them by closest match, if we make a typo.
     These versions need to be "statically" readable because we read this file as xml in our build and tests. -->
     <!-- <VSTestConsoleLatestVersion></VSTestConsoleLatestVersion> is not here, NETTestSdkVersion is used instead, because that is the version of the locally built latest package.  -->
     <VSTestConsoleLatestPreviewVersion>[17.2.0-preview-20220131-20]</VSTestConsoleLatestPreviewVersion>
@@ -75,6 +74,7 @@
 
     <CoverletCoverageVersion>1.2.0</CoverletCoverageVersion>
     <RoslynPublicApiAnalyzersVersion>3.3.4-beta1.21554.2</RoslynPublicApiAnalyzersVersion>
+    <RoslynBannedApiAnalyzersVersion>3.3.3</RoslynBannedApiAnalyzersVersion>
 
     <DependencyVersionsImported>true</DependencyVersionsImported>
   </PropertyGroup>

--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -53,7 +53,14 @@
   <ItemGroup>
     <PackageReference Condition=" '$(OS)' != 'Windows_NT' " Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
-  
+
+  <ItemGroup Condition=" '$(UseBannedApiAnalyzers)' == 'true' ">
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(RoslynBannedApiAnalyzersVersion)">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
   <!-- Include PublicApi analyzers into all projects that are in our src directory, this can't use TestProject == true
   because some projects in test and playground are not tests, but we don't want to analyze those for public apis, because
   we don't ship them.

--- a/src/Microsoft.TestPlatform.Common/BannedSymbols.txt
+++ b/src/Microsoft.TestPlatform.Common/BannedSymbols.txt
@@ -1,0 +1,4 @@
+﻿﻿M:System.Diagnostics.TPDebug.Assert(System.Boolean); Use 'TPTPDebug.Assert' instead
+M:System.Diagnostics.TPDebug.Assert(System.Boolean,System.String); Use 'TPTPDebug.Assert' instead
+M:System.String.IsNullOrEmpty(System.String); Use 'StringUtils.IsNullOrEmpty' instead
+M:System.String.IsNullOrWhiteSpace(System.String); Use 'StringUtils.IsNullOrWhiteSpace' instead

--- a/src/Microsoft.TestPlatform.Common/BannedSymbols.txt
+++ b/src/Microsoft.TestPlatform.Common/BannedSymbols.txt
@@ -1,4 +1,4 @@
-﻿﻿M:System.Diagnostics.TPDebug.Assert(System.Boolean); Use 'TPTPDebug.Assert' instead
-M:System.Diagnostics.TPDebug.Assert(System.Boolean,System.String); Use 'TPTPDebug.Assert' instead
+﻿﻿M:System.Diagnostics.Debug.Assert(System.Boolean); Use 'TPDebug.Assert' instead
+M:System.Diagnostics.Debug.Assert(System.Boolean,System.String); Use 'TPDebug.Assert' instead
 M:System.String.IsNullOrEmpty(System.String); Use 'StringUtils.IsNullOrEmpty' instead
 M:System.String.IsNullOrWhiteSpace(System.String); Use 'StringUtils.IsNullOrWhiteSpace' instead

--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionAttachmentManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionAttachmentManager.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -103,7 +102,7 @@ internal class DataCollectionAttachmentManager : IDataCollectionAttachmentManage
     {
         _messageSink = messageSink;
 
-        if (string.IsNullOrEmpty(outputDirectory))
+        if (outputDirectory.IsNullOrEmpty())
         {
             SessionOutputDirectory = Path.Combine(Path.GetTempPath(), DefaultOutputDirectoryName, id.Id.ToString());
         }
@@ -162,7 +161,7 @@ internal class DataCollectionAttachmentManager : IDataCollectionAttachmentManage
     /// <inheritdoc/>
     public void AddAttachment(FileTransferInformation fileTransferInfo!!, AsyncCompletedEventHandler sendFileCompletedCallback, Uri uri, string friendlyName)
     {
-        if (string.IsNullOrEmpty(SessionOutputDirectory))
+        if (SessionOutputDirectory.IsNullOrEmpty())
         {
             EqtTrace.Error("DataCollectionAttachmentManager.AddAttachment: Initialize not invoked.");
             return;
@@ -239,7 +238,7 @@ internal class DataCollectionAttachmentManager : IDataCollectionAttachmentManage
     private void AddNewFileTransfer(FileTransferInformation fileTransferInfo, AsyncCompletedEventHandler sendFileCompletedCallback, Uri uri, string friendlyName)
     {
         var context = fileTransferInfo.Context;
-        Debug.Assert(
+        TPDebug.Assert(
             context != null,
             "DataCollectionManager.AddNewFileTransfer: FileDataHeaderMessage with null context.");
 

--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
@@ -156,7 +156,7 @@ internal class DataCollectionManager : IDataCollectionManager
     /// <inheritdoc/>
     public IDictionary<string, string> InitializeDataCollectors(string settingsXml!!)
     {
-        if (string.IsNullOrEmpty(settingsXml))
+        if (settingsXml.IsNullOrEmpty())
         {
             EqtTrace.Info("DataCollectionManager.InitializeDataCollectors : Runsettings is null or empty.");
         }
@@ -427,7 +427,7 @@ internal class DataCollectionManager : IDataCollectionManager
 
     protected virtual bool IsUriValid(string uri)
     {
-        if (string.IsNullOrEmpty(uri))
+        if (uri.IsNullOrEmpty())
         {
             return false;
         }
@@ -481,7 +481,7 @@ internal class DataCollectionManager : IDataCollectionManager
             }
 
             ObjectModel.DataCollection.DataCollector dataCollector = null;
-            if (!string.IsNullOrWhiteSpace(dataCollectorUri))
+            if (!dataCollectorUri.IsNullOrWhiteSpace())
             {
                 dataCollector = TryGetTestExtension(dataCollectorUri);
             }

--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectorConfig.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectorConfig.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 
@@ -90,7 +89,7 @@ internal class DataCollectorConfig : TestExtensionPluginInformation
         if (typeUriAttributes != null && typeUriAttributes.Length > 0)
         {
             var typeUriAttribute = (DataCollectorTypeUriAttribute)typeUriAttributes[0];
-            if (!string.IsNullOrWhiteSpace(typeUriAttribute.TypeUri))
+            if (!typeUriAttribute.TypeUri.IsNullOrWhiteSpace())
             {
                 typeUri = new Uri(typeUriAttribute.TypeUri);
             }
@@ -134,7 +133,7 @@ internal class DataCollectorConfig : TestExtensionPluginInformation
         if (friendlyNameAttributes != null && friendlyNameAttributes.Length > 0)
         {
             var friendlyNameAttribute = (DataCollectorFriendlyNameAttribute)friendlyNameAttributes[0];
-            if (!string.IsNullOrEmpty(friendlyNameAttribute.FriendlyName))
+            if (!friendlyNameAttribute.FriendlyName.IsNullOrEmpty())
             {
                 friendlyName = friendlyNameAttribute.FriendlyName;
             }
@@ -157,8 +156,8 @@ internal class DataCollectorConfig : TestExtensionPluginInformation
     /// </returns>
     private static object[] GetAttributes(Type dataCollectorType, Type attributeType)
     {
-        Debug.Assert(dataCollectorType != null, "null dataCollectorType");
-        Debug.Assert(attributeType != null, "null attributeType");
+        TPDebug.Assert(dataCollectorType != null, "null dataCollectorType");
+        TPDebug.Assert(attributeType != null, "null attributeType");
 
         // If any attribute constructor on the type throws, the exception will bubble up through
         // the "GetCustomAttributes" method.

--- a/src/Microsoft.TestPlatform.Common/DataCollection/TestPlatformDataCollectionLogger.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/TestPlatformDataCollectionLogger.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics;
 using System.Globalization;
 
 using Microsoft.VisualStudio.TestPlatform.Common.DataCollector.Interfaces;
@@ -114,7 +113,7 @@ internal class TestPlatformDataCollectionLogger : DataCollectionLogger
     /// </exception>
     private void SendTextMessage(DataCollectionContext context!!, string text!!, TestMessageLevel level)
     {
-        Debug.Assert(
+        TPDebug.Assert(
             level is >= TestMessageLevel.Informational and <= TestMessageLevel.Error,
             "Invalid level: " + level);
 

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestDiscoveryExtensionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestDiscoveryExtensionManager.cs
@@ -150,7 +150,7 @@ internal class TestDiscovererMetadata : ITestDiscovererCapabilities
             FileExtension = new List<string>(fileExtensions);
         }
 
-        if (!string.IsNullOrWhiteSpace(defaultExecutorUri))
+        if (!defaultExecutorUri.IsNullOrWhiteSpace())
         {
             DefaultExecutorUri = new Uri(defaultExecutorUri);
         }

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginCache.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginCache.cs
@@ -410,7 +410,7 @@ public class TestPluginCache
     /// </returns>
     protected virtual IEnumerable<string> GetFilteredExtensions(List<string> extensions, string endsWithPattern)
     {
-        return string.IsNullOrEmpty(endsWithPattern)
+        return endsWithPattern.IsNullOrEmpty()
             ? extensions
             : extensions.Where(ext => ext.EndsWith(endsWithPattern, StringComparison.OrdinalIgnoreCase));
     }
@@ -469,7 +469,7 @@ public class TestPluginCache
 
     protected void SetupAssemblyResolver(string extensionAssembly)
     {
-        IList<string> resolutionPaths = string.IsNullOrEmpty(extensionAssembly) ? GetDefaultResolutionPaths() : GetResolutionPaths(extensionAssembly);
+        IList<string> resolutionPaths = extensionAssembly.IsNullOrEmpty() ? GetDefaultResolutionPaths() : GetResolutionPaths(extensionAssembly);
 
         // Add assembly resolver which can resolve the extensions from the specified directory.
         if (_assemblyResolver == null)

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -63,7 +62,7 @@ internal class TestPluginDiscoverer
     /// </returns>
     public Dictionary<string, TPluginInfo> GetTestExtensionsInformation<TPluginInfo, TExtension>(IEnumerable<string> extensionPaths) where TPluginInfo : TestPluginInformation
     {
-        Debug.Assert(extensionPaths != null);
+        TPDebug.Assert(extensionPaths != null);
 
         var pluginInfos = new Dictionary<string, TPluginInfo>();
 
@@ -105,8 +104,8 @@ internal class TestPluginDiscoverer
         string[] files,
         Dictionary<string, TPluginInfo> pluginInfos) where TPluginInfo : TestPluginInformation
     {
-        Debug.Assert(files != null, "null files");
-        Debug.Assert(pluginInfos != null, "null pluginInfos");
+        TPDebug.Assert(files != null, "null files");
+        TPDebug.Assert(pluginInfos != null, "null pluginInfos");
 
         // Scan each of the files for data extensions.
         foreach (var file in files)
@@ -152,8 +151,8 @@ internal class TestPluginDiscoverer
     /// </typeparam>
     private void GetTestExtensionsFromAssembly<TPluginInfo, TExtension>(Assembly assembly, Dictionary<string, TPluginInfo> pluginInfos, string filePath) where TPluginInfo : TestPluginInformation
     {
-        Debug.Assert(assembly != null, "null assembly");
-        Debug.Assert(pluginInfos != null, "null pluginInfos");
+        TPDebug.Assert(assembly != null, "null assembly");
+        TPDebug.Assert(pluginInfos != null, "null pluginInfos");
 
         List<Type> types = new();
         Type extension = typeof(TExtension);

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginManager.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginManager.cs
@@ -204,7 +204,7 @@ internal class TestPluginManager
         var testPlugins = TestPluginManager.GetValuesFromDictionary(testPluginInfo);
         foreach (var plugin in testPlugins)
         {
-            if (!string.IsNullOrEmpty(plugin.IdentifierData))
+            if (!plugin.IdentifierData.IsNullOrEmpty())
             {
                 var testExtension = new LazyExtension<TExtension, IMetadata>(plugin, typeof(TMetadata));
                 filteredExtensions.Add(testExtension);

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestDiscovererPluginInformation.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestDiscovererPluginInformation.cs
@@ -88,7 +88,7 @@ internal class TestDiscovererPluginInformation : TestPluginInformation
             foreach (var attribute in attributes)
             {
                 var fileExtAttribute = (FileExtensionAttribute)attribute;
-                if (!string.IsNullOrEmpty(fileExtAttribute.FileExtension))
+                if (!fileExtAttribute.FileExtension.IsNullOrEmpty())
                 {
                     fileExtensions.Add(fileExtAttribute.FileExtension);
                 }
@@ -112,7 +112,7 @@ internal class TestDiscovererPluginInformation : TestPluginInformation
         {
             DefaultExecutorUriAttribute executorUriAttribute = (DefaultExecutorUriAttribute)attributes[0];
 
-            if (!string.IsNullOrEmpty(executorUriAttribute.ExecutorUri))
+            if (!executorUriAttribute.ExecutorUri.IsNullOrEmpty())
             {
                 result = executorUriAttribute.ExecutorUri;
             }

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestExtensionPluginInformation.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestExtensionPluginInformation.cs
@@ -75,13 +75,13 @@ internal abstract class TestExtensionPluginInformation : TestPluginInformation
         {
             ExtensionUriAttribute extensionUriAttribute = (ExtensionUriAttribute)attributes[0];
 
-            if (!string.IsNullOrEmpty(extensionUriAttribute.ExtensionUri))
+            if (!extensionUriAttribute.ExtensionUri.IsNullOrEmpty())
             {
                 extensionUri = extensionUriAttribute.ExtensionUri;
             }
         }
 
-        if (string.IsNullOrEmpty(extensionUri))
+        if (extensionUri.IsNullOrEmpty())
         {
             EqtTrace.Error("The type \"{0}\" defined in \"{1}\" does not have ExtensionUri attribute.", testLoggerType.ToString(), testLoggerType.GetTypeInfo().Module.Name);
         }

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestLoggerPluginInformation.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestLoggerPluginInformation.cs
@@ -61,7 +61,7 @@ internal class TestLoggerPluginInformation : TestExtensionPluginInformation
         {
             FriendlyNameAttribute friendlyNameAttribute = (FriendlyNameAttribute)attributes[0];
 
-            if (!string.IsNullOrEmpty(friendlyNameAttribute.FriendlyName))
+            if (!friendlyNameAttribute.FriendlyName.IsNullOrEmpty())
             {
                 friendlyName = friendlyNameAttribute.FriendlyName;
             }

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestRunTimePluginInformation.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestRunTimePluginInformation.cs
@@ -61,7 +61,7 @@ internal class TestRuntimePluginInformation : TestExtensionPluginInformation
         {
             FriendlyNameAttribute friendlyNameAttribute = (FriendlyNameAttribute)attributes[0];
 
-            if (!string.IsNullOrEmpty(friendlyNameAttribute.FriendlyName))
+            if (!friendlyNameAttribute.FriendlyName.IsNullOrEmpty())
             {
                 friendlyName = friendlyNameAttribute.FriendlyName;
             }

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestSettingsProviderPluginInformation.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestSettingsProviderPluginInformation.cs
@@ -75,7 +75,7 @@ internal class TestSettingsProviderPluginInformation : TestPluginInformation
         {
             SettingsNameAttribute settingsNameAttribute = (SettingsNameAttribute)attributes[0];
 
-            if (!string.IsNullOrEmpty(settingsNameAttribute.SettingsName))
+            if (!settingsNameAttribute.SettingsName.IsNullOrEmpty())
             {
                 settingName = settingsNameAttribute.SettingsName;
             }

--- a/src/Microsoft.TestPlatform.Common/Filtering/Condition.cs
+++ b/src/Microsoft.TestPlatform.Common/Filtering/Condition.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -136,7 +135,7 @@ internal class Condition
                 {
                     foreach (string propertyValue in multiValue)
                     {
-                        Debug.Assert(null != propertyValue, "PropertyValue can not be null.");
+                        TPDebug.Assert(null != propertyValue, "PropertyValue can not be null.");
                         result = result || propertyValue.IndexOf(Value, StringComparison.OrdinalIgnoreCase) != -1;
                         if (result)
                         {
@@ -154,7 +153,7 @@ internal class Condition
                 {
                     foreach (string propertyValue in multiValue)
                     {
-                        Debug.Assert(null != propertyValue, "PropertyValue can not be null.");
+                        TPDebug.Assert(null != propertyValue, "PropertyValue can not be null.");
                         result = result && propertyValue.IndexOf(Value, StringComparison.OrdinalIgnoreCase) == -1;
                         if (!result)
                         {
@@ -172,7 +171,7 @@ internal class Condition
     /// </summary>
     internal static Condition Parse(string conditionString)
     {
-        if (string.IsNullOrWhiteSpace(conditionString))
+        if (conditionString.IsNullOrWhiteSpace())
         {
             ThrownFormatExceptionForInvalidCondition(conditionString);
         }
@@ -192,7 +191,7 @@ internal class Condition
 
         for (int index = 0; index < 3; index++)
         {
-            if (string.IsNullOrWhiteSpace(parts[index]))
+            if (parts[index].IsNullOrWhiteSpace())
             {
                 ThrownFormatExceptionForInvalidCondition(conditionString);
             }

--- a/src/Microsoft.TestPlatform.Common/Filtering/FastFilter.cs
+++ b/src/Microsoft.TestPlatform.Common/Filtering/FastFilter.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -85,7 +84,7 @@ internal sealed class FastFilter
     /// <returns>For matching, returns the result of matching, null if no match found. For replacement, returns the result of replacement.</returns>
     private string ApplyRegex(string value)
     {
-        Debug.Assert(PropertyValueRegex != null);
+        TPDebug.Assert(PropertyValueRegex != null);
 
         string result = null;
         if (PropertyValueRegexReplacement == null)

--- a/src/Microsoft.TestPlatform.Common/Filtering/FilterExpression.cs
+++ b/src/Microsoft.TestPlatform.Common/Filtering/FilterExpression.cs
@@ -177,7 +177,7 @@ internal class FilterExpression
         foreach (var inputToken in tokens)
         {
             var token = inputToken.Trim();
-            if (string.IsNullOrEmpty(token))
+            if (token.IsNullOrEmpty())
             {
                 // ignore empty tokens
                 continue;

--- a/src/Microsoft.TestPlatform.Common/Filtering/FilterExpressionWrapper.cs
+++ b/src/Microsoft.TestPlatform.Common/Filtering/FilterExpressionWrapper.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Text.RegularExpressions;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -54,9 +53,9 @@ public class FilterExpressionWrapper
 
                 // TODO: surface an error message to suer.
                 var regexString = options?.FilterRegEx;
-                if (!string.IsNullOrEmpty(regexString))
+                if (!regexString.IsNullOrEmpty())
                 {
-                    Debug.Assert(options.FilterRegExReplacement == null || options.FilterRegEx != null);
+                    TPDebug.Assert(options.FilterRegExReplacement == null || options.FilterRegEx != null);
                     FastFilter.PropertyValueRegex = new Regex(regexString, RegexOptions.Compiled);
                     FastFilter.PropertyValueRegexReplacement = options.FilterRegExReplacement;
                 }

--- a/src/Microsoft.TestPlatform.Common/Filtering/TestCaseFilterExpression.cs
+++ b/src/Microsoft.TestPlatform.Common/Filtering/TestCaseFilterExpression.cs
@@ -31,7 +31,7 @@ public class TestCaseFilterExpression : ITestCaseFilterExpression
     public TestCaseFilterExpression(FilterExpressionWrapper filterWrapper!!)
     {
         _filterWrapper = filterWrapper;
-        _validForMatch = string.IsNullOrEmpty(filterWrapper.ParseError);
+        _validForMatch = filterWrapper.ParseError.IsNullOrEmpty();
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.Common/Interfaces/Engine/IDataCollectorAttachmentsProcessorsFactory.cs
+++ b/src/Microsoft.TestPlatform.Common/Interfaces/Engine/IDataCollectorAttachmentsProcessorsFactory.cs
@@ -41,7 +41,7 @@ internal class DataCollectorAttachmentProcessor : IDisposable
 
     public DataCollectorAttachmentProcessor(string friendlyName, IDataCollectorAttachmentProcessor dataCollectorAttachmentProcessor!!)
     {
-        FriendlyName = string.IsNullOrEmpty(friendlyName) ? throw new ArgumentException("Invalid FriendlyName", nameof(friendlyName)) : friendlyName;
+        FriendlyName = friendlyName.IsNullOrEmpty() ? throw new ArgumentException("Invalid FriendlyName", nameof(friendlyName)) : friendlyName;
         DataCollectorAttachmentProcessorInstance = dataCollectorAttachmentProcessor;
     }
 

--- a/src/Microsoft.TestPlatform.Common/Logging/InternalTestLoggerEvents.cs
+++ b/src/Microsoft.TestPlatform.Common/Logging/InternalTestLoggerEvents.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
@@ -369,7 +368,7 @@ internal class InternalTestLoggerEvents : TestLoggerEvents, IDisposable
 #else
             null;
 #endif
-        if (string.IsNullOrEmpty(enableBoundsOnEventQueueIsDefined))
+        if (enableBoundsOnEventQueueIsDefined.IsNullOrEmpty())
         {
             enableBounds = TestPlatformDefaults.DefaultEnableBoundsOnLoggerEventQueue;
         }
@@ -388,7 +387,7 @@ internal class InternalTestLoggerEvents : TestLoggerEvents, IDisposable
     /// </summary>
     private static int FindTestResultSize(TestResultEventArgs args)
     {
-        Debug.Assert(args != null && args.Result != null);
+        TPDebug.Assert(args != null && args.Result != null);
 
         int size = 0;
 
@@ -396,7 +395,7 @@ internal class InternalTestLoggerEvents : TestLoggerEvents, IDisposable
         {
             foreach (TestResultMessage msg in args.Result.Messages)
             {
-                if (!string.IsNullOrEmpty(msg.Text))
+                if (!msg.Text.IsNullOrEmpty())
                     size += msg.Text.Length;
             }
         }
@@ -416,7 +415,7 @@ internal class InternalTestLoggerEvents : TestLoggerEvents, IDisposable
 #else
             null;
 #endif
-        if (string.IsNullOrEmpty(appSettingValue))
+        if (appSettingValue.IsNullOrEmpty())
         {
             value = defaultValue;
         }

--- a/src/Microsoft.TestPlatform.Common/Logging/TestSessionMessageLogger.cs
+++ b/src/Microsoft.TestPlatform.Common/Logging/TestSessionMessageLogger.cs
@@ -64,7 +64,7 @@ internal class TestSessionMessageLogger : IMessageLogger
     /// <param name="message">The message to be sent.</param>
     public void SendMessage(TestMessageLevel testMessageLevel, string message)
     {
-        if (string.IsNullOrWhiteSpace(message))
+        if (message.IsNullOrWhiteSpace())
         {
             throw new ArgumentException(ObjectModelCommonResources.CannotBeNullOrEmpty, nameof(message));
         }

--- a/src/Microsoft.TestPlatform.Common/Microsoft.TestPlatform.Common.csproj
+++ b/src/Microsoft.TestPlatform.Common/Microsoft.TestPlatform.Common.csproj
@@ -6,11 +6,13 @@
   <Import Project="$(TestPlatformRoot)scripts/build/TestPlatform.Settings.targets" />
   <PropertyGroup>
     <AssemblyName>Microsoft.VisualStudio.TestPlatform.Common</AssemblyName>
-    <TargetFrameworks>netstandard2.0;netstandard1.3;net451</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;netstandard1.3;net451</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">net6.0</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
+    <UseBannedApiAnalyzers>true</UseBannedApiAnalyzers>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\..\NullableAttributes.cs" Link="NullableAttributes.cs" />
     <Compile Include="..\..\scripts\build\ExternalAssemblyVersions.cs" Link="ExternalAssemblyVersions.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -50,6 +52,7 @@
     <RootNamespace>Microsoft.VisualStudio.TestPlatform.Common</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <AdditionalFiles Include="BannedSymbols.txt" />
     <!-- API that is common to all frameworks that we build for. -->
     <AdditionalFiles Include="PublicAPI/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Unshipped.txt" />

--- a/src/Microsoft.TestPlatform.Common/SettingsProvider/SettingsProviderExtensionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/SettingsProvider/SettingsProviderExtensionManager.cs
@@ -162,7 +162,7 @@ public class SettingsProviderExtensionManager
     /// <returns>Settings provider with the provided name or null if one was not found.</returns>
     internal LazyExtension<ISettingsProvider, ISettingsProviderCapabilities> GetSettingsProvider(string settingsName)
     {
-        if (string.IsNullOrWhiteSpace(settingsName))
+        if (settingsName.IsNullOrWhiteSpace())
         {
             throw new ArgumentException(ObjectModelCommonResources.CannotBeNullOrEmpty, nameof(settingsName));
         }

--- a/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs
@@ -85,7 +85,7 @@ internal class AssemblyResolver : IDisposable
     /// </returns>
     private Assembly OnResolve(object sender, AssemblyResolveEventArgs args)
     {
-        if (string.IsNullOrEmpty(args?.Name))
+        if (StringUtils.IsNullOrEmpty(args?.Name))
         {
             Debug.Fail("AssemblyResolver.OnResolve: args.Name is null or empty.");
             return null;
@@ -122,11 +122,11 @@ internal class AssemblyResolver : IDisposable
                 return null;
             }
 
-            Debug.Assert(requestedName != null && !string.IsNullOrEmpty(requestedName.Name), "AssemblyResolver.OnResolve: requested is null or name is empty!");
+            TPDebug.Assert(requestedName != null && !requestedName.Name.IsNullOrEmpty(), "AssemblyResolver.OnResolve: requested is null or name is empty!");
 
             foreach (var dir in _searchDirectories)
             {
-                if (string.IsNullOrEmpty(dir))
+                if (dir.IsNullOrEmpty())
                 {
                     continue;
                 }
@@ -196,8 +196,8 @@ internal class AssemblyResolver : IDisposable
     /// </returns>
     private bool RequestedAssemblyNameMatchesFound(AssemblyName requestedName, AssemblyName foundName)
     {
-        Debug.Assert(requestedName != null);
-        Debug.Assert(foundName != null);
+        TPDebug.Assert(requestedName != null);
+        TPDebug.Assert(foundName != null);
 
         var requestedPublicKey = requestedName.GetPublicKeyToken();
         if (requestedPublicKey != null)

--- a/src/Microsoft.TestPlatform.Common/Utilities/ExceptionUtilities.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/ExceptionUtilities.cs
@@ -43,7 +43,7 @@ public class ExceptionUtilities
 
     private static void AppendStackTrace(StringBuilder stringBuilder, Exception exception)
     {
-        if (!string.IsNullOrEmpty(exception.StackTrace))
+        if (!exception.StackTrace.IsNullOrEmpty())
         {
             stringBuilder
                 .AppendLine()

--- a/src/Microsoft.TestPlatform.Common/Utilities/FakesUtilities.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/FakesUtilities.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Xml;
@@ -71,7 +70,7 @@ public static class FakesUtilities
         }
 
         // Since there are no FrameworkVersion values for .Net Core 2.0 +, we check TargetFramework instead
-        // and default to FrameworkCore10 for .Net Core 
+        // and default to FrameworkCore10 for .Net Core
         if (targetFramework.Name.IndexOf("netstandard", StringComparison.OrdinalIgnoreCase) >= 0 ||
             targetFramework.Name.IndexOf("netcoreapp", StringComparison.OrdinalIgnoreCase) >= 0 ||
             targetFramework.Name.IndexOf("net5", StringComparison.OrdinalIgnoreCase) >= 0)
@@ -79,8 +78,8 @@ public static class FakesUtilities
             return FrameworkVersion.FrameworkCore10;
         }
 
-        // Since the Datacollector is separated on the NetFramework/NetCore line, any value of NETFramework 
-        // can be passed along to the fakes data collector configuration creator. 
+        // Since the Datacollector is separated on the NetFramework/NetCore line, any value of NETFramework
+        // can be passed along to the fakes data collector configuration creator.
         // We default to Framework40 to preserve back compat
         return FrameworkVersion.Framework40;
     }
@@ -97,9 +96,9 @@ public static class FakesUtilities
         FrameworkVersion framework)
     {
         // A new Fakes Configurator API makes the decision to add the right datacollector uri to the configuration
-        // There now exist two data collector URIs to support two different scenarios. The new scenario involves 
-        // using the CLRIE profiler, and the old involves using the Intellitrace profiler (which isn't supported in 
-        // .NET Core scenarios). The old API still exists for fallback measures. 
+        // There now exist two data collector URIs to support two different scenarios. The new scenario involves
+        // using the CLRIE profiler, and the old involves using the Intellitrace profiler (which isn't supported in
+        // .NET Core scenarios). The old API still exists for fallback measures.
 
         var crossPlatformConfigurator = TryGetFakesCrossPlatformDataCollectorConfigurator();
         if (crossPlatformConfigurator != null)
@@ -162,7 +161,7 @@ public static class FakesUtilities
         FrameworkVersion framework)
     {
 
-        // The fallback settings is for the old implementation of fakes 
+        // The fallback settings is for the old implementation of fakes
         // that only supports .Net Framework versions
         if (framework
             is not FrameworkVersion.Framework35
@@ -212,8 +211,8 @@ public static class FakesUtilities
     /// <param name="settingsNode">settingsNode</param>
     private static void EnsureSettingsNode(XmlDocument settings, TestRunSettings settingsNode)
     {
-        Debug.Assert(settingsNode != null, "Invalid Settings Node");
-        Debug.Assert(settings != null, "Invalid Settings");
+        TPDebug.Assert(settingsNode != null, "Invalid Settings Node");
+        TPDebug.Assert(settings != null, "Invalid Settings");
 
         var root = settings.DocumentElement;
         if (root[settingsNode.Name] == null)

--- a/src/Microsoft.TestPlatform.Common/Utilities/InstallationContext.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/InstallationContext.cs
@@ -27,10 +27,10 @@ public class InstallationContext
     public bool TryGetVisualStudioDirectory(out string visualStudioDirectory)
     {
         var vsInstallPath = new DirectoryInfo(typeof(InstallationContext).GetTypeInfo().Assembly.GetAssemblyLocation()).Parent?.Parent?.Parent?.FullName;
-        if (!string.IsNullOrEmpty(vsInstallPath))
+        if (!vsInstallPath.IsNullOrEmpty())
         {
             var pathToDevenv = Path.Combine(vsInstallPath, DevenvExe);
-            if (!string.IsNullOrEmpty(pathToDevenv) && _fileHelper.Exists(pathToDevenv))
+            if (!pathToDevenv.IsNullOrEmpty() && _fileHelper.Exists(pathToDevenv))
             {
                 visualStudioDirectory = vsInstallPath;
                 return true;

--- a/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
@@ -206,7 +206,7 @@ internal static class RunSettingsProviderExtensions
     {
         var doc = new XmlDocument();
 
-        if (!StringUtils.IsNullOrEmpty(runSettingsProvider?.ActiveRunSettings.SettingsXml))
+        if (!StringUtils.IsNullOrEmpty(runSettingsProvider.ActiveRunSettings?.SettingsXml))
         {
             var settingsXml = runSettingsProvider.ActiveRunSettings.SettingsXml;
 

--- a/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
@@ -59,7 +59,7 @@ internal static class RunSettingsProviderExtensions
     {
         var runSettingsXml = runSettingsProvider.ActiveRunSettings?.SettingsXml;
 
-        if (string.IsNullOrWhiteSpace(runSettingsXml))
+        if (runSettingsXml.IsNullOrWhiteSpace())
         {
             runSettingsXml = EmptyRunSettings;
         }
@@ -206,8 +206,7 @@ internal static class RunSettingsProviderExtensions
     {
         var doc = new XmlDocument();
 
-        if (runSettingsProvider.ActiveRunSettings != null &&
-            !string.IsNullOrEmpty(runSettingsProvider.ActiveRunSettings.SettingsXml))
+        if (!StringUtils.IsNullOrEmpty(runSettingsProvider?.ActiveRunSettings.SettingsXml))
         {
             var settingsXml = runSettingsProvider.ActiveRunSettings.SettingsXml;
 

--- a/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsUtilities.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsUtilities.cs
@@ -43,7 +43,7 @@ public static class RunSettingsUtilities
         string resultsDirectory = null;
         if (runConfiguration != null)
         {
-            // It will try to get path from runsettings, if not found then it will return default path. 
+            // It will try to get path from runsettings, if not found then it will return default path.
             resultsDirectory = Environment.ExpandEnvironmentVariables(runConfiguration.ResultsDirectory);
         }
 
@@ -77,7 +77,7 @@ public static class RunSettingsUtilities
         string solutionDirectory = null;
         if (runConfiguration != null)
         {
-            if (!string.IsNullOrEmpty(runConfiguration.SolutionDirectory))
+            if (!runConfiguration.SolutionDirectory.IsNullOrEmpty())
             {
                 // Env var is expanded in run configuration
                 solutionDirectory = runConfiguration.SolutionDirectory;
@@ -96,7 +96,7 @@ public static class RunSettingsUtilities
     {
         int cpuCount = Constants.DefaultCpuCount;
 
-        if (string.IsNullOrEmpty(settingXml))
+        if (settingXml.IsNullOrEmpty())
         {
             return cpuCount;
         }

--- a/src/Microsoft.TestPlatform.Common/Utilities/StringUtils.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/StringUtils.cs
@@ -1,9 +1,9 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.TestPlatform;
+namespace Microsoft.VisualStudio.TestPlatform;
 
 internal static class StringUtils
 {

--- a/src/Microsoft.TestPlatform.Common/Utilities/TPDebug.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/TPDebug.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.TestPlatform;
+
+[SuppressMessage("ApiDesign", "RS0030:Do not used banned APIs", Justification = "Replacement API to allow nullable hints for compiler")]
+internal static class TPDebug
+{
+    /// <inheritdoc cref="Debug.Assert(bool)"/>
+    [Conditional("DEBUG")]
+    public static void Assert([DoesNotReturnIf(false)] bool b)
+        => Debug.Assert(b);
+
+    /// <inheritdoc cref="Debug.Assert(bool, string)"/>
+    [Conditional("DEBUG")]
+    public static void Assert([DoesNotReturnIf(false)] bool b, string message)
+        => Debug.Assert(b, message);
+}

--- a/test/Microsoft.TestPlatform.AcceptanceTests/Microsoft.TestPlatform.AcceptanceTests.csproj
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/Microsoft.TestPlatform.AcceptanceTests.csproj
@@ -4,6 +4,7 @@
     <TestPlatformRoot Condition="$(TestPlatformRoot) == ''">..\..\</TestPlatformRoot>
     <TestProject>true</TestProject>
     <IsTestProject>true</IsTestProject>
+    <UseBannedApiAnalyzers>true</UseBannedApiAnalyzers>
   </PropertyGroup>
   <Import Project="$(TestPlatformRoot)scripts/build/TestPlatform.Settings.targets" />
   <PropertyGroup>
@@ -29,10 +30,6 @@
   <ItemGroup>
     <PackageReference Include="Chutzpah" Version="$(ChutzpahAdapterVersion)" />
     <PackageReference Include="FluentAssertions" Version="6.0.0-alpha0002" />
-    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.TestPlatform.TestAsset.NativeCPP" Version="2.0.0" />
     <PackageReference Include="Microsoft.TestPlatform.QTools.Assets" Version="2.0.0" />
     <PackageReference Include="Procdump" Version="0.0.1" />

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Microsoft.TestPlatform.CrossPlatEngine.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Microsoft.TestPlatform.CrossPlatEngine.UnitTests.csproj
@@ -13,9 +13,6 @@
     <OutputType Condition=" $(TargetFramework.StartsWith('net6')) ">Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\NullableAttributes.cs" Link="NullableAttributes.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.TestHostProvider\Microsoft.TestPlatform.TestHostProvider.csproj" />
     <ProjectReference Include="..\coverlet.collector\coverlet.collector.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.CoreUtilities\Microsoft.TestPlatform.CoreUtilities.csproj">

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -15,6 +15,7 @@ using FluentAssertions;
 
 using Microsoft.TestPlatform.VsTestConsole.TranslationLayer;
 using Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces;
+using Microsoft.VisualStudio.TestPlatform;
 using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Extensions;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestEnvironment.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestEnvironment.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 
+using Microsoft.VisualStudio.TestPlatform;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.TestPlatform.TestUtilities;

--- a/test/Microsoft.TestPlatform.TestUtilities/Microsoft.TestPlatform.TestUtilities.csproj
+++ b/test/Microsoft.TestPlatform.TestUtilities/Microsoft.TestPlatform.TestUtilities.csproj
@@ -9,6 +9,7 @@
     <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">netcoreapp3.1</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
+    <UseBannedApiAnalyzers>true</UseBannedApiAnalyzers>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="BannedSymbols.txt" />
@@ -18,7 +19,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\NullableAttributes.cs" Link="NullableAttributes.cs" />
-    <Compile Include="..\..\StringUtils.cs" Link="StringUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.Common\Microsoft.TestPlatform.Common.csproj" />
@@ -32,10 +32,6 @@
     <PackageReference Include="FluentAssertions" Version="6.0.0-alpha0002" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="MSTest.TestFramework" Version="$(MSTestFrameworkVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.41" />

--- a/test/Microsoft.TestPlatform.TestUtilities/TempDirectory.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/TempDirectory.cs
@@ -79,7 +79,7 @@ public class TempDirectory : IDisposable
     {
         var destination = IO.Path.Combine(Path, IO.Path.GetFileName(filePath));
         File.Copy(filePath, destination);
-        return destination; 
+        return destination;
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

I am needing something similar for Parallel discovery and assembly load context so I thought it would be better to create a separate PR for this feature and have the other PRs simpler.

Contributes to [AB#1549371](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1549371)