### PR TITLE
Console logger splits path using directory and alt directory separators

### DIFF
--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text;
 
@@ -160,7 +161,6 @@ internal class ConsoleLogger : ITestLoggerWithParameters
     /// tracking counts per source for the minimal and quiet output.
     /// </summary>
     private ConcurrentDictionary<Guid, MinimalTestResult>? LeafTestResults { get; set; }
-
 
     #region ITestLoggerWithParameters
 
@@ -678,8 +678,8 @@ internal class ConsoleLogger : ITestLoggerWithParameters
         Output.WriteLine(string.Empty, OutputLevel.Information);
 
         // Printing Run-level Attachments
-        var runLevelAttachementCount = e.AttachmentSets == null ? 0 : e.AttachmentSets.Sum(attachmentSet => attachmentSet.Attachments.Count);
-        if (runLevelAttachementCount > 0)
+        var runLevelAttachmentsCount = e.AttachmentSets == null ? 0 : e.AttachmentSets.Sum(attachmentSet => attachmentSet.Attachments.Count);
+        if (runLevelAttachmentsCount > 0)
         {
             // If ARTIFACTS_POSTPROCESSING is disabled
             if (_featureFlag.IsSet(FeatureFlag.DISABLE_ARTIFACTS_POSTPROCESSING) ||
@@ -689,7 +689,7 @@ internal class ConsoleLogger : ITestLoggerWithParameters
                 CommandLineOptions.Instance.TestSessionCorrelationId is null)
             {
                 Output.Information(false, CommandLineResources.AttachmentsBanner);
-                TPDebug.Assert(e.AttachmentSets != null, "e.AttachmentSets should not be null when runLevelAttachementCount > 0.");
+                TPDebug.Assert(e.AttachmentSets != null, "e.AttachmentSets should not be null when runLevelAttachmentsCount > 0.");
                 foreach (var attachmentSet in e.AttachmentSets)
                 {
                     foreach (var uriDataAttachment in attachmentSet.Attachments)
@@ -765,7 +765,7 @@ internal class ConsoleLogger : ITestLoggerWithParameters
                     : $"({_targetFramework})";
 
                 var duration = GetFormattedDurationString(sourceSummary.Duration);
-                var sourceName = sd.Key.Split('\\').Last();
+                var sourceName = sd.Key.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).Last();
 
                 var outputLine = string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummary,
                     resultString,

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -765,7 +765,7 @@ internal class ConsoleLogger : ITestLoggerWithParameters
                     : $"({_targetFramework})";
 
                 var duration = GetFormattedDurationString(sourceSummary.Duration);
-                var sourceName = sd.Key.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).Last();
+                var sourceName = Path.GetFileName(sd.Key);
 
                 var outputLine = string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummary,
                     resultString,

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -624,7 +624,7 @@ public class IntegrationTestBase
         }
         else if (IsNetCoreRunner())
         {
-            var executablePath = TestUtils.IsWindows ? @"dotnet\dotnet.exe" : @"dotnet-linux/dotnet";
+            var executablePath = OSUtils.IsWindows ? @"dotnet\dotnet.exe" : @"dotnet-linux/dotnet";
             consoleRunnerPath = Path.Combine(_testEnvironment.ToolsDirectory, executablePath);
         }
         else
@@ -676,7 +676,7 @@ public class IntegrationTestBase
         var consoleRunnerPath = IsNetCoreRunner()
                 ? GetDotnetRunnerPath()
                 : GetConsoleRunnerPath();
-        var executablePath = TestUtils.IsWindows ? @"dotnet\dotnet.exe" : @"dotnet-linux/dotnet";
+        var executablePath = OSUtils.IsWindows ? @"dotnet\dotnet.exe" : @"dotnet-linux/dotnet";
         var dotnetPath = Path.Combine(_testEnvironment.ToolsDirectory, executablePath);
 
         if (!File.Exists(dotnetPath))
@@ -768,7 +768,7 @@ public class IntegrationTestBase
 
         environmentVariables["DOTNET_MULTILEVEL_LOOKUP"] = "0";
 
