### PR TITLE
Update framework detection logic to not rely on throwing/catching NRE

### DIFF
--- a/TestPlatform.sln
+++ b/TestPlatform.sln
@@ -189,6 +189,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "testhost.arm64", "src\testh
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DumpMinitool.arm64", "src\DataCollectors\DumpMinitool.arm64\DumpMinitool.arm64.csproj", "{62E9D32B-B989-43CF-81A2-B38B3367FCA3}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Microsoft.TestPlatform.Nullability", "src\Microsoft.TestPlatform.Nullability\Microsoft.TestPlatform.Nullability.shproj", "{9DF3BC3C-2A53-46E7-9291-40728ACE5F82}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1023,6 +1025,7 @@ Global
 		{29270853-90DC-4C39-9621-F47AE40A79B6} = {B27FAFDF-2DBA-4AB0-BA85-FD5F21D359D6}
 		{186069FE-E1E8-4DE1-BEA4-0FF1484D22D1} = {ED0C35EB-7F31-4841-A24F-8EB708FFA959}
 		{62E9D32B-B989-43CF-81A2-B38B3367FCA3} = {B705537C-B82C-4A30-AFA5-6244D9A7DAEB}
+		{9DF3BC3C-2A53-46E7-9291-40728ACE5F82} = {ED0C35EB-7F31-4841-A24F-8EB708FFA959}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0541B30C-FF51-4E28-B172-83F5F3934BCD}
@@ -1037,6 +1040,7 @@ Global
 		src\Microsoft.TestPlatform.Nullability\Microsoft.TestPlatform.Nullability.projitems*{68adc720-316e-4895-9f8e-c3ccadd262be}*SharedItemsImports = 5
 		src\Microsoft.TestPlatform.Execution.Shared\Microsoft.TestPlatform.Execution.Shared.projitems*{71cb42ff-e750-4a3b-9c3a-ac938853cc89}*SharedItemsImports = 5
 		src\Microsoft.TestPlatform.Execution.Shared\Microsoft.TestPlatform.Execution.Shared.projitems*{7f26eda3-c8c4-4b7f-a9b6-d278c2f40a13}*SharedItemsImports = 13
+		src\Microsoft.TestPlatform.Nullability\Microsoft.TestPlatform.Nullability.projitems*{9df3bc3c-2a53-46e7-9291-40728ace5f82}*SharedItemsImports = 13
 		src\Microsoft.TestPlatform.Nullability\Microsoft.TestPlatform.Nullability.projitems*{fbf74c8f-695c-4967-84ac-358eefb1376d}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -434,7 +435,7 @@ public class InferRunSettingsHelper
     public static void UpdateTargetPlatform(XmlDocument runSettingsDocument, string platform, bool overwrite = false)
         => AddNodeIfNotPresent(runSettingsDocument, TargetPlatformNodePath, TargetPlatformNodeName, platform, overwrite);
 
-    public static bool TryGetDeviceXml(XPathNavigator runSettingsNavigator, out string? deviceXml)
+    public static bool TryGetDeviceXml(XPathNavigator runSettingsNavigator, [NotNullWhen(true)] out string? deviceXml)
     {
         ValidateArg.NotNull(runSettingsNavigator, nameof(runSettingsNavigator));
 

--- a/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs
+++ b/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs
@@ -32,7 +32,7 @@ internal class AssemblyMetadataProvider : IAssemblyMetadataProvider
     }
 
     /// <inheritdoc />
-    public FrameworkName GetFrameWork(string filePath)
+    public FrameworkName GetFrameworkName(string filePath)
     {
         FrameworkName frameworkName = new(Framework.DefaultFramework.Name);
         try
@@ -42,10 +42,10 @@ internal class AssemblyMetadataProvider : IAssemblyMetadataProvider
         }
         catch (Exception ex)
         {
-            EqtTrace.Warning("AssemblyMetadataProvider.GetFrameWork: failed to determine TargetFrameworkVersion exception: {0} for assembly: {1}", ex, filePath);
+            EqtTrace.Warning("AssemblyMetadataProvider.GetFrameworkName: failed to determine TargetFrameworkVersion exception: {0} for assembly: {1}", ex, filePath);
         }
 
