### PR TITLE
Keep handler versions on edge

### DIFF
--- a/playground/TestPlatform.Playground/Program.cs
+++ b/playground/TestPlatform.Playground/Program.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Eventing.Reader;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 
 using Microsoft.TestPlatform.VsTestConsole.TranslationLayer;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -71,43 +73,43 @@ internal class Program
 
 
 ////            // net6
-        @"C:\t\ParallelDiscovery2\ReproNetCore\Test1\bin\Debug\net6.0\Test1.dll",
-@"C:\t\ParallelDiscovery2\ReproNetCore\Test7\bin\Debug\net6.0\Test7.dll",
-@"C:\t\ParallelDiscovery2\ReproNetCore\Test2\bin\Debug\net6.0\Test2.dll",
-@"C:\t\ParallelDiscovery2\ReproNetCore\Test6\bin\Debug\net6.0\Test6.dll",
-@"C:\t\ParallelDiscovery2\ReproNetCore\Test8\bin\Debug\net6.0\Test8.dll",
-@"C:\t\ParallelDiscovery2\ReproNetCore\Test5\bin\Debug\net6.0\Test5.dll",
-@"C:\t\ParallelDiscovery2\ReproNetCore\Test3\bin\Debug\net6.0\Test3.dll",
-@"C:\t\ParallelDiscovery2\ReproNetCore\Test4\bin\Debug\net6.0\Test4.dll",
-@"C:\t\ParallelDiscovery2\ReproNetCore\Test10\bin\Debug\net6.0\Test10.dll",
-@"C:\t\ParallelDiscovery2\ReproNetCore\Test9\bin\Debug\net6.0\Test9.dll",
+//        @"C:\t\ParallelDiscovery2\ReproNetCore\Test1\bin\Debug\net6.0\Test1.dll",
+//@"C:\t\ParallelDiscovery2\ReproNetCore\Test7\bin\Debug\net6.0\Test7.dll",
+//@"C:\t\ParallelDiscovery2\ReproNetCore\Test2\bin\Debug\net6.0\Test2.dll",
+//@"C:\t\ParallelDiscovery2\ReproNetCore\Test6\bin\Debug\net6.0\Test6.dll",
+//@"C:\t\ParallelDiscovery2\ReproNetCore\Test8\bin\Debug\net6.0\Test8.dll",
+//@"C:\t\ParallelDiscovery2\ReproNetCore\Test5\bin\Debug\net6.0\Test5.dll",
+//@"C:\t\ParallelDiscovery2\ReproNetCore\Test3\bin\Debug\net6.0\Test3.dll",
+//@"C:\t\ParallelDiscovery2\ReproNetCore\Test4\bin\Debug\net6.0\Test4.dll",
+//@"C:\t\ParallelDiscovery2\ReproNetCore\Test10\bin\Debug\net6.0\Test10.dll",
+//@"C:\t\ParallelDiscovery2\ReproNetCore\Test9\bin\Debug\net6.0\Test9.dll",
 
         //// netfx
          @"C:\t\ParallelDiscovery2\ReproNetFx\Project4\bin\Debug\net472\Project4.dll",
-               @"C:\t\ParallelDiscovery2\ReproNetFx\Project1\bin\Debug\net472\Project1.dll",
-               @"C:\t\ParallelDiscovery2\ReproNetFx\Project2\bin\Debug\net472\Project2.dll",
-               @"C:\t\ParallelDiscovery2\ReproNetFx\Project3\bin\Debug\net472\Project3.dll",
-               @"C:\t\ParallelDiscovery2\ReproNetFx\Project9\bin\Debug\net472\Project9.dll",
-               @"C:\t\ParallelDiscovery2\ReproNetFx\Project10\bin\Debug\net472\Project10.dll",
-               @"C:\t\ParallelDiscovery2\ReproNetFx\Project5\bin\Debug\net472\Project5.dll",
-               @"C:\t\ParallelDiscovery2\ReproNetFx\Project8\bin\Debug\net472\Project8.dll",
-               @"C:\t\ParallelDiscovery2\ReproNetFx\Project7\bin\Debug\net472\Project7.dll",
-               @"C:\t\ParallelDiscovery2\ReproNetFx\Project6\bin\Debug\net472\Project6.dll",
+               //@"C:\t\ParallelDiscovery2\ReproNetFx\Project1\bin\Debug\net472\Project1.dll",
+               //@"C:\t\ParallelDiscovery2\ReproNetFx\Project2\bin\Debug\net472\Project2.dll",
+               //@"C:\t\ParallelDiscovery2\ReproNetFx\Project3\bin\Debug\net472\Project3.dll",
+               //@"C:\t\ParallelDiscovery2\ReproNetFx\Project9\bin\Debug\net472\Project9.dll",
+               //@"C:\t\ParallelDiscovery2\ReproNetFx\Project10\bin\Debug\net472\Project10.dll",
+               //@"C:\t\ParallelDiscovery2\ReproNetFx\Project5\bin\Debug\net472\Project5.dll",
+               //@"C:\t\ParallelDiscovery2\ReproNetFx\Project8\bin\Debug\net472\Project8.dll",
+               //@"C:\t\ParallelDiscovery2\ReproNetFx\Project7\bin\Debug\net472\Project7.dll",
+               //@"C:\t\ParallelDiscovery2\ReproNetFx\Project6\bin\Debug\net472\Project6.dll",
 
         
-        //// mix
-@"C:\t\MultipleTfmAndArch\Tst1\bin\Debug\net472\win7-x86\Tst1.dll",
-@"C:\t\MultipleTfmAndArch\Tst1\bin\Debug\net48\win7-x86\Tst1.dll",
-@"C:\t\MultipleTfmAndArch\Tst3\bin\Debug\net48\win7-x86\Tst3.dll",
-@"C:\t\MultipleTfmAndArch\Tst1\bin\Debug\net5.0\win7-x86\Tst1.dll",
-@"C:\t\MultipleTfmAndArch\Tst2\bin\Debug\net472\win7-x64\Tst2.dll",
-@"C:\t\MultipleTfmAndArch\Tst3\bin\Debug\net472\win7-x86\Tst3.dll",
-@"C:\t\MultipleTfmAndArch\Tst2\bin\Debug\net48\win7-x64\Tst2.dll",
-@"C:\t\MultipleTfmAndArch\Tst2\bin\Debug\netcoreapp3.1\win7-x64\Tst2.dll",
-@"C:\t\MultipleTfmAndArch\Tst3\bin\Debug\netcoreapp3.1\win7-x86\Tst3.dll",
-@"C:\t\MultipleTfmAndArch\Tst2\bin\Debug\net5.0\win7-x64\Tst2.dll",
-@"C:\t\MultipleTfmAndArch\Tst3\bin\Debug\net5.0\win7-x86\Tst3.dll",
-@"C:\t\MultipleTfmAndArch\Tst1\bin\Debug\netcoreapp3.1\win7-x86\Tst1.dll",
+//        //// mix
+//@"C:\t\MultipleTfmAndArch\Tst1\bin\Debug\net472\win7-x86\Tst1.dll",
+//@"C:\t\MultipleTfmAndArch\Tst1\bin\Debug\net48\win7-x86\Tst1.dll",
+//@"C:\t\MultipleTfmAndArch\Tst3\bin\Debug\net48\win7-x86\Tst3.dll",
+//@"C:\t\MultipleTfmAndArch\Tst1\bin\Debug\net5.0\win7-x86\Tst1.dll",
+//@"C:\t\MultipleTfmAndArch\Tst2\bin\Debug\net472\win7-x64\Tst2.dll",
+//@"C:\t\MultipleTfmAndArch\Tst3\bin\Debug\net472\win7-x86\Tst3.dll",
+//@"C:\t\MultipleTfmAndArch\Tst2\bin\Debug\net48\win7-x64\Tst2.dll",
+//@"C:\t\MultipleTfmAndArch\Tst2\bin\Debug\netcoreapp3.1\win7-x64\Tst2.dll",
+//@"C:\t\MultipleTfmAndArch\Tst3\bin\Debug\netcoreapp3.1\win7-x86\Tst3.dll",
+//@"C:\t\MultipleTfmAndArch\Tst2\bin\Debug\net5.0\win7-x64\Tst2.dll",
+//@"C:\t\MultipleTfmAndArch\Tst3\bin\Debug\net5.0\win7-x86\Tst3.dll",
+//@"C:\t\MultipleTfmAndArch\Tst1\bin\Debug\netcoreapp3.1\win7-x86\Tst1.dll",
 
         };
         //// console mode
@@ -253,7 +255,7 @@ internal class Program
                 : "\t<empty>";
     }
 
-    internal class DebuggerTestHostLauncher : ITestHostLauncher2
+    internal class DebuggerTestHostLauncher : ITestHostLauncher3
     {
         public bool IsDebug => true;
 
@@ -263,6 +265,11 @@ internal class Program
         }
 
         public bool AttachDebuggerToProcess(int pid, CancellationToken cancellationToken)
+        {
+            return true;
+        }
+
+        public bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo, CancellationToken cancellationToken)
         {
             return true;
         }

--- a/playground/TestPlatform.Playground/Program.cs
+++ b/playground/TestPlatform.Playground/Program.cs
@@ -257,6 +257,10 @@ internal class Program
 
     internal class DebuggerTestHostLauncher : ITestHostLauncher3
     {
+        public DebuggerTestHostLauncher()
+        {
+
+        }
         public bool IsDebug => true;
 
         public bool AttachDebuggerToProcess(int pid)

--- a/playground/TestPlatform.Playground/Properties/launchSettings.json
+++ b/playground/TestPlatform.Playground/Properties/launchSettings.json
@@ -5,8 +5,8 @@
       "environmentVariables": {
         "VSTEST_CONNECTION_TIMEOUT": "999",
         "VSTEST_DEBUG_NOBP": "1",
-        "VSTEST_RUNNER_DEBUG_ATTACHVS": "0",
-        "VSTEST_HOST_DEBUG_ATTACHVS": "0",
+        "VSTEST_RUNNER_DEBUG_ATTACHVS": "1",
+        "VSTEST_HOST_DEBUG_ATTACHVS": "1",
         "VSTEST_DATACOLLECTOR_DEBUG_ATTACHVS": "0"
       }
     }

--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -84,7 +84,7 @@
       <PropertyGroup>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <!-- Suppress warnings about testhost being x64 (AMD64)/x86 when imported into AnyCPU (MSIL) test projects. -->
-        <NoWarn>$(NoWarn);MSB3270</NoWarn>
+        <NoWarn>$(NoWarn);MSB3270;CS0618;RS0016;RS0017;RS0018</NoWarn>
       </PropertyGroup>
 
       <!-- Test projects are not discovered in test window without test container capability -->

--- a/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
+++ b/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
@@ -18,6 +18,7 @@ using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Helpers;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Payloads;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
@@ -327,7 +328,7 @@ public class DesignModeClient : IDesignModeClient
     }
 
     /// <inheritdoc/>
-    public bool AttachDebuggerToProcess(int pid, CancellationToken cancellationToken)
+    public bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo, CancellationToken cancellationToken)
     {
         // If an attach request is issued but there is no support for attaching on the other
         // side of the communication channel, we simply return and let the caller know the
@@ -347,7 +348,7 @@ public class DesignModeClient : IDesignModeClient
                 waitHandle.Set();
             };
 
-            _communicationManager.SendMessage(MessageType.EditorAttachDebugger, pid, _protocolConfig.Version);
+            _communicationManager.SendMessage(MessageType.EditorAttachDebugger, attachDebuggerInfo.ProcessId, _protocolConfig.Version);
 
             WaitHandle.WaitAny(new WaitHandle[] { waitHandle, cancellationToken.WaitHandle });
 

--- a/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeTestHostLauncher.cs
+++ b/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeTestHostLauncher.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.DesignMode;
 /// <summary>
 /// DesignMode TestHost Launcher for hosting of test process
 /// </summary>
-internal class DesignModeTestHostLauncher : ITestHostLauncher2
+internal class DesignModeTestHostLauncher : IInternalTestHostLauncher
 {
     private readonly IDesignModeClient _designModeClient;
 

--- a/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeTestHostLauncher.cs
+++ b/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeTestHostLauncher.cs
@@ -30,21 +30,9 @@ internal class DesignModeTestHostLauncher : IInternalTestHostLauncher
     public virtual bool IsDebug => false;
 
     /// <inheritdoc/>
-    public bool AttachDebuggerToProcess(int pid)
+    public bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo, CancellationToken cancellationToken)
     {
-        return _designModeClient.AttachDebuggerToProcess(pid, CancellationToken.None);
-    }
-
-    /// <inheritdoc/>
-    public bool AttachDebuggerToProcess(int pid, CancellationToken cancellationToken)
-    {
-        return _designModeClient.AttachDebuggerToProcess(pid, cancellationToken);
-    }
-
-    /// <inheritdoc/>
-    public int LaunchTestHost(TestProcessStartInfo defaultTestHostStartInfo)
-    {
-        return _designModeClient.LaunchCustomHost(defaultTestHostStartInfo, CancellationToken.None);
+        return _designModeClient.AttachDebuggerToProcess(attachDebuggerInfo, cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeTestHostLauncherFactory.cs
+++ b/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeTestHostLauncherFactory.cs
@@ -12,12 +12,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.DesignMode;
 /// </summary>
 public static class DesignModeTestHostLauncherFactory
 {
-    private static ITestHostLauncher s_defaultLauncher;
-    private static ITestHostLauncher s_debugLauncher;
+    private static IInternalTestHostLauncher s_defaultLauncher;
+    private static IInternalTestHostLauncher s_debugLauncher;
 
-    public static ITestHostLauncher GetCustomHostLauncherForTestRun(IDesignModeClient designModeClient, bool debuggingEnabled)
+    public static IInternalTestHostLauncher GetCustomHostLauncherForTestRun(IDesignModeClient designModeClient, bool debuggingEnabled)
     {
-        ITestHostLauncher testHostLauncher = !debuggingEnabled
+        IInternalTestHostLauncher testHostLauncher = !debuggingEnabled
             ? (s_defaultLauncher ??= new DesignModeTestHostLauncher(designModeClient))
             : (s_debugLauncher ??= new DesignModeDebugTestHostLauncher(designModeClient));
         return testHostLauncher;

--- a/src/Microsoft.TestPlatform.Client/DesignMode/IDesignModeClient.cs
+++ b/src/Microsoft.TestPlatform.Client/DesignMode/IDesignModeClient.cs
@@ -6,6 +6,7 @@ using System.Threading;
 
 using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 #nullable disable
@@ -37,7 +38,7 @@ public interface IDesignModeClient : IDisposable
     /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
-    bool AttachDebuggerToProcess(int pid, CancellationToken cancellationToken);
+    bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo, CancellationToken cancellationToken);
 
     /// <summary>
     /// Handles parent process exit

--- a/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
+++ b/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
@@ -653,17 +653,16 @@ public class TestRunRequest : ITestRunRequest, IInternalTestRunEventsHandler
         // Only launch while the test run is in progress and the launcher is a debug one
         if (State == TestRunState.InProgress && TestRunCriteria.TestHostLauncher.IsDebug)
         {
-            processId = TestRunCriteria.TestHostLauncher.LaunchTestHost(testProcessStartInfo);
+            processId = TestRunCriteria.TestHostLauncher.LaunchTestHost(testProcessStartInfo, CancellationToken.None);
         }
 
         return processId;
     }
 
     /// <inheritdoc />
-    public bool AttachDebuggerToProcess(int pid)
+    public bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo)
     {
-        return TestRunCriteria.TestHostLauncher is IInternalTestHostLauncher launcher
-               && launcher.AttachDebuggerToProcess(pid);
+        return TestRunCriteria.TestHostLauncher.AttachDebuggerToProcess(attachDebuggerInfo, CancellationToken.None);
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
+++ b/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
@@ -662,7 +662,7 @@ public class TestRunRequest : ITestRunRequest, IInternalTestRunEventsHandler
     /// <inheritdoc />
     public bool AttachDebuggerToProcess(int pid)
     {
-        return TestRunCriteria.TestHostLauncher is ITestHostLauncher2 launcher
+        return TestRunCriteria.TestHostLauncher is IInternalTestHostLauncher launcher
                && launcher.AttachDebuggerToProcess(pid);
     }
 

--- a/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
+++ b/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
@@ -28,7 +28,7 @@ using ClientResources = Microsoft.VisualStudio.TestPlatform.Client.Resources.Res
 
 namespace Microsoft.VisualStudio.TestPlatform.Client.Execution;
 
-public class TestRunRequest : ITestRunRequest, ITestRunEventsHandler2
+public class TestRunRequest : ITestRunRequest, IInternalTestRunEventsHandler
 {
     /// <summary>
     /// Specifies whether the run is disposed or not

--- a/src/Microsoft.TestPlatform.Client/RequestHelper/ITestRequestManager.cs
+++ b/src/Microsoft.TestPlatform.Client/RequestHelper/ITestRequestManager.cs
@@ -56,7 +56,7 @@ public interface ITestRequestManager : IDisposable
     /// <param name="protocolConfig">Protocol related information.</param>
     void RunTests(
         TestRunRequestPayload testRunRequestPayLoad,
-        ITestHostLauncher customTestHostLauncher,
+        IInternalTestHostLauncher customTestHostLauncher,
         ITestRunEventsRegistrar testRunEventsRegistrar,
         ProtocolConfig protocolConfig);
 
@@ -86,7 +86,7 @@ public interface ITestRequestManager : IDisposable
     /// <param name="protocolConfig">Protocol related information.</param>
     void StartTestSession(
         StartTestSessionPayload payload,
-        ITestHostLauncher testHostLauncher,
+        IInternalTestHostLauncher testHostLauncher,
         ITestSessionEventsHandler eventsHandler,
         ProtocolConfig protocolConfig);
 

--- a/src/Microsoft.TestPlatform.Common/Interfaces/Engine/ClientProtocol/IProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/Interfaces/Engine/ClientProtocol/IProxyExecutionManager.cs
@@ -29,19 +29,19 @@ public interface IProxyExecutionManager
     /// <param name="testRunCriteria">The settings/options for the test run.</param>
     /// <param name="eventHandler">EventHandler for handling execution events from Engine.</param>
     /// <returns>The process id of the runner executing tests.</returns>
-    int StartTestRun(TestRunCriteria testRunCriteria, ITestRunEventsHandler eventHandler);
+    int StartTestRun(TestRunCriteria testRunCriteria, IInternalTestRunEventsHandler eventHandler);
 
     /// <summary>
     /// Cancels the test run. On the test host, this will send a message to adapters.
     /// </summary>
     // <param name="eventHandler"> EventHandler for handling execution events from Engine. </param>
-    void Cancel(ITestRunEventsHandler eventHandler);
+    void Cancel(IInternalTestRunEventsHandler eventHandler);
 
     /// <summary>
     /// Aborts the test operation. This will forcefully terminate the test host.
     /// </summary>
     // <param name="eventHandler"> EventHandler for handling execution events from Engine. </param>
-    void Abort(ITestRunEventsHandler eventHandler);
+    void Abort(IInternalTestRunEventsHandler eventHandler);
 
     /// <summary>
     /// Closes the current test operation by sending a end session message.

--- a/src/Microsoft.TestPlatform.Common/Interfaces/Engine/TesthostProtocol/IExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/Interfaces/Engine/TesthostProtocol/IExecutionManager.cs
@@ -20,7 +20,7 @@ public interface IExecutionManager
     /// Initializes the execution manager.
     /// </summary>
     /// <param name="pathToAdditionalExtensions"> The path to additional extensions. </param>
-    void Initialize(IEnumerable<string> pathToAdditionalExtensions, ITestMessageEventHandler testMessageEventsHandler);
+    void Initialize(IEnumerable<string> pathToAdditionalExtensions, IInternalTestMessageEventHandler testMessageEventsHandler);
 
     /// <summary>
     /// Starts the test run with sources.
@@ -33,7 +33,7 @@ public interface IExecutionManager
     /// <param name="testExecutionContext"> The test Execution Context. </param>
     /// <param name="testCaseEvents"> EventHandler for handling test cases level events from Engine. </param>
     /// <param name="eventHandler"> EventHandler for handling execution events from Engine. </param>
-    void StartTestRun(Dictionary<string, IEnumerable<string>> adapterSourceMap, string package, string runSettings, TestExecutionContext testExecutionContext, ITestCaseEventsHandler testCaseEvents, ITestRunEventsHandler eventHandler);
+    void StartTestRun(Dictionary<string, IEnumerable<string>> adapterSourceMap, string package, string runSettings, TestExecutionContext testExecutionContext, ITestCaseEventsHandler testCaseEvents, IInternalTestRunEventsHandler eventHandler);
 
     /// <summary>
     /// Starts the test run with tests.
@@ -46,17 +46,17 @@ public interface IExecutionManager
     /// <param name="testExecutionContext"> The test Execution Context. </param>
     /// /// <param name="testCaseEvents"> EventHandler for handling test cases level events from Engine. </param>
     /// <param name="eventHandler"> EventHandler for handling execution events from Engine. </param>
-    void StartTestRun(IEnumerable<TestCase> tests, string package, string runSettings, TestExecutionContext testExecutionContext, ITestCaseEventsHandler testCaseEvents, ITestRunEventsHandler eventHandler);
+    void StartTestRun(IEnumerable<TestCase> tests, string package, string runSettings, TestExecutionContext testExecutionContext, ITestCaseEventsHandler testCaseEvents, IInternalTestRunEventsHandler eventHandler);
 
     /// <summary>
     /// Cancel the test execution.
     /// </summary>
     /// <param name="eventHandler"> EventHandler for handling execution events from Engine. </param>
-    void Cancel(ITestRunEventsHandler testRunEventsHandler);
+    void Cancel(IInternalTestRunEventsHandler testRunEventsHandler);
 
     /// <summary>
     /// Aborts the test execution.
     /// </summary>
     /// <param name="eventHandler"> EventHandler for handling execution events from Engine. </param>
-    void Abort(ITestRunEventsHandler testRunEventsHandler);
+    void Abort(IInternalTestRunEventsHandler testRunEventsHandler);
 }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestSender.cs
@@ -100,7 +100,7 @@ public sealed class DataCollectionRequestSender : IDataCollectionRequestSender
     }
 
     /// <inheritdoc/>
-    public BeforeTestRunStartResult SendBeforeTestRunStartAndGetResult(string settingsXml, IEnumerable<string> sources, bool isTelemetryOptedIn, ITestMessageEventHandler runEventsHandler)
+    public BeforeTestRunStartResult SendBeforeTestRunStartAndGetResult(string settingsXml, IEnumerable<string> sources, bool isTelemetryOptedIn, IInternalTestMessageEventHandler runEventsHandler)
     {
         var isDataCollectionStarted = false;
         BeforeTestRunStartResult result = null;
@@ -138,7 +138,7 @@ public sealed class DataCollectionRequestSender : IDataCollectionRequestSender
     }
 
     /// <inheritdoc/>
-    public AfterTestRunEndResult SendAfterTestRunEndAndGetResult(ITestMessageEventHandler runEventsHandler, bool isCancelled)
+    public AfterTestRunEndResult SendAfterTestRunEndAndGetResult(IInternalTestMessageEventHandler runEventsHandler, bool isCancelled)
     {
         var isDataCollectionComplete = false;
         AfterTestRunEndResult result = null;
@@ -170,7 +170,7 @@ public sealed class DataCollectionRequestSender : IDataCollectionRequestSender
         return result;
     }
 
-    private void LogDataCollectorMessage(DataCollectionMessageEventArgs dataCollectionMessageEventArgs, ITestMessageEventHandler requestHandler)
+    private void LogDataCollectorMessage(DataCollectionMessageEventArgs dataCollectionMessageEventArgs, IInternalTestMessageEventHandler requestHandler)
     {
         string logMessage;
         if (string.IsNullOrWhiteSpace(dataCollectionMessageEventArgs.FriendlyName))

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestInitializeEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestInitializeEventsHandler.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.EventHandle
 /// <summary>
 /// The test run events handler.
 /// </summary>
-public class TestInitializeEventsHandler : ITestMessageEventHandler
+public class TestInitializeEventsHandler : IInternalTestMessageEventHandler
 {
     private readonly ITestRequestHandler _requestHandler;
 

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestRunEventsHandler.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 #nullable disable
@@ -100,9 +101,9 @@ public class TestRunEventsHandler : IInternalTestRunEventsHandler
     }
 
     /// <inheritdoc/>
-    public bool AttachDebuggerToProcess(int pid)
+    public bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo)
     {
-        EqtTrace.Info("Sending AttachDebuggerToProcess on additional test process with pid: {0}", pid);
-        return _requestHandler.AttachDebuggerToProcess(pid);
+        EqtTrace.Info("Sending AttachDebuggerToProcess on additional test process with pid: {0}", attachDebuggerInfo.ProcessId);
+        return _requestHandler.AttachDebuggerToProcess(attachDebuggerInfo);
     }
 }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestRunEventsHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.EventHandle
 /// <summary>
 /// The test run events handler.
 /// </summary>
