### PR TITLE
Set discovery batch size to 1000

### DIFF
--- a/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
@@ -24,6 +24,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Utilities;
 public class InferRunSettingsHelper
 {
     private const string DesignModeNodeName = "DesignMode";
+    private const string BatchSizeNodeName = "BatchSize";
     private const string CollectSourceInformationNodeName = "CollectSourceInformation";
     private const string RunSettingsNodeName = "RunSettings";
     private const string RunConfigurationNodeName = "RunConfiguration";
@@ -33,6 +34,7 @@ public class InferRunSettingsHelper
     private const string TargetDevice = "TargetDevice";
 
     private const string DesignModeNodePath = @"/RunSettings/RunConfiguration/DesignMode";
+    private const string BatchSizeNodePath = @"/RunSettings/RunConfiguration/BatchSize";
     private const string CollectSourceInformationNodePath = @"/RunSettings/RunConfiguration/CollectSourceInformation";
     private const string RunConfigurationNodePath = @"/RunSettings/RunConfiguration";
     private const string TargetPlatformNodePath = @"/RunSettings/RunConfiguration/TargetPlatform";
@@ -202,6 +204,16 @@ public class InferRunSettingsHelper
     public static void UpdateDesignMode(XmlDocument runSettingsDocument, bool designModeValue)
     {
         AddNodeIfNotPresent(runSettingsDocument, DesignModeNodePath, DesignModeNodeName, designModeValue);
+    }
+
+    /// <summary>
+    /// Updates the <c>RunConfiguration.BatchSize</c> value for a run settings. Doesn't do anything if the value is already set.
+    /// </summary>
+    /// <param name="runSettingsDocument">Document for runsettings xml</param>
+    /// <param name="batchSizeValue">Value to set</param>
+    public static void UpdateBatchSize(XmlDocument runSettingsDocument, long batchSizeValue)
+    {
+        AddNodeIfNotPresent(runSettingsDocument, BatchSizeNodePath, BatchSizeNodeName, batchSizeValue);
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.Utilities/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TestPlatform.Utilities/PublicAPI/PublicAPI.Shipped.txt
@@ -38,3 +38,5 @@ static Microsoft.VisualStudio.TestPlatform.Utilities.MSTestSettingsUtilities.Imp
 static Microsoft.VisualStudio.TestPlatform.Utilities.MSTestSettingsUtilities.IsLegacyTestSettingsFile(string? settingsFile) -> bool
 static Microsoft.VisualStudio.TestPlatform.Utilities.ParallelRunSettingsUtilities.UpdateRunSettingsWithParallelSettingIfNotConfigured(System.Xml.XPath.XPathNavigator! navigator) -> void
 static Microsoft.VisualStudio.TestPlatform.Utilities.StringExtensions.Tokenize(this string? input, char separator, char escape) -> System.Collections.Generic.IEnumerable<string!>!
+static Microsoft.VisualStudio.TestPlatform.Utilities.InferRunSettingsHelper.UpdateBatchSize(System.Xml.XmlDocument! runSettingsDocument, long batchSizeValue) -> void
+

--- a/src/vstest.console/CommandLine/CommandLineOptions.cs
+++ b/src/vstest.console/CommandLine/CommandLineOptions.cs
@@ -26,7 +26,7 @@ internal class CommandLineOptions
     /// <summary>
     /// The default batch size for Run.
     /// </summary>
-    public const long DefaultBatchSize = 10;
+    public const long DefaultRunBatchSize = 10;
 
     /// <summary>
     /// The default batch size for Discovery.
@@ -67,7 +67,7 @@ internal class CommandLineOptions
     /// </summary>
     internal CommandLineOptions()
     {
-        BatchSize = DefaultBatchSize;
+        BatchSize = DefaultRunBatchSize;
         TestStatsEventTimeout = _defaultRetrievalTimeout;
         FileHelper = new FileHelper();
         FilePatternParser = new FilePatternParser();

--- a/src/vstest.console/CommandLine/CommandLineOptions.cs
+++ b/src/vstest.console/CommandLine/CommandLineOptions.cs
@@ -24,9 +24,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine;
 internal class CommandLineOptions
 {
     /// <summary>
-    /// The default batch size.
+    /// The default batch size for Run.
     /// </summary>
     public const long DefaultBatchSize = 10;
+
+    /// <summary>
+    /// The default batch size for Discovery.
+    /// </summary>
+    public const long DefaultDiscoveryBatchSize = 1000;
 
     /// <summary>
     /// The use vsix extensions key.

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -182,8 +182,6 @@ internal class TestRequestManager : ITestRequestManager
             runsettings = updatedRunsettings;
         }
 
-
-
         var sourceToSourceDetailMap = discoveryPayload.Sources.Select(source => new SourceDetail
         {
             Source = source,
@@ -917,7 +915,7 @@ internal class TestRequestManager : ITestRequestManager
         return updateRequired;
     }
 
-    private bool AddOrUpdateBatchSize(XmlDocument document, RunConfiguration runConfiguration, bool isDiscovery)
+    internal /* for testing purposes */ static bool AddOrUpdateBatchSize(XmlDocument document, RunConfiguration runConfiguration, bool isDiscovery)
     {
         // On run keep it as is to fall back to the current default value (which is 10 right now).
         if (!isDiscovery)
@@ -925,7 +923,6 @@ internal class TestRequestManager : ITestRequestManager
             // We did not update runnsettings.
             return false;
         }
-
 
         // If user is already setting batch size via runsettings or CLI args; we skip.
         bool updateRequired = !runConfiguration.BatchSizeSet;
@@ -935,6 +932,7 @@ internal class TestRequestManager : ITestRequestManager
                 document,
                 CommandLineOptions.DefaultDiscoveryBatchSize);
         }
+
         return updateRequired;
     }
 

--- a/test/vstest.console.UnitTests/CommandLine/CommandLineOptionsTests.cs
+++ b/test/vstest.console.UnitTests/CommandLine/CommandLineOptionsTests.cs
@@ -40,6 +40,12 @@ public class CommandLineOptionsTests
     }
 
     [TestMethod]
