### PR TITLE
Support test discovery in sources that are directories

### DIFF
--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestDiscoveryExtensionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestDiscoveryExtensionManager.cs
@@ -141,7 +141,7 @@ internal class TestDiscovererMetadata : ITestDiscovererCapabilities
     /// </summary>
     /// <param name="fileExtensions"> The file Extensions. </param>
     /// <param name="defaultExecutorUri"> The default Executor Uri. </param>
-    public TestDiscovererMetadata(IReadOnlyCollection<string>? fileExtensions, string? defaultExecutorUri, AssemblyType assemblyType = default)
+    public TestDiscovererMetadata(IReadOnlyCollection<string>? fileExtensions, string? defaultExecutorUri, AssemblyType assemblyType = default, bool isDirectoryBased = false)
     {
         if (fileExtensions != null && fileExtensions.Count > 0)
         {
@@ -154,6 +154,7 @@ internal class TestDiscovererMetadata : ITestDiscovererCapabilities
         }
 
         AssemblyType = assemblyType;
+        IsDirectoryBased = isDirectoryBased;
     }
 
     /// <summary>
@@ -178,6 +179,16 @@ internal class TestDiscovererMetadata : ITestDiscovererCapabilities
     /// Gets assembly type supported by the discoverer.
     /// </summary>
     public AssemblyType AssemblyType
+    {
+        get;
+        private set;
+    }
+
+    /// <summary>
+    /// <c>true</c> if the discoverer plugin is decorated with <see cref="DirectoryBasedTestDiscovererAttribute"/>,
+    /// <c>false</c> otherwise.
+    /// </summary>
+    public bool IsDirectoryBased
     {
         get;
         private set;

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestDiscovererPluginInformation.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestDiscovererPluginInformation.cs
@@ -29,6 +29,7 @@ internal class TestDiscovererPluginInformation : TestPluginInformation
             FileExtensions = GetFileExtensions(testDiscovererType);
             DefaultExecutorUri = GetDefaultExecutorUri(testDiscovererType);
             AssemblyType = GetAssemblyType(testDiscovererType);
+            IsDirectoryBased = GetIsDirectoryBased(testDiscovererType);
         }
     }
 
@@ -39,7 +40,7 @@ internal class TestDiscovererPluginInformation : TestPluginInformation
     {
         get
         {
-            return new object?[] { FileExtensions, DefaultExecutorUri, AssemblyType };
+            return new object?[] { FileExtensions, DefaultExecutorUri, AssemblyType, IsDirectoryBased };
         }
     }
 
@@ -71,15 +72,25 @@ internal class TestDiscovererPluginInformation : TestPluginInformation
     }
 
     /// <summary>
-    /// Helper to get file extensions from the FileExtensionAttribute on the discover plugin.
+    /// <c>true</c> if the discoverer plugin is decorated with <see cref="DirectoryBasedTestDiscovererAttribute"/>,
+    /// <c>false</c> otherwise.
     /// </summary>
-    /// <param name="testDicovererType">Data type of the test discoverer</param>
+    public bool IsDirectoryBased
+    {
+        get;
+        private set;
+    }
+
+    /// <summary>
+    /// Helper to get file extensions from the <see cref="FileExtensionAttribute"/>S on the discover plugin.
+    /// </summary>
+    /// <param name="testDiscovererType">Data type of the test discoverer</param>
     /// <returns>List of file extensions</returns>
