### PR TITLE
Add default platform option to runsettings

### DIFF
--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -28,6 +28,7 @@
     <NUnitConsoleRunnerVersion>3.8.0</NUnitConsoleRunnerVersion>
 
     <ChutzpahAdapterVersion>4.4.12</ChutzpahAdapterVersion>
+    <FluentAssertionsVersion>6.7.0</FluentAssertionsVersion>
 
     <!-- Versions that are used when building projects from TestAssets.sln for compatibility tests. See Invoke-TestAssetsBuild in scripts/build.ps1.
     Exact versions are used to avoid Nuget substituting them by closest match, if we make a typo.

--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -116,21 +116,12 @@
           <FromP2P>true</FromP2P>
         </ProjectReference>
 
-        <PackageReference Include="MSTest.TestFramework">
-          <Version>$(MSTestFrameworkVersion)</Version>
-        </PackageReference>
-        <PackageReference Include="MSTest.TestAdapter">
-          <Version>$(MSTestAdapterVersion)</Version>
-        </PackageReference>
-        <PackageReference Include="Moq">
-          <Version>$(MoqVersion)</Version>
-        </PackageReference>
-        <PackageReference Include="MSTest.Assert.Extensions">
-          <Version>$(MSTestAssertExtensionVersion)</Version>
-        </PackageReference>
-        <PackageReference Include="Microsoft.CodeCoverage">
-          <Version>$(MicrosoftCodeCoverageVersion)</Version>
-        </PackageReference>
+        <PackageReference Include="MSTest.TestFramework" Version="$(MSTestFrameworkVersion)" />
+        <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestAdapterVersion)" />
+        <PackageReference Include="MSTest.Assert.Extensions" Version="$(MSTestAssertExtensionVersion)" />
+        <PackageReference Include="Moq" Version="$(MoqVersion)" />
+        <PackageReference Include="Microsoft.CodeCoverage" Version="$(MicrosoftCodeCoverageVersion)" />
+        <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
       </ItemGroup>
     </When>
   </Choose>

--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -121,7 +121,6 @@
         <PackageReference Include="MSTest.Assert.Extensions" Version="$(MSTestAssertExtensionVersion)" />
         <PackageReference Include="Moq" Version="$(MoqVersion)" />
         <PackageReference Include="Microsoft.CodeCoverage" Version="$(MicrosoftCodeCoverageVersion)" />
-        <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
       </ItemGroup>
     </When>
   </Choose>

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
@@ -958,3 +958,6 @@ Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.DiscoveryCompleteEventArg
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.DiscoveryCompleteEventArgs.NotDiscoveredSources.get -> System.Collections.Generic.IList<string>
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.DiscoveryCompleteEventArgs.PartiallyDiscoveredSources.get -> System.Collections.Generic.IList<string>
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.DiscoveryCompleteEventArgs.SkippedDiscoveredSources.get -> System.Collections.Generic.IList<string>
+Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.DefaultPlatform.get -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture?
+Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.DefaultPlatform.set -> void
+Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.DefaultPlatformSet.get -> bool

--- a/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
@@ -236,7 +236,7 @@ public class RunConfiguration : TestRunSettings
     }
 
     /// <summary>
-    /// Gets or sets the Target platform this run is targeting. Possible values are <see cref="Architecture"/> except for AnyCPU or Default.
+    /// Gets or sets the Target platform this run is targeting. Possible values are <see cref="Architecture"/> except for AnyCPU and Default.
     /// </summary>
     public Architecture TargetPlatform
     {
@@ -253,7 +253,7 @@ public class RunConfiguration : TestRunSettings
     }
 
     /// <summary>
-    /// Gets or sets the default platform that will be used for AnyCPU sources, or non-dll sources. Possible values are <see cref="Architecture"/> except for AnyCPU or Default.
+    /// Gets or sets the default platform that will be used for AnyCPU sources, or non-dll sources. Possible values are <see cref="Architecture"/> except for AnyCPU and Default.
     /// </summary>
     public Architecture? DefaultPlatform
     {

--- a/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
@@ -22,6 +22,8 @@ public class RunConfiguration : TestRunSettings
     /// </summary>
     private Architecture _platform;
 
+    private Architecture? _defaultPlatform;
+
     /// <summary>
     /// Maximum number of cores that the engine can use to run tests in parallel
     /// </summary>
@@ -234,7 +236,7 @@ public class RunConfiguration : TestRunSettings
     }
 
     /// <summary>
