### PR TITLE
Support arm64 native CppUnitTestFramework with `dotnet test`

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
@@ -580,7 +580,7 @@ public class TestEngine : ITestEngine
         // Return true if
         // 1) Not running in parallel;
         // 2) Data collector is not enabled;
-        // 3) Target framework is X64 or anyCpu;
+        // 3) Target platform is compatible or AnyCpu;
         // 4) DisableAppDomain is false;
         // 5) Not running in design mode;
         // 6) target framework is NETFramework (Desktop test);

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -561,7 +561,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
             using var peReader = new PEReader(assemblyStream);
             if (!peReader.HasMetadata || (peReader.PEHeaders.CorHeader?.Flags & CorFlags.ILOnly) == 0)
             {
-                EqtTrace.Verbose($"DotnetTestHostmanager.SilentlyForceToX64: do not force x64 muxer, source '{sourcePath}' is native.");
+                EqtTrace.Verbose($"DotnetTestHostmanager.IsNativeModule: Source '{sourcePath}' is native.");
                 return true;
             }
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -408,7 +408,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
 
             // We silently force x64 only if the target architecture is the default one and is not specified by user
             // through --arch or runsettings or -- RunConfiguration.TargetPlatform=arch
-            bool forceToX64 = SilentlyForceToX64(sourcePath) && _runsettingHelper.IsDefaultTargetArchitecture;
+            bool forceToX64 = _runsettingHelper.IsDefaultTargetArchitecture && SilentlyForceToX64(sourcePath);
             EqtTrace.Verbose($"DotnetTestHostmanager: Current process architetcure '{_processHelper.GetCurrentProcessArchitecture()}'");
             bool isSameArchitecture = IsSameArchitecture(_architecture, _processHelper.GetCurrentProcessArchitecture());
             var currentProcessPath = _processHelper.GetCurrentProcessFileName()!;

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.PortableExecutable;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -260,7 +261,6 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
 
         // Try find testhost.exe (or the architecture specific version). We ship those ngened executables for Windows because they have faster startup time. We ship them only for some platforms.
         // When user specified path to dotnet.exe don't try to find the exexutable, because we will always use the testhost.dll together with their dotnet.exe.
-        // We use dotnet.exe on Windows/ARM.
         bool testHostExeFound = false;
         if (!useCustomDotnetHostpath
             && _platformEnvironment.OperatingSystem.Equals(PlatformOperatingSystem.Windows)
@@ -408,7 +408,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
 
             // We silently force x64 only if the target architecture is the default one and is not specified by user
             // through --arch or runsettings or -- RunConfiguration.TargetPlatform=arch
-            bool forceToX64 = SilentlyForceToX64() && _runsettingHelper.IsDefaultTargetArchitecture;
+            bool forceToX64 = SilentlyForceToX64(sourcePath) && _runsettingHelper.IsDefaultTargetArchitecture;
             EqtTrace.Verbose($"DotnetTestHostmanager: Current process architetcure '{_processHelper.GetCurrentProcessArchitecture()}'");
             bool isSameArchitecture = IsSameArchitecture(_architecture, _processHelper.GetCurrentProcessArchitecture());
             var currentProcessPath = _processHelper.GetCurrentProcessFileName()!;
@@ -531,8 +531,20 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
                 _ => throw new TestPlatformException($"Invalid target architecture '{targetArchitecture}'"),
             };
 
-        bool SilentlyForceToX64()
+        bool SilentlyForceToX64(string sourcePath)
         {
+            // Scenario: dotnet test nativeArm64.dll
+            // If the dll is native and we're not running in process(vstest.console.exe)
+            // the expected target framework is ".NETCoreApp,Version=v1.0".
+            // In this case we don't want to force x64 architecture
+            using var assemblyStream = _fileHelper.GetStream(sourcePath, FileMode.Open, FileAccess.Read);
+            using var peReader = new PEReader(assemblyStream);
+            if (!peReader.HasMetadata || (peReader.PEHeaders.CorHeader?.Flags & CorFlags.ILOnly) == 0)
+            {
+                EqtTrace.Verbose($"DotnetTestHostmanager.SilentlyForceToX64: do not force x64 muxer, source {sourcePath} is native.");
+                return false;
+            }
+
             // We need to force x64 in some scenario
             // https://github.com/dotnet/sdk/blob/main/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets#L140-L143
 

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DotnetTestTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DotnetTestTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.TestPlatform.AcceptanceTests;
@@ -70,5 +72,22 @@ public class DotnetTestTests : AcceptanceTestBase
 
         ValidateSummaryStatus(1, 0, 0);
         ExitCodeEquals(0);
+    }
+
+    [TestMethod]
+    // patched dotnet is not published on non-windows systems
+    [TestCategory("Windows-Review")]
+    [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
+    public void RunDotnetTestWithNativeDll(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        string assemblyRelativePath = @"microsoft.testplatform.testasset.nativecpp\2.0.0\contentFiles\any\any\x64\Microsoft.TestPlatform.TestAsset.NativeCPP.dll";
+        var assemblyAbsolutePath = Path.Combine(_testEnvironment.PackageDirectory, assemblyRelativePath);
+
+        InvokeDotnetTest($@"{assemblyAbsolutePath} --logger:""Console;Verbosity=normal"" --diag:log.txt");
+
+        ValidateSummaryStatus(1, 1, 0);
+        ExitCodeEquals(1);
     }
 }

--- a/test/Microsoft.TestPlatform.AcceptanceTests/DotnetTestTests.cs
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/DotnetTestTests.cs
@@ -85,7 +85,7 @@ public class DotnetTestTests : AcceptanceTestBase
         string assemblyRelativePath = @"microsoft.testplatform.testasset.nativecpp\2.0.0\contentFiles\any\any\x64\Microsoft.TestPlatform.TestAsset.NativeCPP.dll";
         var assemblyAbsolutePath = Path.Combine(_testEnvironment.PackageDirectory, assemblyRelativePath);
 
-        InvokeDotnetTest($@"{assemblyAbsolutePath} --logger:""Console;Verbosity=normal"" --diag:log.txt");
+        InvokeDotnetTest($@"{assemblyAbsolutePath} --logger:""Console;Verbosity=normal""");
 
         ValidateSummaryStatus(1, 1, 0);
         ExitCodeEquals(1);


### PR DESCRIPTION
Support `dotnet test nativeArm64.dll`
<img width="974" alt="image" src="https://user-images.githubusercontent.com/7894084/174069461-ce4988e4-ccce-4236-8168-2042b6f235f8.png">