-        EqtTrace.Info("AssemblyMetadataProvider.GetFrameWork: Determined framework:'{0}' for source: '{1}'", frameworkName, filePath);
+        EqtTrace.Info("AssemblyMetadataProvider.GetFrameworkName: Determined framework:'{0}' for source: '{1}'", frameworkName, filePath);
 
         return frameworkName;
     }

--- a/src/vstest.console/CommandLine/Interfaces/IAssemblyMetadataProvider.cs
+++ b/src/vstest.console/CommandLine/Interfaces/IAssemblyMetadataProvider.cs
@@ -15,7 +15,7 @@ internal interface IAssemblyMetadataProvider
     /// <summary>
     /// Determines FrameworkName from filePath.
     /// </summary>
-    FrameworkName GetFrameWork(string filePath);
+    FrameworkName GetFrameworkName(string filePath);
 
     /// <summary>
     /// Determines Architecture from filePath.

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -859,12 +859,13 @@ internal class TestRequestManager : ITestRequestManager
         XPathNavigator navigator,
         XmlDocument document)
     {
-        bool updateRequired = InferRunSettingsHelper.TryGetDeviceXml(navigator, out string deviceXml);
-        if (updateRequired)
+        if (InferRunSettingsHelper.TryGetDeviceXml(navigator, out string? deviceXml))
         {
             InferRunSettingsHelper.UpdateTargetDevice(document, deviceXml);
+            return true;
         }
-        return updateRequired;
+
+        return false;
     }
 
     private bool UpdateCollectSourceInformation(

--- a/test/vstest.ProgrammerTests/Fakes/FakeAssemblyMetadataProvider.cs
+++ b/test/vstest.ProgrammerTests/Fakes/FakeAssemblyMetadataProvider.cs
@@ -26,7 +26,7 @@ internal class FakeAssemblyMetadataProvider : IAssemblyMetadataProvider
         return file.Architecture;
     }
 