-    /// Gets or sets the Target platform this run is targeting. Possible values are <c>x86|x64|arm|anycpu</c>.
+    /// Gets or sets the Target platform this run is targeting. Possible values are <see cref="Architecture"/> except for AnyCPU or Default.
     /// </summary>
     public Architecture TargetPlatform
     {
@@ -247,6 +249,23 @@ public class RunConfiguration : TestRunSettings
         {
             _platform = value;
             TargetPlatformSet = true;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the default platform that will be used for AnyCPU sources, or non-dll sources. Possible values are <see cref="Architecture"/> except for AnyCPU or Default.
+    /// </summary>
+    public Architecture? DefaultPlatform
+    {
+        get
+        {
+            return _defaultPlatform;
+        }
+
+        set
+        {
+            _defaultPlatform = value;
+            DefaultPlatformSet = true;
         }
     }
 
@@ -343,6 +362,15 @@ public class RunConfiguration : TestRunSettings
     /// Gets a value indicating whether target platform set.
     /// </summary>
     public bool TargetPlatformSet
+    {
+        get;
+        private set;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether default platform is set.
+    /// </summary>
+    public bool DefaultPlatformSet
     {
         get;
         private set;
@@ -454,6 +482,13 @@ public class RunConfiguration : TestRunSettings
         XmlElement targetPlatform = doc.CreateElement("TargetPlatform");
         targetPlatform.InnerXml = TargetPlatform.ToString();
         root.AppendChild(targetPlatform);
+
+        if (DefaultPlatform != null)
+        {
+            XmlElement defaultPlatform = doc.CreateElement("DefaultPlatform");
+            defaultPlatform.InnerXml = DefaultPlatform.ToString();
+            root.AppendChild(defaultPlatform);
+        }
 
         XmlElement maxCpuCount = doc.CreateElement("MaxCpuCount");
         maxCpuCount.InnerXml = MaxCpuCount.ToString();
@@ -735,6 +770,34 @@ public class RunConfiguration : TestRunSettings
                         }
 
                         runConfiguration.TargetPlatform = archType;
+                        break;
+
+                    case nameof(DefaultPlatform):
+                        XmlRunSettingsUtilities.ThrowOnHasAttributes(reader);
+                        Architecture defaultArchType;
+                        string defaultPlatformValue = reader.ReadElementContentAsString();
+                        try
+                        {
+                            defaultArchType = (Architecture)Enum.Parse(typeof(Architecture), defaultPlatformValue, true);
+                            // Ensure that the parsed value is actually in the enum, and that Default or AnyCpu are not provided.
+                            if (!Enum.IsDefined(typeof(Architecture), defaultArchType) || Architecture.Default == defaultArchType || Architecture.AnyCPU == defaultArchType)
+                            {
+                                throw new SettingsException(
+                                    string.Format(
+                                        CultureInfo.CurrentCulture,
+                                        Resources.Resources.InvalidSettingsIncorrectValue,
+                                        Constants.RunConfigurationSettingsName,
+                                        defaultPlatformValue,
+                                        elementName));
+                            }
+                        }
+                        catch (ArgumentException)
+                        {
+                            throw new SettingsException(string.Format(CultureInfo.CurrentCulture,
+                                Resources.Resources.InvalidSettingsIncorrectValue, Constants.RunConfigurationSettingsName, defaultPlatformValue, elementName));
+                        }
+
+                        runConfiguration.DefaultPlatform = defaultArchType;
                         break;
 
                     case "TargetFrameworkVersion":

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -813,15 +813,21 @@ internal class TestRequestManager : ITestRequestManager
                 return runConfiguration.TargetPlatform;
             }
 
+            Architecture? defaultArchitectureFromRunsettings = runConfiguration.DefaultPlatform;
+            if (defaultArchitectureFromRunsettings != null)
+            {
+                return defaultArchitectureFromRunsettings.Value;
+            }
+
             // Returns null, where there are none.
             Dictionary<string, string?>? environmentVariables = InferRunSettingsHelper.GetEnvironmentVariables(runsettingsXml);
             if (environmentVariables != null)
             {
-                string? defaultArchitectureFromRunsettings = environmentVariables.TryGetValue(VSTEST_DEFAULT_ARCHITECTURE_FOR_ANYCPU, out var architecture) ? architecture : null;
+                string? defaultArchitectureFromRunsettingsEnvironmentVariables = environmentVariables.TryGetValue(VSTEST_DEFAULT_ARCHITECTURE_FOR_ANYCPU, out var architecture) ? architecture : null;
 
-                if (defaultArchitectureFromRunsettings != null)
+                if (defaultArchitectureFromRunsettingsEnvironmentVariables != null)
                 {
-                    Architecture? defaultArchitecture = Enum.TryParse<Architecture>(defaultArchitectureFromRunsettings, out var arch) ? arch : null;
+                    Architecture? defaultArchitecture = Enum.TryParse<Architecture>(defaultArchitectureFromRunsettingsEnvironmentVariables, out var arch) ? arch : null;
 
                     if (defaultArchitecture != null)
                     {

--- a/test/Microsoft.TestPlatform.AcceptanceTests/Microsoft.TestPlatform.AcceptanceTests.csproj
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/Microsoft.TestPlatform.AcceptanceTests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Chutzpah" Version="$(ChutzpahAdapterVersion)" />
-    <PackageReference Include="FluentAssertions" Version="6.0.0-alpha0002" />
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.TestPlatform.TestAsset.NativeCPP" Version="2.0.0" />
     <PackageReference Include="Microsoft.TestPlatform.QTools.Assets" Version="2.0.0" />
     <PackageReference Include="Procdump" Version="0.0.1" />

--- a/test/Microsoft.TestPlatform.AcceptanceTests/Microsoft.TestPlatform.AcceptanceTests.csproj
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/Microsoft.TestPlatform.AcceptanceTests.csproj
@@ -29,7 +29,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Chutzpah" Version="$(ChutzpahAdapterVersion)" />
-    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.TestPlatform.TestAsset.NativeCPP" Version="2.0.0" />
     <PackageReference Include="Microsoft.TestPlatform.QTools.Assets" Version="2.0.0" />
     <PackageReference Include="Procdump" Version="0.0.1" />

--- a/test/Microsoft.TestPlatform.AcceptanceTests/Microsoft.TestPlatform.AcceptanceTests.csproj
+++ b/test/Microsoft.TestPlatform.AcceptanceTests/Microsoft.TestPlatform.AcceptanceTests.csproj
@@ -29,6 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Chutzpah" Version="$(ChutzpahAdapterVersion)" />
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.TestPlatform.TestAsset.NativeCPP" Version="2.0.0" />
     <PackageReference Include="Microsoft.TestPlatform.QTools.Assets" Version="2.0.0" />
     <PackageReference Include="Procdump" Version="0.0.1" />

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelOperationManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelOperationManagerTests.cs
@@ -62,7 +62,7 @@ public class ParallelOperationManagerTests
         parallelOperationManager.StartWork(workloads, eventHandler, getEventHandler, runWorkload);
 
         // Assert
-        workerCounts.Should().BeEquivalentTo(3, 3, 3, 2, 1);
+        workerCounts.Should().BeEquivalentTo(new[] { 3, 3, 3, 2, 1 });
     }
 
     [TestMethod]
@@ -95,7 +95,7 @@ public class ParallelOperationManagerTests
         parallelOperationManager.StartWork(workloads, eventHandler, getEventHandler, runWorkload);
 
         // Assert
-        workerCounts.Should().BeEquivalentTo(2, 1);
+        workerCounts.Should().BeEquivalentTo(new[] { 2, 1 });
     }
 
 
@@ -131,10 +131,10 @@ public class ParallelOperationManagerTests
         parallelOperationManager.StartWork(workloads, eventHandler, getEventHandler, runWorkload);
 
         // Assert
-        workerCounts.Should().BeEquivalentTo(2, 1);
+        workerCounts.Should().BeEquivalentTo(new[] { 2, 1 });
         // We create 10 slots, because that is the max parallel level, when we observe, there are 2 workloads running,
         // and then 1 workload running, so we see 8 and 9 (10 - 2, and 10 - 1).
-        availableWorkerCounts.Should().BeEquivalentTo(8, 9);
+        availableWorkerCounts.Should().BeEquivalentTo(new[] { 8, 9 });
     }
 
     [TestMethod]
@@ -177,7 +177,7 @@ public class ParallelOperationManagerTests
         // even though we did not process workloads 4 and 5.
         // (e.g. In real life Abort was called so the handler won't call RunNextWork, because we don't want to run the remaining sources,
         // and all the sources that are currently running be aborted by calling Abort on each manager via DoActionOnAllManagers.)
-        workloadsProcessed.Should().BeEquivalentTo(1, 2, 3);
+        workloadsProcessed.Should().BeEquivalentTo(new[] { 1, 2, 3 });
     }
 
     [TestMethod]
@@ -231,7 +231,7 @@ public class ParallelOperationManagerTests
         // When we aborted workload 1 was already processed, and 2, and 3 were active.
         // We should see that the first manager did not call abort, but second and third called abort,
         // and there were no more managers created because we stopped calling next after 1 was done.
-        createdManagers.Select(manager => manager.AbortCalled).Should().BeEquivalentTo(false, true, true);
+        createdManagers.Select(manager => manager.AbortCalled).Should().BeEquivalentTo(new[] { false, true, true });
     }
 
     /// <summary>

