### PR TITLE
Remove missed #nullable disable on projects already handled

### DIFF
--- a/playground/MSTest1/UnitTest1.cs
+++ b/playground/MSTest1/UnitTest1.cs
@@ -3,8 +3,6 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-#nullable disable
-
 namespace MSTest1;
 
 [TestClass]

--- a/playground/TestPlatform.Playground/Program.cs
+++ b/playground/TestPlatform.Playground/Program.cs
@@ -203,10 +203,10 @@ internal class Program
             throw new NotImplementedException();
         }
 
-        private static string WriteTests(IEnumerable<TestResult> testResults)
+        private static string WriteTests(IEnumerable<TestResult>? testResults)
             => WriteTests(testResults?.Select(t => t.TestCase));
 
-        private static string WriteTests(IEnumerable<TestCase> testCases)
+        private static string WriteTests(IEnumerable<TestCase>? testCases)
             => testCases?.Any() == true
                 ? "\t" + string.Join("\n\t", testCases.Select(r => r.DisplayName))
                 : "\t<empty>";
@@ -240,7 +240,7 @@ internal class Program
 
 internal class TestSessionHandler : ITestSessionEventsHandler
 {
-    public TestSessionInfo TestSessionInfo { get; private set; }
+    public TestSessionInfo? TestSessionInfo { get; private set; }
 
     public void HandleLogMessage(TestMessageLevel level, string message)
     {

--- a/playground/TestPlatform.Playground/Program.cs
+++ b/playground/TestPlatform.Playground/Program.cs
@@ -15,8 +15,6 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
-#nullable disable
-
 namespace TestPlatform.Playground;
 
 internal class Program

--- a/scripts/build/ExternalAssemblyVersions.cs
+++ b/scripts/build/ExternalAssemblyVersions.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.TestPlatform;
 
 internal class ExternalAssemblyVersions
 {
     /// <summary>
-    /// Refers to the versions of the assemblies retrieved from the 
+    /// Refers to the versions of the assemblies retrieved from the
     /// Microsoft.QualityTools.Testing.Fakes.TestRunnerHarness package.
     /// The Package version can be found in "scripts\build\TestPlatform.Dependencies.props"
     /// </summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/TestSession/ProxyTestSessionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/TestSession/ProxyTestSessionManager.cs
@@ -67,7 +67,7 @@ public class ProxyTestSessionManager : IProxyTestSessionManager
     /// <summary>
     /// Initializes a new instance of the <see cref="ProxyTestSessionManager"/> class.
     /// </summary>
-    /// 
+    ///
     /// <param name="criteria">The test session criteria.</param>
     /// <param name="maxTesthostCount">The testhost count.</param>
     /// <param name="proxyCreator">The proxy creator.</param>
@@ -226,10 +226,10 @@ public class ProxyTestSessionManager : IProxyTestSessionManager
     /// <summary>
     /// Dequeues a proxy to be used either by discovery or execution.
     /// </summary>
-    /// 
+    ///
     /// <param name="source">The source to be associated to this proxy.</param>
     /// <param name="runSettings">The run settings.</param>
-    /// 
+    ///
     /// <returns>The dequeued proxy.</returns>
     public virtual ProxyOperationManager DequeueProxy(string source, string runSettings)
     {
@@ -272,9 +272,9 @@ public class ProxyTestSessionManager : IProxyTestSessionManager
     /// <summary>
     /// Enqueues a proxy back once discovery or executions is done with it.
     /// </summary>
-    /// 
+    ///
     /// <param name="proxyId">The id of the proxy to be re-enqueued.</param>
-    /// 
+    ///
     /// <returns>True if the operation succeeded, false otherwise.</returns>
     public virtual bool EnqueueProxy(int proxyId)
     {
@@ -430,7 +430,7 @@ internal class ProxyOperationManagerContainer
     /// <summary>
     /// Initializes a new instance of the <see cref="ProxyOperationManagerContainer"/> class.
     /// </summary>
-    /// 
+    ///
     /// <param name="proxy">The proxy.</param>
     /// <param name="available">A flag indicating if the proxy is available to do work.</param>
     public ProxyOperationManagerContainer(ProxyOperationManager proxy, bool available)

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -553,6 +553,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
 
     internal /* for testing purposes */ void ForwardDotnetRootEnvironmentVariable(TestProcessStartInfo startInfo)
     {
+        TPDebug.Assert(_targetFramework is not null, "Initialize must have been called before this method.");
         const string prefix = "VSTEST_WINAPPHOST_";
         const string dotnetRoot = "DOTNET_ROOT";
         string vstestDotnetRootEnvName = $"{prefix}{dotnetRoot}(x86)";

--- a/src/Microsoft.TestPlatform.TestHostProvider/Properties/TestExtensionTypesAttribute.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Properties/TestExtensionTypesAttribute.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.TestPlatform;
 
 /// <summary>

--- a/src/vstest.console/Internal/Interfaces/IConsoleHelper.cs
+++ b/src/vstest.console/Internal/Interfaces/IConsoleHelper.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Internal;
 
 /// <summary>

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/InProcessProxyDiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/InProcessProxyDiscoveryManagerTests.cs
@@ -17,17 +17,15 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
 
-#nullable disable
-
 namespace TestPlatform.CrossPlatEngine.UnitTests.Client;
 
 [TestClass]
 public class InProcessProxyDiscoveryManagerTests
 {
-    private Mock<ITestHostManagerFactory> _mockTestHostManagerFactory;
+    private readonly Mock<ITestHostManagerFactory> _mockTestHostManagerFactory;
     private InProcessProxyDiscoveryManager _inProcessProxyDiscoveryManager;
-    private Mock<IDiscoveryManager> _mockDiscoveryManager;
-    private Mock<ITestRuntimeProvider> _mockTestHostManager;
+    private readonly Mock<IDiscoveryManager> _mockDiscoveryManager;
+    private readonly Mock<ITestRuntimeProvider> _mockTestHostManager;
 
     public InProcessProxyDiscoveryManagerTests()
     {
@@ -36,15 +34,6 @@ public class InProcessProxyDiscoveryManagerTests
         _mockTestHostManager = new Mock<ITestRuntimeProvider>();
         _mockTestHostManagerFactory.Setup(o => o.GetDiscoveryManager()).Returns(_mockDiscoveryManager.Object);
         _inProcessProxyDiscoveryManager = new InProcessProxyDiscoveryManager(_mockTestHostManager.Object, _mockTestHostManagerFactory.Object);
-    }
-
-    [TestCleanup]
-    public void TestCleanup()
-    {
-        _mockDiscoveryManager = null;
-        _mockTestHostManagerFactory = null;
-        _inProcessProxyDiscoveryManager = null;
-        _mockTestHostManager = null;
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/InProcessProxyexecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/InProcessProxyexecutionManagerTests.cs
@@ -18,17 +18,15 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
 
-#nullable disable
-
 namespace TestPlatform.CrossPlatEngine.UnitTests.Client;
 
 [TestClass]
 public class InProcessProxyExecutionManagerTests
 {
-    private Mock<ITestHostManagerFactory> _mockTestHostManagerFactory;
+    private readonly Mock<ITestHostManagerFactory> _mockTestHostManagerFactory;
     private InProcessProxyExecutionManager _inProcessProxyExecutionManager;
-    private Mock<IExecutionManager> _mockExecutionManager;
-    private Mock<ITestRuntimeProvider> _mockTestHostManager;
+    private readonly Mock<IExecutionManager> _mockExecutionManager;
+    private readonly Mock<ITestRuntimeProvider> _mockTestHostManager;
 
     public InProcessProxyExecutionManagerTests()
     {
@@ -38,16 +36,6 @@ public class InProcessProxyExecutionManagerTests
         _mockTestHostManagerFactory.Setup(o => o.GetExecutionManager()).Returns(_mockExecutionManager.Object);
         _inProcessProxyExecutionManager = new InProcessProxyExecutionManager(_mockTestHostManager.Object, _mockTestHostManagerFactory.Object);
     }
-
-    [TestCleanup]
-    public void TestCleanup()
-    {
-        _mockExecutionManager = null;
-        _mockTestHostManagerFactory = null;
-        _inProcessProxyExecutionManager = null;
-        _mockTestHostManager = null;
-    }
-
 
     [TestMethod]
     public void StartTestRunShouldCallInitialize()
@@ -138,7 +126,7 @@ public class InProcessProxyExecutionManagerTests
         Assert.IsTrue(manualResetEvent.WaitOne(5000), "IExecutionManager.StartTestRun should get called");
         _mockExecutionManager.Verify(o => o.StartTestRun(testRunCriteria.Tests, inputSource.FirstOrDefault(), testRunCriteria.TestRunSettings, It.IsAny<TestExecutionContext>(), null, null));
         _mockTestHostManager.Verify(hm => hm.GetTestSources(inputSource), Times.Once);
-        Assert.AreEqual(actualSources.FirstOrDefault(), testRunCriteria.Tests.FirstOrDefault().Source);
+        Assert.AreEqual(actualSources.FirstOrDefault(), testRunCriteria.Tests.FirstOrDefault()?.Source);
     }
 
     [TestMethod]
@@ -160,7 +148,7 @@ public class InProcessProxyExecutionManagerTests
         Assert.IsTrue(manualResetEvent.WaitOne(5000), "IExecutionManager.StartTestRun should get called");
         _mockExecutionManager.Verify(o => o.StartTestRun(testRunCriteria.Tests, null, testRunCriteria.TestRunSettings, It.IsAny<TestExecutionContext>(), null, null));
         _mockTestHostManager.Verify(hm => hm.GetTestSources(actualSources));
-        Assert.AreEqual(actualSources.FirstOrDefault(), testRunCriteria.Tests.FirstOrDefault().Source);
+        Assert.AreEqual(actualSources.FirstOrDefault(), testRunCriteria.Tests.FirstOrDefault()?.Source);
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyBaseManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyBaseManagerTests.cs
@@ -19,23 +19,24 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
 
-#nullable disable
-
 namespace TestPlatform.CrossPlatEngine.UnitTests.Client;
 
 [TestClass]
 public class ProxyBaseManagerTests
 {
     private const int Clientprocessexitwait = 10 * 1000;
-    private Mock<ICommunicationEndPoint> _mockCommunicationEndpoint;
-    private ITestRequestSender _testRequestSender;
-    readonly ProtocolConfig _protocolConfig = new() { Version = 2 };
+    private readonly ProtocolConfig _protocolConfig = new() { Version = 2 };
     private readonly Mock<IRequestData> _mockRequestData;
-    protected readonly Mock<ITestRuntimeProvider> _mockTestHostManager;
-    protected Mock<IDataSerializer> _mockDataSerializer;
-    protected Mock<ICommunicationChannel> _mockChannel;
     private readonly Mock<IFileHelper> _mockFileHelper;
     private readonly DiscoveryDataAggregator _discoveryDataAggregator;
+
+    protected readonly Mock<ITestRuntimeProvider> _mockTestHostManager;
+
+    private Mock<ICommunicationEndPoint>? _mockCommunicationEndpoint;
+    private ITestRequestSender? _testRequestSender;
+
+    protected Mock<IDataSerializer> _mockDataSerializer;
+    protected Mock<ICommunicationChannel> _mockChannel;
 
     public ProxyBaseManagerTests()
     {

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
@@ -26,21 +26,15 @@ using Moq;
 
 using CrossPlatEngineResources = Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources;
 
-#nullable disable
-
 namespace TestPlatform.CrossPlatEngine.UnitTests.Client;
 
 [TestClass]
 public class ProxyExecutionManagerTests : ProxyBaseManagerTests
 {
     private readonly Mock<ITestRequestSender> _mockRequestSender;
-
     private readonly Mock<TestRunCriteria> _mockTestRunCriteria;
-
     private readonly Mock<IRequestData> _mockRequestData;
-
     private readonly Mock<IMetricsCollection> _mockMetricsCollection;
-
     private readonly Mock<IFileHelper> _mockFileHelper;
 
     private ProxyExecutionManager _testExecutionManager;
@@ -111,7 +105,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
         _testExecutionManager.StartTestRun(testRunCriteria, mockTestRunEventsHandler.Object);
 
         _mockTestHostManager.Verify(hm => hm.GetTestSources(inputSource), Times.Once);
-        Assert.AreEqual(actualSources.FirstOrDefault(), testRunCriteria.Tests.FirstOrDefault().Source);
+        Assert.AreEqual(actualSources.FirstOrDefault(), testRunCriteria.Tests.FirstOrDefault()?.Source);
     }
 
     [TestMethod]
@@ -133,7 +127,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
         _testExecutionManager.StartTestRun(testRunCriteria, mockTestRunEventsHandler.Object);
 
         _mockTestHostManager.Verify(hm => hm.GetTestSources(inputSource), Times.Once);
-        Assert.AreEqual(actualSources.FirstOrDefault(), testRunCriteria.Tests.FirstOrDefault().Source);
+        Assert.AreEqual(actualSources.FirstOrDefault(), testRunCriteria.Tests.FirstOrDefault()?.Source);
     }
 
     [TestMethod]
@@ -277,7 +271,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
     public void StartTestRunShouldInitializeExtensionsWithExistingExtensionsOnly()
     {
         TestPluginCache.Instance = null;
-        TestPluginCache.Instance.UpdateExtensions(new List<string> { "abc.TestAdapter.dll", "def.TestAdapter.dll", "xyz.TestAdapter.dll" }, false);
+        TestPluginCache.Instance!.UpdateExtensions(new List<string> { "abc.TestAdapter.dll", "def.TestAdapter.dll", "xyz.TestAdapter.dll" }, false);
         var expectedOutputPaths = new[] { "abc.TestAdapter.dll", "xyz.TestAdapter.dll" };
 
         _mockTestHostManager.SetupGet(th => th.Shared).Returns(false);
@@ -436,7 +430,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
     [TestMethod]
     public void StartTestRunShouldInitiateTestRunForSourcesThroughTheServer()
     {
-        TestRunCriteriaWithSources testRunCriteriaPassed = null;
+        TestRunCriteriaWithSources? testRunCriteriaPassed = null;
         _mockFileHelper.Setup(fh => fh.Exists(It.IsAny<string>())).Returns(true);
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(true);
         _mockRequestSender.Setup(s => s.StartTestRun(It.IsAny<TestRunCriteriaWithSources>(), _testExecutionManager))
@@ -456,7 +450,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
     [TestMethod]
     public void StartTestRunShouldInitiateTestRunForTestsThroughTheServer()
     {
-        TestRunCriteriaWithTests testRunCriteriaPassed = null;
+        TestRunCriteriaWithTests? testRunCriteriaPassed = null;
         _mockFileHelper.Setup(fh => fh.Exists(It.IsAny<string>())).Returns(true);
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(true);
         _mockRequestSender.Setup(s => s.StartTestRun(It.IsAny<TestRunCriteriaWithTests>(), _testExecutionManager))
@@ -801,7 +795,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
     private void InvokeAndVerifyStartTestRun(bool skipDefaultAdapters)
     {
         TestPluginCache.Instance = null;
-        TestPluginCache.Instance.DefaultExtensionPaths = new List<string> { "default1.dll", "default2.dll" };
+        TestPluginCache.Instance!.DefaultExtensionPaths = new List<string> { "default1.dll", "default2.dll" };
         TestPluginCache.Instance.UpdateExtensions(new List<string> { "filterTestAdapter.dll" }, false);
         TestPluginCache.Instance.UpdateExtensions(new List<string> { "unfilter.dll" }, true);
 
@@ -822,40 +816,4 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
             TestPluginCache.Instance = null;
         }
     }
-
-    //private void SetupReceiveRawMessageAsyncAndDeserializeMessageAndInitialize()
-    //{
-    //    var connectionInfo = new TestHostConnectionInfo
-    //    {
-    //        Endpoint = IPAddress.Loopback + ":0",
-    //        Role = ConnectionRole.Client,
-    //        Transport = Transport.Sockets
-    //    };
-    //    this.mockCommunicationEndpoint = new Mock<ICommunicationEndPoint>();
-    //    this.mockDataSerializer = new Mock<IDataSerializer>();
-    //    this.testRequestSender = new TestRequestSender(this.mockCommunicationEndpoint.Object, connectionInfo, this.mockDataSerializer.Object, this.protocolConfig, CLIENTPROCESSEXITWAIT);
-    //    this.mockCommunicationEndpoint.Setup(mc => mc.Start(connectionInfo.Endpoint)).Returns(connectionInfo.Endpoint).Callback(() =>
-    //    {
-    //        this.mockCommunicationEndpoint.Raise(
-    //            s => s.Connected += null,
-    //            this.mockCommunicationEndpoint.Object,
-    //            new ConnectedEventArgs(this.mockChannel.Object));
-    //    });
-    //    this.SetupChannelMessage(MessageType.VersionCheck, MessageType.VersionCheck, this.protocolConfig.Version);
-
-    //    this.testRequestSender.InitializeCommunication();
-
-    //    this.testExecutionManager = new ProxyExecutionManager(this.mockRequestData.Object, this.testRequestSender, this.mockTestHostManager.Object, this.mockDataSerializer.Object, this.clientConnectionTimeout);
-    //}
-
-    //private void SetupChannelMessage<TPayload>(string messageType, string returnMessageType, TPayload returnPayload)
-    //{
-    //    this.mockChannel.Setup(mc => mc.Send(It.Is<string>(s => s.Contains(messageType))))
-    //                    .Callback(() => this.mockChannel.Raise(c => c.MessageReceived += null, this.mockChannel.Object, new MessageReceivedEventArgs { Data = messageType }));
-
-    //    this.mockDataSerializer.Setup(ds => ds.SerializePayload(It.Is<string>(s => s.Equals(messageType)), It.IsAny<object>())).Returns(messageType);
-    //    this.mockDataSerializer.Setup(ds => ds.SerializePayload(It.Is<string>(s => s.Equals(messageType)), It.IsAny<object>(), It.IsAny<int>())).Returns(messageType);
-    //    this.mockDataSerializer.Setup(ds => ds.DeserializeMessage(It.Is<string>(s => s.Equals(messageType)))).Returns(new Message { MessageType = returnMessageType });
-    //    this.mockDataSerializer.Setup(ds => ds.DeserializePayload<TPayload>(It.Is<Message>(m => m.MessageType.Equals(messageType)))).Returns(returnPayload);
-    //}
 }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerWithDataCollectionTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerWithDataCollectionTests.cs
@@ -21,35 +21,23 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
 
-#nullable disable
-
 namespace TestPlatform.CrossPlatEngine.UnitTests.Client;
 
 [TestClass]
 public class ProxyExecutionManagerWithDataCollectionTests
 {
-    private ProxyExecutionManager _testExecutionManager;
+    private readonly ProxyExecutionManager _testExecutionManager;
+    private readonly Mock<ITestRuntimeProvider> _mockTestHostManager;
+    private readonly Mock<ITestRequestSender> _mockRequestSender;
+    private readonly Mock<IProxyDataCollectionManager> _mockDataCollectionManager;
+    private readonly Mock<IProcessHelper> _mockProcessHelper;
+    private readonly ProxyExecutionManagerWithDataCollection _proxyExecutionManager;
+    private readonly Mock<IDataSerializer> _mockDataSerializer;
+    private readonly Mock<IRequestData> _mockRequestData;
+    private readonly Mock<IMetricsCollection> _mockMetricsCollection;
+    private readonly Mock<IFileHelper> _mockFileHelper;
 
-    private Mock<ITestRuntimeProvider> _mockTestHostManager;
-
-    private Mock<ITestRequestSender> _mockRequestSender;
-
-    private Mock<IProxyDataCollectionManager> _mockDataCollectionManager;
-
-    private Mock<IProcessHelper> _mockProcessHelper;
-
-    private ProxyExecutionManagerWithDataCollection _proxyExecutionManager;
-
-    private Mock<IDataSerializer> _mockDataSerializer;
-
-    private Mock<IRequestData> _mockRequestData;
-
-    private Mock<IMetricsCollection> _mockMetricsCollection;
-
-    private Mock<IFileHelper> _mockFileHelper;
-
-    [TestInitialize]
-    public void TestInit()
+    public ProxyExecutionManagerWithDataCollectionTests()
     {
         _mockTestHostManager = new Mock<ITestRuntimeProvider>();
         _mockRequestSender = new Mock<ITestRequestSender>();
@@ -168,7 +156,7 @@ public class ProxyExecutionManagerWithDataCollectionTests
     {
         // Setup
         var mockRunEventsHandler = new Mock<IInternalTestRunEventsHandler>();
-        TestProcessStartInfo launchedStartInfo = null;
+        TestProcessStartInfo? launchedStartInfo = null;
         mockRunEventsHandler.Setup(runHandler => runHandler.LaunchProcessWithDebuggerAttached(It.IsAny<TestProcessStartInfo>())).Callback
             ((TestProcessStartInfo startInfo) => launchedStartInfo = startInfo);
         var proxyExecutionManager = new ProxyExecutionManagerWithDataCollection(_mockRequestData.Object, _mockRequestSender.Object, _mockTestHostManager.Object, Framework.DefaultFramework, _mockDataCollectionManager.Object);

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyTestSessionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyTestSessionManagerTests.cs
@@ -15,15 +15,13 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
 
-#nullable disable
-
 namespace Microsoft.TestPlatform.CrossPlatEngine.UnitTests.Client;
 
 [TestClass]
 public class ProxyTestSessionManagerTests
 {
     private readonly IList<string> _fakeTestSources = new List<string>() { @"C:\temp\FakeTestAsset.dll" };
-    private Dictionary<string, TestRuntimeProviderInfo> _fakeTestSourcesToRuntimeProviderMap;
+    private readonly Dictionary<string, TestRuntimeProviderInfo> _fakeTestSourcesToRuntimeProviderMap;
     private readonly IList<string> _fakeTestMultipleSources = new List<string>() {
         @"C:\temp\FakeTestAsset1.dll",
         @"C:\temp\FakeTestAsset2.dll",
@@ -72,12 +70,11 @@ public class ProxyTestSessionManagerTests
             </RunSettings>";
     private readonly string _fakeRunSettings = "FakeRunSettings";
     private readonly ProtocolConfig _protocolConfig = new() { Version = 1 };
-    private Mock<ITestSessionEventsHandler> _mockEventsHandler;
-    private Mock<IRequestData> _mockRequestData;
-    private Mock<IMetricsCollection> _mockMetricsCollection;
+    private readonly Mock<ITestSessionEventsHandler> _mockEventsHandler;
+    private readonly Mock<IRequestData> _mockRequestData;
+    private readonly Mock<IMetricsCollection> _mockMetricsCollection;
 
-    [TestInitialize]
-    public void TestInitialize()
+    public ProxyTestSessionManagerTests()
     {
         TestSessionPool.Instance = null;
 
@@ -178,7 +175,7 @@ public class ProxyTestSessionManagerTests
     public void StartSessionShouldFailIfProxyCreatorIsNull()
     {
         var testSessionCriteria = CreateTestSession(_fakeTestSources, _fakeRunSettings);
-        var proxyManager = CreateProxy(testSessionCriteria, null);
+        var proxyManager = CreateProxy(testSessionCriteria, null!);
 
         Assert.IsFalse(proxyManager.StartSession(_mockEventsHandler.Object, _mockRequestData.Object));
         _mockEventsHandler.Verify(eh => eh.HandleStartTestSessionComplete(


### PR DESCRIPTION
Remove missed #nullable disable on projects already handled. Most likely they got removed during some merge.

Contributes to [AB#1549371](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1549371)