-    public FrameworkName GetFrameWork(string filePath)
+    public FrameworkName GetFrameworkName(string filePath)
     {
         var file = FakeFileHelper.GetFakeFile<FakeTestDllFile>(filePath);
         return file.FrameworkName;

--- a/test/vstest.console.PlatformTests/AssemblyMetadataProviderTests.cs
+++ b/test/vstest.console.PlatformTests/AssemblyMetadataProviderTests.cs
@@ -115,7 +115,7 @@ public class AssemblyMetadataProviderTests : IntegrationTestBase
         var assemblyPath = _testEnvironment.GetTestAsset("SimpleTestProject3.dll", framework);
         LoadAssemblyIntoMemory(assemblyPath);
         var stopWatch = Stopwatch.StartNew();
-        var actualFx = _assemblyMetadataProvider.GetFrameWork(assemblyPath);
+        var actualFx = _assemblyMetadataProvider.GetFrameworkName(assemblyPath);
         stopWatch.Stop();
 
         if (framework.Equals("net451"))
@@ -142,7 +142,7 @@ public class AssemblyMetadataProviderTests : IntegrationTestBase
         var assemblyPath = $@"{_testEnvironment.PackageDirectory}\microsoft.testplatform.testasset.nativecpp\2.0.0\contentFiles\any\any\Microsoft.TestPlatform.TestAsset.NativeCPP.dll";
         LoadAssemblyIntoMemory(assemblyPath);
         var stopWatch = Stopwatch.StartNew();
-        var fx = _assemblyMetadataProvider.GetFrameWork(assemblyPath);
+        var fx = _assemblyMetadataProvider.GetFrameworkName(assemblyPath);
         stopWatch.Stop();
 
         Console.WriteLine(PerfAssertMessageFormat, expectedElapsedTime, stopWatch.ElapsedMilliseconds);

--- a/test/vstest.console.UnitTests/CommandLine/InferHelperTests.cs
+++ b/test/vstest.console.UnitTests/CommandLine/InferHelperTests.cs
@@ -222,18 +222,18 @@ public class InferHelperTests
     [TestMethod]
     public void AutoDetectFrameworkShouldReturnHighestVersionFxOnSameFxName()
     {
-        _mockAssemblyHelper.SetupSequence(sh => sh.GetFrameWork(It.IsAny<string>()))
+        _mockAssemblyHelper.SetupSequence(sh => sh.GetFrameworkName(It.IsAny<string>()))
             .Returns(new FrameworkName(_frameworkNet46.Name))
             .Returns(new FrameworkName(_frameworkNet47.Name))
             .Returns(new FrameworkName(_frameworkNet45.Name));
         Assert.AreEqual(_frameworkNet47.Name, _inferHelper.AutoDetectFramework(new List<string?>() { "net46.dll", "net47.exe", "net45.dll" }, out _).Name);
-        _mockAssemblyHelper.Verify(ah => ah.GetFrameWork(It.IsAny<string>()), Times.Exactly(3));
+        _mockAssemblyHelper.Verify(ah => ah.GetFrameworkName(It.IsAny<string>()), Times.Exactly(3));
     }
 
     [TestMethod]
     public void AutoDetectFrameworkShouldPopulatetheDictionaryForAllTheSources()
     {
-        _mockAssemblyHelper.SetupSequence(sh => sh.GetFrameWork(It.IsAny<string>()))
+        _mockAssemblyHelper.SetupSequence(sh => sh.GetFrameworkName(It.IsAny<string>()))
             .Returns(new FrameworkName(_frameworkNet46.Name))
             .Returns(new FrameworkName(_frameworkNet47.Name))
             .Returns(new FrameworkName(_frameworkNet45.Name));
@@ -244,28 +244,28 @@ public class InferHelperTests
         Assert.AreEqual(_frameworkNet46.Name, sourceFrameworks["net46.dll"].Name);
         Assert.AreEqual(_frameworkNet47.Name, sourceFrameworks["net47.exe"].Name);
         Assert.AreEqual(_frameworkNet45.Name, sourceFrameworks["net45.dll"].Name);
-        _mockAssemblyHelper.Verify(ah => ah.GetFrameWork(It.IsAny<string>()), Times.Exactly(3));
+        _mockAssemblyHelper.Verify(ah => ah.GetFrameworkName(It.IsAny<string>()), Times.Exactly(3));
     }
 
     [TestMethod]
     public void AutoDetectFrameworkShouldReturnHighestVersionFxOnEvenManyLowerVersionFxNameExists()
     {
-        _mockAssemblyHelper.SetupSequence(sh => sh.GetFrameWork(It.IsAny<string>()))
+        _mockAssemblyHelper.SetupSequence(sh => sh.GetFrameworkName(It.IsAny<string>()))
             .Returns(new FrameworkName(_frameworkCore10.Name))
             .Returns(new FrameworkName(_frameworkCore11.Name))
             .Returns(new FrameworkName(_frameworkCore10.Name));
         Assert.AreEqual(_frameworkCore11.Name, _inferHelper.AutoDetectFramework(new List<string?>() { "netcore10_1.dll", "netcore11.dll", "netcore10_2.dll" }, out _).Name);
-        _mockAssemblyHelper.Verify(ah => ah.GetFrameWork(It.IsAny<string>()), Times.Exactly(3));
+        _mockAssemblyHelper.Verify(ah => ah.GetFrameworkName(It.IsAny<string>()), Times.Exactly(3));
     }
 
     private void SetupAndValidateForSingleAssembly(string assemblyName, Framework fx, bool verify)
     {
-        _mockAssemblyHelper.Setup(sh => sh.GetFrameWork(assemblyName))
+        _mockAssemblyHelper.Setup(sh => sh.GetFrameworkName(assemblyName))
             .Returns(new FrameworkName(fx.Name));
         Assert.AreEqual(fx.Name, _inferHelper.AutoDetectFramework(new List<string?>() { assemblyName }, out _).Name);
         if (verify)
         {
-            _mockAssemblyHelper.Verify(ah => ah.GetFrameWork(assemblyName));
+            _mockAssemblyHelper.Verify(ah => ah.GetFrameworkName(assemblyName));
         }
     }
 }

