### PR TITLE
Get PlatformAbstractions from ObjectModel

### DIFF
--- a/scripts/verify-nupkgs.ps1
+++ b/scripts/verify-nupkgs.ps1
@@ -21,7 +21,7 @@ function Verify-Nuget-Packages($packageDirectory, $version)
         "Microsoft.TestPlatform.ObjectModel" = 238;
         "Microsoft.TestPlatform.AdapterUtilities" = 62;
         "Microsoft.TestPlatform.Portable" = 648;
-        "Microsoft.TestPlatform.TestHost" = 214;
+        "Microsoft.TestPlatform.TestHost" = 208;
         "Microsoft.TestPlatform.TranslationLayer" = 123;
         "Microsoft.TestPlatform.Internal.Uwp" = 86;
     }

--- a/src/package/nuspec/Microsoft.TestPlatform.TestHost.NetCore.props
+++ b/src/package/nuspec/Microsoft.TestPlatform.TestHost.NetCore.props
@@ -11,11 +11,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)x86\Microsoft.TestPlatform.PlatformAbstractions.dll">
-      <Link>Microsoft.TestPlatform.PlatformAbstractions.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </Content>
   </ItemGroup>
   <ItemGroup Condition=" ('$(Platform)'!= 'x86' AND '$(PlatformTarget)' != 'x86') AND '$(OS)' == 'Windows_NT'" >
     <Content Include="$(MSBuildThisFileDirectory)x64\testhost.exe">
@@ -25,18 +20,6 @@
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)x64\testhost.dll">
       <Link>testhost.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)x64\Microsoft.TestPlatform.PlatformAbstractions.dll">
-      <Link>Microsoft.TestPlatform.PlatformAbstractions.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </Content>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(OS)' != 'Windows_NT'" >
-    <Content Include="$(MSBuildThisFileDirectory)Microsoft.TestPlatform.PlatformAbstractions.dll">
-      <Link>Microsoft.TestPlatform.PlatformAbstractions.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>

--- a/src/package/nuspec/TestPlatform.TestHost.nuspec
+++ b/src/package/nuspec/TestPlatform.TestHost.nuspec
@@ -65,13 +65,10 @@
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp1.0\x86\msdia140.dll" target="lib\netcoreapp1.0\x86\" />
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp1.0\x64\msdia140.dll" target="lib\netcoreapp1.0\x64\" />
   
-    <file src="Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.TestPlatform.PlatformAbstractions.dll" target="build\netcoreapp1.0\" />
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x64\testhost.dll" target="build\netcoreapp1.0\x64\" />
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x64\testhost.exe" target="build\netcoreapp1.0\x64\" />
-    <file src="Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x64\Microsoft.TestPlatform.PlatformAbstractions.dll" target="build\netcoreapp1.0\x64\" />
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x86\testhost.x86.dll" target="build\netcoreapp1.0\x86\" />
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x86\testhost.x86.exe" target="build\netcoreapp1.0\x86\" />
-    <file src="Microsoft.TestPlatform.TestHost\netcoreapp1.0\win7-x86\Microsoft.TestPlatform.PlatformAbstractions.dll" target="build\netcoreapp1.0\x86\" />
 
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp1.0\Microsoft.TestPlatform.TestHost.props" target="build\netcoreapp1.0\" />
 
@@ -83,7 +80,6 @@
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp2.1\x86\msdia140.dll" target="lib\netcoreapp2.1\x86\" />
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp2.1\x64\msdia140.dll" target="lib\netcoreapp2.1\x64\" />
     
-    <file src="Microsoft.TestPlatform.TestHost\netcoreapp2.1\Microsoft.TestPlatform.PlatformAbstractions.dll" target="build\netcoreapp2.1\" />
     <!-- 
           We move AnyCPU version of testhost.dll, at the moment we don't have native code that needs particular architecture inside testhost.dll.
           This prevent possible issue related to override x64(testshost.dll) compilation inside Microsoft.TestPlatform.TestHost.NetCore.prop netcoreapp2.1\x64\testhost.dll to the bin folder
@@ -97,10 +93,8 @@
     -->
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp2.1\testhost.dll" target="build\netcoreapp2.1\x64\" />
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x64\testhost.exe" target="build\netcoreapp2.1\x64\" />
-    <file src="Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x64\Microsoft.TestPlatform.PlatformAbstractions.dll" target="build\netcoreapp2.1\x64\" />
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x86\testhost.x86.dll" target="build\netcoreapp2.1\x86\" />
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x86\testhost.x86.exe" target="build\netcoreapp2.1\x86\" />
-    <file src="Microsoft.TestPlatform.TestHost\netcoreapp2.1\win7-x86\Microsoft.TestPlatform.PlatformAbstractions.dll" target="build\netcoreapp2.1\x86\" />
 
     <file src="Microsoft.TestPlatform.TestHost\netcoreapp2.1\Microsoft.TestPlatform.TestHost.props" target="build\netcoreapp2.1\" />
     


### PR DESCRIPTION
Do not pick up the PlatformAbstractions.dll as Content, since they should be included through the ObjectModel package dependency