### PR TITLE
Increase ThreadPool.MinThreads limit

### DIFF
--- a/src/vstest.console/CommandLine/Executor.cs
+++ b/src/vstest.console/CommandLine/Executor.cs
@@ -72,6 +72,9 @@ internal class Executor
         // The correct fix would be to re-visit all code that offloads work to threadpool and avoid blocking any thread,
         // and also use async await when we need to await a completion of an action. But that is a far away goal, so this
         // is a "temporary" measure to remove the threadpool contention.
+        //
+        // The increase to 5* (1* is the standard + 4*) the standard limit is arbitrary. I saw that making it 2* did not help
+        // and there are usually 2-3 threads blocked by waiting for other actions, so 5 seemed like a good limit.
         var additionalThreadsCount = Environment.ProcessorCount * 4;
         ThreadPool.GetMinThreads(out var workerThreads, out var completionPortThreads);
         ThreadPool.SetMinThreads(workerThreads + additionalThreadsCount, completionPortThreads + additionalThreadsCount);

--- a/src/vstest.console/CommandLine/Executor.cs
+++ b/src/vstest.console/CommandLine/Executor.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 
 using Microsoft.VisualStudio.TestPlatform.CommandLine.Internal;
 using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
@@ -60,6 +61,20 @@ internal class Executor
     /// </summary>
     public Executor(IOutput output) : this(output, TestPlatformEventSource.Instance, new ProcessHelper(), new PlatformEnvironment())
     {
+        // TODO: Get rid of this by making vstest.console code properly async.
+        // The current implementation of vstest.console is blocking many threads that just wait
+        // for completion in non-async way. Because threadpool is setting the limit based on processor count,
+        // we exhaust the threadpool threads quickly when we set maxCpuCount to use as many workers as we have threads.
+        //
+        // This setting allow the threadpool to start start more threads than it normally would without any delay.
+        // This won't pre-start the threads, it just pushes the limit of how many are allowed to start without waiting,
+        // and in effect makes callbacks processed earlier, because we don't have to wait that much to receive the callback.
+        // The correct fix would be to re-visit all code that offloads work to threadpool and avoid blocking any thread,
+        // and also use async await when we need to await a completion of an action. But that is a far away goal, so this
+        // is a "temporary" measure to remove the threadpool contention.
+        var additionalThreadsCount = Environment.ProcessorCount * 4;
+        ThreadPool.GetMinThreads(out var workerThreads, out var completionPortThreads);
+        ThreadPool.SetMinThreads(workerThreads + additionalThreadsCount, completionPortThreads + additionalThreadsCount);
     }
 
     internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment)


### PR DESCRIPTION
## Description
Raise the limit of how many thread can ThreadPool start without waiting. The limit is by default the based on the number of logical cores. But vstest.console blocks many threads because it uses non-async locks to wait for actions to complete, and so when we start many testhosts in parallel, each testhost wants at least 1 thread from threadpool, and so the limit is quickly reached. Threadpool slowly adds new threads (about 1 per second), which makes the testhost callbacks take a long time to complete. This can be observed by looking at the time where testhost reports it connected to server, and the time where we actually see the client was accepted. 

Or by putting this piece of code into TestRequestSender: 

```cs
 public bool WaitForRequestHandlerConnection(int connectionTimeout, CancellationToken cancellationToken)
    {
        var sw = Stopwatch.StartNew();
        EqtTrace.Verbose("TestRequestSender.WaitForRequestHandlerConnection: waiting for connection with timeout: {0}.", connectionTimeout);

        // Wait until either connection is successful, handled by connected.WaitHandle
        // or operation is canceled, handled by cancellationToken.WaitHandle
        // or testhost exits unexpectedly, handled by clientExited.WaitHandle
        var waitIndex = WaitHandle.WaitAny(new WaitHandle[] { _connected.WaitHandle, cancellationToken.WaitHandle, _clientExited.WaitHandle }, connectionTimeout);

        Debug.WriteLine($">>>>> waiting for client for {sw.ElapsedMilliseconds} ms");

        // Return true if connection was successful.
        return waitIndex == 0;
    }
```

Before the change this elapsed time can be from 250ms (which it roughly the time that testhost spends setting up and looking up extensions), till 3-4seconds when there are many testhosts running in parallel and threadpool is saturated and does not have enough non-blocked threads to process the incoming callbacks.

---

Raising the limit allows ThreadPool to start a new thread without waiting, and process the callback as soon as it comes. So the measurement above is much closer to 250ms.

Raising the limit also allows us to see that SkipDefaultAdapters has some impact on the execution time, because before this change the impact it had (~200ms) was greatly offset by the time we spend waiting to connect (~2000ms). We can also see the single channel back to IDE (SocketCommunicationManager.WriteAndFlushToChannel) to be a contention point (because many testhosts are trying to push as much data as they can through this single channel). And so we can also see BatchSize to have significant impact on speed, where moving it up from 10 to 100 and 1000 makes the discovery time progressively shorter.


Fix [AB#1563539](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1563539)