--- a/test/vstest.console.UnitTests/Processors/ListFullyQualifiedTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListFullyQualifiedTestsArgumentProcessorTests.cs
@@ -80,7 +80,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
         _mockTestPlatformEventSource = new Mock<ITestPlatformEventSource>();
         _mockAssemblyMetadataProvider = new Mock<IAssemblyMetadataProvider>();
         _mockAssemblyMetadataProvider.Setup(x => x.GetArchitecture(It.IsAny<string>())).Returns(Architecture.X64);
-        _mockAssemblyMetadataProvider.Setup(x => x.GetFrameWork(It.IsAny<string>())).Returns(new FrameworkName(Constants.DotNetFramework40));
+        _mockAssemblyMetadataProvider.Setup(x => x.GetFrameworkName(It.IsAny<string>())).Returns(new FrameworkName(Constants.DotNetFramework40));
         _inferHelper = new InferHelper(_mockAssemblyMetadataProvider.Object);
         _mockProcessHelper = new Mock<IProcessHelper>();
         _mockAttachmentsProcessingManager = new Mock<ITestRunAttachmentsProcessingManager>();

--- a/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
@@ -78,7 +78,7 @@ public class ListTestsArgumentProcessorTests
         _mockTestPlatformEventSource = new Mock<ITestPlatformEventSource>();
         _mockAssemblyMetadataProvider = new Mock<IAssemblyMetadataProvider>();
         _mockAssemblyMetadataProvider.Setup(x => x.GetArchitecture(It.IsAny<string>())).Returns(Architecture.X64);
-        _mockAssemblyMetadataProvider.Setup(x => x.GetFrameWork(It.IsAny<string>())).Returns(new FrameworkName(Constants.DotNetFramework40));
+        _mockAssemblyMetadataProvider.Setup(x => x.GetFrameworkName(It.IsAny<string>())).Returns(new FrameworkName(Constants.DotNetFramework40));
         _inferHelper = new InferHelper(_mockAssemblyMetadataProvider.Object);
         _mockProcessHelper = new Mock<IProcessHelper>();
         _mockAttachmentsProcessingManager = new Mock<ITestRunAttachmentsProcessingManager>();

--- a/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
@@ -62,7 +62,7 @@ public class RunSpecificTestsArgumentProcessorTests
         _mockAssemblyMetadataProvider = new Mock<IAssemblyMetadataProvider>();
         _inferHelper = new InferHelper(_mockAssemblyMetadataProvider.Object);
         _mockAssemblyMetadataProvider.Setup(x => x.GetArchitecture(It.IsAny<string>())).Returns(Architecture.X64);
-        _mockAssemblyMetadataProvider.Setup(x => x.GetFrameWork(It.IsAny<string>())).Returns(new FrameworkName(Constants.DotNetFramework40));
+        _mockAssemblyMetadataProvider.Setup(x => x.GetFrameworkName(It.IsAny<string>())).Returns(new FrameworkName(Constants.DotNetFramework40));
         _mockFileHelper.Setup(fh => fh.Exists(_dummyTestFilePath)).Returns(true);
         _mockFileHelper.Setup(x => x.GetCurrentDirectory()).Returns("");
         _mockMetricsPublisher = new Mock<IMetricsPublisher>();