-    private static List<string> GetFileExtensions(Type testDicovererType)
+    private static List<string> GetFileExtensions(Type testDiscovererType)
     {
         var fileExtensions = new List<string>();
 
-        var attributes = testDicovererType.GetTypeInfo().GetCustomAttributes(typeof(FileExtensionAttribute), false).ToArray();
+        var attributes = testDiscovererType.GetTypeInfo().GetCustomAttributes(typeof(FileExtensionAttribute), inherit: false).ToArray();
         if (attributes != null && attributes.Length > 0)
         {
             foreach (var attribute in attributes)
@@ -96,15 +107,15 @@ internal class TestDiscovererPluginInformation : TestPluginInformation
     }
 
     /// <summary>
-    /// Returns the value of default executor Uri on this type. 'Null' if not present.
+    /// Returns the value of default executor Uri on this type. <c>null</c> if not present.
     /// </summary>
     /// <param name="testDiscovererType"> The test discoverer Type. </param>
     /// <returns> The default executor URI. </returns>
     private static string GetDefaultExecutorUri(Type testDiscovererType)
     {
-        string result = string.Empty;
+        var result = string.Empty;
 
-        object[] attributes = testDiscovererType.GetTypeInfo().GetCustomAttributes(typeof(DefaultExecutorUriAttribute), false).ToArray();
+        var attributes = testDiscovererType.GetTypeInfo().GetCustomAttributes(typeof(DefaultExecutorUriAttribute), inherit: false).ToArray();
         if (attributes != null && attributes.Length > 0)
         {
             DefaultExecutorUriAttribute executorUriAttribute = (DefaultExecutorUriAttribute)attributes[0];
@@ -119,7 +130,7 @@ internal class TestDiscovererPluginInformation : TestPluginInformation
     }
 
     /// <summary>
-    /// Helper to get the supported assembly type from the CategoryAttribute on the discover plugin.
+    /// Helper to get the supported assembly type from the <see cref="CategoryAttribute"/> on the discover plugin.
     /// </summary>
     /// <param name="testDiscovererType"> The test discoverer Type. </param>
     /// <returns> Supported assembly type. </returns>
@@ -133,5 +144,16 @@ internal class TestDiscovererPluginInformation : TestPluginInformation
         // Get assembly type from category.
         Enum.TryParse(category, true, out AssemblyType assemblyType);
         return assemblyType;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if the discoverer plugin is decorated with
+    /// <see cref="DirectoryBasedTestDiscovererAttribute"/>, <c>false</c> otherwise.
+    /// </summary>
+    /// <param name="testDiscovererType">Data type of the test discoverer</param>
+    private static bool GetIsDirectoryBased(Type testDiscovererType)
+    {
+        var attribute = testDiscovererType.GetTypeInfo().GetCustomAttribute(typeof(DirectoryBasedTestDiscovererAttribute), inherit: false);
+        return attribute is DirectoryBasedTestDiscovererAttribute;
     }
 }

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestDiscovererPluginInformation.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestDiscovererPluginInformation.cs
@@ -82,7 +82,7 @@ internal class TestDiscovererPluginInformation : TestPluginInformation
     }
 
     /// <summary>
-    /// Helper to get file extensions from the <see cref="FileExtensionAttribute"/>S on the discover plugin.
+    /// Helper to get file extensions from the <see cref="FileExtensionAttribute"/> on the discover plugin.
     /// </summary>
     /// <param name="testDiscovererType">Data type of the test discoverer</param>
     /// <returns>List of file extensions</returns>

--- a/src/Microsoft.TestPlatform.Common/Interfaces/ITestDiscovererCapabilities.cs
+++ b/src/Microsoft.TestPlatform.Common/Interfaces/ITestDiscovererCapabilities.cs
@@ -27,4 +27,10 @@ public interface ITestDiscovererCapabilities
     /// Assembly type that the test discoverer supports.
     /// </summary>
     AssemblyType AssemblyType { get; }
+
+    /// <summary>
+    /// <c>true</c> if the discoverer plugin is decorated with <see cref="DirectoryBasedTestDiscovererAttribute"/>,
+    /// <c>false</c> otherwise.
+    /// </summary>
+    bool IsDirectoryBased { get; }
 }

--- a/src/Microsoft.TestPlatform.Common/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.Common/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.VisualStudio.TestPlatform.Common.Interfaces.ITestDiscovererCapabilities.IsDirectoryBased.get -> bool

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscoveryManager.cs
@@ -238,7 +238,7 @@ public class DiscoveryManager : IDiscoveryManager
     /// <summary>
     /// Verify/Normalize the test source files.
     /// </summary>
-    /// <param name="sources"> Paths to source file to look for tests in.  </param>
+    /// <param name="sources"> Paths to source file (or directory) in which to look for tests. </param>
     /// <param name="logger">logger</param>
     /// <param name="package">package</param>
     /// <returns> The list of verified sources. </returns>
@@ -255,7 +255,7 @@ public class DiscoveryManager : IDiscoveryManager
             // It is possible that runtime provider sent relative source path for remote scenario.
             string src = !Path.IsPathRooted(source) ? Path.Combine(Directory.GetCurrentDirectory(), source) : source;
 
