### PR TITLE
Pass sources, to fix native debug

### DIFF
--- a/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
+++ b/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
@@ -368,6 +368,7 @@ public class DesignModeClient : IDesignModeClient
             {
                 var payload = new EditorAttachDebuggerPayload
                 {
+                    Sources = attachDebuggerInfo.Sources,
                     TargetFramework = attachDebuggerInfo.TargetFramework?.ToString(),
                     ProcessID = attachDebuggerInfo.ProcessId,
                 };

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/AttachDebuggerInfo.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/AttachDebuggerInfo.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
 
 public class AttachDebuggerInfo
 {
     public int ProcessId { get; set; }
     public string? TargetFramework { get; set; }
+    public ICollection<string>? Sources { get; set; }
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
@@ -961,3 +961,7 @@ Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.DiscoveryCompleteEventArg
 Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.DefaultPlatform.get -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture?
 Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.DefaultPlatform.set -> void
 Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.DefaultPlatformSet.get -> bool
+Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces.AttachDebuggerInfo.Sources.get -> System.Collections.Generic.ICollection<string>
+Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces.AttachDebuggerInfo.Sources.set -> void
+Microsoft.VisualStudio.TestPlatform.ObjectModel.EditorAttachDebuggerPayload.Sources.get -> System.Collections.Generic.ICollection<string>
+Microsoft.VisualStudio.TestPlatform.ObjectModel.EditorAttachDebuggerPayload.Sources.set -> void

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,4 +1,1 @@
-﻿Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces.AttachDebuggerInfo.Sources.get -> System.Collections.Generic.ICollection<string>
-Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces.AttachDebuggerInfo.Sources.set -> void
-Microsoft.VisualStudio.TestPlatform.ObjectModel.EditorAttachDebuggerPayload.Sources.get -> System.Collections.Generic.ICollection<string>
-Microsoft.VisualStudio.TestPlatform.ObjectModel.EditorAttachDebuggerPayload.Sources.set -> void
+﻿

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
-﻿
+﻿Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces.AttachDebuggerInfo.Sources.get -> System.Collections.Generic.ICollection<string>
+Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces.AttachDebuggerInfo.Sources.set -> void
+Microsoft.VisualStudio.TestPlatform.ObjectModel.EditorAttachDebuggerPayload.Sources.get -> System.Collections.Generic.ICollection<string>
+Microsoft.VisualStudio.TestPlatform.ObjectModel.EditorAttachDebuggerPayload.Sources.set -> void

--- a/src/Microsoft.TestPlatform.ObjectModel/TestProcessAttachDebuggerPayload.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TestProcessAttachDebuggerPayload.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -43,4 +45,7 @@ public class EditorAttachDebuggerPayload
 
     [DataMember]
     public string? TargetFramework { get; set; }
+
+    [DataMember]
+    public ICollection<string>? Sources { get; set; }
 }

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleRequestSender.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleRequestSender.cs
@@ -1447,7 +1447,13 @@ internal class VsTestConsoleRequestSender : ITranslationLayerRequestSender
                 switch (customHostLauncher)
                 {
                     case ITestHostLauncher3 launcher3:
-                        ackPayload.Attached = launcher3.AttachDebuggerToProcess(new AttachDebuggerInfo { ProcessId = attachDebuggerPayload.ProcessID, TargetFramework = attachDebuggerPayload.TargetFramework }, CancellationToken.None);
+                        var attachDebuggerInfo = new AttachDebuggerInfo
+                        {
+                            ProcessId = attachDebuggerPayload.ProcessID,
+                            TargetFramework = attachDebuggerPayload.TargetFramework,
+                            Sources = attachDebuggerPayload.Sources,
+                        };
+                        ackPayload.Attached = launcher3.AttachDebuggerToProcess(attachDebuggerInfo, CancellationToken.None);
                         break;
                     case ITestHostLauncher2 launcher2:
                         ackPayload.Attached = launcher2.AttachDebuggerToProcess(attachDebuggerPayload.ProcessID);


### PR DESCRIPTION
## Description
Pass sources on attach debugger. This allows VS to detect the debug engine in the same way as it did before, and it won't try to attach .NET debugger to the process that is hosting native tests. 

## Related issue
Part of fix for [AB#1556357](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1556357)