--- a/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
@@ -69,7 +69,7 @@ public class RunTestsArgumentProcessorTests
         SetupMockExtensions();
         _mockAssemblyMetadataProvider.Setup(a => a.GetArchitecture(It.IsAny<string>()))
             .Returns(Architecture.X86);
-        _mockAssemblyMetadataProvider.Setup(x => x.GetFrameWork(It.IsAny<string>())).Returns(new FrameworkName(Constants.DotNetFramework40));
+        _mockAssemblyMetadataProvider.Setup(x => x.GetFrameworkName(It.IsAny<string>())).Returns(new FrameworkName(Constants.DotNetFramework40));
         _mockProcessHelper = new Mock<IProcessHelper>();
         _mockAttachmentsProcessingManager = new Mock<ITestRunAttachmentsProcessingManager>();
         _environment = new Mock<IEnvironment>();

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -96,7 +96,7 @@ public class TestRequestManagerTests
             .Returns(_mockRunRequest.Object);
         _mockAssemblyMetadataProvider.Setup(a => a.GetArchitecture(It.IsAny<string>()))
             .Returns(Architecture.X86);
-        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameWork(It.IsAny<string>()))
+        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameworkName(It.IsAny<string>()))
             .Returns(new FrameworkName(Constants.DotNetFramework40));
         _mockProcessHelper.Setup(x => x.GetCurrentProcessId()).Returns(1234);
         _mockProcessHelper.Setup(x => x.GetProcessName(It.IsAny<int>())).Returns("dotnet.exe");
@@ -667,7 +667,7 @@ public class TestRequestManagerTests
         _commandLineOptions.IsDesignMode = true;
         _mockAssemblyMetadataProvider.Setup(a => a.GetArchitecture(It.IsAny<string>()))
             .Returns(Architecture.ARM);
-        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameWork(It.IsAny<string>()))
+        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameworkName(It.IsAny<string>()))
             .Returns(new FrameworkName(Constants.DotNetFramework46));
         DiscoveryCriteria? actualDiscoveryCriteria = null;
         var mockDiscoveryRequest = new Mock<IDiscoveryRequest>();
@@ -677,7 +677,7 @@ public class TestRequestManagerTests
         _testRequestManager.DiscoverTests(payload, new Mock<ITestDiscoveryEventsRegistrar>().Object, _protocolConfig);
 
         _mockAssemblyMetadataProvider.Verify(a => a.GetArchitecture(It.IsAny<string>()));
-        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameWork(It.IsAny<string>()));
+        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameworkName(It.IsAny<string>()));
 
         Assert.IsTrue(actualDiscoveryCriteria!.RunSettings.Contains(Constants.DotNetFramework46));
         Assert.IsTrue(actualDiscoveryCriteria.RunSettings.Contains(nameof(Architecture.ARM)));
@@ -701,7 +701,7 @@ public class TestRequestManagerTests
         _commandLineOptions.IsDesignMode = true;
         _mockAssemblyMetadataProvider.Setup(a => a.GetArchitecture(It.IsAny<string>()))
             .Returns(Architecture.X86);
-        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameWork(It.IsAny<string>()))
+        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameworkName(It.IsAny<string>()))
             .Returns(new FrameworkName(Constants.DotNetFramework451));
         DiscoveryCriteria? actualDiscoveryCriteria = null;
         var mockDiscoveryRequest = new Mock<IDiscoveryRequest>();
@@ -711,7 +711,7 @@ public class TestRequestManagerTests
         _testRequestManager.DiscoverTests(payload, new Mock<ITestDiscoveryEventsRegistrar>().Object, _protocolConfig);
 
         _mockAssemblyMetadataProvider.Verify(a => a.GetArchitecture(It.IsAny<string>()), Times.Never);
