### PR TITLE
Fix CUIT test

### DIFF
--- a/test/Microsoft.TestPlatform.AcceptanceTests/CUITTest.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/CUITTest.cs
@@ -30,7 +30,9 @@ public class CuitTest : AcceptanceTestBase
         }
 
         var assemblyAbsolutePath = _testEnvironment.GetTestAsset("CUITTestProject.dll", "net451");
+
         var arguments = PrepareArguments(assemblyAbsolutePath, string.Empty, string.Empty, FrameworkArgValue, resultsDirectory: TempDirectory.Path);
+        arguments += " -- RunConfiguration.TargetPlatform=x86";
 
         InvokeVsTest(arguments);
         ValidateSummaryStatus(1, 0, 0);


### PR DESCRIPTION
## Description
Force CUIT tests to use x86, because we changed the default platform to the process platform in MultiTFM, so it is now x64.