-public class TestRunEventsHandler : ITestRunEventsHandler2
+public class TestRunEventsHandler : IInternalTestRunEventsHandler
 {
     private readonly ITestRequestHandler _requestHandler;
 

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/IDataCollectionRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/IDataCollectionRequestSender.cs
@@ -60,7 +60,7 @@ internal interface IDataCollectionRequestSender
     /// <returns>
     /// BeforeTestRunStartResult containing environment variables
     /// </returns>
-    BeforeTestRunStartResult SendBeforeTestRunStartAndGetResult(string settingXml, IEnumerable<string> sources, bool isTelemetryOptedIn, ITestMessageEventHandler runEventsHandler);
+    BeforeTestRunStartResult SendBeforeTestRunStartAndGetResult(string settingXml, IEnumerable<string> sources, bool isTelemetryOptedIn, IInternalTestMessageEventHandler runEventsHandler);
 
     /// <summary>
     /// Sends the AfterTestRunEnd event and waits for result
@@ -74,5 +74,5 @@ internal interface IDataCollectionRequestSender
     /// <returns>
     /// AfterTestRunEndResult containing dataCollector attachments and metrics
     /// </returns>
-    AfterTestRunEndResult SendAfterTestRunEndAndGetResult(ITestMessageEventHandler runEventsHandler, bool isCancelled);
+    AfterTestRunEndResult SendAfterTestRunEndAndGetResult(IInternalTestMessageEventHandler runEventsHandler, bool isCancelled);
 }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/ITestRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/ITestRequestHandler.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine.TesthostProtocol;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
@@ -94,5 +95,5 @@ public interface ITestRequestHandler : IDisposable
     /// </summary>
     /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
     /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
-    bool AttachDebuggerToProcess(int pid);
+    bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo);
 }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/ITestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/ITestRequestSender.cs
@@ -65,14 +65,14 @@ public interface ITestRequestSender : IDisposable
     /// </summary>
     /// <param name="runCriteria">RunCriteria for test run</param>
     /// <param name="eventHandler">EventHandler for test run events</param>
-    void StartTestRun(TestRunCriteriaWithSources runCriteria, ITestRunEventsHandler eventHandler);
+    void StartTestRun(TestRunCriteriaWithSources runCriteria, IInternalTestRunEventsHandler eventHandler);
 
     /// <summary>
     /// Starts the TestRun with given test cases and criteria
     /// </summary>
     /// <param name="runCriteria">RunCriteria for test run</param>
     /// <param name="eventHandler">EventHandler for test run events</param>
-    void StartTestRun(TestRunCriteriaWithTests runCriteria, ITestRunEventsHandler eventHandler);
+    void StartTestRun(TestRunCriteriaWithTests runCriteria, IInternalTestRunEventsHandler eventHandler);
 
     /// <summary>
     /// Ends the Session

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -49,7 +49,7 @@ public class TestRequestSender : ITestRequestSender
     // Set to 1 if Discovery/Execution is complete, i.e. complete handlers have been invoked
     private int _operationCompleted;
 
-    private ITestMessageEventHandler _messageEventHandler;
+    private IInternalTestMessageEventHandler _messageEventHandler;
 
     private string _clientExitErrorMessage;
 
@@ -328,7 +328,7 @@ public class TestRequestSender : ITestRequestSender
     }
 
     /// <inheritdoc />