--- a/test/Microsoft.TestPlatform.PerformanceTests/Microsoft.TestPlatform.PerformanceTests.csproj
+++ b/test/Microsoft.TestPlatform.PerformanceTests/Microsoft.TestPlatform.PerformanceTests.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.TestPlatform.TestUtilities\Microsoft.TestPlatform.TestUtilities.csproj" />

--- a/test/Microsoft.TestPlatform.PerformanceTests/Microsoft.TestPlatform.PerformanceTests.csproj
+++ b/test/Microsoft.TestPlatform.PerformanceTests/Microsoft.TestPlatform.PerformanceTests.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />
-    <PackageReference Include="FluentAssertions" Version="6.0.0-alpha0002" />
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.TestPlatform.TestUtilities\Microsoft.TestPlatform.TestUtilities.csproj" />

--- a/test/Microsoft.TestPlatform.PerformanceTests/Microsoft.TestPlatform.PerformanceTests.csproj
+++ b/test/Microsoft.TestPlatform.PerformanceTests/Microsoft.TestPlatform.PerformanceTests.csproj
@@ -13,7 +13,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />
-    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.TestPlatform.TestUtilities\Microsoft.TestPlatform.TestUtilities.csproj" />

--- a/test/Microsoft.TestPlatform.TestUtilities/Microsoft.TestPlatform.TestUtilities.csproj
+++ b/test/Microsoft.TestPlatform.TestUtilities/Microsoft.TestPlatform.TestUtilities.csproj
@@ -26,7 +26,7 @@
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.VsTestConsole.TranslationLayer\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.0.0-alpha0002" />
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="MSTest.TestFramework" Version="$(MSTestFrameworkVersion)" />
   </ItemGroup>

