### PR TITLE
Fix vstest.console source location in Playground

### DIFF
--- a/playground/TestPlatform.Playground/TestPlatform.Playground.csproj
+++ b/playground/TestPlatform.Playground/TestPlatform.Playground.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition=" '$(OS)' == 'WINDOWS_NT' ">
-    <Exec Command="xcopy /i /y $(MSBuildProjectDirectory)\..\..\src\vstest.console\bin\$(Configuration)\net451\win7-x64\ $(TargetDir)\vstest.console\&#xD;&#xA;xcopy /i /y $(MSBuildProjectDirectory)\..\..\src\testhost\bin\$(Configuration)\net451\win7-x64\ $(TargetDir)\vstest.console\&#xD;&#xA;xcopy /i /y $(MSBuildProjectDirectory)\..\..\src\Microsoft.TestPlatform.TestHostProvider\bin\$(Configuration)\net451\ $(TargetDir)\vstest.console\Extensions\&#xD;&#xA;xcopy /i /y $(MSBuildProjectDirectory)\..\..\src\testhost.x86\bin\$(Configuration)\net472\win7-x86 $(TargetDir)\vstest.console\TestHost\" />
+    <Exec Command="xcopy /i /y $(MSBuildProjectDirectory)\..\..\src\vstest.console\bin\$(Configuration)\net451\ $(TargetDir)\vstest.console\&#xD;&#xA;xcopy /i /y $(MSBuildProjectDirectory)\..\..\src\testhost\bin\$(Configuration)\net451\win7-x64\ $(TargetDir)\vstest.console\&#xD;&#xA;xcopy /i /y $(MSBuildProjectDirectory)\..\..\src\Microsoft.TestPlatform.TestHostProvider\bin\$(Configuration)\net451\ $(TargetDir)\vstest.console\Extensions\&#xD;&#xA;xcopy /i /y $(MSBuildProjectDirectory)\..\..\src\testhost.x86\bin\$(Configuration)\net472\win7-x86 $(TargetDir)\vstest.console\TestHost\" />
   </Target>
   <Import Project="$(TestPlatformRoot)scripts\build\TestPlatform.targets" />
 </Project>


### PR DESCRIPTION
## Description
vstest.console does not build into the RID specific folder anymore, copy from the non-specific folder.

