### PR TITLE
[After #3716] Fix debug assert failures on some tests for parallel discovery

### DIFF
--- a/TestPlatform.sln
+++ b/TestPlatform.sln
@@ -189,6 +189,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "testhost.arm64", "src\testh
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DumpMinitool.arm64", "src\DataCollectors\DumpMinitool.arm64\DumpMinitool.arm64.csproj", "{62E9D32B-B989-43CF-81A2-B38B3367FCA3}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Microsoft.TestPlatform.Nullability", "src\Microsoft.TestPlatform.Nullability\Microsoft.TestPlatform.Nullability.shproj", "{9DF3BC3C-2A53-46E7-9291-40728ACE5F82}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1023,6 +1025,7 @@ Global
 		{29270853-90DC-4C39-9621-F47AE40A79B6} = {B27FAFDF-2DBA-4AB0-BA85-FD5F21D359D6}
 		{186069FE-E1E8-4DE1-BEA4-0FF1484D22D1} = {ED0C35EB-7F31-4841-A24F-8EB708FFA959}
 		{62E9D32B-B989-43CF-81A2-B38B3367FCA3} = {B705537C-B82C-4A30-AFA5-6244D9A7DAEB}
+		{9DF3BC3C-2A53-46E7-9291-40728ACE5F82} = {ED0C35EB-7F31-4841-A24F-8EB708FFA959}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0541B30C-FF51-4E28-B172-83F5F3934BCD}
@@ -1037,6 +1040,7 @@ Global
 		src\Microsoft.TestPlatform.Nullability\Microsoft.TestPlatform.Nullability.projitems*{68adc720-316e-4895-9f8e-c3ccadd262be}*SharedItemsImports = 5
 		src\Microsoft.TestPlatform.Execution.Shared\Microsoft.TestPlatform.Execution.Shared.projitems*{71cb42ff-e750-4a3b-9c3a-ac938853cc89}*SharedItemsImports = 5
 		src\Microsoft.TestPlatform.Execution.Shared\Microsoft.TestPlatform.Execution.Shared.projitems*{7f26eda3-c8c4-4b7f-a9b6-d278c2f40a13}*SharedItemsImports = 13
+		src\Microsoft.TestPlatform.Nullability\Microsoft.TestPlatform.Nullability.projitems*{9df3bc3c-2a53-46e7-9291-40728ace5f82}*SharedItemsImports = 13
 		src\Microsoft.TestPlatform.Nullability\Microsoft.TestPlatform.Nullability.projitems*{fbf74c8f-695c-4967-84ac-358eefb1376d}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyDiscoveryManager.cs
@@ -27,7 +27,7 @@ internal class ParallelProxyDiscoveryManager : IParallelProxyDiscoveryManager
     private readonly ParallelOperationManager<IProxyDiscoveryManager, ITestDiscoveryEventsHandler2, DiscoveryCriteria> _parallelOperationManager;
     private readonly Dictionary<string, TestRuntimeProviderInfo> _sourceToTestHostProviderMap;
     private int _discoveryCompletedClients;
-    private int _availableTestSources = -1;
+    private int _availableTestSources;
     private int _availableWorkloads;
     private bool _skipDefaultAdapters;
     private readonly IRequestData _requestData;

--- a/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -434,7 +435,7 @@ public class InferRunSettingsHelper
     public static void UpdateTargetPlatform(XmlDocument runSettingsDocument, string platform, bool overwrite = false)
         => AddNodeIfNotPresent(runSettingsDocument, TargetPlatformNodePath, TargetPlatformNodeName, platform, overwrite);
 
-    public static bool TryGetDeviceXml(XPathNavigator runSettingsNavigator, out string? deviceXml)
+    public static bool TryGetDeviceXml(XPathNavigator runSettingsNavigator, [NotNullWhen(true)] out string? deviceXml)
     {
         ValidateArg.NotNull(runSettingsNavigator, nameof(runSettingsNavigator));
 

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -859,12 +859,13 @@ internal class TestRequestManager : ITestRequestManager
         XPathNavigator navigator,
         XmlDocument document)
     {
-        bool updateRequired = InferRunSettingsHelper.TryGetDeviceXml(navigator, out string deviceXml);
-        if (updateRequired)
+        if (InferRunSettingsHelper.TryGetDeviceXml(navigator, out string? deviceXml))
         {
             InferRunSettingsHelper.UpdateTargetDevice(document, deviceXml);
+            return true;
         }
-        return updateRequired;
+
+        return false;
     }
 
     private bool UpdateCollectSourceInformation(


### PR DESCRIPTION
Not sure why we missed these cases but some tests are failing in debug mode because of some `Debug.Assert` conditions.