### PR TITLE
Allow DotNetHostPath to contain env vars

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
@@ -891,7 +891,6 @@ public class RunConfiguration : TestRunSettings
 
                     case "DotNetHostPath":
                         XmlRunSettingsUtilities.ThrowOnHasAttributes(reader);
-                        
                         string? dotnetHostPath = reader.ReadElementContentAsString();
 
 #if !NETSTANDARD1_0

--- a/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
@@ -891,7 +891,14 @@ public class RunConfiguration : TestRunSettings
 
                     case "DotNetHostPath":
                         XmlRunSettingsUtilities.ThrowOnHasAttributes(reader);
-                        runConfiguration.DotnetHostPath = reader.ReadElementContentAsString();
+                        
+                        string? dotnetHostPath = reader.ReadElementContentAsString();
+
+#if !NETSTANDARD1_0
+                        dotnetHostPath = Environment.ExpandEnvironmentVariables(dotnetHostPath);
+#endif
+
+                        runConfiguration.DotnetHostPath = dotnetHostPath;
                         break;
                     case "TreatNoTestsAsError":
                         XmlRunSettingsUtilities.ThrowOnHasAttributes(reader);

--- a/src/Microsoft.TestPlatform.Utilities/ClientUtilities.cs
+++ b/src/Microsoft.TestPlatform.Utilities/ClientUtilities.cs
@@ -16,6 +16,7 @@ public static class ClientUtilities
 {
     private const string TestSettingsFileXPath = "RunSettings/MSTest/SettingsFile";
     private const string ResultsDirectoryXPath = "RunSettings/RunConfiguration/ResultsDirectory";
+    private const string DotnetHostPathXPath = "RunSettings/RunConfiguration/DotnetHostPath";
     private const string RunsettingsDirectory = "RunSettingsDirectory";
 
     /// <summary>
@@ -42,6 +43,12 @@ public static class ClientUtilities
         if (resultsDirectoryNode != null)
         {
             FixNodeFilePath(resultsDirectoryNode, root);
+        }
+
+        var dotnetHostPathNode = xmlDocument.SelectSingleNode(DotnetHostPathXPath);
+        if (dotnetHostPathNode != null)
+        {
+            FixNodeFilePath(dotnetHostPathNode, root);
         }
     }
 

--- a/src/Microsoft.TestPlatform.Utilities/ClientUtilities.cs
+++ b/src/Microsoft.TestPlatform.Utilities/ClientUtilities.cs
@@ -16,7 +16,7 @@ public static class ClientUtilities
 {
     private const string TestSettingsFileXPath = "RunSettings/MSTest/SettingsFile";
     private const string ResultsDirectoryXPath = "RunSettings/RunConfiguration/ResultsDirectory";
-    private const string DotnetHostPathXPath = "RunSettings/RunConfiguration/DotnetHostPath";
+    private const string DotnetHostPathXPath = "RunSettings/RunConfiguration/DotNetHostPath";
     private const string RunsettingsDirectory = "RunSettingsDirectory";
 
     /// <summary>

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -289,7 +289,7 @@ public class DotnetTestHostManagerTests
         var dotnetHostPath = @"C:\dotnet.exe";
         _mockFileHelper.Setup(ph => ph.Exists("testhost.dll")).Returns(true);
         _mockEnvironment.Setup(ev => ev.OperatingSystem).Returns(PlatformOperatingSystem.Windows);
-        _dotnetHostManager.Initialize(_mockMessageLogger.Object, $"<RunSettings><RunConfiguration><DotnetHostPath>{dotnetHostPath}</DotnetHostPath></RunConfiguration></RunSettings>");
+        _dotnetHostManager.Initialize(_mockMessageLogger.Object, $"<RunSettings><RunConfiguration><DotNetHostPath>{dotnetHostPath}</DotNetHostPath></RunConfiguration></RunSettings>");
         var startInfo = GetDefaultStartInfo();
 
         StringAssert.Contains(startInfo.FileName, dotnetHostPath);

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -289,7 +289,7 @@ public class DotnetTestHostManagerTests
         var dotnetHostPath = @"C:\dotnet.exe";
         _mockFileHelper.Setup(ph => ph.Exists("testhost.dll")).Returns(true);
         _mockEnvironment.Setup(ev => ev.OperatingSystem).Returns(PlatformOperatingSystem.Windows);
-        _dotnetHostManager.Initialize(_mockMessageLogger.Object, $"<RunSettings><RunConfiguration><DotNetHostPath>{dotnetHostPath}</DotNetHostPath></RunConfiguration></RunSettings>");
+        _dotnetHostManager.Initialize(_mockMessageLogger.Object, $"<RunSettings><RunConfiguration><DotnetHostPath>{dotnetHostPath}</DotnetHostPath></RunConfiguration></RunSettings>");
         var startInfo = GetDefaultStartInfo();
 
         StringAssert.Contains(startInfo.FileName, dotnetHostPath);

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/ClientUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/ClientUtilitiesTests.cs
@@ -195,7 +195,7 @@ public class ClientUtilitiesTests
             Environment.SetEnvironmentVariable("TEST_TEMP", Path.GetTempPath());
             // using TEST_TEMP because TMP or TEMP, or HOME are not defined across all tested OSes
             // Using \\ instead of platform specifc path separator does not matter, because the paths are not interpreted by the OS.
-            var runSettingsXml = "<RunSettings><RunConfiguration><ResultsDirectory>%TEST_TEMP%\\results</ResultsDirectory></RunConfiguration></RunSettings>";
+            var runSettingsXml = "<RunSettings><RunConfiguration><ResultsDirectory>%TEST_TEMP%\\results</ResultsDirectory><DotNetHostPath>%TEST_TEMP%\\hostpath</DotNetHostPath></RunConfiguration></RunSettings>";
 
             var doc = new XmlDocument();
             doc.LoadXml(runSettingsXml);
@@ -206,12 +206,15 @@ public class ClientUtilitiesTests
 
             var finalSettingsXml = doc.OuterXml;
 
-            var expectedPath = $"{Environment.GetEnvironmentVariable("TEST_TEMP")}\\results";
+            var expectedResultsPath = $"{Environment.GetEnvironmentVariable("TEST_TEMP")}\\results";
+            var expectedDotNetHostPath = $"{Environment.GetEnvironmentVariable("TEST_TEMP")}\\hostpath";
 
             var expectedSettingsXml = string.Concat(
                 "<RunSettings><RunConfiguration><ResultsDirectory>",
-                expectedPath,
-                "</ResultsDirectory></RunConfiguration><RunSettingsDirectory>",
+                expectedResultsPath,
+                "</ResultsDirectory><DotNetHostPath>",
+                expectedDotNetHostPath,
+                "</DotNetHostPath></RunConfiguration><RunSettingsDirectory>",
                 Path.GetDirectoryName(currentAssemblyLocation),
                 "</RunSettingsDirectory></RunSettings>");
 


### PR DESCRIPTION
This is useful for controlling the paths to the dotnet host path when you're running `dotnet test src/tests/TestProjectA.csproj` to avoid duplicating the runsettings.