-        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameWork(It.IsAny<string>()), Times.Never);
+        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameworkName(It.IsAny<string>()), Times.Never);
 
         Assert.IsTrue(actualDiscoveryCriteria!.RunSettings.Contains(Constants.DotNetFramework46));
         Assert.IsTrue(actualDiscoveryCriteria.RunSettings.Contains(nameof(Architecture.ARM)));
@@ -733,7 +733,7 @@ public class TestRequestManagerTests
         _commandLineOptions.IsDesignMode = false;
         _mockAssemblyMetadataProvider.Setup(a => a.GetArchitecture(It.IsAny<string>()))
             .Returns(Architecture.ARM);
-        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameWork(It.IsAny<string>()))
+        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameworkName(It.IsAny<string>()))
             .Returns(new FrameworkName(Constants.DotNetFramework46));
         DiscoveryCriteria? actualDiscoveryCriteria = null;
         var mockDiscoveryRequest = new Mock<IDiscoveryRequest>();
@@ -742,7 +742,7 @@ public class TestRequestManagerTests
 
         _testRequestManager.DiscoverTests(payload, new Mock<ITestDiscoveryEventsRegistrar>().Object, _protocolConfig);
         _mockAssemblyMetadataProvider.Verify(a => a.GetArchitecture(It.IsAny<string>()));
-        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameWork(It.IsAny<string>()));
+        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameworkName(It.IsAny<string>()));
 
         Assert.IsTrue(actualDiscoveryCriteria!.RunSettings.Contains(Constants.DotNetFramework46));
         Assert.IsTrue(actualDiscoveryCriteria.RunSettings.Contains(nameof(Architecture.ARM)));
@@ -768,7 +768,7 @@ public class TestRequestManagerTests
         _commandLineOptions.TargetArchitecture = Architecture.X86;
         _mockAssemblyMetadataProvider.Setup(a => a.GetArchitecture(It.IsAny<string>()))
             .Returns(Architecture.ARM);
-        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameWork(It.IsAny<string>()))
+        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameworkName(It.IsAny<string>()))
             .Returns(new FrameworkName(Constants.DotNetFramework46));
         DiscoveryCriteria? actualDiscoveryCriteria = null;
         var mockDiscoveryRequest = new Mock<IDiscoveryRequest>();
@@ -782,7 +782,7 @@ public class TestRequestManagerTests
 
         // we infer the architecture and framework, so we can print warning when they don't match settings.
         _mockAssemblyMetadataProvider.Verify(a => a.GetArchitecture(It.IsAny<string>()), Times.Once);
-        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameWork(It.IsAny<string>()), Times.Once);
+        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameworkName(It.IsAny<string>()), Times.Once);
 
         // but we don't update the settings, to keep what user specified
         Assert.IsFalse(actualDiscoveryCriteria!.RunSettings.Contains(Constants.DotNetFramework46));
@@ -881,7 +881,7 @@ public class TestRequestManagerTests
         var mockDiscoveryRequest = new Mock<ITestRunRequest>();
         _mockTestPlatform.Setup(mt => mt.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>())).Callback(
             (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap) => actualTestRunCriteria = runCriteria).Returns(mockDiscoveryRequest.Object);
-        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameWork(It.IsAny<string>())).Returns(new FrameworkName(Constants.DotNetFramework35));
+        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameworkName(It.IsAny<string>())).Returns(new FrameworkName(Constants.DotNetFramework35));
 
         var mockRunEventsRegistrar = new Mock<ITestRunEventsRegistrar>();
         var mockCustomlauncher = new Mock<ITestHostLauncher>();
@@ -1397,7 +1397,7 @@ public class TestRequestManagerTests
         _commandLineOptions.IsDesignMode = true;
         _mockAssemblyMetadataProvider.Setup(a => a.GetArchitecture(It.IsAny<string>()))
             .Returns(Architecture.ARM);
-        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameWork(It.IsAny<string>()))
+        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameworkName(It.IsAny<string>()))
             .Returns(new FrameworkName(Constants.DotNetFramework46));
         TestRunCriteria? actualTestRunCriteria = null;
         var mockTestRunRequest = new Mock<ITestRunRequest>();
