### PR TITLE
Fix which value is used in platform warning

### DIFF
--- a/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
@@ -666,7 +666,7 @@ public class InferRunSettingsHelper
 
         if (incompatiblityFound)
         {
-            incompatibleSettingWarning = string.Format(CultureInfo.CurrentCulture, OMResources.DisplayChosenSettings, chosenFramework, defaultArchitecture, warnings.ToString(), MultiTargetingForwardLink);
+            incompatibleSettingWarning = string.Format(CultureInfo.CurrentCulture, OMResources.DisplayChosenSettings, chosenFramework, chosenPlatform, warnings.ToString(), MultiTargetingForwardLink);
         }
 
         return compatibleSources;


### PR DESCRIPTION
## Description
When compatibility warning is output, it should print the chosen framework and platform in the warning message, not the default platform, because default platform might be different than the one we choose as final.