-            if (!File.Exists(src))
+            if (!File.Exists(src) && !Directory.Exists(src))
             {
                 void SendWarning()
                 {

--- a/src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/ITestDiscoverer.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/ITestDiscoverer.cs
@@ -8,11 +8,21 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 /// <summary>
-/// Interface implemented to provide tests to the test platform.  A class that
-//  implements this interface will be available for use if its containing
-//  assembly is either placed in the Extensions folder or is marked as a 'UnitTestExtension' type
-//  in the vsix package.
+/// Interface implemented to provide tests to the test platform.
 /// </summary>
+/// <remarks>
+/// <para>
+/// A class that implements this interface will be available for use if its containing assembly is either placed in
+/// the Extensions folder or is marked as a 'UnitTestExtension' type in the vsix package.
+/// </para>
+/// <para>
+/// Provide one or more <see cref="FileExtensionAttribute"/>s on the implementing class to indicate the set of file
+/// extensions that are supported for test discovery. If the discoverer supports discovering tests present inside
+/// directories, provide <see cref="DirectoryBasedTestDiscovererAttribute"/> instead. If neither
+/// <see cref="DirectoryBasedTestDiscovererAttribute"/> nor <see cref="FileExtensionAttribute"/> is provided, the
+/// discoverer will be called for all relevant test files and directories.
+/// </para>
+/// </remarks>
 public interface ITestDiscoverer
 {
     /// <summary>

--- a/src/Microsoft.TestPlatform.ObjectModel/DirectoryBasedDiscovererAttribute.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/DirectoryBasedDiscovererAttribute.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+/// <summary>
+/// This attribute is applied to <see cref="ITestDiscoverer"/>s. It indicates the test discoverer discovers tests
+/// present inside a directory (as opposed to the <see cref="FileExtensionAttribute"/> which indicates that the
+/// discoverer discovers tests present in files with a specified extension).
+/// </summary>
+/// <remarks>
+/// If neither this attribute nor the <see cref="FileExtensionAttribute"/> is provided on the test discoverer,
+/// it will be called for all relevant test files and directories.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public sealed class DirectoryBasedTestDiscovererAttribute : Attribute
+{
+}

--- a/src/Microsoft.TestPlatform.ObjectModel/FileExtensionAttribute.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/FileExtensionAttribute.cs
@@ -3,14 +3,18 @@
 
 using System;
 
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 /// <summary>
-/// This attribute is applied to ITestDiscoverers.  It indicates
-/// which file extensions the test discoverer knows how to process.
-/// If this attribute is not provided on the test discoverer it will be
-/// called for all file types.
+/// This attribute is applied to <see cref="ITestDiscoverer"/>s. It indicates that the discoverer discovers tests
+/// present in files with the specified extension.
 /// </summary>
+/// <remarks>
+/// If neither this attribute nor the <see cref="DirectoryBasedTestDiscovererAttribute"/> is provided on the test
+/// discoverer, it will be called for all relevant test files and directories.
+/// </remarks>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
 public sealed class FileExtensionAttribute : Attribute
 {

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+Microsoft.VisualStudio.TestPlatform.ObjectModel.DirectoryBasedTestDiscovererAttribute
+Microsoft.VisualStudio.TestPlatform.ObjectModel.DirectoryBasedTestDiscovererAttribute.DirectoryBasedTestDiscovererAttribute() -> void

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestDiscoveryExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestDiscoveryExtensionManagerTests.cs
@@ -84,6 +84,7 @@ public class TestDiscovererMetadataTests
         var metadata = new TestDiscovererMetadata(null, null);
 
         Assert.IsNull(metadata.FileExtension);
+        Assert.IsFalse(metadata.IsDirectoryBased);
     }
 
     [TestMethod]
@@ -92,6 +93,7 @@ public class TestDiscovererMetadataTests
         var metadata = new TestDiscovererMetadata(new List<string>(), null);
 
         Assert.IsNull(metadata.FileExtension);
+        Assert.IsFalse(metadata.IsDirectoryBased);
     }
 
     [TestMethod]
@@ -100,6 +102,7 @@ public class TestDiscovererMetadataTests
         var metadata = new TestDiscovererMetadata(new List<string>(), null);
 
         Assert.IsNull(metadata.DefaultExecutorUri);
+        Assert.IsFalse(metadata.IsDirectoryBased);
     }
 
     [TestMethod]
@@ -108,6 +111,7 @@ public class TestDiscovererMetadataTests
         var metadata = new TestDiscovererMetadata(new List<string>(), " ");
 
         Assert.IsNull(metadata.DefaultExecutorUri);
+        Assert.IsFalse(metadata.IsDirectoryBased);
     }
 
     [TestMethod]