--- a/test/vstest.ProgrammerTests/vstest.ProgrammerTests.csproj
+++ b/test/vstest.ProgrammerTests/vstest.ProgrammerTests.csproj
@@ -16,7 +16,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.0.0-alpha0002" />
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.CoreUtilities\Microsoft.TestPlatform.CoreUtilities.csproj" />

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -2619,4 +2619,26 @@ public class TestRequestManagerTests
         // The dll that has a specific architecture always remains that specific architecture.
         actualSourceToSourceDetailMap!["x64.dll"].Architecture.Should().Be(Architecture.X64);
     }
+
+    [TestMethod]
+    public void UsingInvalidValueForDefaultPlatformSettingThrowsSettingsException()
+    {
+        var settingXml = @"
+            <RunSettings>
+                <RunConfiguration>
+                    <DefaultPlatform>WRONGPlatform</DefaultPlatform>
+                </RunConfiguration>
+            </RunSettings>";
+
+        var payload = new TestRunRequestPayload()
+        {
+            Sources = new List<string>() { "a.dll" },
+            RunSettings = settingXml
+        };
+
+        _testRequestManager
+            .Invoking(m => m.RunTests(payload, new Mock<ITestHostLauncher3>().Object, new Mock<ITestRunEventsRegistrar>().Object, _protocolConfig))
+            .Should().Throw<SettingsException>()
+            .And.Message.Should().Contain("Invalid value 'WRONGPlatform' specified for 'DefaultPlatform'.");
+    }
 }

--- a/test/vstest.console.UnitTests/vstest.console.UnitTests.csproj
+++ b/test/vstest.console.UnitTests/vstest.console.UnitTests.csproj
@@ -22,6 +22,9 @@
       <FromP2P>true</FromP2P>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
     <Reference Include="System.Runtime" />
     <Reference Include="System" />


### PR DESCRIPTION
## Description
Add default platform option that determines the platform to use for AnyCPU sources, without forcing it at sources that are built for specific platform. 

This is equivalent of this dropdown in VS: 

<img width="431" alt="image" src="https://user-images.githubusercontent.com/5735905/174079418-fd4878b3-67c6-4a43-86d2-c01097a15e21.png">

Not setting DefaultPlatform is equivalent to the `Auto` option. Which is fallback to the platform of the current process. E.g. x64 for x64 VisualStudio, or arm64 for arm64 VisualStudio.

The difference between TargetPlatform and DefaultPlatform, is that TargetPlatform will force the platform on all sources, and the ones that don't match will be skipped or will fail with error.
