### PR TITLE
Run tests with Server GC enabled & concurrent GC disabled.

### DIFF
--- a/src/testhost.arm64/app.config
+++ b/src/testhost.arm64/app.config
@@ -4,6 +4,9 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
   </startup>
   <runtime>
+    <gcServer enabled="true" />
+    <gcConcurrent enabled="false" />
+
     <legacyUnhandledExceptionPolicy enabled="1" />
     <legacyCorruptedStateExceptionsPolicy enabled="true" />
 
@@ -57,7 +60,7 @@
     <!--<add key="ExecutionThreadApartmentState" value ="MTA"/>-->
     <!--<add key="TraceLogMaxFileSizeInKb" value ="10240"/>-->
     <!-- MsTest Adapter Specific AppSettings -->
-    
+
     <!-- This flag is added to support test execution for net35 tests through TMI adapter. -->
     <add key="TestProjectRetargetTo35Allowed" value="true" />
   </appSettings>

--- a/src/testhost.x86/app.config
+++ b/src/testhost.x86/app.config
@@ -4,6 +4,9 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
   </startup>
   <runtime>
+    <gcServer enabled="true" />
+    <gcConcurrent enabled="false" />
+
     <legacyUnhandledExceptionPolicy enabled="1"/>
     <legacyCorruptedStateExceptionsPolicy enabled="true"/>
 
@@ -57,7 +60,7 @@
     <!--<add key="ExecutionThreadApartmentState" value ="MTA"/>-->
     <!--<add key="TraceLogMaxFileSizeInKb" value ="10240"/>-->
     <!-- MsTest Adapter Specific AppSettings -->
-    
+
     <!-- This flag is added to support test execution for net35 tests through TMI adapter. -->
     <add key="TestProjectRetargetTo35Allowed" value="true" />
   </appSettings>

--- a/src/testhost/app.config
+++ b/src/testhost/app.config
@@ -4,6 +4,9 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
   </startup>
   <runtime>
+    <gcServer enabled="true" />
+    <gcConcurrent enabled="false" />
+
     <legacyUnhandledExceptionPolicy enabled="1" />
     <legacyCorruptedStateExceptionsPolicy enabled="true" />
 
@@ -57,7 +60,7 @@
     <!--<add key="ExecutionThreadApartmentState" value ="MTA"/>-->
     <!--<add key="TraceLogMaxFileSizeInKb" value ="10240"/>-->
     <!-- MsTest Adapter Specific AppSettings -->
-    
+
     <!-- This flag is added to support test execution for net35 tests through TMI adapter. -->
     <add key="TestProjectRetargetTo35Allowed" value="true" />
   </appSettings>

--- a/src/vstest.console/app.config
+++ b/src/vstest.console/app.config
@@ -4,6 +4,9 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
   </startup>
   <runtime>
+    <gcServer enabled="true" />
+    <gcConcurrent enabled="false" />
+
     <legacyUnhandledExceptionPolicy enabled="1" />
 
     <!-- To get stacktrace information for portable and embedded pdbs when net472 installed on machine.


### PR DESCRIPTION
## Description
Maximises throughput over latency, reducing runtime for larger test packs or tests that will create a lot of objects on the heap.

## Related issue
See discussion in #1967 
There was also an older PR for these changes that got closed due to inactivity, that also contains some relevant discussion. See #1987