### PR TITLE
Temporary disable ngen for arm64 binaries

### DIFF
--- a/src/package/VSIXProject/TestPlatform.csproj
+++ b/src/package/VSIXProject/TestPlatform.csproj
@@ -259,16 +259,17 @@
     <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net471.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net471.x86.exe" />
     <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net472.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net472.x86.exe" />
     <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net48.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net48.x86.exe" />
-
-    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.arm64.exe" />
-    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net452.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net452.arm64.exe" />
-    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net46.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net46.arm64.exe" />
-    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net461.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net461.arm64.exe" />
-    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net462.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net462.arm64.exe" />
-    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net47.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net47.arm64.exe" />
-    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net471.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net471.arm64.exe" />
-    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net472.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net472.arm64.exe" />
-    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net48.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net48.arm64.exe" />
+    
+    <!-- Arm64 is not yet supported by VsixUtil.exe and it will generate a wrong manifest. We disable temporary the ngen to avoid to enqueue arm64 binaries in the wrong architecture polluting logs with errors.-->
+    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.arm64.exe" Ngen="false" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.arm64.exe" />
+    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net452.arm64.exe" Ngen="false" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net452.arm64.exe" />
+    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net46.arm64.exe" Ngen="false" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net46.arm64.exe" />
+    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net461.arm64.exe" Ngen="false" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net461.arm64.exe" />
+    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net462.arm64.exe" Ngen="false" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net462.arm64.exe" />
+    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net47.arm64.exe" Ngen="false" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net47.arm64.exe" />
+    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net471.arm64.exe" Ngen="false" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net471.arm64.exe" />
+    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net472.arm64.exe" Ngen="false" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net472.arm64.exe" />
+    <VsixSourceItem Update="$(VsixInputFileLocation)\testhost.net48.arm64.exe" Ngen="false" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net48.arm64.exe" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="License.rtf">


### PR DESCRIPTION
VsixUtil doesn't support yet arm64 architecture and will generate a wrong manifest, this lead to wrong enqueuing of arm64 binaries for ngen on x64 machine. 