### PR TITLE
IDE0055: Bump back to warning

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -264,8 +264,8 @@ csharp_style_prefer_parameter_null_checking = true # not default, increased seve
 
 #### .NET Formatting Rules ####
 
-# IDE0055: Fix formatting
-dotnet_diagnostic.IDE0055.severity = warning
+# IDE0055: Fix formatting - Set the severity of all .NET and C# formatting rules (https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules)
+dotnet_diagnostic.IDE0055.severity = warning # ensure all formatting rules are enforced on build
 
 #### C# Formatting Rules ####
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -265,7 +265,7 @@ csharp_style_prefer_parameter_null_checking = true # not default, increased seve
 #### .NET Formatting Rules ####
 
 # IDE0055: Fix formatting
-dotnet_diagnostic.IDE0055.severity = suggestion # Downgraded to suggestion due to https://github.com/dotnet/roslyn/issues/59414
+dotnet_diagnostic.IDE0055.severity = warning
 
 #### C# Formatting Rules ####
 

--- a/src/Microsoft.TestPlatform.Execution.Shared/DebuggerBreakpoint.cs
+++ b/src/Microsoft.TestPlatform.Execution.Shared/DebuggerBreakpoint.cs
@@ -4,9 +4,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-#if !NETCOREAPP1_0 && DEBUG
-using System.Reflection;
-#endif
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.cs.xlf
@@ -29,9 +29,9 @@ Tento test může a nemusí být příčinou chybového ukončení.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="BlameParameterValueIncorrect">
-        <source>The blame parameter key  {0} can only support values {1}/{2}. Ignoring this key.</source>
-        <target state="translated">Klíč parametru blame {0} dokáže podporovat jen hodnoty {1}/{2}. Tento klíč se bude ignorovat.</target>
-        <note></note>
+        <source>The blame parameter key {0}, has incorrect value: {1}. Supported values are: {2}</source>
+        <target state="new">Klíč parametru blame {0} dokáže podporovat jen hodnoty {1}/{2}. Tento klíč se bude ignorovat.</target>
+        <note>{0} and {1} are single values referring to parameters such as BlameHang and Full. {2} is comma separated list of valid values, e.g. Full, Mini, None.</note>
       </trans-unit>
       <trans-unit id="ProcDumpCouldNotStart">
         <source>Could not start process dump: {0}</source>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.de.xlf
@@ -29,9 +29,9 @@ Dieser Test kann, muss aber nicht unbedingt die Absturzursache sein.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="BlameParameterValueIncorrect">
-        <source>The blame parameter key  {0} can only support values {1}/{2}. Ignoring this key.</source>
-        <target state="translated">Der blame-Parameterschlüssel "{0}" kann nur die Werte "{1}"/"{2}" unterstützen. Dieser Schlüssel wird ignoriert.</target>
-        <note></note>
+        <source>The blame parameter key {0}, has incorrect value: {1}. Supported values are: {2}</source>
+        <target state="new">Der blame-Parameterschlüssel "{0}" kann nur die Werte "{1}"/"{2}" unterstützen. Dieser Schlüssel wird ignoriert.</target>
+        <note>{0} and {1} are single values referring to parameters such as BlameHang and Full. {2} is comma separated list of valid values, e.g. Full, Mini, None.</note>
       </trans-unit>
       <trans-unit id="ProcDumpCouldNotStart">
         <source>Could not start process dump: {0}</source>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.es.xlf
@@ -29,9 +29,9 @@ Esta prueba puede ser el origen del bloqueo o no serlo.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="BlameParameterValueIncorrect">
-        <source>The blame parameter key  {0} can only support values {1}/{2}. Ignoring this key.</source>
-        <target state="translated">La clave de parámetro blame {0} solo puede admitir valores {1}/{2}. Se omitirá esta clave.</target>
-        <note></note>
+        <source>The blame parameter key {0}, has incorrect value: {1}. Supported values are: {2}</source>
+        <target state="new">La clave de parámetro blame {0} solo puede admitir valores {1}/{2}. Se omitirá esta clave.</target>
+        <note>{0} and {1} are single values referring to parameters such as BlameHang and Full. {2} is comma separated list of valid values, e.g. Full, Mini, None.</note>
       </trans-unit>
       <trans-unit id="ProcDumpCouldNotStart">
         <source>Could not start process dump: {0}</source>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.fr.xlf