@@ -117,6 +121,7 @@ public class TestDiscovererMetadataTests
         var metadata = new TestDiscovererMetadata(extensions, null);
 
         CollectionAssert.AreEqual(extensions, metadata.FileExtension!.ToList());
+        Assert.IsFalse(metadata.IsDirectoryBased);
     }
 
     [TestMethod]
@@ -125,6 +130,7 @@ public class TestDiscovererMetadataTests
         var metadata = new TestDiscovererMetadata(null, "executor://helloworld");
 
         Assert.AreEqual("executor://helloworld/", metadata.DefaultExecutorUri!.AbsoluteUri);
+        Assert.IsFalse(metadata.IsDirectoryBased);
     }
 
     [TestMethod]
@@ -133,5 +139,14 @@ public class TestDiscovererMetadataTests
         var metadata = new TestDiscovererMetadata(null, "executor://helloworld", AssemblyType.Native);
 
         Assert.AreEqual(AssemblyType.Native, metadata.AssemblyType);
+        Assert.IsFalse(metadata.IsDirectoryBased);
+    }
+
+    [TestMethod]
+    public void TestDiscovererMetadataCtorSetsIsDirectoryBased()
+    {
+        var metadata = new TestDiscovererMetadata(null, "executor://helloworld", isDirectoryBased: true);
+
+        Assert.IsTrue(metadata.IsDirectoryBased);
     }
 }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/LazyExtensionTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/LazyExtensionTests.cs
@@ -94,6 +94,7 @@ public class LazyExtensionTests
         CollectionAssert.AreEqual(new List<string> { "csv" }, metadata.FileExtension!.ToArray());
         Assert.AreEqual("executor://unittestexecutor/", metadata.DefaultExecutorUri!.AbsoluteUri);
         Assert.AreEqual(AssemblyType.Native, metadata.AssemblyType);
+        Assert.IsFalse(metadata.IsDirectoryBased);
     }
 
     #endregion
@@ -120,14 +121,20 @@ public class LazyExtensionTests
             private set;
         }
 
-        public DummyDiscovererCapability(List<string> fileExtensions, string executorUri, AssemblyType assemblyType)
+        public bool IsDirectoryBased
+        {
+            get;
+            private set;
+        }
+
+        public DummyDiscovererCapability(List<string> fileExtensions, string executorUri, AssemblyType assemblyType, bool isDirectoryBased)
         {
             FileExtension = fileExtensions;
             DefaultExecutorUri = new Uri(executorUri);
             AssemblyType = assemblyType;
+            IsDirectoryBased = isDirectoryBased;
         }
     }
-
 
     [FileExtension("csv")]
     [DefaultExecutorUri("executor://unittestexecutor")]

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/TestDiscovererPluginInformationTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/TestDiscovererPluginInformationTests.cs
@@ -38,6 +38,7 @@ public class TestDiscovererPluginInformationTests
         _testPluginInformation = new TestDiscovererPluginInformation(typeof(DummyTestDiscovererWithNoFileExtensions));
         Assert.IsNotNull(_testPluginInformation.FileExtensions);
         Assert.AreEqual(0, _testPluginInformation.FileExtensions.Count);
+        Assert.IsFalse(_testPluginInformation.IsDirectoryBased);
     }
 
     [TestMethod]
@@ -45,6 +46,7 @@ public class TestDiscovererPluginInformationTests
     {
         _testPluginInformation = new TestDiscovererPluginInformation(typeof(DummyTestDiscovererWithOneFileExtensions));
         CollectionAssert.AreEqual(new List<string> { "csv" }, _testPluginInformation.FileExtensions);
+        Assert.IsFalse(_testPluginInformation.IsDirectoryBased);
     }
 
     [TestMethod]
@@ -52,6 +54,7 @@ public class TestDiscovererPluginInformationTests
     {
         _testPluginInformation = new TestDiscovererPluginInformation(typeof(DummyTestDiscovererWithTwoFileExtensions));
         CollectionAssert.AreEqual(new List<string> { "csv", "docx" }, _testPluginInformation.FileExtensions);
+        Assert.IsFalse(_testPluginInformation.IsDirectoryBased);
     }
 
     [TestMethod]
@@ -129,6 +132,36 @@ public class TestDiscovererPluginInformationTests
         CollectionAssert.AreEqual(expectedFileExtensions, ((List<string>)testPluginMetada[0]!).ToArray());
         Assert.AreEqual("csvexecutor", testPluginMetada[1] as string);
         Assert.AreEqual(AssemblyType.Managed, Enum.Parse(typeof(AssemblyType), testPluginMetada[2]!.ToString()!));
+        Assert.IsFalse(bool.Parse(testPluginMetada[3]!.ToString()!));
+    }
+
+    [TestMethod]
+    public void IsDirectoryBasedShouldReturnTrueIfDiscovererIsDirectoryBased()
+    {
+        _testPluginInformation = new TestDiscovererPluginInformation(typeof(DummyDirectoryBasedTestDiscoverer));
+        var testPluginMetada = _testPluginInformation.Metadata.ToArray();
+
+        Assert.IsNotNull(_testPluginInformation.FileExtensions);
+        Assert.AreEqual(0, _testPluginInformation.FileExtensions.Count);
+        Assert.IsNotNull(testPluginMetada[0]);
+        Assert.AreEqual(0, ((List<string>)testPluginMetada[0]!).Count);
+
+        Assert.IsTrue(_testPluginInformation.IsDirectoryBased);
+        Assert.IsTrue(bool.Parse(testPluginMetada[3]!.ToString()!));
+    }
+
+    [TestMethod]
+    public void FileExtensionsAndIsDirectroyBasedShouldReturnCorrectValuesWhenBothAreSupported()
+    {
+        _testPluginInformation = new TestDiscovererPluginInformation(typeof(DummyDirectoryBasedTestDiscovererWithFileExtensions));
+        var testPluginMetada = _testPluginInformation.Metadata.ToArray();
+        var expectedFileExtensions = new List<string> { "csv", "docx" };
+
+        CollectionAssert.AreEqual(expectedFileExtensions, _testPluginInformation.FileExtensions);
+        CollectionAssert.AreEqual(expectedFileExtensions, ((List<string>)testPluginMetada[0]!));
+
+        Assert.IsTrue(_testPluginInformation.IsDirectoryBased);
+        Assert.IsTrue(bool.Parse(testPluginMetada[3]!.ToString()!));
     }
 }
 
@@ -193,4 +226,15 @@ public class DummyTestDiscovererWithTwoFileExtensions
 {
 }
 
+[DirectoryBasedTestDiscoverer]
+public class DummyDirectoryBasedTestDiscoverer
+{
+}
+
+[DirectoryBasedTestDiscoverer]
+[FileExtension("csv")]
+[FileExtension("docx")]
+public class DummyDirectoryBasedTestDiscovererWithFileExtensions
+{
+}
 #endregion


### PR DESCRIPTION
At the moment, test platform only supports discovery of tests present inside test sources that are files. With the change in this PR, it can additionally support discovery of tests present inside test sources that are directories. This helps test adapters for certain languages like python which prefer to discover tests at the granularity of a directory as opposed to individual files.

Python adapter currently supplies test containers that are individual .py files to the VS test explorer. However, when these files are sent to the python test discoverer, the discoverer ignores the individual files and always jumps up to the containing project's directory to discover tests present inside all .py files present under this directory.

Python adapter has some reasons for this behavior (tickets linked below contain more context). However, there doesn't seem to be any significant reason why test platform can't support test discovery at a directory level granularity.

This PR relaxes the requirement that supplied test containers (sources) must always be files. It now also allows test containers that are directories. It also introduces a new `[DirectoryBasedDiscoverer]` attribute that can be applied on `ITestDiscoverer`s that only care to process sources that are directories (similar to the existing `[FileExtension]` attribute that can be applied on `ITestDiscoverer`s that only care to process sources that are files with specific extensions).

Related tickets:
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1586970
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1560000