### PR TITLE
Fixed Selenium test run hang after stopping the debugger

### DIFF
--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -141,7 +141,13 @@ public partial class ProcessHelper : IProcessHelper
                             }
                             else
                             {
-                                cts.Token.Register(() => p.Kill());
+                                cts.Token.Register(() =>
+                                {
+                                    if (!p.HasExited)
+                                    {
+                                        p.Kill();
+                                    }
+                                });
                                 await Task.Run(() => p.WaitForExit(), cts.Token).ConfigureAwait(false);
                             }
 #endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -143,9 +143,18 @@ public partial class ProcessHelper : IProcessHelper
                             {
                                 cts.Token.Register(() =>
                                 {
-                                    if (!p.HasExited)
+                                    try
                                     {
-                                        p.Kill();
+                                        if (!p.HasExited)
+                                        {
+                                            p.Kill();
+                                        }
+                                    }
+                                    catch
+                                    {
+                                        // Ignore all exceptions thrown when trying to kill a process that may be
+                                        // left hanging. This is a best effort to kill it, but should we fail for
+                                        // any reason we'd probably block on 'WaitForExit()' anyway.
                                     }
                                 });
                                 await Task.Run(() => p.WaitForExit(), cts.Token).ConfigureAwait(false);

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -26,6 +26,20 @@ public partial class ProcessHelper : IProcessHelper
     private static readonly string Arm = "arm";
     private readonly Process _currentProcess = Process.GetCurrentProcess();
 
+    private IEnvironment _environment;
+
+    /// <summary>
+    /// Default constructor.
+    /// </summary>
+    public ProcessHelper() : this(new PlatformEnvironment())
+    {
+    }
+
+    internal ProcessHelper(IEnvironment environment)
+    {
+        _environment = environment;
+    }
+
     /// <inheritdoc/>
     public object LaunchProcess(string processPath, string? arguments, string? workingDirectory, IDictionary<string, string?>? envVariables, Action<object?, string?>? errorCallback, Action<object?>? exitCallBack, Action<object?, string?>? outputCallBack)
     {
@@ -84,10 +98,10 @@ public partial class ProcessHelper : IProcessHelper
 
             if (exitCallBack != null)
             {
-                const int timeout = 500;
-
                 process.Exited += async (sender, args) =>
                 {
+                    const int timeout = 500;
+
                     if (sender is Process p)
                     {
                         try
@@ -108,8 +122,20 @@ public partial class ProcessHelper : IProcessHelper
 #if NET5_0_OR_GREATER
                             await p.WaitForExitAsync(cts.Token);
 #else
-                            var os = new PlatformEnvironment().OperatingSystem;
-                            if (os is PlatformOperatingSystem.Windows)
+                            // NOTE: In case we run on Windows we must call 'WaitForExit(timeout)' instead of calling
+                            // the parameterless overload. The reason for this requirement stems from the behavior of
+                            // the Selenium WebDriver when debugging a test. If the debugger is detached, the default
+                            // action is to kill the testhost process that it was attached to, but for some reason we
+                            // end up with a zombie process that would make us wait indefinitely with a simple
+                            // 'WaitForExit()' call. This in turn causes the vstest.console to block waiting for the
+                            // test request to finish and this behavior will be visible to the user since TW will
+                            // show the Selenium test as still running. Only killing the Edge Driver process would help
+                            // unblock vstest.console, but this is not a reasonable ask to our users.
+                            //
+                            // TODO: This fix is not ideal, it's only a workaround to make Selenium tests usable again.
+                            // Ideally, we should spend some more time here in order to better understand what causes
+                            // the testhost to become a zombie process in the first place.
+                            if (_environment.OperatingSystem is PlatformOperatingSystem.Windows)
                             {
                                 p.WaitForExit(timeout);
                             }


### PR DESCRIPTION
Fixed Selenium test run hang after stopping the debugger