@@ -29,9 +29,9 @@ Ce test est éventuellement à l'origine du plantage.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="BlameParameterValueIncorrect">
-        <source>The blame parameter key  {0} can only support values {1}/{2}. Ignoring this key.</source>
-        <target state="translated">La clé de paramètre blame {0} peut prendre en charge uniquement les valeurs {1}/{2}. Cette clé est ignorée.</target>
-        <note></note>
+        <source>The blame parameter key {0}, has incorrect value: {1}. Supported values are: {2}</source>
+        <target state="new">La clé de paramètre blame {0} peut prendre en charge uniquement les valeurs {1}/{2}. Cette clé est ignorée.</target>
+        <note>{0} and {1} are single values referring to parameters such as BlameHang and Full. {2} is comma separated list of valid values, e.g. Full, Mini, None.</note>
       </trans-unit>
       <trans-unit id="ProcDumpCouldNotStart">
         <source>Could not start process dump: {0}</source>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.it.xlf
@@ -29,9 +29,9 @@ Il test potrebbe essere l'origine dell'arresto anomalo.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="BlameParameterValueIncorrect">
-        <source>The blame parameter key  {0} can only support values {1}/{2}. Ignoring this key.</source>
-        <target state="translated">La chiave {0} del parametro di Blame può supportare solo valori {1}/{2}. Questa chiave verrà ignorata.</target>
-        <note></note>
+        <source>The blame parameter key {0}, has incorrect value: {1}. Supported values are: {2}</source>
+        <target state="new">La chiave {0} del parametro di Blame può supportare solo valori {1}/{2}. Questa chiave verrà ignorata.</target>
+        <note>{0} and {1} are single values referring to parameters such as BlameHang and Full. {2} is comma separated list of valid values, e.g. Full, Mini, None.</note>
       </trans-unit>
       <trans-unit id="ProcDumpCouldNotStart">
         <source>Could not start process dump: {0}</source>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.ja.xlf
@@ -29,9 +29,9 @@ This test may, or may not be the source of the crash.</source>
         <note></note>
       </trans-unit>
       <trans-unit id="BlameParameterValueIncorrect">
-        <source>The blame parameter key  {0} can only support values {1}/{2}. Ignoring this key.</source>
-        <target state="translated">blame パラメーター キー {0} は値 {1}/{2} のみをサポートします。このキーは無視されます。</target>
-        <note></note>
+        <source>The blame parameter key {0}, has incorrect value: {1}. Supported values are: {2}</source>
+        <target state="new">blame パラメーター キー {0} は値 {1}/{2} のみをサポートします。このキーは無視されます。</target>
+        <note>{0} and {1} are single values referring to parameters such as BlameHang and Full. {2} is comma separated list of valid values, e.g. Full, Mini, None.</note>
       </trans-unit>
       <trans-unit id="ProcDumpCouldNotStart">
         <source>Could not start process dump: {0}</source>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.ko.xlf
@@ -29,9 +29,9 @@ This test may, or may not be the source of the crash.</source>
         <note></note>
       </trans-unit>
       <trans-unit id="BlameParameterValueIncorrect">
-        <source>The blame parameter key  {0} can only support values {1}/{2}. Ignoring this key.</source>
-        <target state="translated">blame 매개 변수 키 {0}은(는) {1}/{2} 값만 지원할 수 있습니다. 이 키를 무시합니다.</target>
-        <note></note>
+        <source>The blame parameter key {0}, has incorrect value: {1}. Supported values are: {2}</source>
+        <target state="new">blame 매개 변수 키 {0}은(는) {1}/{2} 값만 지원할 수 있습니다. 이 키를 무시합니다.</target>
+        <note>{0} and {1} are single values referring to parameters such as BlameHang and Full. {2} is comma separated list of valid values, e.g. Full, Mini, None.</note>
       </trans-unit>
       <trans-unit id="ProcDumpCouldNotStart">
         <source>Could not start process dump: {0}</source>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.pl.xlf
@@ -29,9 +29,9 @@ Ten test może, ale nie musi być źródłem awarii.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="BlameParameterValueIncorrect">
-        <source>The blame parameter key  {0} can only support values {1}/{2}. Ignoring this key.</source>
-        <target state="translated">Klucz parametru blame {0} może obsługiwać tylko wartości {1}/{2}. Ten klucz jest ignorowany.</target>
-        <note></note>
+        <source>The blame parameter key {0}, has incorrect value: {1}. Supported values are: {2}</source>
+        <target state="new">Klucz parametru blame {0} może obsługiwać tylko wartości {1}/{2}. Ten klucz jest ignorowany.</target>
+        <note>{0} and {1} are single values referring to parameters such as BlameHang and Full. {2} is comma separated list of valid values, e.g. Full, Mini, None.</note>
       </trans-unit>
       <trans-unit id="ProcDumpCouldNotStart">
         <source>Could not start process dump: {0}</source>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.pt-BR.xlf