+    public void CommandLineOptionsDiscoveryDefaultBatchSizeIsThousand()
+    {
+        Assert.AreEqual(1000, CommandLineOptions.DefaultDiscoveryBatchSize);
+    }
+
+    [TestMethod]
     public void CommandLineOptionsDefaultTestRunStatsEventTimeoutIsOnePointFiveSec()
     {
         var timeout = new TimeSpan(0, 0, 0, 1, 500);

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -220,8 +220,8 @@ public class TestRequestManagerTests
         Assert.AreEqual("a", actualDiscoveryCriteria.Sources.First(), "First Source in list is incorrect");
         Assert.AreEqual("b", actualDiscoveryCriteria.Sources.ElementAt(1), "Second Source in list is incorrect");
 
-        // Default frequency is set to 10, unless specified in runsettings.
-        Assert.AreEqual(10, actualDiscoveryCriteria.FrequencyOfDiscoveredTestsEvent);
+        // Default frequency is set to BatchSize (which is set to 1000).
+        Assert.AreEqual(1000, actualDiscoveryCriteria.FrequencyOfDiscoveredTestsEvent);
 
         mockDiscoveryRegistrar.Verify(md => md.RegisterDiscoveryEvents(It.IsAny<IDiscoveryRequest>()), Times.Once);
         mockDiscoveryRegistrar.Verify(md => md.UnregisterDiscoveryEvents(It.IsAny<IDiscoveryRequest>()), Times.Once);


### PR DESCRIPTION
## Description
Measures show that 1000 for discovery size makes it run faster because there is less contention when reporting the test results in parallel. This is because we report through a single channel and so there are less times threads run into each other and need to wait to send back their results.

We also don't want to push the results into a queue because then we have no backpressure.

There no risk that this value will break stuff, if we fail discovering tests we throw the whole dll results away anyway, no matter if we missed 1 tests or 1000 tests from the results.