### PR TITLE
Add some polyfill to simplify code across compilations

### DIFF
--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionAttachmentManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionAttachmentManager.cs
@@ -290,11 +290,7 @@ internal class DataCollectionAttachmentManager : IDataCollectionAttachmentManage
                         ex.ToString(),
                         uri,
                         friendlyName,
-                        Guid.Parse(testCaseId
-#if NET7_0_OR_GREATER
-                            , CultureInfo.InvariantCulture
-#endif
-                            )
+                        GuidPolyfill.Parse(testCaseId, CultureInfo.InvariantCulture)
                         );
 
                     throw;

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestCaseConverter.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestCaseConverter.cs
@@ -73,12 +73,7 @@ public class TestCaseConverter : JsonConverter
             switch (testProperty.Id)
             {
                 case "TestCase.Id":
-                    testCase.Id =
-#if NET7_0_OR_GREATER
-                        Guid.Parse(propertyData!, CultureInfo.InvariantCulture);
-#else
-                        Guid.Parse(propertyData!);
-#endif
+                    testCase.Id = GuidPolyfill.Parse(propertyData!, CultureInfo.InvariantCulture);
                     break;
                 case "TestCase.ExecutorUri":
                     testCase.ExecutorUri = new Uri(propertyData!); break;

--- a/src/Microsoft.TestPlatform.CoreUtilities/Extensions/GuidPolyfill.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Extensions/GuidPolyfill.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System;
+/// <summary>
+/// A polyfill helper for Guid.
+/// </summary>
+internal static class GuidPolyfill
+{
+    public static Guid Parse(string s, IFormatProvider? provider)
+        => Guid.Parse(s
+#if NET7_0_OR_GREATER
+            , System.Globalization.CultureInfo.InvariantCulture
+#endif
+            );
+}

--- a/src/Microsoft.TestPlatform.CoreUtilities/Extensions/StringBuilderPolyfill.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Extensions/StringBuilderPolyfill.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Text;
+internal static class StringBuilderPolyfill
+{
+#if !NET7_0_OR_GREATER
+    [Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Added to match new API.")]
+    public static StringBuilder Append(this StringBuilder builder, IFormatProvider? provider, string? value)
+        => builder.Append(value);
+#endif
+}

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcDumpArgsBuilder.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcDumpArgsBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Helpers;
@@ -50,18 +51,10 @@ public class ProcDumpArgsBuilder : IProcDumpArgsBuilder
 
         foreach (var exceptionFilter in procDumpExceptionsList)
         {
-            procDumpArgument.Append(
-#if NET7_0_OR_GREATER
-                System.Globalization.CultureInfo.InvariantCulture,
-#endif
-                $"-f {exceptionFilter} ");
+            procDumpArgument.Append(CultureInfo.InvariantCulture, $"-f {exceptionFilter} ");
         }
 
-        procDumpArgument.Append(
-#if NET7_0_OR_GREATER
-                System.Globalization.CultureInfo.InvariantCulture,
-#endif
-                $"{processId} {filename}.dmp");
+        procDumpArgument.Append(CultureInfo.InvariantCulture, $"{processId} {filename}.dmp");
 
         var argument = procdumpArgumentsFromEnv.IsNullOrWhiteSpace()
             ? procDumpArgument.ToString()
@@ -87,11 +80,7 @@ public class ProcDumpArgsBuilder : IProcDumpArgsBuilder
             procDumpArgument.Append(" -ma");
         }
 
-        procDumpArgument.Append(
-#if NET7_0_OR_GREATER
-                System.Globalization.CultureInfo.InvariantCulture,
-#endif
-                $" {processId} {filename}.dmp");
+        procDumpArgument.Append(CultureInfo.InvariantCulture, $" {processId} {filename}.dmp");
         var argument = procDumpArgument.ToString();
 
         return argument;

--- a/src/Microsoft.TestPlatform.ObjectModel/TestCase.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TestCase.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-#if NET7_0_OR_GREATER
 using System.Globalization;
-#endif
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -270,11 +268,7 @@ public sealed class TestCase : TestObject
                 }
                 else if (value is string guidString)
                 {
-#if NET7_0_OR_GREATER
-                    Id = Guid.Parse(guidString, CultureInfo.InvariantCulture);
-#else
-                    Id = Guid.Parse(guidString);
-#endif
+                    Id = GuidPolyfill.Parse(guidString, CultureInfo.InvariantCulture);
                 }
                 else
                 {


### PR DESCRIPTION
## Description

Add some polyfill to simplify code across compilations. This way we can use only one API but correctly target the recommended way for newer .NET.