### PR TITLE
Condition out BannedApiAnalyzers usage in source-build

### DIFF
--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -54,7 +54,7 @@
     <PackageReference Condition=" '$(OS)' != 'Windows_NT' " Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(UseBannedApiAnalyzers)' == 'true' ">
+  <ItemGroup Condition=" '$(UseBannedApiAnalyzers)' == 'true' and '$(DotNetBuildFromSource)' != 'true' ">
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(RoslynBannedApiAnalyzersVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
BannedApiAnalyzers is not part of source-build and therefore cannot be referenced without introducing prebuilts.  Other repos have conditioned out the reference for source-build.  This is viewed as acceptable as the "normal" product builds will run the analyzers and surface any issues.

cc @lbussell, @crummel
