### PR TITLE
Remove unused msdia140typelib_clr0200.dll

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -519,9 +519,6 @@ function Publish-Package {
     Copy-Item -Recurse $comComponentsDirectory\* $testhostUapPackageDir -Force
     Copy-Item -Recurse $comComponentsDirectory\* $coreCLR20TestHostPackageDir -Force
 
-    $microsoftInternalDiaInterop = Join-Path $env:TP_PACKAGES_DIR "Microsoft.Internal.Dia.Interop\$testPlatformMsDiaVersion\tools\net451"
-    Copy-Item -Recurse $microsoftInternalDiaInterop\* $coreCLR20TestHostPackageDir -Force
-
     # Copy over the logger assemblies to the Extensions folder.
     $extensions_Dir = "Extensions"
     $fullCLRExtensionsDir = Join-Path $fullCLRPackage451Dir $extensions_Dir
@@ -816,10 +813,6 @@ function Publish-VsixPackage {
     # Copy COM Components and their manifests over
     $comComponentsDirectory = Join-Path $env:TP_PACKAGES_DIR "Microsoft.Internal.Dia\$testPlatformMsDiaVersion\tools\net451"
     Copy-Item -Recurse $comComponentsDirectory\* $packageDir -Force
-
-    # Copy Microsoft.Internal.Dia.Interop
-    $internalDiaInterop = Join-Path $env:TP_PACKAGES_DIR "Microsoft.Internal.Dia.Interop\$testPlatformMsDiaVersion\tools\net451"
-    Copy-Item -Recurse $internalDiaInterop\* $packageDir -Force
 
     # Copy COM Components and their manifests over to Extensions Test Impact directory
     $comComponentsDirectoryTIA = Join-Path $env:TP_PACKAGES_DIR "Microsoft.Internal.Dia\$testPlatformMsDiaVersion\tools\net451"

--- a/scripts/verify-nupkgs.ps1
+++ b/scripts/verify-nupkgs.ps1
@@ -14,13 +14,13 @@ function Verify-Nuget-Packages($packageDirectory, $version)
     $expectedNumOfFiles = @{
         "Microsoft.CodeCoverage" = 57;
         "Microsoft.NET.Test.Sdk" = 27;
-        "Microsoft.TestPlatform" = 624;
+        "Microsoft.TestPlatform" = 623;
         "Microsoft.TestPlatform.Build" = 21;
-        "Microsoft.TestPlatform.CLI" = 427;
+        "Microsoft.TestPlatform.CLI" = 426;
         "Microsoft.TestPlatform.Extensions.TrxLogger" = 35;
         "Microsoft.TestPlatform.ObjectModel" = 238;
         "Microsoft.TestPlatform.AdapterUtilities" = 62;
-        "Microsoft.TestPlatform.Portable" = 648;
+        "Microsoft.TestPlatform.Portable" = 646;
         "Microsoft.TestPlatform.TestHost" = 208;
         "Microsoft.TestPlatform.TranslationLayer" = 123;
         "Microsoft.TestPlatform.Internal.Uwp" = 86;

--- a/src/Microsoft.TestPlatform.CoreUtilities/Microsoft.TestPlatform.CoreUtilities.csproj
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Microsoft.TestPlatform.CoreUtilities.csproj
@@ -31,8 +31,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' OR  '$(TargetFramework)' == 'net45' ">
-    <PackageReference Include="Microsoft.Internal.Dia.Interop" Version="$(TestPlatformMSDiaVersion)" />
-
     <Reference Include="System.Configuration" />
     <Reference Include="System" />
     <Reference Include="System.IO" />

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Microsoft.TestPlatform.PlatformAbstractions.csproj
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Microsoft.TestPlatform.PlatformAbstractions.csproj
@@ -37,8 +37,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' OR '$(TargetFramework)' == 'net45' ">
-    <PackageReference Include="Microsoft.Internal.Dia.Interop" Version="$(TestPlatformMSDiaVersion)" />
-
     <Reference Include="System.Configuration" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/package/external/external.csproj
+++ b/src/package/external/external.csproj
@@ -49,7 +49,6 @@
     <PackageReference Include="Microsoft.VisualStudio.CUIT" Version="$(TestPlatformExternalsVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Internal.Intellitrace" Version="$(TestPlatformExternalsVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Internal.Dia" Version="$(TestPlatformMSDiaVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Internal.Dia.Interop" Version="$(TestPlatformMSDiaVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="$(VSSdkBuildToolsVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Interop" Version="$(InteropExternalsVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="16.3.58" PrivateAssets="All" />

--- a/src/package/nuspec/Microsoft.TestPlatform.Portable.nuspec
+++ b/src/package/nuspec/Microsoft.TestPlatform.Portable.nuspec
@@ -57,7 +57,6 @@
     <file src="net451\$Runtime$\tr\Microsoft.CodeCoverage.IO.resources.dll"	target="tools\net451\tr\Microsoft.CodeCoverage.IO.dll" />
     <file src="net451\$Runtime$\zh-Hans\Microsoft.CodeCoverage.IO.resources.dll"	target="tools\net451\zh-Hans\Microsoft.CodeCoverage.IO.dll" />
     <file src="net451\$Runtime$\zh-Hant\Microsoft.CodeCoverage.IO.resources.dll"	target="tools\net451\zh-Hant\Microsoft.CodeCoverage.IO.dll" />
-    <file src="net451\$Runtime$\msdia140typelib_clr0200.dll"	target="tools\net451\msdia140typelib_clr0200.dll" />
     <file src="net451\$Runtime$\Newtonsoft.Json.dll"	target="tools\net451\Newtonsoft.Json.dll" />
     <file src="net451\$Runtime$\System.Collections.Immutable.dll"	target="tools\net451\System.Collections.Immutable.dll" />
     <file src="net451\$Runtime$\System.Reflection.Metadata.dll"	target="tools\net451\System.Reflection.Metadata.dll" />
@@ -500,7 +499,6 @@
     <file src="netcoreapp2.1\TestHost\Microsoft.VisualStudio.TestPlatform.Common.dll"	target="tools\netcoreapp2.1\TestHost\Microsoft.VisualStudio.TestPlatform.Common.dll" />
     <file src="netcoreapp2.1\TestHost\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll"	target="tools\netcoreapp2.1\TestHost\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" />
     <file src="netcoreapp2.1\TestHost\NuGet.Frameworks.dll"	target="tools\netcoreapp2.1\TestHost\NuGet.Frameworks.dll" />
-    <file src="netcoreapp2.1\TestHost\msdia140typelib_clr0200.dll"	target="tools\netcoreapp2.1\TestHost\msdia140typelib_clr0200.dll" />
     <file src="netcoreapp2.1\TestHost\Newtonsoft.Json.dll"	target="tools\netcoreapp2.1\TestHost\Newtonsoft.Json.dll" />
     <file src="netcoreapp2.1\TestHost\System.Collections.Immutable.dll"	target="tools\netcoreapp2.1\TestHost\System.Collections.Immutable.dll" />
     <file src="netcoreapp2.1\TestHost\System.Reflection.Metadata.dll"	target="tools\netcoreapp2.1\TestHost\System.Reflection.Metadata.dll" />

--- a/src/package/nuspec/Microsoft.TestPlatform.nuspec
+++ b/src/package/nuspec/Microsoft.TestPlatform.nuspec
@@ -111,7 +111,6 @@
     <file src="net451\$Runtime$\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" target="tools\net451\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" />
     <file src="net451\$Runtime$\Microsoft.VisualStudio.TestTools.UITest.Extension.IE.Communication.sxs.manifest" target="tools\net451\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.TestTools.UITest.Extension.IE.Communication.sxs.manifest" />
     <file src="net451\$Runtime$\Microsoft.VisualStudio.TestTools.UITest.Playback.Engine.sxs.manifest" target="tools\net451\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.TestTools.UITest.Playback.Engine.sxs.manifest" />
-    <file src="net451\$Runtime$\msdia140typelib_clr0200.dll" target="tools\net451\Common7\IDE\Extensions\TestPlatform\msdia140typelib_clr0200.dll" />
     <file src="net451\$Runtime$\Newtonsoft.Json.dll" target="tools\net451\Common7\IDE\Extensions\TestPlatform\Newtonsoft.Json.dll" />
     <file src="net451\$Runtime$\QTAgent.exe" target="tools\net451\Common7\IDE\Extensions\TestPlatform\QTAgent.exe" />
     <file src="net451\$Runtime$\QTAgent.exe.Config" target="tools\net451\Common7\IDE\Extensions\TestPlatform\QTAgent.exe.Config" />


### PR DESCRIPTION
Looks like we already moved away from msdia managed wrapper in favor of pinvoke to `msdia140.dll` https://github.com/microsoft/vstest/pull/1018/files#diff-1ce965d15e48a18ef21ff22c84fd034f046ddc15aebea432babfa403cff86473
Remove ref to `Microsoft.Internal.Dia.Interop` that contains `msdia140typelib_clr0200.dll`
<img width="500" alt="image" src="https://user-images.githubusercontent.com/7894084/176229003-885b6013-b187-494f-89f6-c7c793ede2f8.png">