@@ -29,9 +29,9 @@ Esse teste pode ser a origem da falha ou não.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="BlameParameterValueIncorrect">
-        <source>The blame parameter key  {0} can only support values {1}/{2}. Ignoring this key.</source>
-        <target state="translated">A chave de parâmetro de blame {0} oferece suporte apenas aos valores {1}/{2}. Ignorando esta chave.</target>
-        <note></note>
+        <source>The blame parameter key {0}, has incorrect value: {1}. Supported values are: {2}</source>
+        <target state="new">A chave de parâmetro de blame {0} oferece suporte apenas aos valores {1}/{2}. Ignorando esta chave.</target>
+        <note>{0} and {1} are single values referring to parameters such as BlameHang and Full. {2} is comma separated list of valid values, e.g. Full, Mini, None.</note>
       </trans-unit>
       <trans-unit id="ProcDumpCouldNotStart">
         <source>Could not start process dump: {0}</source>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.ru.xlf
@@ -29,9 +29,9 @@ This test may, or may not be the source of the crash.</source>
         <note></note>
       </trans-unit>
       <trans-unit id="BlameParameterValueIncorrect">
-        <source>The blame parameter key  {0} can only support values {1}/{2}. Ignoring this key.</source>
-        <target state="translated">Ключ {0} параметра Blame поддерживает только значения {1}/{2}. Он будет пропущен.</target>
-        <note></note>
+        <source>The blame parameter key {0}, has incorrect value: {1}. Supported values are: {2}</source>
+        <target state="new">Ключ {0} параметра Blame поддерживает только значения {1}/{2}. Он будет пропущен.</target>
+        <note>{0} and {1} are single values referring to parameters such as BlameHang and Full. {2} is comma separated list of valid values, e.g. Full, Mini, None.</note>
       </trans-unit>
       <trans-unit id="ProcDumpCouldNotStart">
         <source>Could not start process dump: {0}</source>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.tr.xlf
@@ -29,9 +29,9 @@ Bu test, kilitlenmenin kaynağı olmayabilir veya olmayabilir.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="BlameParameterValueIncorrect">
-        <source>The blame parameter key  {0} can only support values {1}/{2}. Ignoring this key.</source>
-        <target state="translated">Belirtilen blame parametresi anahtarı {0} yalnızca {1}/{2} değerlerini destekleyebilir. Bu anahtar yoksayılıyor.</target>
-        <note></note>
+        <source>The blame parameter key {0}, has incorrect value: {1}. Supported values are: {2}</source>
+        <target state="new">Belirtilen blame parametresi anahtarı {0} yalnızca {1}/{2} değerlerini destekleyebilir. Bu anahtar yoksayılıyor.</target>
+        <note>{0} and {1} are single values referring to parameters such as BlameHang and Full. {2} is comma separated list of valid values, e.g. Full, Mini, None.</note>
       </trans-unit>
       <trans-unit id="ProcDumpCouldNotStart">
         <source>Could not start process dump: {0}</source>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.xlf
@@ -26,9 +26,9 @@ This test may, or may not be the source of the crash.</source>
         <note></note>
       </trans-unit>
       <trans-unit id="BlameParameterValueIncorrect">
-        <source>The blame parameter key  {0} can only support values {1}/{2}. Ignoring this key.</source>
+        <source>The blame parameter key {0}, has incorrect value: {1}. Supported values are: {2}</source>
         <target state="new">The blame parameter key  {0} can only support values {1}/{2}. Ignoring this parameter.</target>
-        <note></note>
+        <note>{0} and {1} are single values referring to parameters such as BlameHang and Full. {2} is comma separated list of valid values, e.g. Full, Mini, None.</note>
       </trans-unit>
       <trans-unit id="ProcDumpCouldNotStart">
         <source>Could not start process dump: {0}</source>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.zh-Hans.xlf
@@ -29,9 +29,9 @@ This test may, or may not be the source of the crash.</source>
         <note></note>
       </trans-unit>
       <trans-unit id="BlameParameterValueIncorrect">
-        <source>The blame parameter key  {0} can only support values {1}/{2}. Ignoring this key.</source>
-        <target state="translated">追责参数键 {0} 只支持值 {1}/{2}。忽略此键。</target>
-        <note></note>
+        <source>The blame parameter key {0}, has incorrect value: {1}. Supported values are: {2}</source>
+        <target state="new">追责参数键 {0} 只支持值 {1}/{2}。忽略此键。</target>
+        <note>{0} and {1} are single values referring to parameters such as BlameHang and Full. {2} is comma separated list of valid values, e.g. Full, Mini, None.</note>
       </trans-unit>
       <trans-unit id="ProcDumpCouldNotStart">
         <source>Could not start process dump: {0}</source>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.zh-Hant.xlf
