### PR TITLE
Remove portable CPP adapter and dbghelp

### DIFF
--- a/scripts/verify-nupkgs.ps1
+++ b/scripts/verify-nupkgs.ps1
@@ -16,7 +16,7 @@ function Verify-Nuget-Packages($packageDirectory, $version)
         "Microsoft.NET.Test.Sdk" = 16;
         "Microsoft.TestPlatform" = 602;
         "Microsoft.TestPlatform.Build" = 21;
-        "Microsoft.TestPlatform.CLI" = 499;
+        "Microsoft.TestPlatform.CLI" = 479;
         "Microsoft.TestPlatform.Extensions.TrxLogger" = 35;
         "Microsoft.TestPlatform.ObjectModel" = 93;
         "Microsoft.TestPlatform.AdapterUtilities" = 34;

--- a/src/package/nuspec/TestPlatform.CLI.nuspec
+++ b/src/package/nuspec/TestPlatform.CLI.nuspec
@@ -29,6 +29,7 @@
     <!-- Add a third party notice file -->
     <file src="ThirdPartyNotices.txt" target="" />
     
-    <file src="$TargetFramework$\**\*.*" exclude="**\*.pdb" target="contentFiles\any\$TargetFramework$" />
+    <!-- excluding dbghelp and cpp as they cannot be re-distributed with sdk, but need to be distributed with VS -->
+    <file src="$TargetFramework$\**\*.*" exclude="**\*.pdb;**\dbghelp.dll;**\*TestTools.CppUnitTestFramework*" target="contentFiles\any\$TargetFramework$" />
   </files>
 </package>


### PR DESCRIPTION
## Description
Remove portable CPP adapter and dbghelp from SDK insertion package. 

## Related issue
Fix https://github.com/dotnet/sdk/issues/26590