### PR TITLE
Use most recent stable version of Microsoft.CodeCoverage for unit tests

### DIFF
--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -76,6 +76,8 @@
     <RoslynPublicApiAnalyzersVersion>3.3.4-beta1.21554.2</RoslynPublicApiAnalyzersVersion>
     <RoslynBannedApiAnalyzersVersion>3.3.3</RoslynBannedApiAnalyzersVersion>
 
+    <MicrosoftCodeCoverageVersion>17.1.0</MicrosoftCodeCoverageVersion>
+
     <DependencyVersionsImported>true</DependencyVersionsImported>
   </PropertyGroup>
 

--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -129,7 +129,7 @@
           <Version>$(MSTestAssertExtensionVersion)</Version>
         </PackageReference>
         <PackageReference Include="Microsoft.CodeCoverage">
-          <Version>1.0.3</Version>
+          <Version>$(MicrosoftCodeCoverageVersion)</Version>
         </PackageReference>
       </ItemGroup>
     </When>


### PR DESCRIPTION
## Description
For our unit tests use the most recently published stable version of Microsoft.CodeCoverage rather than very old verison.

This won't use the currently built version of the package, even though we build it in the same repo, because to run unit tests we don't need to pre-build whole TP.
