### PR TITLE
Add support for ppc64le processor architecture

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/Architecture.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Architecture.cs
@@ -11,5 +11,6 @@ public enum Architecture
     ARM,
     AnyCPU,
     ARM64,
-    S390x
+    S390x,
+    PPC64le
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/Architecture.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Architecture.cs
@@ -12,5 +12,5 @@ public enum Architecture
     AnyCPU,
     ARM64,
     S390x,
-    PPC64le
+    Ppc64le
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
@@ -113,6 +113,7 @@ Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.ARM = 3 -> Microsof
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.ARM64 = 5 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.Default = 0 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.S390x = 6 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
+Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.Ppc64le = 7 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.X64 = 2 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.X86 = 1 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
 Microsoft.VisualStudio.TestPlatform.ObjectModel.AttachmentSet

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/PlatformArchitecture.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/PlatformArchitecture.cs
@@ -13,4 +13,5 @@ public enum PlatformArchitecture
     ARM,
     ARM64,
     S390x,
+    PPC64le,
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/PlatformArchitecture.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/PlatformArchitecture.cs
@@ -13,5 +13,5 @@ public enum PlatformArchitecture
     ARM,
     ARM64,
     S390x,
-    PPC64le,
+    Ppc64le,
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/PublicAPI/PublicAPI.Shipped.txt
@@ -67,6 +67,7 @@ Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture
 Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture.ARM = 2 -> Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture
 Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture.ARM64 = 3 -> Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture
 Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture.S390x = 4 -> Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture
+Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture.Ppc64le = 5 -> Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture
 Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture.X64 = 1 -> Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture
 Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture.X86 = 0 -> Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture
 Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformAssemblyExtensions

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformEnvironment.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformEnvironment.cs
@@ -28,7 +28,7 @@ public class PlatformEnvironment : IEnvironment
                 // preview 6 or later, so use the numerical value for now.
                 // case System.Runtime.InteropServices.Architecture.S390x:
                 (Architecture)5 => PlatformArchitecture.S390x,
-                (Architecture)6 => PlatformArchitecture.PPC64le,
+                (Architecture)8 => PlatformArchitecture.Ppc64le,
                 _ => throw new NotSupportedException(),
             };
         }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformEnvironment.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformEnvironment.cs
@@ -28,6 +28,7 @@ public class PlatformEnvironment : IEnvironment
                 // preview 6 or later, so use the numerical value for now.
                 // case System.Runtime.InteropServices.Architecture.S390x:
                 (Architecture)5 => PlatformArchitecture.S390x,
+                (Architecture)6 => PlatformArchitecture.PPC64le,
                 _ => throw new NotSupportedException(),
             };
         }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
@@ -41,7 +41,7 @@ public partial class ProcessHelper : IProcessHelper
             // preview 6 or later, so use the numerical value for now.
             // case System.Runtime.InteropServices.Architecture.S390x:
             (Architecture)5 => PlatformArchitecture.S390x,
-            (Architecture)6 => PlatformArchitecture.PPC64le,
+            (Architecture)8 => PlatformArchitecture.Ppc64le,
             _ => throw new NotSupportedException(),
         };
     }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
@@ -41,6 +41,7 @@ public partial class ProcessHelper : IProcessHelper
             // preview 6 or later, so use the numerical value for now.
             // case System.Runtime.InteropServices.Architecture.S390x:
             (Architecture)5 => PlatformArchitecture.S390x,
+            (Architecture)6 => PlatformArchitecture.PPC64le,
             _ => throw new NotSupportedException(),
         };
     }

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -274,7 +274,7 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
             PlatformArchitecture.ARM => Architecture.ARM,
             PlatformArchitecture.ARM64 => Architecture.ARM64,
             PlatformArchitecture.S390x => Architecture.S390x,
-            PlatformArchitecture.PPC64le => Architecture.PPC64le,
+            PlatformArchitecture.Ppc64le => Architecture.Ppc64le,
             _ => throw new NotSupportedException(),
         };
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -274,6 +274,7 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
             PlatformArchitecture.ARM => Architecture.ARM,
             PlatformArchitecture.ARM64 => Architecture.ARM64,
             PlatformArchitecture.S390x => Architecture.S390x,
+            PlatformArchitecture.PPC64le => Architecture.PPC64le,
             _ => throw new NotSupportedException(),
         };
 

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -841,8 +841,8 @@ internal class TestRequestManager : ITestRequestManager
                     return Architecture.ARM64;
                 case PlatformArchitecture.S390x:
                     return Architecture.S390x;
-                case PlatformArchitecture.PPC64le:
-                    return Architecture.PPC64le;
+                case PlatformArchitecture.Ppc64le:
+                    return Architecture.Ppc64le;
                 default:
                     EqtTrace.Error($"TestRequestManager.TranslateToArchitecture: Unhandled architecture '{targetArchitecture}'.");
                     break;

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -841,6 +841,8 @@ internal class TestRequestManager : ITestRequestManager
                     return Architecture.ARM64;
                 case PlatformArchitecture.S390x:
                     return Architecture.S390x;
+                case PlatformArchitecture.PPC64le:
+                    return Architecture.PPC64le;
                 default:
                     EqtTrace.Error($"TestRequestManager.TranslateToArchitecture: Unhandled architecture '{targetArchitecture}'.");
                     break;

--- a/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
@@ -85,7 +85,7 @@ public class PlatformArgumentProcessorTests
     {
         ExceptionUtilities.ThrowsException<CommandLineException>(
             () => _executor.Initialize("foo"),
-            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x, ppc64le.",
+            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x, Ppc64le.",
             "foo");
     }
 
@@ -94,7 +94,7 @@ public class PlatformArgumentProcessorTests
     {
         ExceptionUtilities.ThrowsException<CommandLineException>(
             () => _executor.Initialize("AnyCPU"),
-            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x, ppc64le.",
+            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x, Ppc64le.",
             "AnyCPU");
     }
 

--- a/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
@@ -85,7 +85,7 @@ public class PlatformArgumentProcessorTests
     {
         ExceptionUtilities.ThrowsException<CommandLineException>(
             () => _executor.Initialize("foo"),
-            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x, PPC64le.",
+            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x, ppc64le.",
             "foo");
     }
 
@@ -94,7 +94,7 @@ public class PlatformArgumentProcessorTests
     {
         ExceptionUtilities.ThrowsException<CommandLineException>(
             () => _executor.Initialize("AnyCPU"),
-            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x, PPC64le.",
+            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x, ppc64le.",
             "AnyCPU");
     }
 

--- a/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
@@ -85,7 +85,7 @@ public class PlatformArgumentProcessorTests
     {
         ExceptionUtilities.ThrowsException<CommandLineException>(
             () => _executor.Initialize("foo"),
-            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x.",
+            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x, PPC64le.",
             "foo");
     }
 
@@ -94,7 +94,7 @@ public class PlatformArgumentProcessorTests
     {
         ExceptionUtilities.ThrowsException<CommandLineException>(
             () => _executor.Initialize("AnyCPU"),
-            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x.",
+            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x, PPC64le.",
             "AnyCPU");
     }
 


### PR DESCRIPTION
## Description
We have added support for the ppc64le processor architecture to the dotnet runtime. For that we have added a new value for the System.Runtime.InteropServices.Architecture enum: dotnet/runtime#67428
Code in Microsoft.VisualStudio.TestPlatform.PlatformAbstractions does not recognize this new value. This patch adds a new value to Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture.

## Related issue
NA