@@ -29,9 +29,9 @@ This test may, or may not be the source of the crash.</source>
         <note></note>
       </trans-unit>
       <trans-unit id="BlameParameterValueIncorrect">
-        <source>The blame parameter key  {0} can only support values {1}/{2}. Ignoring this key.</source>
-        <target state="translated">blame 參數索引鍵 {0} 僅支援值 {1}/{2}。即將忽略此索引鍵。</target>
-        <note></note>
+        <source>The blame parameter key {0}, has incorrect value: {1}. Supported values are: {2}</source>
+        <target state="new">blame 參數索引鍵 {0} 僅支援值 {1}/{2}。即將忽略此索引鍵。</target>
+        <note>{0} and {1} are single values referring to parameters such as BlameHang and Full. {2} is comma separated list of valid values, e.g. Full, Mini, None.</note>
       </trans-unit>
       <trans-unit id="ProcDumpCouldNotStart">
         <source>Could not start process dump: {0}</source>

--- a/src/Microsoft.TestPlatform.ObjectModel/AttachmentSet.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/AttachmentSet.cs
@@ -45,7 +45,7 @@ public class AttachmentSet
 
     public override string ToString()
     {
-        return $"{nameof(Uri)}: {Uri.AbsoluteUri}, {nameof(DisplayName)}: {DisplayName}, {nameof(Attachments)}: [{ string.Join(",", Attachments)}]";
+        return $"{nameof(Uri)}: {Uri.AbsoluteUri}, {nameof(DisplayName)}: {DisplayName}, {nameof(Attachments)}: [{string.Join(",", Attachments)}]";
     }
 }
 

--- a/src/datacollector/DataCollectorMain.cs
+++ b/src/datacollector/DataCollectorMain.cs
@@ -107,7 +107,7 @@ public class DataCollectorMain
                 .GetTypeInfo()
                 .Assembly
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-            EqtTrace.Verbose($"Version: { version }");
+            EqtTrace.Verbose($"Version: {version}");
         }
 
         UiLanguageOverride.SetCultureSpecifiedByUser();

--- a/src/testhost.x86/DefaultEngineInvoker.cs
+++ b/src/testhost.x86/DefaultEngineInvoker.cs
@@ -102,7 +102,7 @@ internal class DefaultEngineInvoker :
                 .GetTypeInfo()
                 .Assembly
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-            EqtTrace.Verbose($"Version: { version }");
+            EqtTrace.Verbose($"Version: {version}");
         }
 
         if (EqtTrace.IsInfoEnabled)

--- a/src/testhost.x86/TestHostTraceListener.cs
+++ b/src/testhost.x86/TestHostTraceListener.cs
@@ -25,7 +25,7 @@ internal class TestHostTraceListener : DefaultTraceListener
             var listener = Trace.Listeners[i];
             if (listener is DefaultTraceListener)
             {
-                EqtTrace.Verbose($"TestPlatformTraceListener.Setup: Replacing listener {0} with { nameof(TestHostTraceListener) }.", Trace.Listeners[i]);
+                EqtTrace.Verbose($"TestPlatformTraceListener.Setup: Replacing listener {Trace.Listeners[i]} with {nameof(TestHostTraceListener)}.");
                 Trace.Listeners[i] = new TestHostTraceListener();
             }
         }
@@ -121,7 +121,7 @@ internal class TestHostTraceListener : DefaultTraceListener
         var stackTrace = string.Join(Environment.NewLine, stack.ToString().Split(Environment.NewLine).TakeLast(frameCount));
 #endif
         var methodName = method != null ? $"{method.DeclaringType.Name}.{method.Name}" : "<method>";
-        var wholeMessage = $"Method {methodName} failed with '{message}', and was translated to { typeof(DebugAssertException).FullName } to avoid terminating the process hosting the test.";
+        var wholeMessage = $"Method {methodName} failed with '{message}', and was translated to {typeof(DebugAssertException).FullName} to avoid terminating the process hosting the test.";
 
         return new DebugAssertException(wholeMessage, stackTrace);
     }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/RunTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/RunTests.cs