@@ -1407,7 +1407,7 @@ public class TestRequestManagerTests
         _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
 
         _mockAssemblyMetadataProvider.Verify(a => a.GetArchitecture(It.IsAny<string>()));
-        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameWork(It.IsAny<string>()));
+        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameworkName(It.IsAny<string>()));
 
         Assert.IsTrue(actualTestRunCriteria!.TestRunSettings.Contains(Constants.DotNetFramework46));
         Assert.IsTrue(actualTestRunCriteria.TestRunSettings.Contains(nameof(Architecture.ARM)));
@@ -1434,7 +1434,7 @@ public class TestRequestManagerTests
         _commandLineOptions.IsDesignMode = true;
         _mockAssemblyMetadataProvider.Setup(a => a.GetArchitecture(It.IsAny<string>()))
             .Returns(Architecture.X86);
-        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameWork(It.IsAny<string>()))
+        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameworkName(It.IsAny<string>()))
             .Returns(new FrameworkName(Constants.DotNetFramework451));
         TestRunCriteria? actualTestRunCriteria = null;
         var mockTestRunRequest = new Mock<ITestRunRequest>();
@@ -1445,7 +1445,7 @@ public class TestRequestManagerTests
 
         // infer them so we can print warning when dlls are not compatible with runsettings
         _mockAssemblyMetadataProvider.Verify(a => a.GetArchitecture(It.IsAny<string>()), Times.Once);
-        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameWork(It.IsAny<string>()), Times.Once);
+        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameworkName(It.IsAny<string>()), Times.Once);
 
         // but don't update runsettings because we want to keep what user specified
         Assert.IsTrue(actualTestRunCriteria!.TestRunSettings.Contains(Constants.DotNetFramework46));
@@ -1475,7 +1475,7 @@ public class TestRequestManagerTests
         _commandLineOptions.IsDesignMode = true;
         _mockAssemblyMetadataProvider.Setup(a => a.GetArchitecture(It.IsAny<string>()))
             .Returns(Architecture.X86);
-        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameWork(It.IsAny<string>()))
+        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameworkName(It.IsAny<string>()))
             .Returns(new FrameworkName(Constants.DotNetFramework451));
         TestRunCriteria? actualTestRunCriteria = null;
         var mockTestRunRequest = new Mock<ITestRunRequest>();
@@ -1486,7 +1486,7 @@ public class TestRequestManagerTests
 
         // infer platform and framework so we can print warnings when dlls are not compatible with runsettings
         _mockAssemblyMetadataProvider.Verify(a => a.GetArchitecture(It.IsAny<string>()), Times.Once);
-        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameWork(It.IsAny<string>()), Times.Once);
+        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameworkName(It.IsAny<string>()), Times.Once);
 
         // don't update it in runsettings to keep what user provided
         Assert.IsTrue(actualTestRunCriteria!.TestRunSettings.Contains(targetPlatform));
@@ -1509,7 +1509,7 @@ public class TestRequestManagerTests
         _commandLineOptions.IsDesignMode = false;
         _mockAssemblyMetadataProvider.Setup(a => a.GetArchitecture(It.IsAny<string>()))
             .Returns(Architecture.ARM);
-        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameWork(It.IsAny<string>()))
+        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameworkName(It.IsAny<string>()))
             .Returns(new FrameworkName(Constants.DotNetFramework46));
         TestRunCriteria? actualTestRunCriteria = null;
         var mockTestRunRequest = new Mock<ITestRunRequest>();
@@ -1519,7 +1519,7 @@ public class TestRequestManagerTests
         _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
 
         _mockAssemblyMetadataProvider.Verify(a => a.GetArchitecture(It.IsAny<string>()));
