### PR TITLE
Make vstest.console, and datacollector upgrade across major .NET version

### DIFF
--- a/src/datacollector/datacollector.csproj
+++ b/src/datacollector/datacollector.csproj
@@ -17,6 +17,7 @@
     <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">net6.0</TargetFrameworks>
     <PlatformTarget Condition=" $(TargetFramework.StartsWith('net4')) AND '$(RuntimeIdentifier)' == '' ">AnyCPU</PlatformTarget>
     <OutputType>Exe</OutputType>
+    <RollForward>LatestMajor</RollForward>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/src/datacollector/datacollector.csproj
+++ b/src/datacollector/datacollector.csproj
@@ -17,7 +17,7 @@
     <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">net6.0</TargetFrameworks>
     <PlatformTarget Condition=" $(TargetFramework.StartsWith('net4')) AND '$(RuntimeIdentifier)' == '' ">AnyCPU</PlatformTarget>
     <OutputType>Exe</OutputType>
-    <RollForward>LatestMajor</RollForward>
+    <RollForward>Major</RollForward>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/src/vstest.console/vstest.console.csproj
+++ b/src/vstest.console/vstest.console.csproj
@@ -11,7 +11,7 @@
     <TargetFrameworks>netcoreapp2.1;net451</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <RollForward>LatestMajor</RollForward>
+    <RollForward>Major</RollForward>
     <IsTestProject>false</IsTestProject>
     <PlatformTarget Condition="'$(TargetFramework)' == 'net451' AND '$(RuntimeIdentifier)' == '' " >AnyCPU</PlatformTarget>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/vstest.console/vstest.console.csproj
+++ b/src/vstest.console/vstest.console.csproj
@@ -11,6 +11,7 @@
     <TargetFrameworks>netcoreapp2.1;net451</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
+    <RollForward>LatestMajor</RollForward>
     <IsTestProject>false</IsTestProject>
     <PlatformTarget Condition="'$(TargetFramework)' == 'net451' AND '$(RuntimeIdentifier)' == '' " >AnyCPU</PlatformTarget>
     <ApplicationManifest>app.manifest</ApplicationManifest>


### PR DESCRIPTION
## Description
vstest.console and datacollector are our tools and they should be able to run on any .NET version from netcoreapp2.1 onwards. But in the cli, and portable packages we ship runtime config with them that ties them to netcoreapp2.1. 

dotnet SDK rewrites our runtime.config.json to use the same version as what the SDK is, but our nugets don't have that change, and tooling authors work around this by setting DOTNET_ROLL_FORWARD policy by environment variables, which inherits downwards to testhost where that policy is undesirable.

Setting RollForward in our project will emit it in runtimeconfig.json and will tell vstest.console and datacollector and allows us to upgrade to a newer runtime even across major version. This won't upgrade to pre-releases, and won't upgrade to the latest version available, because we currently have no way to rewrite this option in the actual SDK shipment.