-        var executablePath = TestUtils.IsWindows ? @"dotnet\dotnet.exe" : @"dotnet-linux/dotnet";
+        var executablePath = OSUtils.IsWindows ? @"dotnet\dotnet.exe" : @"dotnet-linux/dotnet";
         var patchedDotnetPath = Path.Combine(_testEnvironment.TestArtifactsDirectory, executablePath);
         ExecuteApplication(patchedDotnetPath, string.Join(" ", command, args), out stdOut, out stdError, out exitCode, environmentVariables);
     }
@@ -952,7 +952,7 @@ public class IntegrationTestBase
             architecture == "X86" ?
             "dotnet_x86" :
             $"dotnet",
-            $"dotnet{(TestUtils.IsWindows ? ".exe" : "")}");
+            $"dotnet{(OSUtils.IsWindows ? ".exe" : "")}");
 
         Assert.IsTrue(File.Exists(path));
 

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -50,8 +50,6 @@ public class IntegrationTestBase
     private readonly string _xUnitTestAdapterRelativePath = @"xunit.runner.visualstudio\{0}\build\_common".Replace('\\', Path.DirectorySeparatorChar);
     private readonly string _chutzpahTestAdapterRelativePath = @"chutzpah\{0}\tools".Replace('\\', Path.DirectorySeparatorChar);
 
-    protected static readonly bool IsWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win");
-
     public enum UnitTestFramework
     {
         NUnit, XUnit, MSTest, CPP, Chutzpah
@@ -626,7 +624,7 @@ public class IntegrationTestBase
         }
         else if (IsNetCoreRunner())
         {
-            var executablePath = IsWindows ? @"dotnet\dotnet.exe" : @"dotnet-linux/dotnet";
+            var executablePath = TestUtils.IsWindows ? @"dotnet\dotnet.exe" : @"dotnet-linux/dotnet";
             consoleRunnerPath = Path.Combine(_testEnvironment.ToolsDirectory, executablePath);
         }
         else
@@ -678,7 +676,7 @@ public class IntegrationTestBase
         var consoleRunnerPath = IsNetCoreRunner()
                 ? GetDotnetRunnerPath()
                 : GetConsoleRunnerPath();
-        var executablePath = IsWindows ? @"dotnet\dotnet.exe" : @"dotnet-linux/dotnet";
+        var executablePath = TestUtils.IsWindows ? @"dotnet\dotnet.exe" : @"dotnet-linux/dotnet";
         var dotnetPath = Path.Combine(_testEnvironment.ToolsDirectory, executablePath);
 
         if (!File.Exists(dotnetPath))
@@ -770,7 +768,7 @@ public class IntegrationTestBase
 
         environmentVariables["DOTNET_MULTILEVEL_LOOKUP"] = "0";
 
-        var executablePath = IsWindows ? @"dotnet\dotnet.exe" : @"dotnet-linux/dotnet";
+        var executablePath = TestUtils.IsWindows ? @"dotnet\dotnet.exe" : @"dotnet-linux/dotnet";
         var patchedDotnetPath = Path.Combine(_testEnvironment.TestArtifactsDirectory, executablePath);
         ExecuteApplication(patchedDotnetPath, string.Join(" ", command, args), out stdOut, out stdError, out exitCode, environmentVariables);
     }
@@ -954,7 +952,7 @@ public class IntegrationTestBase
             architecture == "X86" ?
             "dotnet_x86" :
             $"dotnet",
-            $"dotnet{(IsWindows ? ".exe" : "")}");
+            $"dotnet{(TestUtils.IsWindows ? ".exe" : "")}");
 
         Assert.IsTrue(File.Exists(path));
 

--- a/test/Microsoft.TestPlatform.TestUtilities/OSUtils.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/OSUtils.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-
 namespace Microsoft.TestPlatform.TestUtilities;
 