@@ -45,7 +45,7 @@ public class RunTests : AcceptanceTestBase
     public void RunAllTests(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
-        
+
         var vstestConsoleWrapper = GetVsTestConsoleWrapper();
         var runEventHandler = new RunEventHandler();
         vstestConsoleWrapper.RunTests(GetTestDlls("MSTestProject1.dll", "MSTestProject2.dll"), GetDefaultRunSettings(), runEventHandler);

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -782,7 +782,7 @@ public class TrxLoggerTests
         _parameters.Remove(TrxLoggerConstants.LogFileNameKey);
         _testableTrxLogger.Initialize(_events.Object, _parameters);
 
-        string message = $"one line{ Environment.NewLine }second line\r\nthird line";
+        string message = $"one line{Environment.NewLine}second line\r\nthird line";
         var pass = CreatePassTestResultEventArgsMock("Pass1", new List<TestResultMessage> { new TestResultMessage(TestResultMessage.StandardOutCategory, message) });
 
         _testableTrxLogger.TestResultHandler(new object(), pass.Object);

--- a/test/Microsoft.TestPlatform.PerformanceTests/PerfInstrumentation/PerformanceTestBase.cs
+++ b/test/Microsoft.TestPlatform.PerformanceTests/PerfInstrumentation/PerformanceTestBase.cs
@@ -42,7 +42,7 @@ public class PerformanceTestBase : IntegrationTestBase
     /// </param>
     public void RunExecutionPerformanceTests(string testAsset, string testAdapterPath, string runSettings)
     {
-        using(_perfAnalyzer.Start())
+        using (_perfAnalyzer.Start())
         {
             InvokeVsTestForExecution(testAsset, testAdapterPath, framework: string.Empty, runSettings);
         }

--- a/test/coverlet.collector/CoverletInProcDataCollector.cs
+++ b/test/coverlet.collector/CoverletInProcDataCollector.cs
@@ -11,36 +11,35 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.InProcDataCollector;
 [assembly: AssemblyKeyFile("key.snk")]
 [assembly: AssemblyVersion("9.9.9.9")]
 
-namespace Coverlet.Collector.DataCollection
+namespace Coverlet.Collector.DataCollection;
+
+// This class MUST have the same full name as
+// https://github.com/tonerdo/coverlet/blob/master/src/coverlet.collector/InProcDataCollection/CoverletInProcDataCollector.cs
+// to mimic real behavior
+public class CoverletInProcDataCollector : InProcDataCollection
 {
-    // This class MUST have the same full name as
-    // https://github.com/tonerdo/coverlet/blob/master/src/coverlet.collector/InProcDataCollection/CoverletInProcDataCollector.cs
-    // to mimic real behavior
-    public class CoverletInProcDataCollector : InProcDataCollection
+    public void Initialize(IDataCollectionSink dataCollectionSink)
     {
-        public void Initialize(IDataCollectionSink dataCollectionSink)
-        {
-            throw new NotImplementedException();
-        }
+        throw new NotImplementedException();
+    }
 
-        public void TestCaseEnd(TestCaseEndArgs testCaseEndArgs)
-        {
-            throw new NotImplementedException();
-        }
+    public void TestCaseEnd(TestCaseEndArgs testCaseEndArgs)
+    {
+        throw new NotImplementedException();
+    }
 
-        public void TestCaseStart(TestCaseStartArgs testCaseStartArgs)
-        {
-            throw new NotImplementedException();
-        }
+    public void TestCaseStart(TestCaseStartArgs testCaseStartArgs)
+    {
+        throw new NotImplementedException();
+    }
 
-        public void TestSessionEnd(TestSessionEndArgs testSessionEndArgs)
-        {
-            throw new NotImplementedException();
-        }
+    public void TestSessionEnd(TestSessionEndArgs testSessionEndArgs)
+    {
+        throw new NotImplementedException();
+    }
 
-        public void TestSessionStart(TestSessionStartArgs testSessionStartArgs)
-        {
-            throw new NotImplementedException();
-        }
+    public void TestSessionStart(TestSessionStartArgs testSessionStartArgs)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/test/coverlet.collector/coverlet.collector.csproj
+++ b/test/coverlet.collector/coverlet.collector.csproj
@@ -5,6 +5,7 @@
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsTestProject>false</IsTestProject>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/vstest.ProgrammerTests/Fakes/TestRequestManagerHelper.cs
+++ b/test/vstest.ProgrammerTests/Fakes/TestRequestManagerHelper.cs
@@ -5,7 +5,9 @@ using System.Diagnostics;
 
 using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
 
+#pragma warning disable IDE1006 // Naming Styles
 namespace vstest.ProgrammerTests.Fakes;
+#pragma warning restore IDE1006 // Naming Styles
 
 internal class TestRequestManagerTestHelper
 {


### PR DESCRIPTION
Ensure all formatting rules are enforced on build and set their severity to warning. More information about the formatting rules here:  https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules.