### PR TITLE
Adapter time without TP overhead

### DIFF
--- a/playground/TestPlatform.Playground/Program.cs
+++ b/playground/TestPlatform.Playground/Program.cs
@@ -42,7 +42,7 @@ internal class Program
         var consoleOptions = new ConsoleParameters
         {
             LogFilePath = Path.Combine(here, "logs", "log.txt"),
-            TraceLevel = TraceLevel.Verbose,
+            TraceLevel = TraceLevel.Off,
         };
 
         var r = new VsTestConsoleWrapper(console, consoleOptions);
@@ -56,7 +56,7 @@ internal class Program
                 </RunSettings>
             ";
         var sources = new[] {
-            Path.Combine(playground, "MSTest1", "bin", "Debug", "net472", "MSTest1.dll")
+            @"C:\p\vstest3\test\TestAssets\performance\Perfy.TestAdapter\bin\Debug\net472\Perfy.TestAdapter.dll"
         };
 
         var options = new TestPlatformOptions();

--- a/src/Microsoft.TestPlatform.Common/Logging/TestSessionMessageLogger.cs
+++ b/src/Microsoft.TestPlatform.Common/Logging/TestSessionMessageLogger.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -16,7 +17,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Logging;
 /// <summary>
 /// The test session message logger.
 /// </summary>
-internal class TestSessionMessageLogger : IMessageLogger
+internal class TestSessionMessageLogger : OverheadLogger, IMessageLogger
 {
     private static TestSessionMessageLogger s_instance;
 
@@ -64,22 +65,38 @@ internal class TestSessionMessageLogger : IMessageLogger
     /// <param name="message">The message to be sent.</param>
     public void SendMessage(TestMessageLevel testMessageLevel, string message)
     {
-        if (message.IsNullOrWhiteSpace())
+        try
         {
-            throw new ArgumentException(ObjectModelCommonResources.CannotBeNullOrEmpty, nameof(message));
-        }
+            CallbackOverhead.Start();
+            if (message.IsNullOrWhiteSpace())
+            {
+                throw new ArgumentException(ObjectModelCommonResources.CannotBeNullOrEmpty, nameof(message));
+            }
 
-        if (TreatTestAdapterErrorsAsWarnings
-            && testMessageLevel == TestMessageLevel.Error)
-        {
-            // Downgrade the message severity to Warning...
-            testMessageLevel = TestMessageLevel.Warning;
-        }
+            if (TreatTestAdapterErrorsAsWarnings
+                && testMessageLevel == TestMessageLevel.Error)
+            {
+                // Downgrade the message severity to Warning...
+                testMessageLevel = TestMessageLevel.Warning;
+            }
 
-        if (TestRunMessage != null)
+            if (TestRunMessage != null)
+            {
+                var args = new TestRunMessageEventArgs(testMessageLevel, message);
+                TestRunMessage.SafeInvoke(this, args, "TestRunMessageLoggerProxy.SendMessage");
+            }
+        }
+        finally
         {
-            var args = new TestRunMessageEventArgs(testMessageLevel, message);
-            TestRunMessage.SafeInvoke(this, args, "TestRunMessageLoggerProxy.SendMessage");
+            CallbackOverhead.Stop();
         }
     }
+}
+
+internal class OverheadLogger
+{
+    /// <summary>
+    /// Measures time spent in callbacks to TestPlatform. It should not include time spent in constructors, because it is TP that is constructing this object, so we are already accounting for that time.
+    /// </summary>
+    public Stopwatch CallbackOverhead { get; } = new();
 }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Adapter/FrameworkHandle.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Adapter/FrameworkHandle.cs
@@ -72,34 +72,50 @@ internal class FrameworkHandle : TestExecutionRecorder, IFrameworkHandle2, IDisp
     /// <returns>Process ID of the started process.</returns>
     public int LaunchProcessWithDebuggerAttached(string filePath, string workingDirectory, string arguments, IDictionary<string, string> environmentVariables)
     {
-        // If an adapter attempts to launch a process after the run is complete (=> this object is disposed)
-        // throw an error. 
-        if (_isDisposed)
+        try
         {
-            throw new ObjectDisposedException("IFrameworkHandle");
+            CallbackOverhead.Start();
+            // If an adapter attempts to launch a process after the run is complete (=> this object is disposed)
+            // throw an error. 
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException("IFrameworkHandle");
+            }
+
+            // If it is not a debug run, then throw an error
+            if (!_testExecutionContext.IsDebug)
+            {
+                throw new InvalidOperationException(CrossPlatEngineResources.LaunchDebugProcessNotAllowedForANonDebugRun);
+            }
+
+            var processInfo = new TestProcessStartInfo()
+            {
+                Arguments = arguments,
+                EnvironmentVariables = environmentVariables,
+                FileName = filePath,
+                WorkingDirectory = workingDirectory
+            };
+
+            return _testRunEventsHandler.LaunchProcessWithDebuggerAttached(processInfo);
         }
-
-        // If it is not a debug run, then throw an error
-        if (!_testExecutionContext.IsDebug)
+        finally
         {
-            throw new InvalidOperationException(CrossPlatEngineResources.LaunchDebugProcessNotAllowedForANonDebugRun);
+            CallbackOverhead.Stop();
         }
-
-        var processInfo = new TestProcessStartInfo()
-        {
-            Arguments = arguments,
-            EnvironmentVariables = environmentVariables,
-            FileName = filePath,
-            WorkingDirectory = workingDirectory
-        };
-
-        return _testRunEventsHandler.LaunchProcessWithDebuggerAttached(processInfo);
     }
 
     /// <inheritdoc />
     public bool AttachDebuggerToProcess(int pid)
     {
-        return ((ITestRunEventsHandler2)_testRunEventsHandler).AttachDebuggerToProcess(pid);
+        try
+        {
+            CallbackOverhead.Start();
+            return ((ITestRunEventsHandler2)_testRunEventsHandler).AttachDebuggerToProcess(pid);
+        }
+        finally
+        {
+            CallbackOverhead.Stop();
+        }
     }
 
     public void Dispose()

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -433,6 +433,7 @@ internal abstract class BaseRunTests
                     "BaseRunTests.RunTestInternalWithExecutors: Running tests for {0}",
                     executor.Metadata.ExtensionUri);
 
+                FrameworkHandle.CallbackOverhead.Reset();
                 // set the active executor
                 _activeExecutor = executor.Value;
 
@@ -491,8 +492,9 @@ internal abstract class BaseRunTests
                     "BaseRunTests.RunTestInternalWithExecutors: Completed running tests for {0}",
                     executor.Metadata.ExtensionUri);
 
-                // Collecting Time Taken by each executor Uri
-                _requestData.MetricsCollection.Add(string.Format("{0}.{1}", TelemetryDataConstants.TimeTakenToRunTestsByAnAdapter, executorUri), totalTimeTaken.TotalSeconds);
+                // Collecting Time Taken by each executor Uri, this takes the whole time spent in adapter, and removes the time we spent in callbacks to test platform.
+                double totalTime = totalTimeTaken.TotalSeconds - FrameworkHandle.CallbackOverhead.Elapsed.TotalSeconds;
+                _requestData.MetricsCollection.Add(string.Format("{0}.{1}", TelemetryDataConstants.TimeTakenToRunTestsByAnAdapter, executorUri), totalTime);
                 totalTimeTakenByAdapters += totalTimeTaken.TotalSeconds;
             }
             catch (Exception e)

--- a/test/Microsoft.TestPlatform.PerformanceTests/TranslationLayer/ExecutionPerfTests.cs
+++ b/test/Microsoft.TestPlatform.PerformanceTests/TranslationLayer/ExecutionPerfTests.cs
@@ -15,18 +15,18 @@ public class ExecutionPerfTests : TelemetryPerfTestBase
 {
     [TestMethod]
     [TestCategory("TelemetryPerf")]
-    [DataRow("MSTest1Passing", 1)]
-    [DataRow("MSTest100Passing", 100)]
-    [DataRow("MSTest1000Passing", 1000)]
-    [DataRow("MSTest10kPassing", 10_000)]
-    [DataRow("NUnit1Passing", 1)]
-    [DataRow("NUnit100Passing", 100)]
-    [DataRow("NUnit1000Passing", 1000)]
-    [DataRow("NUnit10kPassing", 10_000)]
-    [DataRow("XUnit1Passing", 1)]
-    [DataRow("XUnit100Passing", 100)]
-    [DataRow("XUnit1000Passing", 1000)]
-    [DataRow("XUnit10kPassing", 10_000)]
+    //[DataRow("MSTest1Passing", 1)]
+    //[DataRow("MSTest100Passing", 100)]
+    //[DataRow("MSTest1000Passing", 1000)]
+    //[DataRow("MSTest10kPassing", 10_000)]
+    //[DataRow("NUnit1Passing", 1)]
+    //[DataRow("NUnit100Passing", 100)]
+    //[DataRow("NUnit1000Passing", 1000)]
+    //[DataRow("NUnit10kPassing", 10_000)]
+    //[DataRow("XUnit1Passing", 1)]
+    //[DataRow("XUnit100Passing", 100)]
+    //[DataRow("XUnit1000Passing", 1000)]
+    // [DataRow("XUnit10kPassing", 10_000)]
     [DataRow("Perfy.TestAdapter", 1)]
     [DataRow("Perfy.TestAdapter", 100)]
     [DataRow("Perfy.TestAdapter", 1000)]
@@ -41,12 +41,13 @@ public class ExecutionPerfTests : TelemetryPerfTestBase
         {
             // This tells to PerfyTestAdapter how many tests it should return, this is our overhead baseline.
             var perfyTestAdapterEnv = new Dictionary<string, string?> { ["TEST_COUNT"] = expectedNumberOfTests.ToString() };
-            var vstestConsoleWrapper = GetVsTestConsoleWrapper(perfyTestAdapterEnv, traceLevel: System.Diagnostics.TraceLevel.Off);
+            var vstestConsoleWrapper = GetVsTestConsoleWrapper(perfyTestAdapterEnv, traceLevel: System.Diagnostics.TraceLevel.Verbose);
             vstestConsoleWrapper.RunTests(GetPerfAssetFullPath(projectName), GetDefaultRunSettings(), options, runEventHandler);
             vstestConsoleWrapper.EndSession();
         }
 
         Assert.AreEqual(expectedNumberOfTests, runEventHandler.Metrics[TelemetryDataConstants.TotalTestsRun]);
+        //Assert.Fail("fail");
         PostTelemetry(runEventHandler.Metrics, perfAnalyzer, projectName);
     }
 

--- a/test/TestAssets/performance/Perfy.TestAdapter/Perfy.TestAdapter.csproj
+++ b/test/TestAssets/performance/Perfy.TestAdapter/Perfy.TestAdapter.csproj
@@ -2,7 +2,7 @@
   <!-- Package dependency versions -->
   <Import Project="..\..\..\..\scripts\build\TestAssets.props" />
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net6.0;net48;net472</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DotNetBuildFromSource)' == 'true' ">netcoreapp3.1</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <IsPackable>false</IsPackable>

--- a/test/TestAssets/performance/Perfy.TestAdapter/Perfy.cs
+++ b/test/TestAssets/performance/Perfy.TestAdapter/Perfy.cs
@@ -13,6 +13,8 @@ using System.Linq;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using System.Threading;
+using System.Diagnostics;
 
 namespace PerfyPassing
 {
@@ -45,15 +47,30 @@ namespace PerfyPassing
 
         public void RunTests(IEnumerable<string> sources, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
+            var sw = Stopwatch.StartNew();
             var location = typeof(Perfy).Assembly.Location;
+            var results = new List<TestResult>(Count);
             for (var i = 0; i < Count; i++)
             {
-                var tc = new TestCase($"Test{i}", Uri, location);
-                frameworkHandle.RecordResult(new TestResult(tc)
+                var tc = new TestCase($"Test{i}", Uri, location)
                 {
-                    Outcome = TestOutcome.Passed
-                });
+                    Id = Guid.NewGuid(),
+                };
+                var result = new TestResult(tc)
+                {
+                    Outcome = TestOutcome.Passed,
+
+                };
+
+                results.Add(result);
             }
+            System.IO.File.AppendAllText(@"C:\temp\rr.txt", $"Creating results took: {sw.ElapsedMilliseconds} ms\n");
+            sw.Restart();
+            for (var i = 0; i < Count; i++)
+            {
+                frameworkHandle.RecordResult(results[i]);
+            }
+            System.IO.File.AppendAllText(@"C:\temp\rr.txt", $"Reporting results took: {sw.ElapsedMilliseconds} ms\n");
         }
 
         public void DiscoverTests(IEnumerable<string> _, IDiscoveryContext _2,


### PR DESCRIPTION
This is a proof of concept to report time that is actually spent executing adapter code, and not executing test platform code. Every callback is wrapped in timer and the total is subtracted from the total. It works fine with non-parallel execution but probably won't work with parallel execution.