-public static class TestUtils
+public static class OSUtils
 {
-    public static bool IsWindows { get; } = Environment.OSVersion.Platform.ToString().StartsWith("Win");
+    public static bool IsWindows { get; } = System.Environment.OSVersion.Platform.ToString().StartsWith("Win");
 }

--- a/test/Microsoft.TestPlatform.TestUtilities/TestUtils.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/TestUtils.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.TestPlatform.TestUtilities;
+
+public static class TestUtils
+{
+    public static bool IsWindows { get; } = Environment.OSVersion.Platform.ToString().StartsWith("Win");
+}

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -856,14 +856,22 @@ public class ConsoleLoggerTests
         loggerEvents.CompleteTestRun(null, false, false, null, null, null, new TimeSpan(1, 0, 0, 0));
 
         // Assert
-        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, "MyApp1.Tests.dll", ""), OutputLevel.Information), Times.Once());
-        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, "MyApp2.Tests.dll", ""), OutputLevel.Information), Times.Once());
+        VerifyCall("MyApp1.Tests.dll");
+        VerifyCall("MyApp2.Tests.dll");
         // On Linux and MAC we don't support backslash for path so source name will contain backslashes.
-        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, OSUtils.IsWindows ? "MyApp3.Tests.dll" : "MyApp3.Tests\\MyApp3.Tests.dll", ""), OutputLevel.Information), Times.Once());
+        VerifyCall(OSUtils.IsWindows ? "MyApp3.Tests.dll" : "MyApp3.Tests\\MyApp3.Tests.dll");
         // On Linux and MAC we don't support backslash for path so source name will contain backslashes.
-        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, OSUtils.IsWindows ? "MyApp4.Tests.dll" : "C:\\MyApp4\\Tests\\MyApp4.Tests\\MyApp4.Tests.dll", ""), OutputLevel.Information), Times.Once());
-        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, "MyApp5.Tests.dll", ""), OutputLevel.Information), Times.Once());
-        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, "MyApp6.Tests.dll", ""), OutputLevel.Information), Times.Once());
+        VerifyCall(OSUtils.IsWindows ? "MyApp4.Tests.dll" : @"C:\MyApp4\Tests\MyApp4.Tests\MyApp4.Tests.dll");
+        VerifyCall("MyApp5.Tests.dll");
+        VerifyCall(OSUtils.IsWindows ? "MyApp6.Tests.dll" : @"\\MyApp6\Tests\MyApp6.Tests\MyApp6.Tests.dll");
+
+        // Local functions
+        void VerifyCall(string testName)
+            => _mockOutput.Verify(
+                o => o.WriteLine(
+                    string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, testName, ""),
+                    OutputLevel.Information),
+                Times.Once());
     }
 
     [TestMethod]

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -19,6 +19,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
 using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.TestPlatform.TestUtilities;
 
 using Moq;
 
@@ -855,8 +856,10 @@ public class ConsoleLoggerTests
         // Assert
         _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, "MyApp1.Tests.dll", ""), OutputLevel.Information), Times.Once());
         _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, "MyApp2.Tests.dll", ""), OutputLevel.Information), Times.Once());
-        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, "MyApp3.Tests.dll", ""), OutputLevel.Information), Times.Once());
-        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, "MyApp4.Tests.dll", ""), OutputLevel.Information), Times.Once());
+        // On Linux and MAC we don't support backslash for path so source name will contain backslashes.
+        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, TestUtils.IsWindows ? "MyApp3.Tests.dll" : "MyApp3.Tests\\MyApp3.Tests.dll", ""), OutputLevel.Information), Times.Once());
+        // On Linux and MAC we don't support backslash for path so source name will contain backslashes.
+        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, TestUtils.IsWindows ? "MyApp4.Tests.dll" : "C:\\MyApp4\\Tests\\MyApp4.Tests\\MyApp4.Tests.dll", ""), OutputLevel.Information), Times.Once());
         _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, "MyApp5.Tests.dll", ""), OutputLevel.Information), Times.Once());
     }
 

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -861,7 +861,7 @@ public class ConsoleLoggerTests
         // On Linux and MAC we don't support backslash for path so source name will contain backslashes.
         VerifyCall(OSUtils.IsWindows ? "MyApp3.Tests.dll" : "MyApp3.Tests\\MyApp3.Tests.dll");
         // On Linux and MAC we don't support backslash for path so source name will contain backslashes.