-    public void StartTestRun(TestRunCriteriaWithSources runCriteria, ITestRunEventsHandler eventHandler)
+    public void StartTestRun(TestRunCriteriaWithSources runCriteria, IInternalTestRunEventsHandler eventHandler)
     {
         _messageEventHandler = eventHandler;
         _onDisconnected = (disconnectedEventArgs) => OnTestRunAbort(eventHandler, disconnectedEventArgs.Error, true);
@@ -350,7 +350,7 @@ public class TestRequestSender : ITestRequestSender
             && _runtimeProvider is ITestRuntimeProvider2 convertedRuntimeProvider
             && _protocolVersion < ObjectModelConstants.MinimumProtocolVersionWithDebugSupport)
         {
-            var handler = (ITestRunEventsHandler2)eventHandler;
+            var handler = (IInternalTestRunEventsHandler)eventHandler;
             if (!convertedRuntimeProvider.AttachDebuggerToTestHost())
             {
                 EqtTrace.Warning(
@@ -371,7 +371,7 @@ public class TestRequestSender : ITestRequestSender
     }
 
     /// <inheritdoc />
-    public void StartTestRun(TestRunCriteriaWithTests runCriteria, ITestRunEventsHandler eventHandler)
+    public void StartTestRun(TestRunCriteriaWithTests runCriteria, IInternalTestRunEventsHandler eventHandler)
     {
         _messageEventHandler = eventHandler;
         _onDisconnected = (disconnectedEventArgs) => OnTestRunAbort(eventHandler, disconnectedEventArgs.Error, true);
@@ -393,7 +393,7 @@ public class TestRequestSender : ITestRequestSender
             && _runtimeProvider is ITestRuntimeProvider2 convertedRuntimeProvider
             && _protocolVersion < ObjectModelConstants.MinimumProtocolVersionWithDebugSupport)
         {
-            var handler = (ITestRunEventsHandler2)eventHandler;
+            var handler = (IInternalTestRunEventsHandler)eventHandler;
             if (!convertedRuntimeProvider.AttachDebuggerToTestHost())
             {
                 EqtTrace.Warning(
@@ -487,7 +487,7 @@ public class TestRequestSender : ITestRequestSender
         GC.SuppressFinalize(this);
     }
 
-    private void OnExecutionMessageReceived(MessageReceivedEventArgs messageReceived, ITestRunEventsHandler testRunEventsHandler)
+    private void OnExecutionMessageReceived(MessageReceivedEventArgs messageReceived, IInternalTestRunEventsHandler testRunEventsHandler)
     {
         try
         {
@@ -537,7 +537,7 @@ public class TestRequestSender : ITestRequestSender
 
                 case MessageType.AttachDebugger:
                     var testProcessPid = _dataSerializer.DeserializePayload<TestProcessAttachDebuggerPayload>(message);
-                    bool result = ((ITestRunEventsHandler2)testRunEventsHandler).AttachDebuggerToProcess(testProcessPid.ProcessID);
+                    bool result = ((IInternalTestRunEventsHandler)testRunEventsHandler).AttachDebuggerToProcess(testProcessPid.ProcessID);
 
                     var resultMessage = _dataSerializer.SerializePayload(
                         MessageType.AttachDebuggerCallback,
@@ -611,7 +611,7 @@ public class TestRequestSender : ITestRequestSender
         }
     }
 
-    private void OnTestRunAbort(ITestRunEventsHandler testRunEventsHandler, Exception exception, bool getClientError)
+    private void OnTestRunAbort(IInternalTestRunEventsHandler testRunEventsHandler, Exception exception, bool getClientError)
     {
         if (IsOperationComplete())
         {

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Helpers;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Host;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
@@ -23,7 +24,8 @@ using ObjectModelConstants = Microsoft.VisualStudio.TestPlatform.ObjectModel.Con
 namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 
 /// <summary>
-/// Test request sender implementation.
+/// Sends test requests from vstest.console (runner) to a testhost. See <see cref="StartTestRun"/> for example of how a request is sent. And <see cref="OnExecutionMessageReceived"/> for how a received message is processed.
+/// This class also handles discovery.
 /// </summary>
 public class TestRequestSender : ITestRequestSender
 {
@@ -537,7 +539,9 @@ public class TestRequestSender : ITestRequestSender
 
                 case MessageType.AttachDebugger:
                     var testProcessPid = _dataSerializer.DeserializePayload<TestProcessAttachDebuggerPayload>(message);
-                    bool result = ((IInternalTestRunEventsHandler)testRunEventsHandler).AttachDebuggerToProcess(testProcessPid.ProcessID);
+                    bool result = testRunEventsHandler.AttachDebuggerToProcess(
+                        // TODO: Add anti corruption layer here.
+                        new AttachDebuggerInfo { ProcessId = testProcessPid.ProcessID });
 
                     var resultMessage = _dataSerializer.SerializePayload(
                         MessageType.AttachDebuggerCallback,

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Adapter/FrameworkHandle.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Adapter/FrameworkHandle.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine.ClientProtocol;
 
@@ -99,7 +100,11 @@ internal class FrameworkHandle : TestExecutionRecorder, IFrameworkHandle2, IDisp
     /// <inheritdoc />
     public bool AttachDebuggerToProcess(int pid)
     {
-        return ((IInternalTestRunEventsHandler)_testRunEventsHandler).AttachDebuggerToProcess(pid);
+        return _testRunEventsHandler.AttachDebuggerToProcess(new AttachDebuggerInfo
+        {
+            ProcessId = pid
+            //TODO: populate framwork and architecture
+        });
     }
 
     public void Dispose()

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Adapter/FrameworkHandle.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Adapter/FrameworkHandle.cs
@@ -32,7 +32,7 @@ internal class FrameworkHandle : TestExecutionRecorder, IFrameworkHandle2, IDisp
     /// <summary>
     /// DebugLauncher for launching additional adapter processes under debugger
     /// </summary>
-    private readonly ITestRunEventsHandler _testRunEventsHandler;
+    private readonly IInternalTestRunEventsHandler _testRunEventsHandler;
 
     /// <summary>
     /// Specifies whether the handle is disposed or not
@@ -47,7 +47,7 @@ internal class FrameworkHandle : TestExecutionRecorder, IFrameworkHandle2, IDisp
     /// <param name="testExecutionContext"> The test execution context. </param>
     /// <param name="testRunEventsHandler">TestRun Events Handler</param>
     public FrameworkHandle(ITestCaseEventsHandler testCaseEventsHandler, ITestRunCache testRunCache,
-        TestExecutionContext testExecutionContext, ITestRunEventsHandler testRunEventsHandler)
+        TestExecutionContext testExecutionContext, IInternalTestRunEventsHandler testRunEventsHandler)
         : base(testCaseEventsHandler, testRunCache)
     {
         _testExecutionContext = testExecutionContext;
@@ -99,7 +99,7 @@ internal class FrameworkHandle : TestExecutionRecorder, IFrameworkHandle2, IDisp
     /// <inheritdoc />
     public bool AttachDebuggerToProcess(int pid)
     {
-        return ((ITestRunEventsHandler2)_testRunEventsHandler).AttachDebuggerToProcess(pid);
+        return ((IInternalTestRunEventsHandler)_testRunEventsHandler).AttachDebuggerToProcess(pid);
     }
 
     public void Dispose()

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/InProcessProxyexecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/InProcessProxyexecutionManager.cs
@@ -54,7 +54,7 @@ internal class InProcessProxyExecutionManager : IProxyExecutionManager
     }
 
     /// <inheritdoc/>
-    public int StartTestRun(TestRunCriteria testRunCriteria, ITestRunEventsHandler eventHandler)
+    public int StartTestRun(TestRunCriteria testRunCriteria, IInternalTestRunEventsHandler eventHandler)
     {
         try
         {
@@ -113,7 +113,7 @@ internal class InProcessProxyExecutionManager : IProxyExecutionManager
     /// Aborts the test operation.
     /// </summary>
     /// <param name="eventHandler"> EventHandler for handling execution events from Engine. </param>
-    public void Abort(ITestRunEventsHandler eventHandler)
+    public void Abort(IInternalTestRunEventsHandler eventHandler)
     {
         Task.Run(() => _testHostManagerFactory.GetExecutionManager().Abort(eventHandler));
     }
@@ -122,7 +122,7 @@ internal class InProcessProxyExecutionManager : IProxyExecutionManager
     /// Cancels the test run.
     /// </summary>
     /// <param name="eventHandler"> EventHandler for handling execution events from Engine. </param>
-    public void Cancel(ITestRunEventsHandler eventHandler)
+    public void Cancel(IInternalTestRunEventsHandler eventHandler)
     {
         Task.Run(() => _testHostManagerFactory.GetExecutionManager().Cancel(eventHandler));
     }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyExecutionManager.cs
@@ -30,7 +30,7 @@ internal class ParallelProxyExecutionManager : IParallelProxyExecutionManager
 {
     private readonly IDataSerializer _dataSerializer;
     private readonly bool _isParallel;
-    private readonly ParallelOperationManager<IProxyExecutionManager, ITestRunEventsHandler, TestRunCriteria> _parallelOperationManager;
+    private readonly ParallelOperationManager<IProxyExecutionManager, IInternalTestRunEventsHandler, TestRunCriteria> _parallelOperationManager;
     private readonly Dictionary<string, TestRuntimeProviderInfo> _sourceToTestHostProviderMap;
 
     #region TestRunSpecificData
@@ -91,7 +91,7 @@ internal class ParallelProxyExecutionManager : IParallelProxyExecutionManager
         _skipDefaultAdapters = skipDefaultAdapters;
     }
 
-    public int StartTestRun(TestRunCriteria testRunCriteria, ITestRunEventsHandler eventHandler)
+    public int StartTestRun(TestRunCriteria testRunCriteria, IInternalTestRunEventsHandler eventHandler)
     {
         var workloads = SplitToWorkloads(testRunCriteria, _sourceToTestHostProviderMap);
         _availableWorkloads = workloads.Count;
@@ -111,14 +111,14 @@ internal class ParallelProxyExecutionManager : IParallelProxyExecutionManager
         return 1;
     }
 
-    public void Abort(ITestRunEventsHandler runEventsHandler)
+    public void Abort(IInternalTestRunEventsHandler runEventsHandler)
     {
         // Test platform initiated abort.
         _abortRequested = true;
         _parallelOperationManager.DoActionOnAllManagers((proxyManager) => proxyManager.Abort(runEventsHandler), doActionsInParallel: true);
     }
 
-    public void Cancel(ITestRunEventsHandler runEventsHandler)
+    public void Cancel(IInternalTestRunEventsHandler runEventsHandler)
     {
         _parallelOperationManager.DoActionOnAllManagers((proxyManager) => proxyManager.Cancel(runEventsHandler), doActionsInParallel: true);
     }
@@ -324,7 +324,7 @@ internal class ParallelProxyExecutionManager : IParallelProxyExecutionManager
         }
     }
 
-    private ParallelRunEventsHandler GetParallelEventHandler(ITestRunEventsHandler eventHandler, IProxyExecutionManager concurrentManager)
+    private ParallelRunEventsHandler GetParallelEventHandler(IInternalTestRunEventsHandler eventHandler, IProxyExecutionManager concurrentManager)
     {
         if (concurrentManager is ProxyExecutionManagerWithDataCollection)
         {
@@ -355,7 +355,7 @@ internal class ParallelProxyExecutionManager : IParallelProxyExecutionManager
     /// </summary>
     /// <param name="proxyExecutionManager">Proxy execution manager instance.</param>
     /// <returns>True, if execution triggered</returns>
-    private void StartTestRunOnConcurrentManager(IProxyExecutionManager proxyExecutionManager, ITestRunEventsHandler eventHandler, TestRunCriteria testRunCriteria)
+    private void StartTestRunOnConcurrentManager(IProxyExecutionManager proxyExecutionManager, IInternalTestRunEventsHandler eventHandler, TestRunCriteria testRunCriteria)
     {
         if (testRunCriteria != null)
         {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelRunEventsHandler.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
@@ -188,9 +189,9 @@ internal class ParallelRunEventsHandler : IInternalTestRunEventsHandler
     }
 
     /// <inheritdoc />
-    public bool AttachDebuggerToProcess(int pid)
+    public bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo)
     {
-        return ((IInternalTestRunEventsHandler)_actualRunEventsHandler).AttachDebuggerToProcess(pid);
+        return _actualRunEventsHandler.AttachDebuggerToProcess(attachDebuggerInfo);
     }
 
     private void ConvertToRawMessageAndSend(string messageType, object payload)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelRunEventsHandler.cs
@@ -20,11 +20,11 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel;
 /// <summary>
 /// ParallelRunEventsHandler for handling the run events in case of parallel execution
 /// </summary>
-internal class ParallelRunEventsHandler : ITestRunEventsHandler2
+internal class ParallelRunEventsHandler : IInternalTestRunEventsHandler
 {
     private readonly IProxyExecutionManager _proxyExecutionManager;
 
-    private readonly ITestRunEventsHandler _actualRunEventsHandler;
+    private readonly IInternalTestRunEventsHandler _actualRunEventsHandler;
 
     private readonly IParallelProxyExecutionManager _parallelProxyExecutionManager;
 
@@ -36,7 +36,7 @@ internal class ParallelRunEventsHandler : ITestRunEventsHandler2
 
     public ParallelRunEventsHandler(IRequestData requestData,
         IProxyExecutionManager proxyExecutionManager,
-        ITestRunEventsHandler actualRunEventsHandler,
+        IInternalTestRunEventsHandler actualRunEventsHandler,
         IParallelProxyExecutionManager parallelProxyExecutionManager,
         ParallelRunDataAggregator runDataAggregator) :
         this(requestData, proxyExecutionManager, actualRunEventsHandler, parallelProxyExecutionManager, runDataAggregator, JsonDataSerializer.Instance)
@@ -45,7 +45,7 @@ internal class ParallelRunEventsHandler : ITestRunEventsHandler2
 
     internal ParallelRunEventsHandler(IRequestData requestData,
         IProxyExecutionManager proxyExecutionManager,
-        ITestRunEventsHandler actualRunEventsHandler,
+        IInternalTestRunEventsHandler actualRunEventsHandler,
         IParallelProxyExecutionManager parallelProxyExecutionManager,
         ParallelRunDataAggregator runDataAggregator,
         IDataSerializer dataSerializer)
@@ -190,7 +190,7 @@ internal class ParallelRunEventsHandler : ITestRunEventsHandler2
     /// <inheritdoc />
     public bool AttachDebuggerToProcess(int pid)
     {
-        return ((ITestRunEventsHandler2)_actualRunEventsHandler).AttachDebuggerToProcess(pid);
+        return ((IInternalTestRunEventsHandler)_actualRunEventsHandler).AttachDebuggerToProcess(pid);
     }
 
     private void ConvertToRawMessageAndSend(string messageType, object payload)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -16,6 +16,7 @@ using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Utilities;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine.ClientProtocol;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Host;
@@ -338,9 +339,9 @@ internal class ProxyExecutionManager : IProxyExecutionManager, IBaseProxy, IInte
     }
 
     /// <inheritdoc />
-    public bool AttachDebuggerToProcess(int pid)
+    public bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo)
     {
-        return ((IInternalTestRunEventsHandler)_baseTestRunEventsHandler).AttachDebuggerToProcess(pid);
+        return _baseTestRunEventsHandler.AttachDebuggerToProcess(attachDebuggerInfo);
     }
 
     /// <inheritdoc/>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client;
 /// <summary>
 /// Orchestrates test execution operations for the engine communicating with the client.
 /// </summary>
-internal class ProxyExecutionManager : IProxyExecutionManager, IBaseProxy, ITestRunEventsHandler2
+internal class ProxyExecutionManager : IProxyExecutionManager, IBaseProxy, IInternalTestRunEventsHandler
 {
     private readonly TestSessionInfo _testSessionInfo;
     private readonly Func<string, ProxyExecutionManager, ProxyOperationManager> _proxyOperationManagerCreator;
@@ -42,7 +42,7 @@ internal class ProxyExecutionManager : IProxyExecutionManager, IBaseProxy, ITest
     private bool _isCommunicationEstablished;
 
     private ProxyOperationManager _proxyOperationManager;
-    private ITestRunEventsHandler _baseTestRunEventsHandler;
+    private IInternalTestRunEventsHandler _baseTestRunEventsHandler;
     private bool _skipDefaultAdapters;
     private readonly bool _debugEnabledForTestSession;
 
@@ -146,7 +146,7 @@ internal class ProxyExecutionManager : IProxyExecutionManager, IBaseProxy, ITest
     }
 
     /// <inheritdoc/>
-    public virtual int StartTestRun(TestRunCriteria testRunCriteria, ITestRunEventsHandler eventHandler)
+    public virtual int StartTestRun(TestRunCriteria testRunCriteria, IInternalTestRunEventsHandler eventHandler)
     {
         if (_proxyOperationManager == null)
         {
@@ -261,7 +261,7 @@ internal class ProxyExecutionManager : IProxyExecutionManager, IBaseProxy, ITest
     }
 
     /// <inheritdoc/>
-    public virtual void Cancel(ITestRunEventsHandler eventHandler)
+    public virtual void Cancel(IInternalTestRunEventsHandler eventHandler)
     {
         // Just in case ExecuteAsync isn't called yet, set the eventhandler.
         if (_baseTestRunEventsHandler == null)
@@ -284,7 +284,7 @@ internal class ProxyExecutionManager : IProxyExecutionManager, IBaseProxy, ITest
     }
 
     /// <inheritdoc/>
-    public void Abort(ITestRunEventsHandler eventHandler)
+    public void Abort(IInternalTestRunEventsHandler eventHandler)
     {
         // Just in case ExecuteAsync isn't called yet, set the eventhandler.
         if (_baseTestRunEventsHandler == null)
@@ -340,7 +340,7 @@ internal class ProxyExecutionManager : IProxyExecutionManager, IBaseProxy, ITest
     /// <inheritdoc />
     public bool AttachDebuggerToProcess(int pid)
     {
-        return ((ITestRunEventsHandler2)_baseTestRunEventsHandler).AttachDebuggerToProcess(pid);
+        return ((IInternalTestRunEventsHandler)_baseTestRunEventsHandler).AttachDebuggerToProcess(pid);
     }
 
     /// <inheritdoc/>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManagerWithDataCollection.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManagerWithDataCollection.cs
@@ -122,7 +122,7 @@ internal class ProxyExecutionManagerWithDataCollection : ProxyExecutionManager
     /// <param name="testRunCriteria"> The settings/options for the test run. </param>
     /// <param name="eventHandler"> EventHandler for handling execution events from Engine. </param>
     /// <returns> The process id of the runner executing tests. </returns>
-    public override int StartTestRun(TestRunCriteria testRunCriteria, ITestRunEventsHandler eventHandler)
+    public override int StartTestRun(TestRunCriteria testRunCriteria, IInternalTestRunEventsHandler eventHandler)
     {
         var currentEventHandler = eventHandler;
         if (ProxyDataCollectionManager != null)
@@ -196,7 +196,7 @@ internal class ProxyExecutionManagerWithDataCollection : ProxyExecutionManager
 /// <summary>
 /// Handles Log events and stores them in list. Messages in the list will be logged after test execution begins.
 /// </summary>
-internal class DataCollectionRunEventsHandler : ITestMessageEventHandler
+internal class DataCollectionRunEventsHandler : IInternalTestMessageEventHandler
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="DataCollectionRunEventsHandler"/> class.

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -145,7 +145,7 @@ public class ProxyOperationManager
     public virtual bool SetupChannel(
         IEnumerable<string> sources,
         string runSettings,
-        ITestMessageEventHandler eventHandler)
+        IInternalTestMessageEventHandler eventHandler)
     {
         // NOTE: Event handler is ignored here, but it is used in the overloaded method.
         return SetupChannel(sources, runSettings);

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManagerWithDataCollection.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManagerWithDataCollection.cs
@@ -108,7 +108,7 @@ public class ProxyOperationManagerWithDataCollection : ProxyOperationManager
     public override bool SetupChannel(
         IEnumerable<string> sources,
         string runSettings,
-        ITestMessageEventHandler eventHandler)
+        IInternalTestMessageEventHandler eventHandler)
     {
         // Log all the messages that are reported while initializing the DataCollectionClient.
         if (DataCollectionRunEventsHandler.Messages.Count > 0)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionTestRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionTestRunEventsHandler.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 #nullable disable
@@ -180,9 +181,9 @@ internal class DataCollectionTestRunEventsHandler : IInternalTestRunEventsHandle
     }
 
     /// <inheritdoc />
-    public bool AttachDebuggerToProcess(int pid)
+    public bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo)
     {
-        return ((IInternalTestRunEventsHandler)_testRunEventsHandler).AttachDebuggerToProcess(pid);
+        return _testRunEventsHandler.AttachDebuggerToProcess(attachDebuggerInfo);
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionTestRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionTestRunEventsHandler.cs
@@ -22,10 +22,10 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection;
 /// Handles DataCollection attachments by calling DataCollection Process on Test Run Complete.
 /// Existing functionality of ITestRunEventsHandler is decorated with additional call to Data Collection Process.
 /// </summary>
-internal class DataCollectionTestRunEventsHandler : ITestRunEventsHandler2
+internal class DataCollectionTestRunEventsHandler : IInternalTestRunEventsHandler
 {
     private readonly IProxyDataCollectionManager _proxyDataCollectionManager;
-    private readonly ITestRunEventsHandler _testRunEventsHandler;
+    private readonly IInternalTestRunEventsHandler _testRunEventsHandler;
     private CancellationToken _cancellationToken;
     private readonly IDataSerializer _dataSerializer;
     private Collection<AttachmentSet> _dataCollectionAttachmentSets;
@@ -40,7 +40,7 @@ internal class DataCollectionTestRunEventsHandler : ITestRunEventsHandler2
     /// <param name="proxyDataCollectionManager">
     /// The proxy Data Collection Manager.
     /// </param>
-    public DataCollectionTestRunEventsHandler(ITestRunEventsHandler baseTestRunEventsHandler, IProxyDataCollectionManager proxyDataCollectionManager, CancellationToken cancellationToken)
+    public DataCollectionTestRunEventsHandler(IInternalTestRunEventsHandler baseTestRunEventsHandler, IProxyDataCollectionManager proxyDataCollectionManager, CancellationToken cancellationToken)
         : this(baseTestRunEventsHandler, proxyDataCollectionManager, JsonDataSerializer.Instance, cancellationToken)
     {
     }
@@ -57,7 +57,7 @@ internal class DataCollectionTestRunEventsHandler : ITestRunEventsHandler2
     /// <param name="dataSerializer">
     /// The data Serializer.
     /// </param>
-    public DataCollectionTestRunEventsHandler(ITestRunEventsHandler baseTestRunEventsHandler, IProxyDataCollectionManager proxyDataCollectionManager, IDataSerializer dataSerializer, CancellationToken cancellationToken)
+    public DataCollectionTestRunEventsHandler(IInternalTestRunEventsHandler baseTestRunEventsHandler, IProxyDataCollectionManager proxyDataCollectionManager, IDataSerializer dataSerializer, CancellationToken cancellationToken)
     {
         _proxyDataCollectionManager = proxyDataCollectionManager;
         _testRunEventsHandler = baseTestRunEventsHandler;
@@ -182,7 +182,7 @@ internal class DataCollectionTestRunEventsHandler : ITestRunEventsHandler2
     /// <inheritdoc />
     public bool AttachDebuggerToProcess(int pid)
     {
-        return ((ITestRunEventsHandler2)_testRunEventsHandler).AttachDebuggerToProcess(pid);
+        return ((IInternalTestRunEventsHandler)_testRunEventsHandler).AttachDebuggerToProcess(pid);
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/Interfaces/IProxyDataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/Interfaces/IProxyDataCollectionManager.cs
@@ -48,7 +48,7 @@ public interface IProxyDataCollectionManager : IDisposable
     DataCollectionParameters BeforeTestRunStart(
         bool resetDataCollectors,
         bool isRunStartingNow,
-        ITestMessageEventHandler runEventsHandler);
+        IInternalTestMessageEventHandler runEventsHandler);
 
     /// <summary>
     /// Invoked after ending of test run
@@ -62,7 +62,7 @@ public interface IProxyDataCollectionManager : IDisposable
     /// <returns>
     /// The <see cref="DataCollectionResult"/>.
     /// </returns>
-    DataCollectionResult AfterTestRunEnd(bool isCanceled, ITestMessageEventHandler runEventsHandler);
+    DataCollectionResult AfterTestRunEnd(bool isCanceled, IInternalTestMessageEventHandler runEventsHandler);
 
     /// <summary>
     /// Invoked after initialization of test host

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ParallelDataCollectionEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ParallelDataCollectionEventsHandler.cs
@@ -23,7 +23,7 @@ internal class ParallelDataCollectionEventsHandler : ParallelRunEventsHandler
 
     public ParallelDataCollectionEventsHandler(IRequestData requestData,
         IProxyExecutionManager proxyExecutionManager,
-        ITestRunEventsHandler actualRunEventsHandler,
+        IInternalTestRunEventsHandler actualRunEventsHandler,
         IParallelProxyExecutionManager parallelProxyExecutionManager,
         ParallelRunDataAggregator runDataAggregator,
         ITestRunAttachmentsProcessingManager attachmentsProcessingManager,
@@ -36,7 +36,7 @@ internal class ParallelDataCollectionEventsHandler : ParallelRunEventsHandler
 
     internal ParallelDataCollectionEventsHandler(IRequestData requestData,
         IProxyExecutionManager proxyExecutionManager,
-        ITestRunEventsHandler actualRunEventsHandler,
+        IInternalTestRunEventsHandler actualRunEventsHandler,
         IParallelProxyExecutionManager parallelProxyExecutionManager,
         ParallelRunDataAggregator runDataAggregator,
         IDataSerializer dataSerializer) :

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
@@ -147,7 +147,7 @@ internal class ProxyDataCollectionManager : IProxyDataCollectionManager
     /// <returns>
     /// The <see cref="DataCollectionResult"/>.
     /// </returns>
-    public DataCollectionResult AfterTestRunEnd(bool isCanceled, ITestMessageEventHandler runEventsHandler)
+    public DataCollectionResult AfterTestRunEnd(bool isCanceled, IInternalTestMessageEventHandler runEventsHandler)
     {
         AfterTestRunEndResult afterTestRunEnd = null;
         InvokeDataCollectionServiceAction(
@@ -187,7 +187,7 @@ internal class ProxyDataCollectionManager : IProxyDataCollectionManager
     public DataCollectionParameters BeforeTestRunStart(
         bool resetDataCollectors,
         bool isRunStartingNow,
-        ITestMessageEventHandler runEventsHandler)
+        IInternalTestMessageEventHandler runEventsHandler)
     {
         var areTestCaseLevelEventsRequired = false;
         IDictionary<string, string> environmentVariables = new Dictionary<string, string>();
@@ -281,7 +281,7 @@ internal class ProxyDataCollectionManager : IProxyDataCollectionManager
         return connectionTimeout;
     }
 
-    private void InvokeDataCollectionServiceAction(Action action, ITestMessageEventHandler runEventsHandler)
+    private void InvokeDataCollectionServiceAction(Action action, IInternalTestMessageEventHandler runEventsHandler)
     {
         try
         {
@@ -296,7 +296,7 @@ internal class ProxyDataCollectionManager : IProxyDataCollectionManager
         }
     }
 
-    private void HandleExceptionMessage(ITestMessageEventHandler runEventsHandler, Exception exception)
+    private void HandleExceptionMessage(IInternalTestMessageEventHandler runEventsHandler, Exception exception)
     {
         EqtTrace.Error(exception);
         runEventsHandler.HandleLogMessage(ObjectModel.Logging.TestMessageLevel.Error, exception.ToString());

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.EventHandlers;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine.TesthostProtocol;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -271,7 +272,7 @@ public class TestRequestHandler : ITestRequestHandler, IDeploymentAwareTestReque
     }
 
     /// <inheritdoc />
-    public bool AttachDebuggerToProcess(int pid)
+    public bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo)
     {
         // If an attach request is issued but there is no support for attaching on the other
         // side of the communication channel, we simply return and let the caller know the
@@ -292,7 +293,12 @@ public class TestRequestHandler : ITestRequestHandler, IDeploymentAwareTestReque
 
         var data = _dataSerializer.SerializePayload(
             MessageType.AttachDebugger,
-            new TestProcessAttachDebuggerPayload(pid),
+            // TODO: Add anti corruption layer here?
+            new TestProcessAttachDebuggerPayload(attachDebuggerInfo.ProcessId)
+            {
+                Framework = attachDebuggerInfo.TargetFramework,
+                Architecture = attachDebuggerInfo.Architecture,
+            },
             _protocolVersion);
         SendData(data);
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -89,7 +89,7 @@ internal abstract class BaseRunTests
         string runSettings,
         TestExecutionContext testExecutionContext,
         ITestCaseEventsHandler testCaseEventsHandler,
-        ITestRunEventsHandler testRunEventsHandler,
+        IInternalTestRunEventsHandler testRunEventsHandler,
         ITestPlatformEventSource testPlatformEventSource)
         : this(
             requestData,
@@ -124,7 +124,7 @@ internal abstract class BaseRunTests
         string runSettings,
         TestExecutionContext testExecutionContext,
         ITestCaseEventsHandler testCaseEventsHandler,
-        ITestRunEventsHandler testRunEventsHandler,
+        IInternalTestRunEventsHandler testRunEventsHandler,
         ITestPlatformEventSource testPlatformEventSource,
         ITestEventsPublisher testEventsPublisher,
         IThread platformThread,
@@ -180,7 +180,7 @@ internal abstract class BaseRunTests
     /// <summary>
     /// Gets the test run events handler.
     /// </summary>
-    protected ITestRunEventsHandler TestRunEventsHandler { get; }
+    protected IInternalTestRunEventsHandler TestRunEventsHandler { get; }
 
     /// <summary>
     /// Gets the test run cache.

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/ExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/ExecutionManager.cs
@@ -35,7 +35,7 @@ public class ExecutionManager : IExecutionManager
     private BaseRunTests _activeTestRun;
     private readonly IRequestData _requestData;
     private readonly TestSessionMessageLogger _sessionMessageLogger;
-    private ITestMessageEventHandler _testMessageEventsHandler;
+    private IInternalTestMessageEventHandler _testMessageEventsHandler;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ExecutionManager"/> class.
@@ -62,7 +62,7 @@ public class ExecutionManager : IExecutionManager
     /// Initializes the execution manager.
     /// </summary>
     /// <param name="pathToAdditionalExtensions"> The path to additional extensions. </param>
-    public void Initialize(IEnumerable<string> pathToAdditionalExtensions, ITestMessageEventHandler testMessageEventsHandler)
+    public void Initialize(IEnumerable<string> pathToAdditionalExtensions, IInternalTestMessageEventHandler testMessageEventsHandler)
     {
         // Clear the request data metrics left over from a potential previous run.
         _requestData.MetricsCollection?.Metrics?.Clear();
@@ -99,7 +99,7 @@ public class ExecutionManager : IExecutionManager
         string runSettings,
         TestExecutionContext testExecutionContext,
         ITestCaseEventsHandler testCaseEventsHandler,
-        ITestRunEventsHandler runEventsHandler)
+        IInternalTestRunEventsHandler runEventsHandler)
     {
         try
         {
@@ -135,7 +135,7 @@ public class ExecutionManager : IExecutionManager
         string runSettings,
         TestExecutionContext testExecutionContext,
         ITestCaseEventsHandler testCaseEventsHandler,
-        ITestRunEventsHandler runEventsHandler)
+        IInternalTestRunEventsHandler runEventsHandler)
     {
         try
         {
@@ -159,7 +159,7 @@ public class ExecutionManager : IExecutionManager
     /// <summary>
     /// Cancel the test execution.
     /// </summary>
-    public void Cancel(ITestRunEventsHandler testRunEventsHandler)
+    public void Cancel(IInternalTestRunEventsHandler testRunEventsHandler)
     {
         if (_activeTestRun == null)
         {
@@ -175,7 +175,7 @@ public class ExecutionManager : IExecutionManager
     /// <summary>
     /// Aborts the test execution.
     /// </summary>
-    public void Abort(ITestRunEventsHandler testRunEventsHandler)
+    public void Abort(IInternalTestRunEventsHandler testRunEventsHandler)
     {
         if (_activeTestRun == null)
         {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/RunTestsWithSources.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/RunTestsWithSources.cs
@@ -34,7 +34,7 @@ internal class RunTestsWithSources : BaseRunTests
 
     private readonly ITestCaseEventsHandler _testCaseEventsHandler;
 
-    public RunTestsWithSources(IRequestData requestData, Dictionary<string, IEnumerable<string>> adapterSourceMap, string package, string runSettings, TestExecutionContext testExecutionContext, ITestCaseEventsHandler testCaseEventsHandler, ITestRunEventsHandler testRunEventsHandler)
+    public RunTestsWithSources(IRequestData requestData, Dictionary<string, IEnumerable<string>> adapterSourceMap, string package, string runSettings, TestExecutionContext testExecutionContext, ITestCaseEventsHandler testCaseEventsHandler, IInternalTestRunEventsHandler testRunEventsHandler)
         : this(requestData, adapterSourceMap, package, runSettings, testExecutionContext, testCaseEventsHandler, testRunEventsHandler, null)
     {
     }
@@ -51,7 +51,7 @@ internal class RunTestsWithSources : BaseRunTests
     /// <param name="testRunEventsHandler"></param>
     /// <param name="executorUriVsSourceList"></param>
     /// <param name="testRunCache"></param>
-    internal RunTestsWithSources(IRequestData requestData, Dictionary<string, IEnumerable<string>> adapterSourceMap, string package, string runSettings, TestExecutionContext testExecutionContext, ITestCaseEventsHandler testCaseEventsHandler, ITestRunEventsHandler testRunEventsHandler, Dictionary<Tuple<Uri, string>, IEnumerable<string>> executorUriVsSourceList)
+    internal RunTestsWithSources(IRequestData requestData, Dictionary<string, IEnumerable<string>> adapterSourceMap, string package, string runSettings, TestExecutionContext testExecutionContext, ITestCaseEventsHandler testCaseEventsHandler, IInternalTestRunEventsHandler testRunEventsHandler, Dictionary<Tuple<Uri, string>, IEnumerable<string>> executorUriVsSourceList)
         : base(requestData, package, runSettings, testExecutionContext, testCaseEventsHandler, testRunEventsHandler, TestPlatformEventSource.Instance)
     {
         _adapterSourceMap = adapterSourceMap;

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/RunTestsWithTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/RunTestsWithTests.cs
@@ -28,7 +28,7 @@ internal class RunTestsWithTests : BaseRunTests
 
     private readonly ITestCaseEventsHandler _testCaseEventsHandler;
 
-    public RunTestsWithTests(IRequestData requestData, IEnumerable<TestCase> testCases, string package, string runSettings, TestExecutionContext testExecutionContext, ITestCaseEventsHandler testCaseEventsHandler, ITestRunEventsHandler testRunEventsHandler)
+    public RunTestsWithTests(IRequestData requestData, IEnumerable<TestCase> testCases, string package, string runSettings, TestExecutionContext testExecutionContext, ITestCaseEventsHandler testCaseEventsHandler, IInternalTestRunEventsHandler testRunEventsHandler)
         : this(requestData, testCases, package, runSettings, testExecutionContext, testCaseEventsHandler, testRunEventsHandler, null)
     {
     }
@@ -44,7 +44,7 @@ internal class RunTestsWithTests : BaseRunTests
     /// <param name="testCaseEventsHandler"></param>
     /// <param name="testRunEventsHandler"></param>
     /// <param name="executorUriVsTestList"></param>
-    internal RunTestsWithTests(IRequestData requestData, IEnumerable<TestCase> testCases, string package, string runSettings, TestExecutionContext testExecutionContext, ITestCaseEventsHandler testCaseEventsHandler, ITestRunEventsHandler testRunEventsHandler, Dictionary<Tuple<Uri, string>, List<TestCase>> executorUriVsTestList)
+    internal RunTestsWithTests(IRequestData requestData, IEnumerable<TestCase> testCases, string package, string runSettings, TestExecutionContext testExecutionContext, ITestCaseEventsHandler testCaseEventsHandler, IInternalTestRunEventsHandler testRunEventsHandler, Dictionary<Tuple<Uri, string>, List<TestCase>> executorUriVsTestList)
         : base(requestData, package, runSettings, testExecutionContext, testCaseEventsHandler, testRunEventsHandler, TestPlatformEventSource.Instance)
     {
         _testCases = testCases;

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestDiscoveryEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestDiscoveryEventsHandler.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 /// <summary>
 /// Interface contract for handling discovery events during test discovery operation
 /// </summary>
-public interface ITestDiscoveryEventsHandler : ITestMessageEventHandler
+public interface ITestDiscoveryEventsHandler : IInternalTestMessageEventHandler
 {
     /// <summary>
     /// Dispatch DiscoveryComplete event to listeners.

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestDiscoveryEventsHandler2.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestDiscoveryEventsHandler2.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 /// <summary>
 /// Interface contract for handling discovery events during test discovery operation
 /// </summary>
-public interface ITestDiscoveryEventsHandler2 : ITestMessageEventHandler
+public interface ITestDiscoveryEventsHandler2 : IInternalTestMessageEventHandler
 {
     /// <summary>
     /// Dispatch DiscoveryComplete event to listeners.

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher.cs
@@ -32,3 +32,6 @@ public interface ITestHostLauncher
     /// <returns>Process id of the launched test host</returns>
     int LaunchTestHost(TestProcessStartInfo defaultTestHostStartInfo, CancellationToken cancellationToken);
 }
+
+
+

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher.cs
@@ -21,34 +21,12 @@ public interface IInternalTestHostLauncher
     /// Launches custom test host using the default test process start info
     /// </summary>
     /// <param name="defaultTestHostStartInfo">Default TestHost Process Info</param>
-    /// <returns>Process id of the launched test host</returns>
-    int LaunchTestHost(TestProcessStartInfo defaultTestHostStartInfo);
-
-    /// <summary>
-    /// Launches custom test host using the default test process start info
-    /// </summary>
-    /// <param name="defaultTestHostStartInfo">Default TestHost Process Info</param>
     /// <param name="cancellationToken">The cancellation Token.</param>
     /// <returns>Process id of the launched test host</returns>
     int LaunchTestHost(TestProcessStartInfo defaultTestHostStartInfo, CancellationToken cancellationToken);
 
-    /// <summary>
-    /// Attach debugger to already running custom test host process.
-    /// </summary>
-    /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
-    /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
-    bool AttachDebuggerToProcess(int pid);
-
-    /// <summary>
-    /// Attach debugger to already running custom test host process.
-    /// </summary>
-    /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
-    bool AttachDebuggerToProcess(int pid, CancellationToken cancellationToken);
-
     // new in this version
-    // bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo, CancellationToken cancellationToken);
+    bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo, CancellationToken cancellationToken);
 }
 
 

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
 /// <summary>
 /// Interface defining contract for custom test host implementations
 /// </summary>
-public interface ITestHostLauncher
+public interface IInternalTestHostLauncher
 {
     /// <summary>
     /// Gets a value indicating whether this is a debug launcher.
@@ -31,6 +31,24 @@ public interface ITestHostLauncher
     /// <param name="cancellationToken">The cancellation Token.</param>
     /// <returns>Process id of the launched test host</returns>
     int LaunchTestHost(TestProcessStartInfo defaultTestHostStartInfo, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Attach debugger to already running custom test host process.
+    /// </summary>
+    /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
+    /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
+    bool AttachDebuggerToProcess(int pid);
+
+    /// <summary>
+    /// Attach debugger to already running custom test host process.
+    /// </summary>
+    /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
+    bool AttachDebuggerToProcess(int pid, CancellationToken cancellationToken);
+
+    // new in this version
+    // bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo, CancellationToken cancellationToken);
 }
 
 

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher2.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher2.cs
@@ -63,8 +63,8 @@ public interface ITestHostLauncher3 : ITestHostLauncher2
 [Obsolete("Do not use this api, it is not ready yet.")]
 public class AttachDebuggerInfo
 {
-    public Version Version { get; set; }
     public int ProcessId { get; set; }
     public Framework TargetFramework { get; set; }
-    public CancellationToken CancellationToken { get; set; }
+    public Architecture Architecture { get; set; }
+    public bool IsNative { get; set; }
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher2.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher2.cs
@@ -29,10 +29,62 @@ public interface ITestHostLauncher2 : ITestHostLauncher
     bool AttachDebuggerToProcess(int pid, CancellationToken cancellationToken);
 }
 
+public interface ITestHostLauncher_
+{
+    /// <summary>
+    /// Gets a value indicating whether this is a debug launcher.
+    /// </summary>
+    bool IsDebug { get; }
+
+    /// <summary>
+    /// Launches custom test host using the default test process start info
+    /// </summary>
+    /// <param name="defaultTestHostStartInfo">Default TestHost Process Info</param>
+    /// <returns>Process id of the launched test host</returns>
+    int LaunchTestHost(TestProcessStartInfo defaultTestHostStartInfo);
+
+    /// <summary>
+    /// Launches custom test host using the default test process start info
+    /// </summary>
+    /// <param name="defaultTestHostStartInfo">Default TestHost Process Info</param>
+    /// <param name="cancellationToken">The cancellation Token.</param>
+    /// <returns>Process id of the launched test host</returns>
+    int LaunchTestHost(TestProcessStartInfo defaultTestHostStartInfo, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Interface defining contract for custom test host implementations
+/// </summary>
+public interface ITestHostLauncher2_ : ITestHostLauncher_
+{
+    /// <summary>
+    /// Attach debugger to already running custom test host process.
+    /// </summary>
+    /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
+    /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
+    bool AttachDebuggerToProcess(int pid);
+
+    /// <summary>
+    /// Attach debugger to already running custom test host process.
+    /// </summary>
+    /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
+    bool AttachDebuggerToProcess(int pid, CancellationToken cancellationToken);
+}
+
 [Obsolete("Do not use this api, it is not ready yet.")]
 public interface ITestHostLauncher3 : ITestHostLauncher2
 {
-    bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo);
+    bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo, CancellationToken cancellationToken);
+}
+
+
+
+[Obsolete("Do not use this api, it is not ready yet.")]
+public interface ITestHostLauncher3_ : ITestHostLauncher2_
+{
+    bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo, CancellationToken cancellationToken);
 }
 
 [Obsolete("Do not use this api, it is not ready yet.")]

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher2.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher2.cs
@@ -8,28 +8,8 @@ using System.Threading;
 
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
 
-/// <summary>
-/// Interface defining contract for custom test host implementations
-/// </summary>
-public interface ITestHostLauncher2 : ITestHostLauncher
-{
-    /// <summary>
-    /// Attach debugger to already running custom test host process.
-    /// </summary>
-    /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
-    /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
-    bool AttachDebuggerToProcess(int pid);
 
-    /// <summary>
-    /// Attach debugger to already running custom test host process.
-    /// </summary>
-    /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
-    bool AttachDebuggerToProcess(int pid, CancellationToken cancellationToken);
-}
-
-public interface ITestHostLauncher_
+public interface ITestHostLauncher
 {
     /// <summary>
     /// Gets a value indicating whether this is a debug launcher.
@@ -55,7 +35,7 @@ public interface ITestHostLauncher_
 /// <summary>
 /// Interface defining contract for custom test host implementations
 /// </summary>
-public interface ITestHostLauncher2_ : ITestHostLauncher_
+public interface ITestHostLauncher2 : ITestHostLauncher
 {
     /// <summary>
     /// Attach debugger to already running custom test host process.
@@ -73,16 +53,9 @@ public interface ITestHostLauncher2_ : ITestHostLauncher_
     bool AttachDebuggerToProcess(int pid, CancellationToken cancellationToken);
 }
 
+
 [Obsolete("Do not use this api, it is not ready yet.")]
 public interface ITestHostLauncher3 : ITestHostLauncher2
-{
-    bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo, CancellationToken cancellationToken);
-}
-
-
-
-[Obsolete("Do not use this api, it is not ready yet.")]
-public interface ITestHostLauncher3_ : ITestHostLauncher2_
 {
     bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo, CancellationToken cancellationToken);
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestRunAttachmentsProcessingEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestRunAttachmentsProcessingEventsHandler.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 /// <summary>
 /// Interface contract for handling test run attachments processing events
 /// </summary>
-public interface ITestRunAttachmentsProcessingEventsHandler : ITestMessageEventHandler
+public interface ITestRunAttachmentsProcessingEventsHandler : IInternalTestMessageEventHandler
 {
     /// <summary>
     /// Dispatch TestRunAttachmentsProcessingComplete event to listeners.

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestRunEventsHandler.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Threading;
 
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 #nullable disable
@@ -42,7 +44,7 @@ public interface IInternalTestRunEventsHandler : IInternalTestMessageEventHandle
     /// </summary>
     /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
     /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
-    bool AttachDebuggerToProcess(int pid);
+    bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo);
 }
 
 /// <summary>

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestRunEventsHandler.cs
@@ -12,6 +12,63 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 /// <summary>
 /// Interface contract for handling test run events during run operation
 /// </summary>
+public interface IInternalTestRunEventsHandler : IInternalTestMessageEventHandler
+{
+    /// <summary>
+    /// Handle the TestRunCompletion event from a test engine
+    /// </summary>
+    /// <param name="testRunCompleteArgs">TestRunCompletion Data</param>
+    /// <param name="lastChunkArgs">Last set of test results</param>
+    /// <param name="runContextAttachments">Attachments of the test run</param>
+    /// <param name="executorUris">ExecutorURIs of the adapters involved in test run</param>
+    void HandleTestRunComplete(TestRunCompleteEventArgs testRunCompleteArgs, TestRunChangedEventArgs lastChunkArgs, ICollection<AttachmentSet> runContextAttachments, ICollection<string> executorUris);
+
+    /// <summary>
+    /// Handle a change in TestRun i.e. new testresults and stats
+    /// </summary>
+    /// <param name="testRunChangedArgs">TestRunChanged Data</param>
+    void HandleTestRunStatsChange(TestRunChangedEventArgs testRunChangedArgs);
+
+    /// <summary>
+    /// Launches a process with a given process info under debugger
+    /// Adapter get to call into this to launch any additional processes under debugger
+    /// </summary>
+    /// <param name="testProcessStartInfo">Process start info</param>
+    /// <returns>ProcessId of the launched process</returns>
+    int LaunchProcessWithDebuggerAttached(TestProcessStartInfo testProcessStartInfo);
+
+    /// <summary>
+    /// Attach debugger to an already running process.
+    /// </summary>
+    /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
+    /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
+    bool AttachDebuggerToProcess(int pid);
+}
+
+/// <summary>
+/// Interface for handling generic message events during various operations
+/// </summary>
+public interface IInternalTestMessageEventHandler
+{
+    /// <summary>
+    /// Raw Message from the host directly
+    /// </summary>
+    /// <param name="rawMessage">raw message args from host</param>
+    void HandleRawMessage(string rawMessage);
+
+    /// <summary>
+    /// Handle a IMessageLogger message event from Adapter
+    /// Whenever adapters call IMessageLogger.SendMessage, TestEngine notifies client with this event
+    /// </summary>
+    /// <param name="level">Message Level</param>
+    /// <param name="message">string message</param>
+    void HandleLogMessage(TestMessageLevel level, string message);
+}
+
+
+/// <summary>
+/// Interface contract for handling test run events during run operation
+/// </summary>
 public interface ITestRunEventsHandler : ITestMessageEventHandler
 {
     /// <summary>

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestSessionEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestSessionEventsHandler.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 /// <summary>
 /// Interface contract for handling test session events.
 /// </summary>
-public interface ITestSessionEventsHandler : ITestMessageEventHandler
+public interface ITestSessionEventsHandler : IInternalTestMessageEventHandler
 {
     /// <summary>
     /// Dispatch StartTestSession complete event to listeners.

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/StartTestSessionCriteria.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/StartTestSessionCriteria.cs
@@ -32,5 +32,5 @@ public class StartTestSessionCriteria
     /// Gets or sets the test host launcher used for starting the test session.
     /// </summary>
     [DataMember]
-    public ITestHostLauncher TestHostLauncher { get; set; }
+    public IInternalTestHostLauncher TestHostLauncher { get; set; }
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/TestRunCriteria.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/TestRunCriteria.cs
@@ -134,7 +134,7 @@ public class TestRunCriteria : BaseTestRunCriteria, ITestRunConfiguration
         bool keepAlive,
         string testSettings,
         TimeSpan runStatsChangeEventTimeout,
-        ITestHostLauncher testHostLauncher)
+        IInternalTestHostLauncher testHostLauncher)
         : this(
             sources,
             frequencyOfRunStatsChangeEvent,
@@ -171,7 +171,7 @@ public class TestRunCriteria : BaseTestRunCriteria, ITestRunConfiguration
         bool keepAlive,
         string testSettings,
         TimeSpan runStatsChangeEventTimeout,
-        ITestHostLauncher testHostLauncher,
+        IInternalTestHostLauncher testHostLauncher,
         string testCaseFilter,
         FilterOptions filterOptions)
         : this(
@@ -216,7 +216,7 @@ public class TestRunCriteria : BaseTestRunCriteria, ITestRunConfiguration
         bool keepAlive,
         string testSettings,
         TimeSpan runStatsChangeEventTimeout,
-        ITestHostLauncher testHostLauncher,
+        IInternalTestHostLauncher testHostLauncher,
         string testCaseFilter,
         FilterOptions filterOptions,
         TestSessionInfo testSessionInfo,
@@ -291,7 +291,7 @@ public class TestRunCriteria : BaseTestRunCriteria, ITestRunConfiguration
         bool keepAlive,
         string testSettings,
         TimeSpan runStatsChangeEventTimeout,
-        ITestHostLauncher testHostLauncher)
+        IInternalTestHostLauncher testHostLauncher)
         : base(
             frequencyOfRunStatsChangeEvent,
             keepAlive,
@@ -431,7 +431,7 @@ public class TestRunCriteria : BaseTestRunCriteria, ITestRunConfiguration
         bool keepAlive,
         string testSettings,
         TimeSpan runStatsChangeEventTimeout,
-        ITestHostLauncher testHostLauncher)
+        IInternalTestHostLauncher testHostLauncher)
         : this(
             tests,
             frequencyOfRunStatsChangeEvent,
@@ -470,7 +470,7 @@ public class TestRunCriteria : BaseTestRunCriteria, ITestRunConfiguration
         bool keepAlive,
         string testSettings,
         TimeSpan runStatsChangeEventTimeout,
-        ITestHostLauncher testHostLauncher,
+        IInternalTestHostLauncher testHostLauncher,
         TestSessionInfo testSessionInfo,
         bool debugEnabledForTestSession)
         : base(
@@ -765,7 +765,7 @@ public class BaseTestRunCriteria
         bool keepAlive,
         string testSettings,
         TimeSpan runStatsChangeEventTimeout,
-        ITestHostLauncher testHostLauncher)
+        IInternalTestHostLauncher testHostLauncher)
     {
         if (frequencyOfRunStatsChangeEvent <= 0)
         {
@@ -805,7 +805,7 @@ public class BaseTestRunCriteria
     /// Gets the custom launcher for test executor.
     /// </summary>
     [DataMember]
-    public ITestHostLauncher TestHostLauncher { get; private set; }
+    public IInternalTestHostLauncher TestHostLauncher { get; private set; }
 
     /// <summary>
     /// Gets the frequency of run stats test event.

--- a/src/Microsoft.TestPlatform.ObjectModel/Host/ITestRunTimeProvider.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Host/ITestRunTimeProvider.cs
@@ -59,7 +59,7 @@ public interface ITestRuntimeProvider
     /// Sets a custom launcher
     /// </summary>
     /// <param name="customLauncher">Custom launcher to set</param>
-    void SetCustomLauncher(ITestHostLauncher customLauncher);
+    void SetCustomLauncher(IInternalTestHostLauncher customLauncher);
 
     /// <summary>
     /// Gets the end point address and behavior of TestRuntime

--- a/src/Microsoft.TestPlatform.ObjectModel/TestProcessAttachDebuggerPayload.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TestProcessAttachDebuggerPayload.cs
@@ -27,4 +27,10 @@ public class TestProcessAttachDebuggerPayload
     /// </summary>
     [DataMember]
     public int ProcessID { get; set; }
+
+    [DataMember]
+    public Framework Framework { get; set; }
+
+    [DataMember]
+    public Architecture Architecture { get; set; }
 }

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -332,8 +332,13 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
     /// <inheritdoc />
     public bool AttachDebuggerToTestHost()
     {
-        return _customTestHostLauncher is IInternalTestHostLauncher launcher
-               && launcher.AttachDebuggerToProcess(_testHostProcess.Id);
+        return _customTestHostLauncher.AttachDebuggerToProcess(new AttachDebuggerInfo
+        {
+            ProcessId = _testHostProcess.Id,
+            IsNative = false,
+            TargetFramework = _targetFramework,
+            Architecture = _architecture,
+        }, CancellationToken.None);
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -58,7 +58,7 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
     private readonly IEnvironment _environment;
     private readonly IDotnetHostHelper _dotnetHostHelper;
 
-    private ITestHostLauncher _customTestHostLauncher;
+    private IInternalTestHostLauncher _customTestHostLauncher;
     private Process _testHostProcess;
     private StringBuilder _testHostProcessStdError;
     private IMessageLogger _messageLogger;
@@ -112,7 +112,7 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
     private Action<object, string> ErrorReceivedCallback => (process, data) => TestHostManagerCallbacks.ErrorReceivedCallback(_testHostProcessStdError, data);
 
     /// <inheritdoc/>
-    public void SetCustomLauncher(ITestHostLauncher customLauncher)
+    public void SetCustomLauncher(IInternalTestHostLauncher customLauncher)
     {
         _customTestHostLauncher = customLauncher;
     }
@@ -332,7 +332,7 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
     /// <inheritdoc />
     public bool AttachDebuggerToTestHost()
     {
-        return _customTestHostLauncher is ITestHostLauncher2 launcher
+        return _customTestHostLauncher is IInternalTestHostLauncher launcher
                && launcher.AttachDebuggerToProcess(_testHostProcess.Id);
     }
 
@@ -445,7 +445,7 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
         // additional environmental variables for us to help with probing.
         if ((_customTestHostLauncher == null)
             || (_customTestHostLauncher.IsDebug
-                && _customTestHostLauncher is ITestHostLauncher2))
+                && _customTestHostLauncher is IInternalTestHostLauncher))
         {
             EqtTrace.Verbose("DefaultTestHostManager: Starting process '{0}' with command line '{1}'", testHostStartInfo.FileName, testHostStartInfo.Arguments);
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -618,8 +618,13 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
     /// <inheritdoc />
     public bool AttachDebuggerToTestHost()
     {
-        return _customTestHostLauncher is IInternalTestHostLauncher launcher
-               && launcher.AttachDebuggerToProcess(_testHostProcess.Id);
+        return _customTestHostLauncher.AttachDebuggerToProcess(new AttachDebuggerInfo
+        {
+            ProcessId = _testHostProcess.Id,
+            IsNative = false,
+            TargetFramework = _targetFramework,
+            Architecture = _architecture,
+        }, CancellationToken.None);
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -60,7 +60,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
     private readonly IWindowsRegistryHelper _windowsRegistryHelper;
     private readonly IEnvironmentVariableHelper _environmentVariableHelper;
 
-    private ITestHostLauncher _customTestHostLauncher;
+    private IInternalTestHostLauncher _customTestHostLauncher;
 
     private Process _testHostProcess;
 
@@ -181,7 +181,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
     }
 
     /// <inheritdoc/>
-    public void SetCustomLauncher(ITestHostLauncher customLauncher)
+    public void SetCustomLauncher(IInternalTestHostLauncher customLauncher)
     {
         _customTestHostLauncher = customLauncher;
     }
@@ -618,7 +618,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
     /// <inheritdoc />
     public bool AttachDebuggerToTestHost()
     {
-        return _customTestHostLauncher is ITestHostLauncher2 launcher
+        return _customTestHostLauncher is IInternalTestHostLauncher launcher
                && launcher.AttachDebuggerToProcess(_testHostProcess.Id);
     }
 
@@ -662,7 +662,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
         // additional environmental variables for us to help with probing.
         if ((_customTestHostLauncher == null)
             || (_customTestHostLauncher.IsDebug
-                && _customTestHostLauncher is ITestHostLauncher2))
+                && _customTestHostLauncher is IInternalTestHostLauncher))
         {
             EqtTrace.Verbose("DotnetTestHostManager: Starting process '{0}' with command line '{1}'", testHostStartInfo.FileName, testHostStartInfo.Arguments);
 

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -261,7 +261,7 @@ internal class TestRequestManager : ITestRequestManager
     /// <inheritdoc />
     public void RunTests(
         TestRunRequestPayload testRunRequestPayload,
-        ITestHostLauncher testHostLauncher,
+        IInternalTestHostLauncher testHostLauncher,
         ITestRunEventsRegistrar testRunEventsRegistrar,
         ProtocolConfig protocolConfig)
     {
@@ -449,7 +449,7 @@ internal class TestRequestManager : ITestRequestManager
     /// <inheritdoc/>
     public void StartTestSession(
         StartTestSessionPayload payload,
-        ITestHostLauncher testHostLauncher,
+        IInternalTestHostLauncher testHostLauncher,
         ITestSessionEventsHandler eventsHandler,
         ProtocolConfig protocolConfig)
     {

--- a/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/CustomTestHostTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/TranslationLayerTests/CustomTestHostTests.cs
@@ -267,7 +267,7 @@ public class CustomTestHostTests : AcceptanceTestBase
 
         public List<AttachDebuggerInfo> AttachDebuggerInfos { get; } = new();
 
-        public bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo)
+        public bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo, CancellationToken cancellationToken)
         {
             AttachDebuggerInfos.Add(attachDebuggerInfo);
 
@@ -282,7 +282,7 @@ public class CustomTestHostTests : AcceptanceTestBase
                 TargetFramework = null,
                 Version = null,
                 CancellationToken = CancellationToken.None
-            });
+            }, CancellationToken.None);
         }
 
         public bool AttachDebuggerToProcess(int pid, CancellationToken cancellationToken)
@@ -293,7 +293,7 @@ public class CustomTestHostTests : AcceptanceTestBase
                 TargetFramework = null,
                 Version = null,
                 CancellationToken = cancellationToken
-            });
+            }, CancellationToken.None);
         }
 
         public int LaunchTestHost(TestProcessStartInfo defaultTestHostStartInfo)

--- a/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeClientTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeClientTests.cs
@@ -181,12 +181,12 @@ public class DesignModeClientTests
                 trm =>
                     trm.RunTests(
                         It.IsAny<TestRunRequestPayload>(),
-                        It.IsAny<ITestHostLauncher>(),
+                        It.IsAny<IInternalTestHostLauncher>(),
                         It.IsAny<ITestRunEventsRegistrar>(),
                         It.IsAny<ProtocolConfig>()))
             .Callback(
                 (TestRunRequestPayload trp,
-                    ITestHostLauncher testHostManager,
+                    IInternalTestHostLauncher testHostManager,
                     ITestRunEventsRegistrar testRunEventsRegistrar,
                     ProtocolConfig config) =>
                 {
@@ -243,12 +243,12 @@ public class DesignModeClientTests
                 trm =>
                     trm.RunTests(
                         It.IsAny<TestRunRequestPayload>(),
-                        It.IsAny<ITestHostLauncher>(),
+                        It.IsAny<IInternalTestHostLauncher>(),
                         It.IsAny<ITestRunEventsRegistrar>(),
                         It.IsAny<ProtocolConfig>()))
             .Callback(
                 (TestRunRequestPayload trp,
-                    ITestHostLauncher testHostManager,
+                    IInternalTestHostLauncher testHostManager,
                     ITestRunEventsRegistrar testRunEventsRegistrar,
                     ProtocolConfig config) =>
                 {
@@ -559,7 +559,7 @@ public class DesignModeClientTests
         _mockTestRequestManager.Setup(
             rm => rm.StartTestSession(
                 It.IsAny<StartTestSessionPayload>(),
-                It.IsAny<ITestHostLauncher>(),
+                It.IsAny<IInternalTestHostLauncher>(),
                 It.IsAny<ITestSessionEventsHandler>(),
                 It.IsAny<ProtocolConfig>())).Throws(new SettingsException("DummyException"));
 

--- a/test/Microsoft.TestPlatform.Client.UnitTests/Execution/TestRunRequestTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/Execution/TestRunRequestTests.cs
@@ -105,7 +105,7 @@ public class TestRunRequestTests
     {
         //ExecuteAsync has not been called, so State is not InProgress
         _testRunRequest.Abort();
-        _executionManager.Verify(dm => dm.Abort(It.IsAny<ITestRunEventsHandler>()), Times.Never);
+        _executionManager.Verify(dm => dm.Abort(It.IsAny<IInternalTestRunEventsHandler>()), Times.Never);
     }
 
     [TestMethod]
@@ -115,7 +115,7 @@ public class TestRunRequestTests
         _testRunRequest.ExecuteAsync();
 
         _testRunRequest.Abort();
-        _executionManager.Verify(dm => dm.Abort(It.IsAny<ITestRunEventsHandler>()), Times.Once);
+        _executionManager.Verify(dm => dm.Abort(It.IsAny<IInternalTestRunEventsHandler>()), Times.Once);
     }
 
     [TestMethod]
@@ -142,7 +142,7 @@ public class TestRunRequestTests
     public void CancelAsyncIfTestRunStateNotInProgressWillNotCallExecutionManagerCancel()
     {
         _testRunRequest.CancelAsync();
-        _executionManager.Verify(dm => dm.Cancel(It.IsAny<ITestRunEventsHandler>()), Times.Never);
+        _executionManager.Verify(dm => dm.Cancel(It.IsAny<IInternalTestRunEventsHandler>()), Times.Never);
     }
 
     [TestMethod]
@@ -150,7 +150,7 @@ public class TestRunRequestTests
     {
         _testRunRequest.ExecuteAsync();
         _testRunRequest.CancelAsync();
-        _executionManager.Verify(dm => dm.Cancel(It.IsAny<ITestRunEventsHandler>()), Times.Once);
+        _executionManager.Verify(dm => dm.Cancel(It.IsAny<IInternalTestRunEventsHandler>()), Times.Once);
     }
 
     [TestMethod]
@@ -158,7 +158,7 @@ public class TestRunRequestTests
     {
         _testRunRequest.ExecuteAsync();
         _testRunRequest.OnTestSessionTimeout(null);
-        _executionManager.Verify(o => o.Abort(It.IsAny<ITestRunEventsHandler>()), Times.Once);
+        _executionManager.Verify(o => o.Abort(It.IsAny<IInternalTestRunEventsHandler>()), Times.Once);
     }
 
     [TestMethod]
@@ -198,12 +198,12 @@ public class TestRunRequestTests
 
         ManualResetEvent onTestSessionTimeoutCalled = new(true);
         onTestSessionTimeoutCalled.Reset();
-        executionManager.Setup(o => o.Abort(It.IsAny<ITestRunEventsHandler>())).Callback(() => onTestSessionTimeoutCalled.Set());
+        executionManager.Setup(o => o.Abort(It.IsAny<IInternalTestRunEventsHandler>())).Callback(() => onTestSessionTimeoutCalled.Set());
 
         testRunRequest.ExecuteAsync();
         onTestSessionTimeoutCalled.WaitOne(20 * 1000);
 
-        executionManager.Verify(o => o.Abort(It.IsAny<ITestRunEventsHandler>()), Times.Once);
+        executionManager.Verify(o => o.Abort(It.IsAny<IInternalTestRunEventsHandler>()), Times.Once);
     }
 
     /// <summary>
@@ -224,11 +224,11 @@ public class TestRunRequestTests
         var executionManager = new Mock<IProxyExecutionManager>();
         var testRunRequest = new TestRunRequest(_mockRequestData.Object, testRunCriteria, executionManager.Object, _loggerManager.Object);
 
-        executionManager.Setup(o => o.StartTestRun(It.IsAny<TestRunCriteria>(), It.IsAny<ITestRunEventsHandler>())).Callback(() => Thread.Sleep(5 * 1000));
+        executionManager.Setup(o => o.StartTestRun(It.IsAny<TestRunCriteria>(), It.IsAny<IInternalTestRunEventsHandler>())).Callback(() => Thread.Sleep(5 * 1000));
 
         testRunRequest.ExecuteAsync();
 
-        executionManager.Verify(o => o.Abort(It.IsAny<ITestRunEventsHandler>()), Times.Never);
+        executionManager.Verify(o => o.Abort(It.IsAny<IInternalTestRunEventsHandler>()), Times.Never);
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Client.UnitTests/Execution/TestRunRequestTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/Execution/TestRunRequestTests.cs
@@ -593,7 +593,7 @@ public class TestRunRequestTests
     [TestMethod]
     public void LaunchProcessWithDebuggerAttachedShouldNotCallCustomLauncherIfTestRunIsNotInProgress()
     {
-        var mockCustomLauncher = new Mock<ITestHostLauncher>();
+        var mockCustomLauncher = new Mock<IInternalTestHostLauncher>();
         _testRunCriteria = new TestRunCriteria(new List<string> { "foo" }, 1, false, null, TimeSpan.Zero, mockCustomLauncher.Object);
         _executionManager = new Mock<IProxyExecutionManager>();
         _testRunRequest = new TestRunRequest(_mockRequestData.Object, _testRunCriteria, _executionManager.Object, _loggerManager.Object);
@@ -607,7 +607,7 @@ public class TestRunRequestTests
     [TestMethod]
     public void LaunchProcessWithDebuggerAttachedShouldNotCallCustomLauncherIfLauncherIsNotDebug()
     {
-        var mockCustomLauncher = new Mock<ITestHostLauncher>();
+        var mockCustomLauncher = new Mock<IInternalTestHostLauncher>();
         _testRunCriteria = new TestRunCriteria(new List<string> { "foo" }, 1, false, null, TimeSpan.Zero, mockCustomLauncher.Object);
         _executionManager = new Mock<IProxyExecutionManager>();
         _testRunRequest = new TestRunRequest(_mockRequestData.Object, _testRunCriteria, _executionManager.Object, _loggerManager.Object);
@@ -623,7 +623,7 @@ public class TestRunRequestTests
     [TestMethod]
     public void LaunchProcessWithDebuggerAttachedShouldCallCustomLauncherIfLauncherIsDebugAndRunInProgress()
     {
-        var mockCustomLauncher = new Mock<ITestHostLauncher>();
+        var mockCustomLauncher = new Mock<IInternalTestHostLauncher>();
         _testRunCriteria = new TestRunCriteria(new List<string> { "foo" }, 1, false, null, TimeSpan.Zero, mockCustomLauncher.Object);
         _executionManager = new Mock<IProxyExecutionManager>();
         _testRunRequest = new TestRunRequest(_mockRequestData.Object, _testRunCriteria, _executionManager.Object, _loggerManager.Object);

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Hosting/TestHostProviderManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Hosting/TestHostProviderManagerTests.cs
@@ -208,7 +208,7 @@ public class TestHostProviderManagerTests
             HostLaunched.Invoke(this, new HostProviderEventArgs("Error"));
         }
 
-        public void SetCustomLauncher(ITestHostLauncher customLauncher)
+        public void SetCustomLauncher(IInternalTestHostLauncher customLauncher)
         {
             throw new NotImplementedException();
         }
@@ -276,7 +276,7 @@ public class TestHostProviderManagerTests
             HostLaunched.Invoke(this, new HostProviderEventArgs("Error"));
         }
 
-        public void SetCustomLauncher(ITestHostLauncher customLauncher)
+        public void SetCustomLauncher(IInternalTestHostLauncher customLauncher)
         {
             throw new NotImplementedException();
         }

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
@@ -35,7 +35,7 @@ public class TestRequestSenderTests
 
     private readonly List<string> _pathToAdditionalExtensions = new() { "Hello", "World" };
     private readonly Mock<ITestDiscoveryEventsHandler2> _mockDiscoveryEventsHandler;
-    private readonly Mock<ITestRunEventsHandler> _mockExecutionEventsHandler;
+    private readonly Mock<IInternalTestRunEventsHandler> _mockExecutionEventsHandler;
     private readonly TestRunCriteriaWithSources _testRunCriteriaWithSources;
     private TestHostConnectionInfo _connectionInfo;
     private readonly ITestRequestSender _testRequestSender;
@@ -56,7 +56,7 @@ public class TestRequestSenderTests
 
         _connectedEventArgs = new ConnectedEventArgs(_mockChannel.Object);
         _mockDiscoveryEventsHandler = new Mock<ITestDiscoveryEventsHandler2>();
-        _mockExecutionEventsHandler = new Mock<ITestRunEventsHandler>();
+        _mockExecutionEventsHandler = new Mock<IInternalTestRunEventsHandler>();
         _testRunCriteriaWithSources = new TestRunCriteriaWithSources(new Dictionary<string, IEnumerable<string>>(), "runsettings", null, null);
     }
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Adapter/FrameworkHandleTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Adapter/FrameworkHandleTests.cs
@@ -73,7 +73,7 @@ public class FrameworkHandleTests
     {
         var tec = GetTestExecutionContext();
         tec.IsDebug = true;
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var frameworkHandle = new FrameworkHandle(
             null,

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/InProcessProxyexecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/InProcessProxyexecutionManagerTests.cs
@@ -53,10 +53,10 @@ public class InProcessProxyExecutionManagerTests
     public void StartTestRunShouldCallInitialize()
     {
         var testRunCriteria = new TestRunCriteria(new List<string> { "source.dll" }, 10);
-        var mockTestMessageEventHandler = new Mock<ITestMessageEventHandler>();
+        var mockTestMessageEventHandler = new Mock<IInternalTestMessageEventHandler>();
         _inProcessProxyExecutionManager.StartTestRun(testRunCriteria, null);
 
-        _mockExecutionManager.Verify(o => o.Initialize(Enumerable.Empty<string>(), It.IsAny<ITestMessageEventHandler>()), Times.Once, "StartTestRun should call Initialize if not already initialized");
+        _mockExecutionManager.Verify(o => o.Initialize(Enumerable.Empty<string>(), It.IsAny<IInternalTestMessageEventHandler>()), Times.Once, "StartTestRun should call Initialize if not already initialized");
     }
 
     [TestMethod]
@@ -167,7 +167,7 @@ public class InProcessProxyExecutionManagerTests
     public void StartTestRunShouldCatchExceptionAndCallHandleRunComplete()
     {
         var testRunCriteria = new TestRunCriteria(new List<string> { "source.dll" }, 10);
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
         var manualResetEvent = new ManualResetEvent(true);
 
         _mockExecutionManager.Setup(o => o.StartTestRun(testRunCriteria.AdapterSourceMap, null, testRunCriteria.TestRunSettings, It.IsAny<TestExecutionContext>(), null, mockTestRunEventsHandler.Object)).Callback(
@@ -186,10 +186,10 @@ public class InProcessProxyExecutionManagerTests
     {
         var manualResetEvent = new ManualResetEvent(true);
 
-        _mockExecutionManager.Setup(o => o.Abort(It.IsAny<ITestRunEventsHandler>())).Callback(
+        _mockExecutionManager.Setup(o => o.Abort(It.IsAny<IInternalTestRunEventsHandler>())).Callback(
             () => manualResetEvent.Set());
 
-        _inProcessProxyExecutionManager.Abort(It.IsAny<ITestRunEventsHandler>());
+        _inProcessProxyExecutionManager.Abort(It.IsAny<IInternalTestRunEventsHandler>());
 
         Assert.IsTrue(manualResetEvent.WaitOne(5000), "IExecutionManager.Abort should get called");
     }
@@ -199,10 +199,10 @@ public class InProcessProxyExecutionManagerTests
     {
         var manualResetEvent = new ManualResetEvent(true);
 
-        _mockExecutionManager.Setup(o => o.Cancel(It.IsAny<ITestRunEventsHandler>())).Callback(
+        _mockExecutionManager.Setup(o => o.Cancel(It.IsAny<IInternalTestRunEventsHandler>())).Callback(
             () => manualResetEvent.Set());
 
-        _inProcessProxyExecutionManager.Cancel(It.IsAny<ITestRunEventsHandler>());
+        _inProcessProxyExecutionManager.Cancel(It.IsAny<IInternalTestRunEventsHandler>());
 
         Assert.IsTrue(manualResetEvent.WaitOne(5000), "IExecutionManager.Abort should get called");
     }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelProxyExecutionManagerTests.cs
@@ -32,7 +32,7 @@ public class ParallelProxyExecutionManagerTests
 
     private readonly List<Mock<IProxyExecutionManager>> _usedMockManagers;
     private readonly Func<TestRuntimeProviderInfo, IProxyExecutionManager> _createMockManager;
-    private readonly Mock<ITestRunEventsHandler> _mockEventHandler;
+    private readonly Mock<IInternalTestRunEventsHandler> _mockEventHandler;
 
     private readonly List<string> _sources;
     private readonly List<string> _processedSources;
@@ -66,7 +66,7 @@ public class ParallelProxyExecutionManagerTests
             _usedMockManagers.Add(manager);
             return manager.Object;
         };
-        _mockEventHandler = new Mock<ITestRunEventsHandler>();
+        _mockEventHandler = new Mock<IInternalTestRunEventsHandler>();
 
         // Configure sources
         _sources = new List<string>() { "1.dll", "2.dll" };
@@ -115,11 +115,11 @@ public class ParallelProxyExecutionManagerTests
         var parallelExecutionManager = new ParallelProxyExecutionManager(_mockRequestData.Object, _createMockManager, parallelLevel: 1000, _runtimeProviders);
 
         // Starting parallel run will create 2 proxy managers, which we will then promptly abort.
-        parallelExecutionManager.StartTestRun(_testRunCriteriaWith2Sources, new Mock<ITestRunEventsHandler>().Object);
-        parallelExecutionManager.Abort(It.IsAny<ITestRunEventsHandler>());
+        parallelExecutionManager.StartTestRun(_testRunCriteriaWith2Sources, new Mock<IInternalTestRunEventsHandler>().Object);
+        parallelExecutionManager.Abort(It.IsAny<IInternalTestRunEventsHandler>());
 
         Assert.AreEqual(2, _usedMockManagers.Count, "Number of Concurrent Managers created should be equal to the amount of dlls that run");
-        _usedMockManagers.ForEach(em => em.Verify(m => m.Abort(It.IsAny<ITestRunEventsHandler>()), Times.Once));
+        _usedMockManagers.ForEach(em => em.Verify(m => m.Abort(It.IsAny<IInternalTestRunEventsHandler>()), Times.Once));
     }
 
     [TestMethod]
@@ -128,11 +128,11 @@ public class ParallelProxyExecutionManagerTests
         var parallelExecutionManager = new ParallelProxyExecutionManager(_mockRequestData.Object, _createMockManager, 4, _runtimeProviders);
 
         // Starting parallel run will create 2 proxy managers, which we will then promptly cancel.
-        parallelExecutionManager.StartTestRun(_testRunCriteriaWith2Sources, new Mock<ITestRunEventsHandler>().Object);
-        parallelExecutionManager.Cancel(It.IsAny<ITestRunEventsHandler>());
+        parallelExecutionManager.StartTestRun(_testRunCriteriaWith2Sources, new Mock<IInternalTestRunEventsHandler>().Object);
+        parallelExecutionManager.Cancel(It.IsAny<IInternalTestRunEventsHandler>());
 
         Assert.AreEqual(2, _usedMockManagers.Count, "Number of Concurrent Managers created should be equal to the amount of dlls that run");
-        _usedMockManagers.ForEach(em => em.Verify(m => m.Cancel(It.IsAny<ITestRunEventsHandler>()), Times.Once));
+        _usedMockManagers.ForEach(em => em.Verify(m => m.Cancel(It.IsAny<IInternalTestRunEventsHandler>()), Times.Once));
     }
 
     [TestMethod]
@@ -265,7 +265,7 @@ public class ParallelProxyExecutionManagerTests
         SetupMockManagers(_processedSources, isCanceled: false, isAborted: false);
         SetupHandleTestRunComplete(_executionCompleted);
 
-        parallelExecutionManager.Abort(It.IsAny<ITestRunEventsHandler>());
+        parallelExecutionManager.Abort(It.IsAny<IInternalTestRunEventsHandler>());
         Task.Run(() => parallelExecutionManager.StartTestRun(_testRunCriteriaWith2Sources, _mockEventHandler.Object));
 
         Assert.IsTrue(_executionCompleted.Wait(Timeout3Seconds), "Test run not completed.");
@@ -294,7 +294,7 @@ public class ParallelProxyExecutionManagerTests
         var parallelExecutionManager = SetupExecutionManager(_createMockManager, 2);
         var mockManagers = _preCreatedMockManagers.ToArray();
         mockManagers[1].Reset();
-        mockManagers[1].Setup(em => em.StartTestRun(It.IsAny<TestRunCriteria>(), It.IsAny<ITestRunEventsHandler>()))
+        mockManagers[1].Setup(em => em.StartTestRun(It.IsAny<TestRunCriteria>(), It.IsAny<IInternalTestRunEventsHandler>()))
             .Throws<NotImplementedException>();
 
         Task.Run(() => parallelExecutionManager.StartTestRun(_testRunCriteriaWith2Sources, _mockEventHandler.Object));
@@ -310,7 +310,7 @@ public class ParallelProxyExecutionManagerTests
         var parallelExecutionManager = SetupExecutionManager(_createMockManager, 2);
         var mockManagers = _preCreatedMockManagers.ToArray();
         mockManagers[1].Reset();
-        mockManagers[1].Setup(em => em.StartTestRun(It.IsAny<TestRunCriteria>(), It.IsAny<ITestRunEventsHandler>()))
+        mockManagers[1].Setup(em => em.StartTestRun(It.IsAny<TestRunCriteria>(), It.IsAny<IInternalTestRunEventsHandler>()))
             .Throws<NotImplementedException>();
 
         Task.Run(() => parallelExecutionManager.StartTestRun(_testRunCriteriaWith2Sources, _mockEventHandler.Object));
@@ -325,7 +325,7 @@ public class ParallelProxyExecutionManagerTests
         var parallelExecutionManager = SetupExecutionManager(_createMockManager, 2);
         var mockManagers = _preCreatedMockManagers.ToArray();
         mockManagers[1].Reset();
-        mockManagers[1].Setup(em => em.StartTestRun(It.IsAny<TestRunCriteria>(), It.IsAny<ITestRunEventsHandler>()))
+        mockManagers[1].Setup(em => em.StartTestRun(It.IsAny<TestRunCriteria>(), It.IsAny<IInternalTestRunEventsHandler>()))
             .Throws<NotImplementedException>();
 
         Task.Run(() => parallelExecutionManager.StartTestRun(_testRunCriteriaWith2Sources, _mockEventHandler.Object));
@@ -342,8 +342,8 @@ public class ParallelProxyExecutionManagerTests
 
         foreach (var manager in _preCreatedMockManagers)
         {
-            manager.Setup(m => m.StartTestRun(It.IsAny<TestRunCriteria>(), It.IsAny<ITestRunEventsHandler>())).
-                Callback<TestRunCriteria, ITestRunEventsHandler>(
+            manager.Setup(m => m.StartTestRun(It.IsAny<TestRunCriteria>(), It.IsAny<IInternalTestRunEventsHandler>())).
+                Callback<TestRunCriteria, IInternalTestRunEventsHandler>(
                     (criteria, handler) =>
                     {
                         lock (syncObject)
@@ -520,8 +520,8 @@ public class ParallelProxyExecutionManagerTests
         var syncObject = new object();
         foreach (var manager in _preCreatedMockManagers)
         {
-            manager.Setup(m => m.StartTestRun(It.IsAny<TestRunCriteria>(), It.IsAny<ITestRunEventsHandler>())).
-                Callback<TestRunCriteria, ITestRunEventsHandler>(
+            manager.Setup(m => m.StartTestRun(It.IsAny<TestRunCriteria>(), It.IsAny<IInternalTestRunEventsHandler>())).
+                Callback<TestRunCriteria, IInternalTestRunEventsHandler>(
                     (criteria, handler) =>
                     {
                         lock (syncObject)
@@ -555,8 +555,8 @@ public class ParallelProxyExecutionManagerTests
         var syncObject = new object();
         foreach (var manager in _preCreatedMockManagers)
         {
-            manager.Setup(m => m.StartTestRun(It.IsAny<TestRunCriteria>(), It.IsAny<ITestRunEventsHandler>())).
-                Callback<TestRunCriteria, ITestRunEventsHandler>(
+            manager.Setup(m => m.StartTestRun(It.IsAny<TestRunCriteria>(), It.IsAny<IInternalTestRunEventsHandler>())).
+                Callback<TestRunCriteria, IInternalTestRunEventsHandler>(
                     (criteria, handler) =>
                     {
                         lock (syncObject)

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelRunEventsHandlerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelRunEventsHandlerTests.cs
@@ -24,7 +24,7 @@ public class ParallelRunEventsHandlerTests
 {
     private readonly ParallelRunEventsHandler _parallelRunEventsHandler;
     private readonly Mock<IProxyExecutionManager> _mockProxyExecutionManager;
-    private readonly Mock<ITestRunEventsHandler> _mockTestRunEventsHandler;
+    private readonly Mock<IInternalTestRunEventsHandler> _mockTestRunEventsHandler;
     private readonly Mock<IParallelProxyExecutionManager> _mockParallelProxyExecutionManager;
     private readonly Mock<IDataSerializer> _mockDataSerializer;
     private readonly Mock<IRequestData> _mockRequestData;
@@ -33,7 +33,7 @@ public class ParallelRunEventsHandlerTests
     public ParallelRunEventsHandlerTests()
     {
         _mockProxyExecutionManager = new Mock<IProxyExecutionManager>();
-        _mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        _mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
         _mockParallelProxyExecutionManager = new Mock<IParallelProxyExecutionManager>();
         _mockDataSerializer = new Mock<IDataSerializer>();
         _mockRequestData = new Mock<IRequestData>();

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
@@ -507,7 +507,7 @@ public class ProxyDiscoveryManagerTests : ProxyBaseManagerTests
         var mockTestDiscoveryEventsHandler = new Mock<ITestDiscoveryEventsHandler2>();
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(true);
 
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
 
         _discoveryManager.DiscoverTests(_discoveryCriteria, mockTestDiscoveryEventsHandler.Object);
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
@@ -85,7 +85,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
         _mockTestHostManager.Setup(hm => hm.GetTestSources(_mockTestRunCriteria.Object.Sources)).Returns(_mockTestRunCriteria.Object.Sources);
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(true);
 
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
 
         _testExecutionManager.StartTestRun(_mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
 
@@ -106,7 +106,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
         _mockTestHostManager.Setup(tmh => tmh.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
         _mockTestHostManager.Setup(th => th.GetTestPlatformExtensions(It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>())).Returns(new List<string>());
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(true);
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
 
         _testExecutionManager.StartTestRun(testRunCriteria, mockTestRunEventsHandler.Object);
 
@@ -128,7 +128,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
         _mockTestHostManager.Setup(tmh => tmh.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
         _mockTestHostManager.Setup(th => th.GetTestPlatformExtensions(It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>())).Returns(new List<string>());
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(true);
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
 
         _testExecutionManager.StartTestRun(testRunCriteria, mockTestRunEventsHandler.Object);
 
@@ -144,7 +144,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
 
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
 
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
 
         _testExecutionManager.StartTestRun(_mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
 
@@ -253,11 +253,11 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
         // Make sure TestPlugincache is refreshed.
         TestPluginCache.Instance = null;
 
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
 
         _testExecutionManager.StartTestRun(_mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
 
-        _mockRequestSender.Verify(s => s.StartTestRun(It.IsAny<TestRunCriteriaWithSources>(), It.IsAny<ITestRunEventsHandler>()), Times.Never);
+        _mockRequestSender.Verify(s => s.StartTestRun(It.IsAny<TestRunCriteriaWithSources>(), It.IsAny<IInternalTestRunEventsHandler>()), Times.Never);
     }
 
     [TestMethod]
@@ -289,7 +289,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
         _mockFileHelper.Setup(fh => fh.Exists("def.TestAdapter.dll")).Returns(false);
         _mockFileHelper.Setup(fh => fh.Exists("xyz.TestAdapter.dll")).Returns(true);
 
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
         _testExecutionManager.StartTestRun(_mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
 
         _mockRequestSender.Verify(s => s.InitializeExecution(expectedOutputPaths), Times.Once);
@@ -323,7 +323,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
         _mockTestHostManager.Setup(tmh => tmh.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(false));
 
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
 
         _testExecutionManager.StartTestRun(_mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
 
@@ -350,7 +350,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
             return message;
         });
 
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
 
         _testExecutionManager.StartTestRun(_mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
 
@@ -377,7 +377,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
             return message;
         });
 
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
 
         _testExecutionManager.StartTestRun(_mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
 
@@ -390,7 +390,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
         _mockTestHostManager.Setup(tmh => tmh.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(false));
 
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
 
         _testExecutionManager.StartTestRun(_mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
 
@@ -403,7 +403,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
         _mockTestHostManager.Setup(tmh => tmh.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(false));
 
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
 
         _testExecutionManager.StartTestRun(_mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
 
@@ -414,7 +414,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
     [TestMethod]
     public void StartTestRunForCancelRequestShouldHandleLogMessageWithProperErrorMessage()
     {
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
         _testExecutionManager.Cancel(mockTestRunEventsHandler.Object);
 
         _testExecutionManager.StartTestRun(_mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
@@ -425,7 +425,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
     [TestMethod]
     public void StartTestRunForAnExceptionDuringLaunchOfTestShouldHandleLogMessageWithProperErrorMessage()
     {
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
         _mockTestHostManager.Setup(tmh => tmh.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>())).Throws(new Exception("DummyException"));
 
         _testExecutionManager.StartTestRun(_mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
@@ -441,7 +441,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(true);
         _mockRequestSender.Setup(s => s.StartTestRun(It.IsAny<TestRunCriteriaWithSources>(), _testExecutionManager))
             .Callback(
-                (TestRunCriteriaWithSources criteria, ITestRunEventsHandler sink) => testRunCriteriaPassed = criteria);
+                (TestRunCriteriaWithSources criteria, IInternalTestRunEventsHandler sink) => testRunCriteriaPassed = criteria);
 
         _testExecutionManager.StartTestRun(_mockTestRunCriteria.Object, null);
 
@@ -461,7 +461,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(true);
         _mockRequestSender.Setup(s => s.StartTestRun(It.IsAny<TestRunCriteriaWithTests>(), _testExecutionManager))
             .Callback(
-                (TestRunCriteriaWithTests criteria, ITestRunEventsHandler sink) => testRunCriteriaPassed = criteria);
+                (TestRunCriteriaWithTests criteria, IInternalTestRunEventsHandler sink) => testRunCriteriaPassed = criteria);
         var runCriteria = new Mock<TestRunCriteria>(
             new List<TestCase> { new TestCase("A.C.M", new Uri("executor://dummy"), "source.dll") },
             10);
@@ -523,11 +523,11 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
     {
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
 
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
 
         _testExecutionManager.StartTestRun(_mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
 
-        _testExecutionManager.Cancel(It.IsAny<ITestRunEventsHandler>());
+        _testExecutionManager.Cancel(It.IsAny<IInternalTestRunEventsHandler>());
 
         _mockRequestSender.Verify(s => s.SendTestRunCancel(), Times.Never);
     }
@@ -537,11 +537,11 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
     {
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(true);
 
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
 
         _testExecutionManager.StartTestRun(_mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
 
-        _testExecutionManager.Abort(It.IsAny<ITestRunEventsHandler>());
+        _testExecutionManager.Abort(It.IsAny<IInternalTestRunEventsHandler>());
 
         _mockRequestSender.Verify(s => s.SendTestRunAbort(), Times.Once);
     }
@@ -551,11 +551,11 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
     {
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
 
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
 
         _testExecutionManager.StartTestRun(_mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
 
-        _testExecutionManager.Abort(It.IsAny<ITestRunEventsHandler>());
+        _testExecutionManager.Abort(It.IsAny<IInternalTestRunEventsHandler>());
 
         _mockRequestSender.Verify(s => s.SendTestRunAbort(), Times.Never);
     }
@@ -563,7 +563,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
     [TestMethod]
     public void ExecuteTestsCloseTestHostIfRawMessageIfOfTypeExecutionComplete()
     {
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
 
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
 
@@ -591,7 +591,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
     [TestMethod]
     public void ExecuteTestsShouldNotCloseTestHostIfRawMessageIsNotOfTypeExecutionComplete()
     {
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
 
         _mockDataSerializer.Setup(mds => mds.DeserializeMessage(It.IsAny<string>())).Returns(() =>
@@ -615,7 +615,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
     public void ExecutionManagerShouldPassOnTestRunStatsChange()
     {
         _mockFileHelper.Setup(fh => fh.Exists(It.IsAny<string>())).Returns(true);
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
         var runCriteria = new Mock<TestRunCriteria>(
             new List<TestCase> { new TestCase("A.C.M", new Uri("executor://dummy"), "source.dll") },
             10);
@@ -661,7 +661,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
     [TestMethod]
     public void ExecutionManagerShouldPassOnHandleLogMessage()
     {
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
 
         _mockDataSerializer.Setup(mds => mds.DeserializeMessage(It.IsAny<string>())).Returns(() =>
@@ -685,7 +685,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
     public void ExecutionManagerShouldPassOnLaunchProcessWithDebuggerAttached()
     {
         _mockFileHelper.Setup(fh => fh.Exists(It.IsAny<string>())).Returns(true);
-        Mock<ITestRunEventsHandler> mockTestRunEventsHandler = new();
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
         var runCriteria = new Mock<TestRunCriteria>(
             new List<TestCase> { new TestCase("A.C.M", new Uri("executor://dummy"), "source.dll") },
             10);
@@ -773,7 +773,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
             testExecutionManager.Initialize(true);
             testExecutionManager.StartTestRun(
                 _mockTestRunCriteria.Object,
-                new Mock<ITestRunEventsHandler>().Object);
+                new Mock<IInternalTestRunEventsHandler>().Object);
 
             mockTestSessionPool.Verify(
                 tsp => tsp.TryTakeProxy(

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerWithDataCollectionTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerWithDataCollectionTests.cs
@@ -69,7 +69,7 @@ public class ProxyExecutionManagerWithDataCollectionTests
     {
         _proxyExecutionManager.Initialize(false);
 
-        _mockDataCollectionManager.Verify(dc => dc.BeforeTestRunStart(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<ITestMessageEventHandler>()), Times.Once);
+        _mockDataCollectionManager.Verify(dc => dc.BeforeTestRunStart(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IInternalTestMessageEventHandler>()), Times.Once);
     }
 
     [TestMethod]
@@ -83,12 +83,12 @@ public class ProxyExecutionManagerWithDataCollectionTests
     [TestMethod]
     public void InitializeShouldCallAfterTestRunIfExceptionIsThrownWhileCreatingDataCollectionProcess()
     {
-        _mockDataCollectionManager.Setup(dc => dc.BeforeTestRunStart(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<ITestMessageEventHandler>())).Throws(new Exception("MyException"));
+        _mockDataCollectionManager.Setup(dc => dc.BeforeTestRunStart(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IInternalTestMessageEventHandler>())).Throws(new Exception("MyException"));
 
         Assert.ThrowsException<Exception>(() => _proxyExecutionManager.Initialize(false));
 
-        _mockDataCollectionManager.Verify(dc => dc.BeforeTestRunStart(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<ITestMessageEventHandler>()), Times.Once);
-        _mockDataCollectionManager.Verify(dc => dc.AfterTestRunEnd(It.IsAny<bool>(), It.IsAny<ITestMessageEventHandler>()), Times.Once);
+        _mockDataCollectionManager.Verify(dc => dc.BeforeTestRunStart(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IInternalTestMessageEventHandler>()), Times.Once);
+        _mockDataCollectionManager.Verify(dc => dc.AfterTestRunEnd(It.IsAny<bool>(), It.IsAny<IInternalTestMessageEventHandler>()), Times.Once);
     }
 
     [TestMethod]
@@ -96,7 +96,7 @@ public class ProxyExecutionManagerWithDataCollectionTests
     {
         var mockRequestSender = new Mock<IDataCollectionRequestSender>();
         var testSources = new List<string>() { "abc.dll", "efg.dll" };
-        mockRequestSender.Setup(x => x.SendBeforeTestRunStartAndGetResult(string.Empty, testSources, It.IsAny<bool>(), It.IsAny<ITestMessageEventHandler>())).Throws(new Exception("MyException"));
+        mockRequestSender.Setup(x => x.SendBeforeTestRunStartAndGetResult(string.Empty, testSources, It.IsAny<bool>(), It.IsAny<IInternalTestMessageEventHandler>())).Throws(new Exception("MyException"));
         mockRequestSender.Setup(x => x.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(true);
 
         var mockDataCollectionLauncher = new Mock<IDataCollectionLauncher>();
@@ -112,7 +112,7 @@ public class ProxyExecutionManagerWithDataCollectionTests
     [TestMethod]
     public void UpdateTestProcessStartInfoShouldUpdateDataCollectionPortArg()
     {
-        _mockDataCollectionManager.Setup(x => x.BeforeTestRunStart(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<ITestMessageEventHandler>())).Returns(DataCollectionParameters.CreateDefaultParameterInstance());
+        _mockDataCollectionManager.Setup(x => x.BeforeTestRunStart(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IInternalTestMessageEventHandler>())).Returns(DataCollectionParameters.CreateDefaultParameterInstance());
 
         var testProcessStartInfo = new TestProcessStartInfo();
         testProcessStartInfo.Arguments = string.Empty;
@@ -129,7 +129,7 @@ public class ProxyExecutionManagerWithDataCollectionTests
         var mockRequestData = new Mock<IRequestData>();
         _mockRequestData.Setup(rd => rd.IsTelemetryOptedIn).Returns(true);
 
-        _mockDataCollectionManager.Setup(x => x.BeforeTestRunStart(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<ITestMessageEventHandler>())).Returns(DataCollectionParameters.CreateDefaultParameterInstance());
+        _mockDataCollectionManager.Setup(x => x.BeforeTestRunStart(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IInternalTestMessageEventHandler>())).Returns(DataCollectionParameters.CreateDefaultParameterInstance());
 
         var testProcessStartInfo = new TestProcessStartInfo();
         testProcessStartInfo.Arguments = string.Empty;
@@ -149,7 +149,7 @@ public class ProxyExecutionManagerWithDataCollectionTests
         var mockRequestData = new Mock<IRequestData>();
         _mockRequestData.Setup(rd => rd.IsTelemetryOptedIn).Returns(false);
 
-        _mockDataCollectionManager.Setup(x => x.BeforeTestRunStart(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<ITestMessageEventHandler>())).Returns(DataCollectionParameters.CreateDefaultParameterInstance());
+        _mockDataCollectionManager.Setup(x => x.BeforeTestRunStart(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IInternalTestMessageEventHandler>())).Returns(DataCollectionParameters.CreateDefaultParameterInstance());
 
         var testProcessStartInfo = new TestProcessStartInfo();
         testProcessStartInfo.Arguments = string.Empty;
@@ -167,7 +167,7 @@ public class ProxyExecutionManagerWithDataCollectionTests
     public void LaunchProcessWithDebuggerAttachedShouldUpdateEnvironmentVariables()
     {
         // Setup
-        var mockRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
         TestProcessStartInfo launchedStartInfo = null;
         mockRunEventsHandler.Setup(runHandler => runHandler.LaunchProcessWithDebuggerAttached(It.IsAny<TestProcessStartInfo>())).Callback
             ((TestProcessStartInfo startInfo) => launchedStartInfo = startInfo);

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/DataCollectionTestRunEventsHandlerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/DataCollectionTestRunEventsHandlerTests.cs
@@ -23,14 +23,14 @@ namespace Microsoft.TestPlatform.CrossPlatEngine.UnitTests.DataCollection;
 [TestClass]
 public class DataCollectionTestRunEventsHandlerTests
 {
-    private readonly Mock<ITestRunEventsHandler> _baseTestRunEventsHandler;
+    private readonly Mock<IInternalTestRunEventsHandler> _baseTestRunEventsHandler;
     private DataCollectionTestRunEventsHandler _testRunEventHandler;
     private readonly Mock<IProxyDataCollectionManager> _proxyDataCollectionManager;
     private readonly Mock<IDataSerializer> _mockDataSerializer;
 
     public DataCollectionTestRunEventsHandlerTests()
     {
-        _baseTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        _baseTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
         _proxyDataCollectionManager = new Mock<IProxyDataCollectionManager>();
         _mockDataSerializer = new Mock<IDataSerializer>();
         _testRunEventHandler = new DataCollectionTestRunEventsHandler(_baseTestRunEventsHandler.Object, _proxyDataCollectionManager.Object, _mockDataSerializer.Object, CancellationToken.None);
@@ -62,7 +62,7 @@ public class DataCollectionTestRunEventsHandlerTests
 
         _testRunEventHandler.HandleRawMessage(string.Empty);
         _proxyDataCollectionManager.Verify(
-            dcm => dcm.AfterTestRunEnd(false, It.IsAny<ITestRunEventsHandler>()),
+            dcm => dcm.AfterTestRunEnd(false, It.IsAny<IInternalTestRunEventsHandler>()),
             Times.Once);
     }
 
@@ -81,7 +81,7 @@ public class DataCollectionTestRunEventsHandlerTests
         _testRunEventHandler.HandleRawMessage(string.Empty);
 
         _proxyDataCollectionManager.Verify(
-            dcm => dcm.AfterTestRunEnd(false, It.IsAny<ITestRunEventsHandler>()),
+            dcm => dcm.AfterTestRunEnd(false, It.IsAny<IInternalTestRunEventsHandler>()),
             Times.Once);
     }
 
@@ -101,7 +101,7 @@ public class DataCollectionTestRunEventsHandlerTests
         _testRunEventHandler.HandleRawMessage(string.Empty);
 
         _proxyDataCollectionManager.Verify(
-            dcm => dcm.AfterTestRunEnd(true, It.IsAny<ITestRunEventsHandler>()),
+            dcm => dcm.AfterTestRunEnd(true, It.IsAny<IInternalTestRunEventsHandler>()),
             Times.Once);
     }
 
@@ -117,7 +117,7 @@ public class DataCollectionTestRunEventsHandlerTests
         _mockDataSerializer.Setup(x => x.DeserializeMessage(It.IsAny<string>())).Returns(new Message() { MessageType = MessageType.ExecutionComplete });
         _mockDataSerializer.Setup(x => x.DeserializePayload<TestRunCompletePayload>(It.IsAny<Message>()))
             .Returns(new TestRunCompletePayload() { TestRunCompleteArgs = testRunCompleteEventArgs });
-        _proxyDataCollectionManager.Setup(p => p.AfterTestRunEnd(It.IsAny<bool>(), It.IsAny<ITestMessageEventHandler>()))
+        _proxyDataCollectionManager.Setup(p => p.AfterTestRunEnd(It.IsAny<bool>(), It.IsAny<IInternalTestMessageEventHandler>()))
             .Returns(new DataCollectionResult(null, invokedDataCollectors));
         _mockDataSerializer.Setup(r => r.SerializePayload(It.IsAny<string>(), It.IsAny<object>())).Callback((string message, object o) =>
         {
@@ -134,7 +134,7 @@ public class DataCollectionTestRunEventsHandlerTests
         Assert.AreEqual(invokedDataCollectors[0], testRunCompleteEventArgs2.InvokedDataCollectors[0]);
 
         _proxyDataCollectionManager.Verify(
-            dcm => dcm.AfterTestRunEnd(false, It.IsAny<ITestRunEventsHandler>()),
+            dcm => dcm.AfterTestRunEnd(false, It.IsAny<IInternalTestRunEventsHandler>()),
             Times.Once);
     }
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ParallelDataCollectionEventsHandlerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ParallelDataCollectionEventsHandlerTests.cs
@@ -29,7 +29,7 @@ public class ParallelDataCollectionEventsHandlerTests
 
     private readonly Mock<IRequestData> _mockRequestData;
     private readonly Mock<IProxyExecutionManager> _mockProxyExecutionManager;
-    private readonly Mock<ITestRunEventsHandler> _mockTestRunEventsHandler;
+    private readonly Mock<IInternalTestRunEventsHandler> _mockTestRunEventsHandler;
     private readonly Mock<IParallelProxyExecutionManager> _mockParallelProxyExecutionManager;
     private readonly Mock<ITestRunAttachmentsProcessingManager> _mockTestRunAttachmentsProcessingManager;
     private readonly CancellationTokenSource _cancellationTokenSource;
@@ -40,7 +40,7 @@ public class ParallelDataCollectionEventsHandlerTests
         _mockRequestData = new Mock<IRequestData>();
         _mockRequestData.Setup(r => r.ProtocolConfig).Returns(new ProtocolConfig());
         _mockProxyExecutionManager = new Mock<IProxyExecutionManager>();
-        _mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        _mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
         _mockParallelProxyExecutionManager = new Mock<IParallelProxyExecutionManager>();
         _mockTestRunAttachmentsProcessingManager = new Mock<ITestRunAttachmentsProcessingManager>();
         _cancellationTokenSource = new CancellationTokenSource();

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
@@ -155,14 +155,14 @@ public class ProxyDataCollectionManagerTests
         _mockRequestData.Setup(r => r.IsTelemetryOptedIn).Returns(true);
 
         BeforeTestRunStartResult res = new(new Dictionary<string, string>(), 123);
-        _mockDataCollectionRequestSender.Setup(x => x.SendBeforeTestRunStartAndGetResult(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<ITestMessageEventHandler>())).Returns(res);
+        _mockDataCollectionRequestSender.Setup(x => x.SendBeforeTestRunStartAndGetResult(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<IInternalTestMessageEventHandler>())).Returns(res);
 
         var result = _proxyDataCollectionManager.BeforeTestRunStart(true, true, null);
 
         var extensionsFolderPath = Path.Combine(Path.GetDirectoryName(typeof(ITestPlatform).GetTypeInfo().Assembly.Location)!, "Extensions");
         var expectedSettingsXml = $"<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><RunConfiguration><TestAdaptersPaths>{extensionsFolderPath}</TestAdaptersPaths></RunConfiguration></RunSettings>";
         _mockDataCollectionRequestSender.Verify(
-            x => x.SendBeforeTestRunStartAndGetResult(expectedSettingsXml, sourceList, true, It.IsAny<ITestMessageEventHandler>()), Times.Once);
+            x => x.SendBeforeTestRunStartAndGetResult(expectedSettingsXml, sourceList, true, It.IsAny<IInternalTestMessageEventHandler>()), Times.Once);
     }
 
     [TestMethod]
@@ -170,12 +170,12 @@ public class ProxyDataCollectionManagerTests
     {
         BeforeTestRunStartResult res = new(new Dictionary<string, string>(), 123);
         var sourceList = new List<string>() { "testsource1.dll" };
-        _mockDataCollectionRequestSender.Setup(x => x.SendBeforeTestRunStartAndGetResult(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<ITestMessageEventHandler>())).Returns(res);
+        _mockDataCollectionRequestSender.Setup(x => x.SendBeforeTestRunStartAndGetResult(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<IInternalTestMessageEventHandler>())).Returns(res);
 
         var result = _proxyDataCollectionManager.BeforeTestRunStart(true, true, null);
 
         _mockDataCollectionRequestSender.Verify(
-            x => x.SendBeforeTestRunStartAndGetResult(It.IsAny<string>(), sourceList, false, It.IsAny<ITestMessageEventHandler>()), Times.Once);
+            x => x.SendBeforeTestRunStartAndGetResult(It.IsAny<string>(), sourceList, false, It.IsAny<IInternalTestMessageEventHandler>()), Times.Once);
         Assert.IsNotNull(result);
         Assert.AreEqual(res.DataCollectionEventsPort, result.DataCollectionEventsPort);
         Assert.AreEqual(res.EnvironmentVariables.Count, result.EnvironmentVariables.Count);
@@ -184,9 +184,9 @@ public class ProxyDataCollectionManagerTests
     [TestMethod]
     public void BeforeTestRunStartsShouldInvokeRunEventsHandlerIfExceptionIsThrown()
     {
-        var mockRunEventsHandler = new Mock<ITestMessageEventHandler>();
+        var mockRunEventsHandler = new Mock<IInternalTestMessageEventHandler>();
         _mockDataCollectionRequestSender.Setup(
-                x => x.SendBeforeTestRunStartAndGetResult(It.IsAny<string>(), new List<string>() { "testsource1.dll" }, false, It.IsAny<ITestMessageEventHandler>()))
+                x => x.SendBeforeTestRunStartAndGetResult(It.IsAny<string>(), new List<string>() { "testsource1.dll" }, false, It.IsAny<IInternalTestMessageEventHandler>()))
             .Throws<Exception>();
 
         var result = _proxyDataCollectionManager.BeforeTestRunStart(true, true, mockRunEventsHandler.Object);
@@ -204,12 +204,12 @@ public class ProxyDataCollectionManagerTests
         _proxyDataCollectionManager = new ProxyDataCollectionManager(_mockRequestData.Object, string.Empty, testSources, _mockDataCollectionRequestSender.Object, _mockProcessHelper.Object, _mockDataCollectionLauncher.Object);
 
         BeforeTestRunStartResult res = new(new Dictionary<string, string>(), 123);
-        _mockDataCollectionRequestSender.Setup(x => x.SendBeforeTestRunStartAndGetResult(string.Empty, testSources, It.IsAny<bool>(), It.IsAny<ITestMessageEventHandler>())).Returns(res);
+        _mockDataCollectionRequestSender.Setup(x => x.SendBeforeTestRunStartAndGetResult(string.Empty, testSources, It.IsAny<bool>(), It.IsAny<IInternalTestMessageEventHandler>())).Returns(res);
 
         var result = _proxyDataCollectionManager.BeforeTestRunStart(true, true, null);
 
         _mockDataCollectionRequestSender.Verify(
-            x => x.SendBeforeTestRunStartAndGetResult(string.Empty, testSources, false, It.IsAny<ITestMessageEventHandler>()), Times.Once);
+            x => x.SendBeforeTestRunStartAndGetResult(string.Empty, testSources, false, It.IsAny<IInternalTestMessageEventHandler>()), Times.Once);
         Assert.IsNotNull(result);
         Assert.AreEqual(res.DataCollectionEventsPort, result.DataCollectionEventsPort);
         Assert.AreEqual(res.EnvironmentVariables.Count, result.EnvironmentVariables.Count);
@@ -233,7 +233,7 @@ public class ProxyDataCollectionManagerTests
             {"key", "value"}
         };
 
-        _mockDataCollectionRequestSender.Setup(x => x.SendAfterTestRunEndAndGetResult(It.IsAny<ITestRunEventsHandler>(), It.IsAny<bool>())).Returns(new AfterTestRunEndResult(attachments, invokedDataCollectors, metrics));
+        _mockDataCollectionRequestSender.Setup(x => x.SendAfterTestRunEndAndGetResult(It.IsAny<IInternalTestRunEventsHandler>(), It.IsAny<bool>())).Returns(new AfterTestRunEndResult(attachments, invokedDataCollectors, metrics));
 
         var result = _proxyDataCollectionManager.AfterTestRunEnd(false, null);
 
@@ -256,9 +256,9 @@ public class ProxyDataCollectionManagerTests
     [TestMethod]
     public void AfterTestRunEndShouldInvokeRunEventsHandlerIfExceptionIsThrown()
     {
-        var mockRunEventsHandler = new Mock<ITestMessageEventHandler>();
+        var mockRunEventsHandler = new Mock<IInternalTestMessageEventHandler>();
         _mockDataCollectionRequestSender.Setup(
-                x => x.SendAfterTestRunEndAndGetResult(It.IsAny<ITestMessageEventHandler>(), It.IsAny<bool>()))
+                x => x.SendAfterTestRunEndAndGetResult(It.IsAny<IInternalTestMessageEventHandler>(), It.IsAny<bool>()))
             .Throws<Exception>();
 
         var result = _proxyDataCollectionManager.AfterTestRunEnd(false, mockRunEventsHandler.Object);

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/EventHandlers/TestRequestHandlerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/EventHandlers/TestRequestHandlerTests.cs
@@ -222,7 +222,7 @@ public class TestRequestHandlerTests
         SendMessageOnChannel(message);
         _jobQueue.Flush();
 
-        _mockExecutionManager.Verify(e => e.Initialize(It.Is<IEnumerable<string>>(paths => paths.Any(p => p.Equals("testadapter.dll"))), It.IsAny<ITestMessageEventHandler>()));
+        _mockExecutionManager.Verify(e => e.Initialize(It.Is<IEnumerable<string>>(paths => paths.Any(p => p.Equals("testadapter.dll"))), It.IsAny<IInternalTestMessageEventHandler>()));
         SendSessionEnd();
     }
 
@@ -246,7 +246,7 @@ public class TestRequestHandlerTests
                 It.Is<Dictionary<string, IEnumerable<string>>>(d => d.ContainsKey("mstestv2")), It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<TestExecutionContext>(), It.IsAny<ITestCaseEventsHandler>(),
-                It.IsAny<ITestRunEventsHandler>()));
+                It.IsAny<IInternalTestRunEventsHandler>()));
         SendSessionEnd();
     }
 
@@ -271,7 +271,7 @@ public class TestRequestHandlerTests
                     tcs.Any(t => t.FullyQualifiedName.Equals("N.C.M2"))), It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<TestExecutionContext>(), It.IsAny<ITestCaseEventsHandler>(),
-                It.IsAny<ITestRunEventsHandler>()));
+                It.IsAny<IInternalTestRunEventsHandler>()));
         SendSessionEnd();
     }
 
@@ -283,7 +283,7 @@ public class TestRequestHandlerTests
         ProcessRequestsAsync(_mockTestHostManagerFactory.Object);
         SendMessageOnChannel(message);
 
-        _mockExecutionManager.Verify(e => e.Cancel(It.IsAny<ITestRunEventsHandler>()));
+        _mockExecutionManager.Verify(e => e.Cancel(It.IsAny<IInternalTestRunEventsHandler>()));
         SendSessionEnd();
     }
 
@@ -307,7 +307,7 @@ public class TestRequestHandlerTests
         ProcessRequestsAsync(_mockTestHostManagerFactory.Object);
         SendMessageOnChannel(message);
 
-        _mockExecutionManager.Verify(e => e.Abort(It.IsAny<ITestRunEventsHandler>()));
+        _mockExecutionManager.Verify(e => e.Abort(It.IsAny<IInternalTestRunEventsHandler>()));
         SendSessionEnd();
     }
 
@@ -322,7 +322,7 @@ public class TestRequestHandlerTests
         _mockExecutionManager.Setup(em => em.StartTestRun(It.IsAny<IEnumerable<TestCase>>(), It.IsAny<string>(),
             It.IsAny<string>(),
             It.IsAny<TestExecutionContext>(), It.IsAny<ITestCaseEventsHandler>(),
-            It.IsAny<ITestRunEventsHandler>())).Callback(() => _requestHandler.SendExecutionComplete(It.IsAny<TestRunCompleteEventArgs>(), It.IsAny<TestRunChangedEventArgs>(), It.IsAny<ICollection<AttachmentSet>>(), It.IsAny<ICollection<string>>()));
+            It.IsAny<IInternalTestRunEventsHandler>())).Callback(() => _requestHandler.SendExecutionComplete(It.IsAny<TestRunCompleteEventArgs>(), It.IsAny<TestRunChangedEventArgs>(), It.IsAny<ICollection<AttachmentSet>>(), It.IsAny<ICollection<string>>()));
 
         ProcessRequestsAsync(_mockTestHostManagerFactory.Object);
         _mockChannel.Setup(mc => mc.Send(It.Is<string>(d => d.Contains(MessageType.ExecutionComplete))))
@@ -343,7 +343,7 @@ public class TestRequestHandlerTests
                     tcs.Any(t => t.FullyQualifiedName.Equals("N.C.M2"))), It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<TestExecutionContext>(), It.IsAny<ITestCaseEventsHandler>(),
-                It.IsAny<ITestRunEventsHandler>()));
+                It.IsAny<IInternalTestRunEventsHandler>()));
         SendSessionEnd();
     }
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/BaseRunTestsTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/BaseRunTestsTests.cs
@@ -42,7 +42,7 @@ public class BaseRunTestsTests
     private const string BadBaseRunTestsExecutorUri = "executor://BadBaseRunTestsExecutor/";
 
     private readonly TestExecutionContext _testExecutionContext;
-    private readonly Mock<ITestRunEventsHandler> _mockTestRunEventsHandler;
+    private readonly Mock<IInternalTestRunEventsHandler> _mockTestRunEventsHandler;
     private readonly Mock<ITestPlatformEventSource> _mockTestPlatformEventSource;
     private readonly Mock<IRequestData> _mockRequestData;
     private readonly Mock<IMetricsCollection> _mockMetricsCollection;
@@ -69,7 +69,7 @@ public class BaseRunTestsTests
             isDebug: false,
             testCaseFilter: string.Empty,
             filterOptions: null);
-        _mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        _mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
 
         _mockTestPlatformEventSource = new Mock<ITestPlatformEventSource>();
 
@@ -921,7 +921,7 @@ public class BaseRunTestsTests
             string? runSettings,
             TestExecutionContext testExecutionContext,
             ITestCaseEventsHandler? testCaseEventsHandler,
-            ITestRunEventsHandler testRunEventsHandler,
+            IInternalTestRunEventsHandler testRunEventsHandler,
             ITestPlatformEventSource testPlatformEventSource,
             ITestEventsPublisher? testEventsPublisher,
             IThread platformThread,
@@ -962,7 +962,7 @@ public class BaseRunTestsTests
         /// <summary>
         /// Gets the test run events handler.
         /// </summary>
-        public ITestRunEventsHandler GetTestRunEventsHandler => TestRunEventsHandler;
+        public IInternalTestRunEventsHandler GetTestRunEventsHandler => TestRunEventsHandler;
 
         /// <summary>
         /// Gets the test run cache.

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/ExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/ExecutionManagerTests.cs
@@ -77,7 +77,7 @@ public class ExecutionManagerTests
     public void InitializeShouldLoadAndInitializeAllExtensions()
     {
         var commonAssemblyLocation = typeof(ExecutionManagerTests).GetTypeInfo().Assembly.Location;
-        var mockTestMessageEventHandler = new Mock<ITestMessageEventHandler>();
+        var mockTestMessageEventHandler = new Mock<IInternalTestMessageEventHandler>();
         TestPluginCacheHelper.SetupMockExtensions(
             new string[] { commonAssemblyLocation },
             () => { });
@@ -154,7 +154,7 @@ public class ExecutionManagerTests
             { assemblyLocation, new List<string> { assemblyLocation } }
         };
 
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var isExecutorCalled = false;
         RunTestWithSourcesExecutor.RunTestsWithSourcesCallback = (s, rc, fh) =>
@@ -192,7 +192,7 @@ public class ExecutionManagerTests
             new TestCase("A.C.M1", new Uri(RunTestsWithSourcesTestsExecutorUri), assemblyLocation)
         };
 
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var isExecutorCalled = false;
         RunTestWithSourcesExecutor.RunTestsWithTestsCallback = (s, rc, fh) =>
@@ -225,7 +225,7 @@ public class ExecutionManagerTests
     [TestMethod]
     public void StartTestRunShouldAbortTheRunIfAnyExceptionComesForTheProvidedTests()
     {
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
 
         // Call StartTestRun with faulty runsettings so that it will throw exception
         _executionManager.StartTestRun(new List<TestCase>(), null, @"<RunSettings><RunConfiguration><TestSessionTimeout>-1</TestSessionTimeout></RunConfiguration></RunSettings>", _testExecutionContext, null, mockTestRunEventsHandler.Object);
@@ -238,7 +238,7 @@ public class ExecutionManagerTests
     [TestMethod]
     public void StartTestRunShouldAbortTheRunIfAnyExceptionComesForTheProvidedSources()
     {
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
 
         // Call StartTestRun with faulty runsettings so that it will throw exception
         _executionManager.StartTestRun(new Dictionary<string, IEnumerable<string>>(), null, @"<RunSettings><RunConfiguration><TestSessionTimeout>-1</TestSessionTimeout></RunConfiguration></RunSettings>", _testExecutionContext, null, mockTestRunEventsHandler.Object);
@@ -269,7 +269,7 @@ public class ExecutionManagerTests
     [TestMethod]
     public void InitializeShouldVerifyTheHandlerInitializationWhenAdapterIsFailedToLoad()
     {
-        var mockLogger = new Mock<ITestMessageEventHandler>();
+        var mockLogger = new Mock<IInternalTestMessageEventHandler>();
 
         //when handler instance is null
         _sessionLogger.SendMessage(It.IsAny<TestMessageLevel>(), "verify that the HandleLogMessage method will not be invoked when handler is not initialized");

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/RunTestsWithSourcesTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/RunTestsWithSourcesTests.cs
@@ -30,7 +30,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution;
 public class RunTestsWithSourcesTests
 {
     private readonly TestExecutionContext _testExecutionContext;
-    private readonly Mock<ITestRunEventsHandler> _mockTestRunEventsHandler;
+    private readonly Mock<IInternalTestRunEventsHandler> _mockTestRunEventsHandler;
     private TestableRunTestsWithSources? _runTestsInstance;
     private readonly Mock<IRequestData> _mockRequestData;
     private readonly Mock<IMetricsCollection> _mockMetricsCollection;
@@ -50,7 +50,7 @@ public class RunTestsWithSourcesTests
             isDebug: false,
             testCaseFilter: null,
             filterOptions: null);
-        _mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        _mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
         _mockMetricsCollection = new Mock<IMetricsCollection>();
         _mockRequestData = new Mock<IRequestData>();
         _mockRequestData.Setup(rd => rd.MetricsCollection).Returns(_mockMetricsCollection.Object);
@@ -338,7 +338,7 @@ public class RunTestsWithSourcesTests
     private class TestableRunTestsWithSources : RunTestsWithSources
     {
         public TestableRunTestsWithSources(Dictionary<string, IEnumerable<string>> adapterSourceMap, string? runSettings,
-            TestExecutionContext testExecutionContext, ITestCaseEventsHandler? testCaseEventsHandler, ITestRunEventsHandler testRunEventsHandler,
+            TestExecutionContext testExecutionContext, ITestCaseEventsHandler? testCaseEventsHandler, IInternalTestRunEventsHandler testRunEventsHandler,
             IRequestData requestData)
             : base(requestData, adapterSourceMap, null, runSettings, testExecutionContext, testCaseEventsHandler, testRunEventsHandler)
         {
@@ -346,7 +346,7 @@ public class RunTestsWithSourcesTests
 
         internal TestableRunTestsWithSources(Dictionary<string, IEnumerable<string>> adapterSourceMap, string? runSettings,
             TestExecutionContext testExecutionContext,
-            ITestCaseEventsHandler? testCaseEventsHandler, ITestRunEventsHandler testRunEventsHandler, Dictionary<Tuple<Uri, string>,
+            ITestCaseEventsHandler? testCaseEventsHandler, IInternalTestRunEventsHandler testRunEventsHandler, Dictionary<Tuple<Uri, string>,
             IEnumerable<string>> executorUriVsSourceList, IRequestData requestData)
             : base(requestData, adapterSourceMap, null, runSettings, testExecutionContext, testCaseEventsHandler, testRunEventsHandler,
                   executorUriVsSourceList)

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/RunTestsWithTestsTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/RunTestsWithTestsTests.cs
@@ -25,7 +25,7 @@ namespace TestPlatform.CrossPlatEngine.UnitTests.Execution;
 public class RunTestsWithTestsTests
 {
     private readonly TestExecutionContext _testExecutionContext;
-    private readonly Mock<ITestRunEventsHandler> _mockTestRunEventsHandler;
+    private readonly Mock<IInternalTestRunEventsHandler> _mockTestRunEventsHandler;
     private TestableRunTestsWithTests? _runTestsInstance;
     private readonly Mock<IRequestData> _mockRequestData;
     private readonly Mock<IMetricsCollection> _mockMetricsCollection;
@@ -46,7 +46,7 @@ public class RunTestsWithTestsTests
             isDebug: false,
             testCaseFilter: null,
             filterOptions: null);
-        _mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        _mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
     }
 
     [TestMethod]
@@ -192,7 +192,7 @@ public class RunTestsWithTestsTests
     {
         public TestableRunTestsWithTests(IEnumerable<TestCase> testCases,
             string? runSettings, TestExecutionContext testExecutionContext,
-            ITestCaseEventsHandler? testCaseEventsHandler, ITestRunEventsHandler testRunEventsHandler,
+            ITestCaseEventsHandler? testCaseEventsHandler, IInternalTestRunEventsHandler testRunEventsHandler,
             IRequestData requestData)
             : base(requestData, testCases, null, runSettings, testExecutionContext, testCaseEventsHandler, testRunEventsHandler)
         {
@@ -200,7 +200,7 @@ public class RunTestsWithTestsTests
 
 
         internal TestableRunTestsWithTests(IEnumerable<TestCase> testCases, string? runSettings, TestExecutionContext testExecutionContext,
-            ITestCaseEventsHandler? testCaseEventsHandler, ITestRunEventsHandler testRunEventsHandler, Dictionary<Tuple<Uri, string>,
+            ITestCaseEventsHandler? testCaseEventsHandler, IInternalTestRunEventsHandler testRunEventsHandler, Dictionary<Tuple<Uri, string>,
                 List<TestCase>> executorUriVsTestList, IRequestData requestData)
             : base(
                 requestData, testCases, null, runSettings, testExecutionContext,

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestableImplementations/TestableRuntimeProvider.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestableImplementations/TestableRuntimeProvider.cs
@@ -41,7 +41,7 @@ public class TestableRuntimeProvider : ITestRuntimeProvider
         return true;
     }
 
-    public void SetCustomLauncher(ITestHostLauncher customLauncher)
+    public void SetCustomLauncher(IInternalTestHostLauncher customLauncher)
     {
     }
 

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -372,7 +372,7 @@ public class DefaultTestHostManagerTests
     [TestMethod]
     public void LaunchTestHostShouldUseCustomHostIfSet()
     {
-        var mockCustomLauncher = new Mock<ITestHostLauncher>();
+        var mockCustomLauncher = new Mock<IInternalTestHostLauncher>();
         _testHostManager.SetCustomLauncher(mockCustomLauncher.Object);
         var currentProcess = Process.GetCurrentProcess();
         mockCustomLauncher.Setup(mc => mc.LaunchTestHost(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>())).Returns(currentProcess.Id);
@@ -390,7 +390,7 @@ public class DefaultTestHostManagerTests
     [TestMethod]
     public void LaunchTestHostShouldSetExitCallbackInCaseCustomHost()
     {
-        var mockCustomLauncher = new Mock<ITestHostLauncher>();
+        var mockCustomLauncher = new Mock<IInternalTestHostLauncher>();
         _testHostManager.SetCustomLauncher(mockCustomLauncher.Object);
         var currentProcess = Process.GetCurrentProcess();
         mockCustomLauncher.Setup(mc => mc.LaunchTestHost(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>())).Returns(currentProcess.Id);

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -34,7 +34,7 @@ public class DotnetTestHostManagerTests
 {
     private const string DefaultDotnetPath = "c:\\tmp\\dotnet.exe";
 
-    private readonly Mock<ITestHostLauncher> _mockTestHostLauncher;
+    private readonly Mock<IInternalTestHostLauncher> _mockTestHostLauncher;
     private readonly Mock<IProcessHelper> _mockProcessHelper;
     private readonly Mock<IFileHelper> _mockFileHelper;
     private readonly Mock<IWindowsRegistryHelper> _mockWindowsRegistry;
@@ -56,7 +56,7 @@ public class DotnetTestHostManagerTests
 
     public DotnetTestHostManagerTests()
     {
-        _mockTestHostLauncher = new Mock<ITestHostLauncher>();
+        _mockTestHostLauncher = new Mock<IInternalTestHostLauncher>();
         _mockProcessHelper = new Mock<IProcessHelper>();
         _mockFileHelper = new Mock<IFileHelper>();
         _mockMessageLogger = new Mock<IMessageLogger>();

--- a/test/TranslationLayer.UnitTests/TestSessionTests.cs
+++ b/test/TranslationLayer.UnitTests/TestSessionTests.cs
@@ -122,7 +122,7 @@ public class TestSessionTests
     [TestMethod]
     public void RunTestsWithSourcesShouldCallConsoleWrapperRunTestsWithCorrectArguments1()
     {
-        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
 
         _testSession.RunTests(
             _testSources,
@@ -143,7 +143,7 @@ public class TestSessionTests
     public void RunTestsWithSourcesShouldCallConsoleWrapperRunTestsWithCorrectArguments2()
     {
         var testPlatformOptions = new TestPlatformOptions();
-        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
 
         _testSession.RunTests(
             _testSources,
@@ -164,7 +164,7 @@ public class TestSessionTests
     [TestMethod]
     public void RunTestsWithTestCasesShouldCallConsoleWrapperRunTestsWithCorrectArguments1()
     {
-        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
 
         _testSession.RunTests(
             _testCases,
@@ -185,7 +185,7 @@ public class TestSessionTests
     public void RunTestsWithTestCasesShouldCallConsoleWrapperRunTestsWithCorrectArguments2()
     {
         var testPlatformOptions = new TestPlatformOptions();
-        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
 
         _testSession.RunTests(
             _testCases,
@@ -206,7 +206,7 @@ public class TestSessionTests
     [TestMethod]
     public void RunTestsWithSourcesAndCustomTesthostShouldCallConsoleWrapperRunTestsWithCorrectArguments1()
     {
-        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
         var mockTestHostLauncher = new Mock<ITestHostLauncher>();
 
         _testSession.RunTestsWithCustomTestHost(
@@ -230,7 +230,7 @@ public class TestSessionTests
     public void RunTestsWithSourcesAndCustomTesthostShouldCallConsoleWrapperRunTestsWithCorrectArguments2()
     {
         var testPlatformOptions = new TestPlatformOptions();
-        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
         var mockTestHostLauncher = new Mock<ITestHostLauncher>();
 
         _testSession.RunTestsWithCustomTestHost(
@@ -254,7 +254,7 @@ public class TestSessionTests
     [TestMethod]
     public void RunTestsWithTestCasesAndCustomTesthostShouldCallConsoleWrapperRunTestsWithCorrectArguments1()
     {
-        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
         var mockTestHostLauncher = new Mock<ITestHostLauncher>();
 
         _testSession.RunTestsWithCustomTestHost(
@@ -278,7 +278,7 @@ public class TestSessionTests
     public void RunTestsWithTestCasesAndCustomTesthostShouldCallConsoleWrapperRunTestsWithCorrectArguments2()
     {
         var testPlatformOptions = new TestPlatformOptions();
-        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
         var mockTestHostLauncher = new Mock<ITestHostLauncher>();
 
         _testSession.RunTestsWithCustomTestHost(
@@ -390,7 +390,7 @@ public class TestSessionTests
     [TestMethod]
     public async Task RunTestsAsyncWithSourcesShouldCallConsoleWrapperRunTestsWithCorrectArguments1()
     {
-        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
 
         await _testSession.RunTestsAsync(
                 _testSources,
@@ -412,7 +412,7 @@ public class TestSessionTests
     public async Task RunTestsAsyncWithSourcesShouldCallConsoleWrapperRunTestsWithCorrectArguments2()
     {
         var testPlatformOptions = new TestPlatformOptions();
-        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
 
         await _testSession.RunTestsAsync(
                 _testSources,
@@ -434,7 +434,7 @@ public class TestSessionTests
     [TestMethod]
     public async Task RunTestsAsyncWithTestCasesShouldCallConsoleWrapperRunTestsWithCorrectArguments1()
     {
-        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
 
         await _testSession.RunTestsAsync(
                 _testCases,
@@ -456,7 +456,7 @@ public class TestSessionTests
     public async Task RunTestsAsyncWithTestCasesShouldCallConsoleWrapperRunTestsWithCorrectArguments2()
     {
         var testPlatformOptions = new TestPlatformOptions();
-        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
 
         await _testSession.RunTestsAsync(
                 _testCases,
@@ -478,7 +478,7 @@ public class TestSessionTests
     [TestMethod]
     public async Task RunTestsAsyncWithSourcesAndCustomTesthostShouldCallConsoleWrapperRunTestsWithCorrectArguments1()
     {
-        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
         var mockTestHostLauncher = new Mock<ITestHostLauncher>();
 
         await _testSession.RunTestsWithCustomTestHostAsync(
@@ -503,7 +503,7 @@ public class TestSessionTests
     public async Task RunTestsAsyncWithSourcesAndCustomTesthostShouldCallConsoleWrapperRunTestsWithCorrectArguments2()
     {
         var testPlatformOptions = new TestPlatformOptions();
-        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
         var mockTestHostLauncher = new Mock<ITestHostLauncher>();
 
         await _testSession.RunTestsWithCustomTestHostAsync(
@@ -528,7 +528,7 @@ public class TestSessionTests
     [TestMethod]
     public async Task RunTestsAsyncWithTestCasesAndCustomTesthostShouldCallConsoleWrapperRunTestsWithCorrectArguments1()
     {
-        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
         var mockTestHostLauncher = new Mock<ITestHostLauncher>();
 
         await _testSession.RunTestsWithCustomTestHostAsync(
@@ -553,7 +553,7 @@ public class TestSessionTests
     public async Task RunTestsAsyncWithTestCasesAndCustomTesthostShouldCallConsoleWrapperRunTestsWithCorrectArguments2()
     {
         var testPlatformOptions = new TestPlatformOptions();
-        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
         var mockTestHostLauncher = new Mock<ITestHostLauncher>();
 
         await _testSession.RunTestsWithCustomTestHostAsync(

--- a/test/TranslationLayer.UnitTests/TestSessionTests.cs
+++ b/test/TranslationLayer.UnitTests/TestSessionTests.cs
@@ -122,7 +122,7 @@ public class TestSessionTests
     [TestMethod]
     public void RunTestsWithSourcesShouldCallConsoleWrapperRunTestsWithCorrectArguments1()
     {
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
 
         _testSession.RunTests(
             _testSources,
@@ -143,7 +143,7 @@ public class TestSessionTests
     public void RunTestsWithSourcesShouldCallConsoleWrapperRunTestsWithCorrectArguments2()
     {
         var testPlatformOptions = new TestPlatformOptions();
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
 
         _testSession.RunTests(
             _testSources,
@@ -164,7 +164,7 @@ public class TestSessionTests
     [TestMethod]
     public void RunTestsWithTestCasesShouldCallConsoleWrapperRunTestsWithCorrectArguments1()
     {
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
 
         _testSession.RunTests(
             _testCases,
@@ -185,7 +185,7 @@ public class TestSessionTests
     public void RunTestsWithTestCasesShouldCallConsoleWrapperRunTestsWithCorrectArguments2()
     {
         var testPlatformOptions = new TestPlatformOptions();
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
 
         _testSession.RunTests(
             _testCases,
@@ -206,7 +206,7 @@ public class TestSessionTests
     [TestMethod]
     public void RunTestsWithSourcesAndCustomTesthostShouldCallConsoleWrapperRunTestsWithCorrectArguments1()
     {
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
         var mockTestHostLauncher = new Mock<ITestHostLauncher>();
 
         _testSession.RunTestsWithCustomTestHost(
@@ -230,7 +230,7 @@ public class TestSessionTests
     public void RunTestsWithSourcesAndCustomTesthostShouldCallConsoleWrapperRunTestsWithCorrectArguments2()
     {
         var testPlatformOptions = new TestPlatformOptions();
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
         var mockTestHostLauncher = new Mock<ITestHostLauncher>();
 
         _testSession.RunTestsWithCustomTestHost(
@@ -254,7 +254,7 @@ public class TestSessionTests
     [TestMethod]
     public void RunTestsWithTestCasesAndCustomTesthostShouldCallConsoleWrapperRunTestsWithCorrectArguments1()
     {
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
         var mockTestHostLauncher = new Mock<ITestHostLauncher>();
 
         _testSession.RunTestsWithCustomTestHost(
@@ -278,7 +278,7 @@ public class TestSessionTests
     public void RunTestsWithTestCasesAndCustomTesthostShouldCallConsoleWrapperRunTestsWithCorrectArguments2()
     {
         var testPlatformOptions = new TestPlatformOptions();
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
         var mockTestHostLauncher = new Mock<ITestHostLauncher>();
 
         _testSession.RunTestsWithCustomTestHost(
@@ -390,7 +390,7 @@ public class TestSessionTests
     [TestMethod]
     public async Task RunTestsAsyncWithSourcesShouldCallConsoleWrapperRunTestsWithCorrectArguments1()
     {
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
 
         await _testSession.RunTestsAsync(
                 _testSources,
@@ -412,7 +412,7 @@ public class TestSessionTests
     public async Task RunTestsAsyncWithSourcesShouldCallConsoleWrapperRunTestsWithCorrectArguments2()
     {
         var testPlatformOptions = new TestPlatformOptions();
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
 
         await _testSession.RunTestsAsync(
                 _testSources,
@@ -434,7 +434,7 @@ public class TestSessionTests
     [TestMethod]
     public async Task RunTestsAsyncWithTestCasesShouldCallConsoleWrapperRunTestsWithCorrectArguments1()
     {
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
 
         await _testSession.RunTestsAsync(
                 _testCases,
@@ -456,7 +456,7 @@ public class TestSessionTests
     public async Task RunTestsAsyncWithTestCasesShouldCallConsoleWrapperRunTestsWithCorrectArguments2()
     {
         var testPlatformOptions = new TestPlatformOptions();
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
 
         await _testSession.RunTestsAsync(
                 _testCases,
@@ -478,7 +478,7 @@ public class TestSessionTests
     [TestMethod]
     public async Task RunTestsAsyncWithSourcesAndCustomTesthostShouldCallConsoleWrapperRunTestsWithCorrectArguments1()
     {
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
         var mockTestHostLauncher = new Mock<ITestHostLauncher>();
 
         await _testSession.RunTestsWithCustomTestHostAsync(
@@ -503,7 +503,7 @@ public class TestSessionTests
     public async Task RunTestsAsyncWithSourcesAndCustomTesthostShouldCallConsoleWrapperRunTestsWithCorrectArguments2()
     {
         var testPlatformOptions = new TestPlatformOptions();
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
         var mockTestHostLauncher = new Mock<ITestHostLauncher>();
 
         await _testSession.RunTestsWithCustomTestHostAsync(
@@ -528,7 +528,7 @@ public class TestSessionTests
     [TestMethod]
     public async Task RunTestsAsyncWithTestCasesAndCustomTesthostShouldCallConsoleWrapperRunTestsWithCorrectArguments1()
     {
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
         var mockTestHostLauncher = new Mock<ITestHostLauncher>();
 
         await _testSession.RunTestsWithCustomTestHostAsync(
@@ -553,7 +553,7 @@ public class TestSessionTests
     public async Task RunTestsAsyncWithTestCasesAndCustomTesthostShouldCallConsoleWrapperRunTestsWithCorrectArguments2()
     {
         var testPlatformOptions = new TestPlatformOptions();
-        var mockTestRunEventsHandler = new Mock<ITestRunEventsHandler>();
+        var mockTestRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
         var mockTestHostLauncher = new Mock<ITestHostLauncher>();
 
         await _testSession.RunTestsWithCustomTestHostAsync(

--- a/test/TranslationLayer.UnitTests/VsTestConsoleRequestSenderTests.cs
+++ b/test/TranslationLayer.UnitTests/VsTestConsoleRequestSenderTests.cs
@@ -804,7 +804,7 @@ public class VsTestConsoleRequestSenderTests
     {
         InitializeCommunication();
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         var dummyCompleteArgs = new TestRunCompleteEventArgs(null, false, false, null, null, null, TimeSpan.FromMilliseconds(1));
         var dummyLastRunArgs = new TestRunChangedEventArgs(null, null, null);
@@ -833,7 +833,7 @@ public class VsTestConsoleRequestSenderTests
     {
         await InitializeCommunicationAsync();
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         var dummyCompleteArgs = new TestRunCompleteEventArgs(null, false, false, null, null, null, TimeSpan.FromMilliseconds(1));
         var dummyLastRunArgs = new TestRunChangedEventArgs(null, null, null);
@@ -862,7 +862,7 @@ public class VsTestConsoleRequestSenderTests
     {
         InitializeCommunication();
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -914,7 +914,7 @@ public class VsTestConsoleRequestSenderTests
     {
         await InitializeCommunicationAsync();
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -968,7 +968,7 @@ public class VsTestConsoleRequestSenderTests
         var sources = new List<string>() { "1.dll" };
         TestRunRequestPayload? receivedRequest = null;
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         SetupMockCommunicationForRunRequest();
         _mockCommunicationManager.Setup(cm => cm.SendMessage(MessageType.TestRunAllSourcesWithDefaultHost, It.IsAny<TestRunRequestPayload>(), It.IsAny<int>())).
@@ -991,7 +991,7 @@ public class VsTestConsoleRequestSenderTests
         var filter = "GivingCampaign";
         TestRunRequestPayload? receivedRequest = null;
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         SetupMockCommunicationForRunRequest();
         _mockCommunicationManager.Setup(cm => cm.SendMessage(MessageType.TestRunAllSourcesWithDefaultHost, It.IsAny<TestRunRequestPayload>(), It.IsAny<int>())).
@@ -1011,7 +1011,7 @@ public class VsTestConsoleRequestSenderTests
     {
         InitializeCommunication();
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -1072,7 +1072,7 @@ public class VsTestConsoleRequestSenderTests
     {
         await InitializeCommunicationAsync();
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -1133,7 +1133,7 @@ public class VsTestConsoleRequestSenderTests
     {
         InitializeCommunication();
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -1182,7 +1182,7 @@ public class VsTestConsoleRequestSenderTests
     {
         await InitializeCommunicationAsync();
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -1233,7 +1233,7 @@ public class VsTestConsoleRequestSenderTests
         var sources = new List<string>() { "1.dll" };
         TestRunRequestPayload? receivedRequest = null;
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         SetupMockCommunicationForRunRequest();
         _mockCommunicationManager.Setup(cm => cm.SendMessage(MessageType.GetTestRunnerProcessStartInfoForRunAll, It.IsAny<TestRunRequestPayload>(), It.IsAny<int>())).
@@ -1256,7 +1256,7 @@ public class VsTestConsoleRequestSenderTests
         var filter = "GivingCampaign";
         TestRunRequestPayload? receivedRequest = null;
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         SetupMockCommunicationForRunRequest();
         _mockCommunicationManager.Setup(cm => cm.SendMessage(MessageType.GetTestRunnerProcessStartInfoForRunAll, It.IsAny<TestRunRequestPayload>(), It.IsAny<int>())).
@@ -1276,7 +1276,7 @@ public class VsTestConsoleRequestSenderTests
     {
         InitializeCommunication();
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
         var dummyCompleteArgs = new TestRunCompleteEventArgs(null, false, false, null, null, null, TimeSpan.FromMilliseconds(1));
         var dummyLastRunArgs = new TestRunChangedEventArgs(null, null, null);
 
@@ -1303,7 +1303,7 @@ public class VsTestConsoleRequestSenderTests
     {
         await InitializeCommunicationAsync();
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
         var dummyCompleteArgs = new TestRunCompleteEventArgs(null, false, false, null, null, null, TimeSpan.FromMilliseconds(1));
         var dummyLastRunArgs = new TestRunChangedEventArgs(null, null, null);
 
@@ -1330,7 +1330,7 @@ public class VsTestConsoleRequestSenderTests
     {
         InitializeCommunication();
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -1381,7 +1381,7 @@ public class VsTestConsoleRequestSenderTests
     {
         await InitializeCommunicationAsync();
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -1432,7 +1432,7 @@ public class VsTestConsoleRequestSenderTests
     {
         InitializeCommunication();
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         testCase.Traits.Add(new Trait("a", "b"));
@@ -1485,7 +1485,7 @@ public class VsTestConsoleRequestSenderTests
     {
         await InitializeCommunicationAsync();
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         testCase.Traits.Add(new Trait("a", "b"));
@@ -1538,7 +1538,7 @@ public class VsTestConsoleRequestSenderTests
     {
         InitializeCommunication();
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         testCase.Traits.Add(new Trait("a", "b"));
@@ -1595,7 +1595,7 @@ public class VsTestConsoleRequestSenderTests
     {
         await InitializeCommunicationAsync();
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         testCase.Traits.Add(new Trait("a", "b"));
@@ -1652,7 +1652,7 @@ public class VsTestConsoleRequestSenderTests
     {
         InitializeCommunication();
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -1711,7 +1711,7 @@ public class VsTestConsoleRequestSenderTests
     {
         await InitializeCommunicationAsync();
 
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -1769,7 +1769,7 @@ public class VsTestConsoleRequestSenderTests
     public void StartTestRunWithCustomHostInParallelShouldCallCustomHostMultipleTimes()
     {
         var mockLauncher = new Mock<ITestHostLauncher>();
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
         IEnumerable<string> sources = new List<string> { "1.dll" };
         var p1 = new TestProcessStartInfo() { FileName = "X" };
         var p2 = new TestProcessStartInfo() { FileName = "Y" };
@@ -1808,7 +1808,7 @@ public class VsTestConsoleRequestSenderTests
     public async Task StartTestRunWithCustomHostAsyncInParallelShouldCallCustomHostMultipleTimes()
     {
         var mockLauncher = new Mock<ITestHostLauncher>();
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
         IEnumerable<string> sources = new List<string> { "1.dll" };
         var p1 = new TestProcessStartInfo() { FileName = "X" };
         var p2 = new TestProcessStartInfo() { FileName = "Y" };
@@ -1847,7 +1847,7 @@ public class VsTestConsoleRequestSenderTests
     [TestMethod]
     public void StartTestRunShouldAbortOnExceptionInSendMessage()
     {
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
         var sources = new List<string> { "1.dll" };
         var payload = new TestRunRequestPayload { Sources = sources, RunSettings = null };
         var exception = new IOException();
@@ -1864,7 +1864,7 @@ public class VsTestConsoleRequestSenderTests
     [TestMethod]
     public async Task StartTestRunAsyncShouldAbortOnExceptionInSendMessage()
     {
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
         var sources = new List<string> { "1.dll" };
         var payload = new TestRunRequestPayload { Sources = sources, RunSettings = null };
         var exception = new IOException();
@@ -1881,7 +1881,7 @@ public class VsTestConsoleRequestSenderTests
     [TestMethod]
     public void StartTestRunShouldLogErrorOnProcessExited()
     {
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
         var manualEvent = new ManualResetEvent(false);
         var sources = new List<string> { "1.dll" };
         var dummyCompleteArgs = new TestRunCompleteEventArgs(null, false, false, null, null, null, TimeSpan.FromMilliseconds(1));
@@ -1913,7 +1913,7 @@ public class VsTestConsoleRequestSenderTests
     [TestMethod]
     public async Task StartTestRunAsyncShouldLogErrorOnProcessExited()
     {
-        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
+        var mockHandler = new Mock<ITestRunEventsHandler>();
         var sources = new List<string> { "1.dll" };
         var dummyCompleteArgs = new TestRunCompleteEventArgs(null, false, false, null, null, null, TimeSpan.FromMilliseconds(1));
         var dummyLastRunArgs = new TestRunChangedEventArgs(null, null, null);

--- a/test/TranslationLayer.UnitTests/VsTestConsoleRequestSenderTests.cs
+++ b/test/TranslationLayer.UnitTests/VsTestConsoleRequestSenderTests.cs
@@ -804,7 +804,7 @@ public class VsTestConsoleRequestSenderTests
     {
         InitializeCommunication();
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var dummyCompleteArgs = new TestRunCompleteEventArgs(null, false, false, null, null, null, TimeSpan.FromMilliseconds(1));
         var dummyLastRunArgs = new TestRunChangedEventArgs(null, null, null);
@@ -833,7 +833,7 @@ public class VsTestConsoleRequestSenderTests
     {
         await InitializeCommunicationAsync();
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var dummyCompleteArgs = new TestRunCompleteEventArgs(null, false, false, null, null, null, TimeSpan.FromMilliseconds(1));
         var dummyLastRunArgs = new TestRunChangedEventArgs(null, null, null);
@@ -862,7 +862,7 @@ public class VsTestConsoleRequestSenderTests
     {
         InitializeCommunication();
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -914,7 +914,7 @@ public class VsTestConsoleRequestSenderTests
     {
         await InitializeCommunicationAsync();
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -968,7 +968,7 @@ public class VsTestConsoleRequestSenderTests
         var sources = new List<string>() { "1.dll" };
         TestRunRequestPayload? receivedRequest = null;
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         SetupMockCommunicationForRunRequest();
         _mockCommunicationManager.Setup(cm => cm.SendMessage(MessageType.TestRunAllSourcesWithDefaultHost, It.IsAny<TestRunRequestPayload>(), It.IsAny<int>())).
@@ -991,7 +991,7 @@ public class VsTestConsoleRequestSenderTests
         var filter = "GivingCampaign";
         TestRunRequestPayload? receivedRequest = null;
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         SetupMockCommunicationForRunRequest();
         _mockCommunicationManager.Setup(cm => cm.SendMessage(MessageType.TestRunAllSourcesWithDefaultHost, It.IsAny<TestRunRequestPayload>(), It.IsAny<int>())).
@@ -1011,7 +1011,7 @@ public class VsTestConsoleRequestSenderTests
     {
         InitializeCommunication();
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -1072,7 +1072,7 @@ public class VsTestConsoleRequestSenderTests
     {
         await InitializeCommunicationAsync();
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -1133,7 +1133,7 @@ public class VsTestConsoleRequestSenderTests
     {
         InitializeCommunication();
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -1182,7 +1182,7 @@ public class VsTestConsoleRequestSenderTests
     {
         await InitializeCommunicationAsync();
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -1233,7 +1233,7 @@ public class VsTestConsoleRequestSenderTests
         var sources = new List<string>() { "1.dll" };
         TestRunRequestPayload? receivedRequest = null;
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         SetupMockCommunicationForRunRequest();
         _mockCommunicationManager.Setup(cm => cm.SendMessage(MessageType.GetTestRunnerProcessStartInfoForRunAll, It.IsAny<TestRunRequestPayload>(), It.IsAny<int>())).
@@ -1256,7 +1256,7 @@ public class VsTestConsoleRequestSenderTests
         var filter = "GivingCampaign";
         TestRunRequestPayload? receivedRequest = null;
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         SetupMockCommunicationForRunRequest();
         _mockCommunicationManager.Setup(cm => cm.SendMessage(MessageType.GetTestRunnerProcessStartInfoForRunAll, It.IsAny<TestRunRequestPayload>(), It.IsAny<int>())).
@@ -1276,7 +1276,7 @@ public class VsTestConsoleRequestSenderTests
     {
         InitializeCommunication();
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
         var dummyCompleteArgs = new TestRunCompleteEventArgs(null, false, false, null, null, null, TimeSpan.FromMilliseconds(1));
         var dummyLastRunArgs = new TestRunChangedEventArgs(null, null, null);
 
@@ -1303,7 +1303,7 @@ public class VsTestConsoleRequestSenderTests
     {
         await InitializeCommunicationAsync();
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
         var dummyCompleteArgs = new TestRunCompleteEventArgs(null, false, false, null, null, null, TimeSpan.FromMilliseconds(1));
         var dummyLastRunArgs = new TestRunChangedEventArgs(null, null, null);
 
@@ -1330,7 +1330,7 @@ public class VsTestConsoleRequestSenderTests
     {
         InitializeCommunication();
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -1381,7 +1381,7 @@ public class VsTestConsoleRequestSenderTests
     {
         await InitializeCommunicationAsync();
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -1432,7 +1432,7 @@ public class VsTestConsoleRequestSenderTests
     {
         InitializeCommunication();
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         testCase.Traits.Add(new Trait("a", "b"));
@@ -1485,7 +1485,7 @@ public class VsTestConsoleRequestSenderTests
     {
         await InitializeCommunicationAsync();
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         testCase.Traits.Add(new Trait("a", "b"));
@@ -1538,7 +1538,7 @@ public class VsTestConsoleRequestSenderTests
     {
         InitializeCommunication();
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         testCase.Traits.Add(new Trait("a", "b"));
@@ -1595,7 +1595,7 @@ public class VsTestConsoleRequestSenderTests
     {
         await InitializeCommunicationAsync();
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         testCase.Traits.Add(new Trait("a", "b"));
@@ -1652,7 +1652,7 @@ public class VsTestConsoleRequestSenderTests
     {
         InitializeCommunication();
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -1711,7 +1711,7 @@ public class VsTestConsoleRequestSenderTests
     {
         await InitializeCommunicationAsync();
 
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
 
         var testCase = new TestCase("hello", new Uri("world://how"), "1.dll");
         var testResult = new TestResult(testCase);
@@ -1769,7 +1769,7 @@ public class VsTestConsoleRequestSenderTests
     public void StartTestRunWithCustomHostInParallelShouldCallCustomHostMultipleTimes()
     {
         var mockLauncher = new Mock<ITestHostLauncher>();
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
         IEnumerable<string> sources = new List<string> { "1.dll" };
         var p1 = new TestProcessStartInfo() { FileName = "X" };
         var p2 = new TestProcessStartInfo() { FileName = "Y" };
@@ -1808,7 +1808,7 @@ public class VsTestConsoleRequestSenderTests
     public async Task StartTestRunWithCustomHostAsyncInParallelShouldCallCustomHostMultipleTimes()
     {
         var mockLauncher = new Mock<ITestHostLauncher>();
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
         IEnumerable<string> sources = new List<string> { "1.dll" };
         var p1 = new TestProcessStartInfo() { FileName = "X" };
         var p2 = new TestProcessStartInfo() { FileName = "Y" };
@@ -1847,7 +1847,7 @@ public class VsTestConsoleRequestSenderTests
     [TestMethod]
     public void StartTestRunShouldAbortOnExceptionInSendMessage()
     {
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
         var sources = new List<string> { "1.dll" };
         var payload = new TestRunRequestPayload { Sources = sources, RunSettings = null };
         var exception = new IOException();
@@ -1864,7 +1864,7 @@ public class VsTestConsoleRequestSenderTests
     [TestMethod]
     public async Task StartTestRunAsyncShouldAbortOnExceptionInSendMessage()
     {
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
         var sources = new List<string> { "1.dll" };
         var payload = new TestRunRequestPayload { Sources = sources, RunSettings = null };
         var exception = new IOException();
@@ -1881,7 +1881,7 @@ public class VsTestConsoleRequestSenderTests
     [TestMethod]
     public void StartTestRunShouldLogErrorOnProcessExited()
     {
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
         var manualEvent = new ManualResetEvent(false);
         var sources = new List<string> { "1.dll" };
         var dummyCompleteArgs = new TestRunCompleteEventArgs(null, false, false, null, null, null, TimeSpan.FromMilliseconds(1));
@@ -1913,7 +1913,7 @@ public class VsTestConsoleRequestSenderTests
     [TestMethod]
     public async Task StartTestRunAsyncShouldLogErrorOnProcessExited()
     {
-        var mockHandler = new Mock<ITestRunEventsHandler>();
+        var mockHandler = new Mock<IInternalTestRunEventsHandler>();
         var sources = new List<string> { "1.dll" };
         var dummyCompleteArgs = new TestRunCompleteEventArgs(null, false, false, null, null, null, TimeSpan.FromMilliseconds(1));
         var dummyLastRunArgs = new TestRunChangedEventArgs(null, null, null);

--- a/test/datacollector.PlatformTests/CommunicationLayerIntegrationTests.cs
+++ b/test/datacollector.PlatformTests/CommunicationLayerIntegrationTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.TestPlatform.DataCollector.PlatformTests;
 public class CommunicationLayerIntegrationTests
 {
     private readonly string _defaultRunSettings = "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<RunSettings>\r\n  <DataCollectionRunSettings>\r\n    <DataCollectors >{0}</DataCollectors>\r\n  </DataCollectionRunSettings>\r\n</RunSettings>";
-    private readonly Mock<ITestMessageEventHandler> _mockTestMessageEventHandler;
+    private readonly Mock<IInternalTestMessageEventHandler> _mockTestMessageEventHandler;
     private readonly string _dataCollectorSettings, _runSettings;
     private readonly IDataCollectionLauncher _dataCollectionLauncher;
     private readonly IProcessHelper _processHelper;
@@ -33,7 +33,7 @@ public class CommunicationLayerIntegrationTests
 
     public CommunicationLayerIntegrationTests()
     {
-        _mockTestMessageEventHandler = new Mock<ITestMessageEventHandler>();
+        _mockTestMessageEventHandler = new Mock<IInternalTestMessageEventHandler>();
         _mockRequestData = new Mock<IRequestData>();
         _mockMetricsCollection = new Mock<IMetricsCollection>();
         _mockRequestData.Setup(rd => rd.MetricsCollection).Returns(_mockMetricsCollection.Object);

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -816,7 +816,7 @@ public class TestRequestManagerTests
         };
 
         var mockRunEventsRegistrar = new Mock<ITestRunEventsRegistrar>();
-        var mockCustomlauncher = new Mock<ITestHostLauncher>();
+        var mockCustomlauncher = new Mock<IInternalTestHostLauncher>();
 
         _testRequestManager.RunTests(payload, mockCustomlauncher.Object, mockRunEventsRegistrar.Object, _protocolConfig);
         _testRequestManager.CancelTestRun();
@@ -832,7 +832,7 @@ public class TestRequestManagerTests
         };
 
         var mockRunEventsRegistrar = new Mock<ITestRunEventsRegistrar>();
-        var mockCustomlauncher = new Mock<ITestHostLauncher>();
+        var mockCustomlauncher = new Mock<IInternalTestHostLauncher>();
 
         _testRequestManager.RunTests(payload, mockCustomlauncher.Object, mockRunEventsRegistrar.Object, _protocolConfig);
         _testRequestManager.AbortTestRun();
@@ -858,7 +858,7 @@ public class TestRequestManagerTests
         _mockTestPlatform.Setup(mt => mt.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>())).Callback(
             (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap) => actualTestRunCriteria = runCriteria).Returns(mockDiscoveryRequest.Object);
 
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
         Assert.AreEqual(15, actualTestRunCriteria!.FrequencyOfRunStatsChangeEvent);
     }
 
@@ -884,7 +884,7 @@ public class TestRequestManagerTests
         _mockAssemblyMetadataProvider.Setup(a => a.GetFrameWork(It.IsAny<string>())).Returns(new FrameworkName(Constants.DotNetFramework35));
 
         var mockRunEventsRegistrar = new Mock<ITestRunEventsRegistrar>();
-        var mockCustomlauncher = new Mock<ITestHostLauncher>();
+        var mockCustomlauncher = new Mock<IInternalTestHostLauncher>();
 
         _testRequestManager.RunTests(payload, mockCustomlauncher.Object, mockRunEventsRegistrar.Object, _protocolConfig);
 
@@ -908,7 +908,7 @@ public class TestRequestManagerTests
             (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap) => actualRequestData = requestData).Returns(mockDiscoveryRequest.Object);
 
         // Act.
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, mockProtocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, mockProtocolConfig);
 
         // Verify.
         Assert.AreEqual(6, actualRequestData!.ProtocolConfig.Version);
@@ -949,7 +949,7 @@ public class TestRequestManagerTests
         CommandLineOptions.Instance.SettingsFile = @"c://temp/.runsettings";
 
         // Act.
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, mockProtocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, mockProtocolConfig);
 
         // Verify
         Assert.IsTrue(actualRequestData!.MetricsCollection.Metrics.TryGetValue(TelemetryDataConstants.CommandLineSwitches, out var commandLineSwitches));
@@ -1008,7 +1008,7 @@ public class TestRequestManagerTests
             _mockEnvironment.Object);
 
         // Act.
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, mockProtocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, mockProtocolConfig);
 
         // Verify
         Assert.IsTrue(actualRequestData!.MetricsCollection.Metrics.TryGetValue("VS.TestRun.LegacySettings.Elements", out var legacySettingsNodes));
@@ -1056,7 +1056,7 @@ public class TestRequestManagerTests
             _mockEnvironment.Object);
 
         // Act.
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, mockProtocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, mockProtocolConfig);
 
         // Verify
         Assert.IsTrue(actualRequestData!.MetricsCollection.Metrics.TryGetValue(TelemetryDataConstants.TestSettingsUsed, out var testSettingsUsed));
@@ -1102,7 +1102,7 @@ public class TestRequestManagerTests
             _mockEnvironment.Object);
 
         // Act.
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, mockProtocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, mockProtocolConfig);
 
         // Verify
         Assert.IsTrue(actualRequestData!.MetricsCollection.Metrics.TryGetValue(TelemetryDataConstants.TargetDevice, out var targetDevice));
@@ -1135,7 +1135,7 @@ public class TestRequestManagerTests
             }).Returns(mockRunRequest.Object);
 
         var mockRunEventsRegistrar = new Mock<ITestRunEventsRegistrar>();
-        var mockCustomlauncher = new Mock<ITestHostLauncher>();
+        var mockCustomlauncher = new Mock<IInternalTestHostLauncher>();
 
         string testCaseFilterValue = "TestFilter";
         payload.TestPlatformOptions = new TestPlatformOptions { TestCaseFilter = testCaseFilterValue };
@@ -1224,7 +1224,7 @@ public class TestRequestManagerTests
             run2Stop = sw.ElapsedMilliseconds;
         });
 
-        var mockCustomlauncher = new Mock<ITestHostLauncher>();
+        var mockCustomlauncher = new Mock<IInternalTestHostLauncher>();
         var task1 = Task.Run(() => _testRequestManager.RunTests(payload1, mockCustomlauncher.Object, mockRunEventsRegistrar1.Object, _protocolConfig));
         var task2 = Task.Run(() => _testRequestManager.RunTests(payload2, mockCustomlauncher.Object, mockRunEventsRegistrar2.Object, _protocolConfig));
 
@@ -1254,7 +1254,7 @@ public class TestRequestManagerTests
         };
 
         var mockRunEventsRegistrar = new Mock<ITestRunEventsRegistrar>();
-        var mockCustomlauncher = new Mock<ITestHostLauncher>();
+        var mockCustomlauncher = new Mock<IInternalTestHostLauncher>();
 
         _testRequestManager.RunTests(payload, mockCustomlauncher.Object, mockRunEventsRegistrar.Object, _protocolConfig);
 
@@ -1359,7 +1359,7 @@ public class TestRequestManagerTests
         };
         _commandLineOptions.IsDesignMode = designModeValue;
 
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
 
         var designmode = $"<DesignMode>{designModeValue}</DesignMode>";
         _mockTestPlatform.Verify(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.Is<TestRunCriteria>(rc => rc.TestRunSettings.Contains(designmode)), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>()));
@@ -1404,7 +1404,7 @@ public class TestRequestManagerTests
         _mockTestPlatform.Setup(mt => mt.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>())).Callback(
             (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap) => actualTestRunCriteria = runCriteria).Returns(mockTestRunRequest.Object);
 
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
 
         _mockAssemblyMetadataProvider.Verify(a => a.GetArchitecture(It.IsAny<string>()));
         _mockAssemblyMetadataProvider.Verify(a => a.GetFrameWork(It.IsAny<string>()));
@@ -1441,7 +1441,7 @@ public class TestRequestManagerTests
         _mockTestPlatform.Setup(mt => mt.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>())).Callback(
             (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap) => actualTestRunCriteria = runCriteria).Returns(mockTestRunRequest.Object);
 
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
 
         // infer them so we can print warning when dlls are not compatible with runsettings
         _mockAssemblyMetadataProvider.Verify(a => a.GetArchitecture(It.IsAny<string>()), Times.Once);
@@ -1482,7 +1482,7 @@ public class TestRequestManagerTests
         _mockTestPlatform.Setup(mt => mt.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>())).Callback(
             (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap) => actualTestRunCriteria = runCriteria).Returns(mockTestRunRequest.Object);
 
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
 
         // infer platform and framework so we can print warnings when dlls are not compatible with runsettings
         _mockAssemblyMetadataProvider.Verify(a => a.GetArchitecture(It.IsAny<string>()), Times.Once);
@@ -1516,7 +1516,7 @@ public class TestRequestManagerTests
         _mockTestPlatform.Setup(mt => mt.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>())).Callback(
             (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap) => actualTestRunCriteria = runCriteria).Returns(mockTestRunRequest.Object);
 
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
 
         _mockAssemblyMetadataProvider.Verify(a => a.GetArchitecture(It.IsAny<string>()));
         _mockAssemblyMetadataProvider.Verify(a => a.GetFrameWork(It.IsAny<string>()));
@@ -1554,7 +1554,7 @@ public class TestRequestManagerTests
         _mockTestPlatform.Setup(mt => mt.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>())).Callback(
             (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap) => actualTestRunCriteria = runCriteria).Returns(mockTestRunRequest.Object);
 
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
 
         // infer them so we can print warnings when the assemblies are not compatible
         _mockAssemblyMetadataProvider.Verify(a => a.GetArchitecture(It.IsAny<string>()), Times.Once);
@@ -1596,7 +1596,7 @@ public class TestRequestManagerTests
         _mockTestPlatform.Setup(mt => mt.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>())).Callback(
             (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap) => actualTestRunCriteria = runCriteria).Returns(mockTestRunRequest.Object);
 
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
 
         _mockAssemblyMetadataProvider.Verify(a => a.GetArchitecture(It.IsAny<string>()));
         _mockAssemblyMetadataProvider.Verify(a => a.GetFrameWork(It.IsAny<string>()));
@@ -1636,7 +1636,7 @@ public class TestRequestManagerTests
 
         try
         {
-            _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
+            _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
         }
         catch (SettingsException ex)
         {
@@ -1676,7 +1676,7 @@ public class TestRequestManagerTests
 
         try
         {
-            _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
+            _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
         }
         catch (SettingsException ex)
         {
@@ -1708,7 +1708,7 @@ public class TestRequestManagerTests
         };
 
         _commandLineOptions.EnableCodeCoverage = true;
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
     }
 
     [TestMethod]
@@ -1731,7 +1731,7 @@ public class TestRequestManagerTests
         _mockTestPlatform.Setup(mt => mt.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>())).Callback(
             (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap) => actualTestRunCriteria = runCriteria).Returns(mockTestRunRequest.Object);
 
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
 
         var loggerSettingsList = XmlRunSettingsUtilities.GetLoggerRunSettings(actualTestRunCriteria!.TestRunSettings).LoggerSettingsList;
         Assert.AreEqual(1, loggerSettingsList.Count);
@@ -1769,7 +1769,7 @@ public class TestRequestManagerTests
         var mockTestRunRequest = new Mock<ITestRunRequest>();
         _mockTestPlatform.Setup(mt => mt.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>())).Callback(
             (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap) => actualTestRunCriteria = runCriteria).Returns(mockTestRunRequest.Object);
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
 
         var loggerSettingsList = XmlRunSettingsUtilities.GetLoggerRunSettings(actualTestRunCriteria!.TestRunSettings).LoggerSettingsList;
         Assert.AreEqual(2, loggerSettingsList.Count);
@@ -1843,7 +1843,7 @@ public class TestRequestManagerTests
         var mockTestRunRequest = new Mock<ITestRunRequest>();
         _mockTestPlatform.Setup(mt => mt.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>())).Callback(
             (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap) => actualTestRunCriteria = runCriteria).Returns(mockTestRunRequest.Object);
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
 
         Assert.IsFalse(actualTestRunCriteria!.TestRunSettings.Contains("LoggerRunSettings"));
     }
@@ -1941,7 +1941,7 @@ public class TestRequestManagerTests
         var mockTestRunRequest = new Mock<ITestRunRequest>();
         _mockTestPlatform.Setup(mt => mt.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>())).Callback(
             (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap) => actualTestRunCriteria = runCriteria).Returns(mockTestRunRequest.Object);
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
 
         var loggerSettingsList = XmlRunSettingsUtilities.GetLoggerRunSettings(actualTestRunCriteria!.TestRunSettings).LoggerSettingsList;
         Assert.AreEqual(2, loggerSettingsList.Count);
@@ -2042,7 +2042,7 @@ public class TestRequestManagerTests
         var mockTestRunRequest = new Mock<ITestRunRequest>();
         _mockTestPlatform.Setup(mt => mt.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>())).Callback(
             (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap) => actualTestRunCriteria = runCriteria).Returns(mockTestRunRequest.Object);
-        _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
+        _testRequestManager.RunTests(payload, new Mock<IInternalTestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
 
         var loggerSettingsList = XmlRunSettingsUtilities.GetLoggerRunSettings(actualTestRunCriteria!.TestRunSettings).LoggerSettingsList;
         Assert.AreEqual(2, loggerSettingsList.Count);
@@ -2234,7 +2234,7 @@ public class TestRequestManagerTests
                     CollectMetrics = true
                 }
             },
-            new Mock<ITestHostLauncher>().Object,
+            new Mock<IInternalTestHostLauncher>().Object,
             new Mock<ITestSessionEventsHandler>().Object,
             _protocolConfig);
     }
@@ -2277,7 +2277,7 @@ public class TestRequestManagerTests
 
         _testRequestManager.StartTestSession(
             payload,
-            new Mock<ITestHostLauncher>().Object,
+            new Mock<IInternalTestHostLauncher>().Object,
             new Mock<ITestSessionEventsHandler>().Object,
             _protocolConfig);
 
@@ -2316,7 +2316,7 @@ public class TestRequestManagerTests
         {
             _testRequestManager.StartTestSession(
                 payload,
-                new Mock<ITestHostLauncher>().Object,
+                new Mock<IInternalTestHostLauncher>().Object,
                 new Mock<ITestSessionEventsHandler>().Object,
                 _protocolConfig);
         }
@@ -2348,7 +2348,7 @@ public class TestRequestManagerTests
                     CollectMetrics = true
                 }
             },
-            new Mock<ITestHostLauncher>().Object,
+            new Mock<IInternalTestHostLauncher>().Object,
             new Mock<ITestSessionEventsHandler>().Object,
             _protocolConfig);
 
@@ -2539,7 +2539,7 @@ public class TestRequestManagerTests
         mockRunRequest.Setup(mr => mr.ExecuteAsync()).Throws(exception);
 
         var mockRunEventsRegistrar = new Mock<ITestRunEventsRegistrar>();
-        var mockCustomlauncher = new Mock<ITestHostLauncher>();
+        var mockCustomlauncher = new Mock<IInternalTestHostLauncher>();
 
         _testRequestManager.RunTests(payload, mockCustomlauncher.Object, mockRunEventsRegistrar.Object, _protocolConfig);
     }
@@ -2560,7 +2560,7 @@ public class TestRequestManagerTests
         mockDiscoveryRequest.Setup(mr => mr.DiscoverAsync()).Throws(exception);
 
         var mockDiscoveryEventsRegistrar = new Mock<ITestDiscoveryEventsRegistrar>();
-        var mockCustomlauncher = new Mock<ITestHostLauncher>();
+        var mockCustomlauncher = new Mock<IInternalTestHostLauncher>();
 
         _testRequestManager.DiscoverTests(payload, mockDiscoveryEventsRegistrar.Object, _protocolConfig);
     }


### PR DESCRIPTION
## Description
Replace the public interfaces we re-use in way too many places with internal interfaces that we can improve, and then on edges translate data. 

- [ ] Discovery
- [ ] Replace all primitive messages with messages that carry objects, so they are expandable.

## Related issue
Kindly link any related issues. E.g. Fixes #xyz.