### PR TITLE
Collect artifacts in case of test abort/cancelled

### DIFF
--- a/src/vstest.console/Processors/RunTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunTestsArgumentProcessor.cs
@@ -227,12 +227,12 @@ internal class RunTestsArgumentExecutor : IArgumentExecutor
                 {
                     _output.Warning(false, CommandLineResources.SuggestTestAdapterPathIfNoTestsIsFound);
                 }
+            }
 
-                // Collect tests session artifacts for post processing
-                if (_commandLineOptions.ArtifactProcessingMode == ArtifactProcessingMode.Collect)
-                {
-                    _artifactProcessingManager.CollectArtifacts(e, RunSettingsManager.Instance.ActiveRunSettings.SettingsXml);
-                }
+            // Collect tests session artifacts for post processing
+            if (_commandLineOptions.ArtifactProcessingMode == ArtifactProcessingMode.Collect)
+            {
+                _artifactProcessingManager.CollectArtifacts(e, RunSettingsManager.Instance.ActiveRunSettings.SettingsXml);
             }
         }
     }


### PR DESCRIPTION
We're not collecting artifacts in case of abort or cancelled and for this reason when we use `--blame-hang` we're not showing in console the dump artifacts.
After the fix:
<img width="1037" alt="image" src="https://user-images.githubusercontent.com/7894084/165277113-f658c7be-b95b-4335-896f-f5def811acd2.png">