-        VerifyCall(OSUtils.IsWindows ? "MyApp4.Tests.dll" : @"C:\MyApp4\Tests\MyApp4.Tests\MyApp4.Tests.dll");
+        VerifyCall(OSUtils.IsWindows ? "MyApp4.Tests.dll" : @"C:\\MyApp4\\Tests\\MyApp4.Tests\\MyApp4.Tests.dll");
         VerifyCall("MyApp5.Tests.dll");
         VerifyCall(OSUtils.IsWindows ? "MyApp6.Tests.dll" : @"\\MyApp6\Tests\MyApp6.Tests\MyApp6.Tests.dll");
 

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -849,6 +849,8 @@ public class ConsoleLoggerTests
         loggerEvents.RaiseTestResult(new(new(new("FQN4", new Uri("some://uri"), "C:\\\\MyApp4\\\\Tests\\\\MyApp4.Tests\\\\MyApp4.Tests.dll"))));
         // Mix backslashes and forward slashes path
         loggerEvents.RaiseTestResult(new(new(new("FQN5", new Uri("some://uri"), "C:\\MyApp5/Tests\\\\MyApp5.Tests///MyApp5.Tests.dll"))));
+        // UNC path
+        loggerEvents.RaiseTestResult(new(new(new("FQN6", new Uri("some://uri"), @"\\MyApp6\Tests\MyApp6.Tests\MyApp6.Tests.dll"))));
 
         // Act
         loggerEvents.CompleteTestRun(null, false, false, null, null, null, new TimeSpan(1, 0, 0, 0));
@@ -857,10 +859,11 @@ public class ConsoleLoggerTests
         _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, "MyApp1.Tests.dll", ""), OutputLevel.Information), Times.Once());
         _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, "MyApp2.Tests.dll", ""), OutputLevel.Information), Times.Once());
         // On Linux and MAC we don't support backslash for path so source name will contain backslashes.
-        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, TestUtils.IsWindows ? "MyApp3.Tests.dll" : "MyApp3.Tests\\MyApp3.Tests.dll", ""), OutputLevel.Information), Times.Once());
+        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, OSUtils.IsWindows ? "MyApp3.Tests.dll" : "MyApp3.Tests\\MyApp3.Tests.dll", ""), OutputLevel.Information), Times.Once());
         // On Linux and MAC we don't support backslash for path so source name will contain backslashes.
-        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, TestUtils.IsWindows ? "MyApp4.Tests.dll" : "C:\\MyApp4\\Tests\\MyApp4.Tests\\MyApp4.Tests.dll", ""), OutputLevel.Information), Times.Once());
+        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, OSUtils.IsWindows ? "MyApp4.Tests.dll" : "C:\\MyApp4\\Tests\\MyApp4.Tests\\MyApp4.Tests.dll", ""), OutputLevel.Information), Times.Once());
         _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, "MyApp5.Tests.dll", ""), OutputLevel.Information), Times.Once());
+        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryAssemblyAndFramework, "MyApp6.Tests.dll", ""), OutputLevel.Information), Times.Once());
     }
 
     [TestMethod]

--- a/test/vstest.console.UnitTests/vstest.console.UnitTests.csproj
+++ b/test/vstest.console.UnitTests/vstest.console.UnitTests.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.PlatformAbstractions\Microsoft.TestPlatform.PlatformAbstractions.csproj">
       <FromP2P>true</FromP2P>
     </ProjectReference>
+    <ProjectReference Include="..\Microsoft.TestPlatform.TestUtilities\Microsoft.TestPlatform.TestUtilities.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />


### PR DESCRIPTION
## Description

Console logger splits path using directory and alt directory separators. I decided to use both separators because I have no idea if we are ensured to receive backslashes for windows paths.

## Related issue

Fixes #3376