-        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameWork(It.IsAny<string>()));
+        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameworkName(It.IsAny<string>()));
 
         Assert.IsTrue(actualTestRunCriteria!.TestRunSettings.Contains(Constants.DotNetFramework46));
         Assert.IsTrue(actualTestRunCriteria.TestRunSettings.Contains(nameof(Architecture.ARM)));
@@ -1547,7 +1547,7 @@ public class TestRequestManagerTests
 
         _mockAssemblyMetadataProvider.Setup(a => a.GetArchitecture(It.IsAny<string>()))
             .Returns(Architecture.ARM);
-        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameWork(It.IsAny<string>()))
+        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameworkName(It.IsAny<string>()))
             .Returns(new FrameworkName(Constants.DotNetFramework46));
         TestRunCriteria? actualTestRunCriteria = null;
         var mockTestRunRequest = new Mock<ITestRunRequest>();
@@ -1558,7 +1558,7 @@ public class TestRequestManagerTests
 
         // infer them so we can print warnings when the assemblies are not compatible
         _mockAssemblyMetadataProvider.Verify(a => a.GetArchitecture(It.IsAny<string>()), Times.Once);
-        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameWork(It.IsAny<string>()), Times.Once);
+        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameworkName(It.IsAny<string>()), Times.Once);
 
         // but don't update them in runsettings so we keep what user specified
         Assert.IsFalse(actualTestRunCriteria!.TestRunSettings.Contains(Constants.DotNetFramework46));
@@ -1589,7 +1589,7 @@ public class TestRequestManagerTests
         _commandLineOptions.IsDesignMode = true;
         _mockAssemblyMetadataProvider.Setup(a => a.GetArchitecture(It.IsAny<string>())).Callback<string>(archSources.Add)
             .Returns(Architecture.ARM);
-        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameWork(It.IsAny<string>())).Callback<string>(fxSources.Add)
+        _mockAssemblyMetadataProvider.Setup(a => a.GetFrameworkName(It.IsAny<string>())).Callback<string>(fxSources.Add)
             .Returns(new FrameworkName(Constants.DotNetFramework46));
         TestRunCriteria? actualTestRunCriteria = null;
         var mockTestRunRequest = new Mock<ITestRunRequest>();
@@ -1599,7 +1599,7 @@ public class TestRequestManagerTests
         _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig);
 
         _mockAssemblyMetadataProvider.Verify(a => a.GetArchitecture(It.IsAny<string>()));
-        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameWork(It.IsAny<string>()));
+        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameworkName(It.IsAny<string>()));
 
         Assert.IsTrue(actualTestRunCriteria!.TestRunSettings.Contains(Constants.DotNetFramework46));
         Assert.IsTrue(actualTestRunCriteria.TestRunSettings.Contains(nameof(Architecture.ARM)));
@@ -2264,7 +2264,7 @@ public class TestRequestManagerTests
                 a => a.GetArchitecture(It.IsAny<string>()))
             .Returns(Architecture.ARM);
         _mockAssemblyMetadataProvider.Setup(
-                a => a.GetFrameWork(It.IsAny<string>()))
+                a => a.GetFrameworkName(It.IsAny<string>()))
             .Returns(new FrameworkName(Constants.DotNetFramework46));
 
         _mockTestPlatform.Setup(
@@ -2288,7 +2288,7 @@ public class TestRequestManagerTests
             _protocolConfig);
 
         _mockAssemblyMetadataProvider.Verify(a => a.GetArchitecture(It.IsAny<string>()));
-        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameWork(It.IsAny<string>()));
+        _mockAssemblyMetadataProvider.Verify(a => a.GetFrameworkName(It.IsAny<string>()));
     }
 
     [TestMethod]


### PR DESCRIPTION
## Description

Update framework detection logic to not rely on throwing/catching NRE. When running some tests locally in Debug we had `Debug.Assert` failures, in CI/release the behavior was the same as before because assert are ignored.
