### PR TITLE
Add postmortem blame mode

### DIFF
--- a/playground/TestPlatform.Playground/TestPlatform.Playground.csproj
+++ b/playground/TestPlatform.Playground/TestPlatform.Playground.csproj
@@ -47,7 +47,7 @@
 
     <ItemGroup>
       <FileToCopy Include="$(SourcePath)vstest.console\bin\$(Configuration)\$(NetFrameworkMinimum)\**\*.*" SubFolder="" />
-      <FileToCopy Include="$(SourcePath)Microsoft.TestPlatform.TestHostProvider\bin\$(Configuration)\$(NetFrameworkMinimum)\**\*.*" SubFolder="vstest.console\Extensions\" />
+      <FileToCopy Include="$(SourcePath)Microsoft.TestPlatform.TestHostProvider\bin\$(Configuration)\$(NetFrameworkMinimum)\**\*.*" SubFolder="Extensions\" />
 
       <!-- copy net462, net47, net471, net472 and net48 testhosts" -->
       <FileToCopy Include="$(SourcePath)testhost.x86\bin\$(Configuration)\$(NetFrameworkMinimum)\win7-x86\**\*.*" SubFolder="TestHostNetFramework\" />

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
@@ -8,11 +8,16 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
 using System.Xml;
 
 using Microsoft.VisualStudio.TestPlatform.Execution;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
+using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
+using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
 using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
 using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
@@ -37,11 +42,13 @@ public class BlameCollector : DataCollector, ITestExecutionEnvironmentSpecifier
     private Dictionary<Guid, BlameTestObject>? _testObjectDictionary;
     private readonly IBlameReaderWriter _blameReaderWriter;
     private readonly IFileHelper _fileHelper;
+    private readonly IProcessHelper _processHelper;
     private XmlElement? _configurationElement;
     private int _testStartCount;
     private int _testEndCount;
     private bool _collectProcessDumpOnCrash;
     private bool _collectProcessDumpOnHang;
+    private bool _monitorPostmortemDumpFolder;
     private bool _collectDumpAlways;
     private string? _attachmentGuid;
 
@@ -53,17 +60,19 @@ public class BlameCollector : DataCollector, ITestExecutionEnvironmentSpecifier
     private TimeSpan _inactivityTimespan = TimeSpan.FromMinutes(DefaultInactivityTimeInMinutes);
 
     private int _testHostProcessId;
+    private string? _testHostProcessName;
     private string? _targetFramework;
     private readonly List<KeyValuePair<string, string>> _environmentVariables = new();
     private bool _uploadDumpFiles;
     private string? _tempDirectory;
+    private string? _monitorPostmortemDumpFolderPath;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BlameCollector"/> class.
     /// Using XmlReaderWriter by default
     /// </summary>
     public BlameCollector()
-        : this(new XmlReaderWriter(), new ProcessDumpUtility(), null, new FileHelper())
+        : this(new XmlReaderWriter(), new ProcessDumpUtility(), null, new FileHelper(), new ProcessHelper())
     {
     }
 
@@ -86,12 +95,14 @@ public class BlameCollector : DataCollector, ITestExecutionEnvironmentSpecifier
         IBlameReaderWriter blameReaderWriter,
         IProcessDumpUtility processDumpUtility,
         IInactivityTimer? inactivityTimer,
-        IFileHelper fileHelper)
+        IFileHelper fileHelper,
+        IProcessHelper processHelper)
     {
         _blameReaderWriter = blameReaderWriter;
         _processDumpUtility = processDumpUtility;
         _inactivityTimer = inactivityTimer;
         _fileHelper = fileHelper;
+        _processHelper = processHelper;
     }
 
     /// <summary>
@@ -171,6 +182,10 @@ public class BlameCollector : DataCollector, ITestExecutionEnvironmentSpecifier
             {
                 _collectProcessDumpOnHang = false;
             }
+
+            _monitorPostmortemDumpFolder = _configurationElement[Constants.MonitorPostmortemDebugger] is XmlElement monitorPostmortemNode &&
+                ValidateMonitorPostmortemDebuggerParameters(monitorPostmortemNode);
+            EqtTrace.Info($"[MonitorPostmortemDump]Monitor enabled: '{_monitorPostmortemDumpFolder}'");
 
             var tfm = _configurationElement[Constants.TargetFramework]?.InnerText;
             if (!tfm.IsNullOrWhiteSpace())
@@ -308,6 +323,24 @@ public class BlameCollector : DataCollector, ITestExecutionEnvironmentSpecifier
         {
             EqtTrace.Error(ex);
         }
+    }
+
+    private bool ValidateMonitorPostmortemDebuggerParameters(XmlElement collectDumpNode)
+    {
+        TPDebug.Assert(_logger != null && _context != null, "Initialize must be called before calling this method");
+        if (StringUtils.IsNullOrEmpty(_monitorPostmortemDumpFolderPath = collectDumpNode.GetAttribute("DumpDirectoryPath")))
+        {
+            _logger.LogWarning(_context.SessionDataCollectionContext, Resources.Resources.MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter);
+            return false;
+        }
+
+        if (!_fileHelper.DirectoryExists(_monitorPostmortemDumpFolderPath))
+        {
+            _logger.LogWarning(_context.SessionDataCollectionContext, Resources.Resources.MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter);
+            return false;
+        }
+
+        return true;
     }
 
     private void ValidateAndAddCrashProcessDumpParameters(XmlElement collectDumpNode)
@@ -466,7 +499,7 @@ public class BlameCollector : DataCollector, ITestExecutionEnvironmentSpecifier
     /// <param name="args">SessionEndEventArgs</param>
     private void SessionEndedHandler(object? sender, SessionEndEventArgs args)
     {
-        TPDebug.Assert(_testSequence != null && _testObjectDictionary != null && _context != null && _dataCollectionSink != null && _logger != null, "Initialize must be called before calling this method");
+        TPDebug.Assert(_testHostProcessName != null && _testSequence != null && _testObjectDictionary != null && _context != null && _dataCollectionSink != null && _logger != null, "Initialize must be called before calling this method");
         ResetInactivityTimer();
 
         EqtTrace.Info("Blame Collector: Session End");
@@ -525,6 +558,55 @@ public class BlameCollector : DataCollector, ITestExecutionEnvironmentSpecifier
             {
                 EqtTrace.Info("BlameCollector.CollectDumpAndAbortTesthost: Custom path to dump directory was provided via VSTEST_DUMP_PATH. Skipping attachment upload, the caller is responsible for collecting and uploading the dumps themselves.");
             }
+
+            if (_monitorPostmortemDumpFolder)
+            {
+                if (!_fileHelper.DirectoryExists(_monitorPostmortemDumpFolderPath))
+                {
+                    _logger.LogWarning(_context.SessionDataCollectionContext, Resources.Resources.MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter);
+                }
+                else
+                {
+                    // We do ToArray() because we're moving files and we cannot move file and enumerate at the same time
+                    foreach (var dumpFileNameFullPath in _fileHelper.GetFiles(_monitorPostmortemDumpFolderPath, "*.dmp", SearchOption.TopDirectoryOnly).ToArray())
+                    {
+                        EqtTrace.Info($"[MonitorPostmortemDump]'{dumpFileNameFullPath}' dump file found during postmortem monitoring");
+                        // Ensure exclusive access to the dump file, it can happen if we run more test module in parallel.
+                        // We cannot ensure that we'll move only "our" dump because procdump -i produce a name that doesn't have the pid in it(because PID is reusable).
+                        // The name of the file starts with the process name, that's the only filtering we can do.
+                        // So there's one possible benign race condition when another test is dumping an host and we take lock on the name but the dump is not finished.
+                        // In that case we'll fail for file locking but it's fine. The correct or subsequent "SessionEndedHandler" will move that one.
+                        using MD5 md5LockName = MD5.Create();
+                        // BitConverter converts into something like EC-1B-B6-22-81-00-41-C8-31-1D-B6-61-27-6A-65-8A valid muxer name
+                        // LPCSTR An LPCSTR is a 32-bit pointer to a constant null-terminated string of 8-bit Windows (ANSI) characters.
+                        string muxerName = @$"Global\{BitConverter.ToString(md5LockName.ComputeHash(Encoding.UTF8.GetBytes(dumpFileNameFullPath)))}";
+                        using Mutex lockFile = new(true, muxerName, out bool createdNew);
+                        EqtTrace.Info($"[MonitorPostmortemDump]Acquired global muxer '{muxerName}' for {dumpFileNameFullPath}");
+                        if (createdNew)
+                        {
+                            string dumpFileName = Path.GetFileNameWithoutExtension(dumpFileNameFullPath);
+
+                            // Expected format testhost.exe_221004_123127.dmp processName.exe_yyMMdd_HHmmss.dmp
+                            if (dumpFileName.StartsWith(_testHostProcessName, StringComparison.OrdinalIgnoreCase))
+                            {
+                                EqtTrace.Info($"[MonitorPostmortemDump]Valid pattern start with '{_testHostProcessName}' found for {dumpFileNameFullPath}");
+                                try
+                                {
+                                    var fileTranferInformation = new FileTransferInformation(_context.SessionDataCollectionContext, dumpFileNameFullPath, true);
+                                    EqtTrace.Info($"[MonitorPostmortemDump]Transferring {dumpFileNameFullPath}");
+                                    _dataCollectionSink.SendFileAsync(fileTranferInformation);
+                                }
+                                catch (IOException ex)
+                                {
+                                    // In case of race explained in the comment above we simply log a warning.
+                                    EqtTrace.Warning(ex.ToString());
+                                    _logger.LogWarning(args.Context, ex.ToString());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
         finally
         {
@@ -547,6 +629,7 @@ public class BlameCollector : DataCollector, ITestExecutionEnvironmentSpecifier
     {
         ResetInactivityTimer();
         _testHostProcessId = args.TestHostProcessId;
+        _testHostProcessName = _processHelper.GetProcessName(args.TestHostProcessId);
 
         if (!_collectProcessDumpOnCrash)
         {

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
@@ -598,7 +598,7 @@ public class BlameCollector : DataCollector, ITestExecutionEnvironmentSpecifier
                                 }
                                 catch (IOException ex)
                                 {
-                                    // In case of race explained in the comment above we simply log a warning.
+                                    // In case of race condition explained in the comment above we simply log a warning.
                                     EqtTrace.Warning(ex.ToString());
                                     _logger.LogWarning(args.Context, ex.ToString());
                                 }

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Constants.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Constants.cs
@@ -84,6 +84,11 @@ internal static class Constants
     public const string CollectDumpOnTestSessionHang = "CollectDumpOnTestSessionHang";
 
     /// <summary>
+    /// Configuration key name for monitoring a folder for postmortem dumps
+    /// </summary>
+    public const string MonitorPostmortemDebugger = "MonitorPostmortemDebugger";
+
+    /// <summary>
     /// Configuration key name for specifying what the expected execution time for the longest running test is.
     /// If no events come from the test host for this period a dump will be collected and the test host process will
     /// be killed.

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/Resources.Designer.cs
@@ -136,6 +136,15 @@ namespace Microsoft.TestPlatform.Extensions.BlameDataCollector.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid &apos;DumpDirectoryPath&apos; for postmortem debugger monitor.
+        /// </summary>
+        internal static string MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter {
+            get {
+                return ResourceManager.GetString("MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to All tests finished running, Sequence file will not be generated.
         /// </summary>
         internal static string NotGeneratingSequenceFile {

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/Resources.resx
@@ -171,4 +171,7 @@ This test may, or may not be the source of the crash.</value>
   <data name="UnexpectedValueForInactivityTimespanValue" xml:space="preserve">
     <value>Unexpected value '{0}' provided as timeout. Please provide a value in this format: 1.5h / 90m / 5400s / 5400000ms / 5400000</value>
   </data>
+  <data name="MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter" xml:space="preserve">
+    <value>Invalid 'DumpDirectoryPath' for postmortem debugger monitor</value>
+  </data>
 </root>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.cs.xlf
@@ -83,6 +83,11 @@ Tento test může a nemusí být příčinou chybového ukončení.</target>
         <target state="translated">{0} nelze najít. Zkontrolujte, zda je spustitelný soubor k dispozici v cestě PATH, případně nastavte proměnnou prostředí PROCDUMP_PATH na adresář, který obsahuje spustitelný soubor {0}.</target>
         <note>0 is procDumpPath, a name of procdump executable such as procdump64.exe, 0 is used twice on purpose. PROCDUMP_PATH and PATH are literal and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter">
+        <source>Invalid 'DumpDirectoryPath' for postmortem debugger monitor</source>
+        <target state="new">Invalid 'DumpDirectoryPath' for postmortem debugger monitor</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.de.xlf
@@ -83,6 +83,11 @@ Dieser Test kann, muss aber nicht unbedingt die Absturzursache sein.</target>
         <target state="translated">{0} wurde nicht gefunden. Stellen Sie sicher, dass die ausführbare Datei unter PATH verfügbar ist. Legen Sie alternativ die Umgebungsvariable PROCDUMP_PATH auf ein Verzeichnis fest, das {0} ausführbare Datei enthält.</target>
         <note>0 is procDumpPath, a name of procdump executable such as procdump64.exe, 0 is used twice on purpose. PROCDUMP_PATH and PATH are literal and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter">
+        <source>Invalid 'DumpDirectoryPath' for postmortem debugger monitor</source>
+        <target state="new">Invalid 'DumpDirectoryPath' for postmortem debugger monitor</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.es.xlf
@@ -83,6 +83,11 @@ Esta prueba puede ser el origen del bloqueo o no serlo.</target>
         <target state="translated">no se encontró {0}. Cerciórese de que el ejecutable está disponible en PATH o establezca variable de entorno PROCDUMP_PATH en un directorio que contenga {0} ejecutable</target>
         <note>0 is procDumpPath, a name of procdump executable such as procdump64.exe, 0 is used twice on purpose. PROCDUMP_PATH and PATH are literal and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter">
+        <source>Invalid 'DumpDirectoryPath' for postmortem debugger monitor</source>
+        <target state="new">Invalid 'DumpDirectoryPath' for postmortem debugger monitor</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.fr.xlf
@@ -83,6 +83,11 @@ Ce test est éventuellement à l'origine du plantage.</target>
         <target state="translated">{0} est introuvable, vérifiez que l’exécutable est disponible sur PATH. Vous pouvez également définir PROCDUMP_PATH variable d’environnement sur un répertoire qui contient l’exécutable {0}</target>
         <note>0 is procDumpPath, a name of procdump executable such as procdump64.exe, 0 is used twice on purpose. PROCDUMP_PATH and PATH are literal and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter">
+        <source>Invalid 'DumpDirectoryPath' for postmortem debugger monitor</source>
+        <target state="new">Invalid 'DumpDirectoryPath' for postmortem debugger monitor</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.it.xlf
@@ -83,6 +83,11 @@ Il test potrebbe essere l'origine dell'arresto anomalo.</target>
         <target state="translated">{0} non è stato trovato, verificare che il file eseguibile sia disponibile in PATH. In alternativa, impostare la variabile di ambiente PROCDUMP_PATH su una directory che contiene {0} eseguibile</target>
         <note>0 is procDumpPath, a name of procdump executable such as procdump64.exe, 0 is used twice on purpose. PROCDUMP_PATH and PATH are literal and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter">
+        <source>Invalid 'DumpDirectoryPath' for postmortem debugger monitor</source>
+        <target state="new">Invalid 'DumpDirectoryPath' for postmortem debugger monitor</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.ja.xlf
@@ -83,6 +83,11 @@ This test may, or may not be the source of the crash.</source>
         <target state="translated">{0} が見つかりませんでした。PATH で実行可能ファイルを使用できることを確認してください。または、PROCDUMP_PATH 環境変数を、実行可能ファイル {0} が含まれるディレクトリに設定してください</target>
         <note>0 is procDumpPath, a name of procdump executable such as procdump64.exe, 0 is used twice on purpose. PROCDUMP_PATH and PATH are literal and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter">
+        <source>Invalid 'DumpDirectoryPath' for postmortem debugger monitor</source>
+        <target state="new">Invalid 'DumpDirectoryPath' for postmortem debugger monitor</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.ko.xlf
@@ -83,6 +83,11 @@ This test may, or may not be the source of the crash.</source>
         <target state="translated">{0}을(를) 찾을 수 없습니다. 실행 파일을 PATH에서 사용할 수 있는지 확인합니다. 또는 PROCDUMP_PATH 환경 변수를 {0} 실행 파일이 포함된 디렉터리로 설정하세요.</target>
         <note>0 is procDumpPath, a name of procdump executable such as procdump64.exe, 0 is used twice on purpose. PROCDUMP_PATH and PATH are literal and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter">
+        <source>Invalid 'DumpDirectoryPath' for postmortem debugger monitor</source>
+        <target state="new">Invalid 'DumpDirectoryPath' for postmortem debugger monitor</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.pl.xlf
@@ -83,6 +83,11 @@ Ten test może, ale nie musi być źródłem awarii.</target>
         <target state="translated">Nie można odnaleźć pliku wykonywalnego {0}. Upewnij się, że plik wykonywalny jest dostępny w ścieżce PATH. Możesz też ustawić zmienną środowiskową PROCDUMP_PATH na katalog zawierający plik wykonywalny {0}.</target>
         <note>0 is procDumpPath, a name of procdump executable such as procdump64.exe, 0 is used twice on purpose. PROCDUMP_PATH and PATH are literal and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter">
+        <source>Invalid 'DumpDirectoryPath' for postmortem debugger monitor</source>
+        <target state="new">Invalid 'DumpDirectoryPath' for postmortem debugger monitor</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.pt-BR.xlf
@@ -83,6 +83,11 @@ Esse teste pode ser a origem da falha ou não.</target>
         <target state="translated">{0} não pôde ser encontrado, verifique se o executável está disponível no CAMINHO. Alternativamente, defina a variável de ambiente PROCDUMP_PATH para um diretório que contenha o executável {0}</target>
         <note>0 is procDumpPath, a name of procdump executable such as procdump64.exe, 0 is used twice on purpose. PROCDUMP_PATH and PATH are literal and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter">
+        <source>Invalid 'DumpDirectoryPath' for postmortem debugger monitor</source>
+        <target state="new">Invalid 'DumpDirectoryPath' for postmortem debugger monitor</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.ru.xlf
@@ -83,6 +83,11 @@ This test may, or may not be the source of the crash.</source>
         <target state="translated">Не удалось найти {0}. Убедитесь, что исполняемый файл доступен в PATH. Также можно настроить переменную среды PROCDUMP_PATH, указав каталог, содержащий исполняемый файл {0}.</target>
         <note>0 is procDumpPath, a name of procdump executable such as procdump64.exe, 0 is used twice on purpose. PROCDUMP_PATH and PATH are literal and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter">
+        <source>Invalid 'DumpDirectoryPath' for postmortem debugger monitor</source>
+        <target state="new">Invalid 'DumpDirectoryPath' for postmortem debugger monitor</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.tr.xlf
@@ -83,6 +83,11 @@ Bu test, kilitlenmenin kaynağı olmayabilir veya olmayabilir.</target>
         <target state="translated">{0} bulunamadı, lütfen yürütülebilir dosyanın PATH üzerinde kullanılabilir olduğundan emin olun veya PROCDUMP_PATH ortam değişkenini {0} yürütülebilir dosyasını içeren bir dizine ayarlayın.</target>
         <note>0 is procDumpPath, a name of procdump executable such as procdump64.exe, 0 is used twice on purpose. PROCDUMP_PATH and PATH are literal and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter">
+        <source>Invalid 'DumpDirectoryPath' for postmortem debugger monitor</source>
+        <target state="new">Invalid 'DumpDirectoryPath' for postmortem debugger monitor</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.xlf
@@ -80,6 +80,11 @@ This test may, or may not be the source of the crash.</source>
         <target state="new">{0} could not be found, please make sure that the executable is available on PATH, or set PROCDUMP_PATH environment variable to a directory that contains {0} executable.</target>
         <note>0 is procDumpPath, a name of procdump executable such as procdump64.exe, 0 is used twice on purpose. PROCDUMP_PATH and PATH are literal and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter">
+        <source>Invalid 'DumpDirectoryPath' for postmortem debugger monitor</source>
+        <target state="new">Invalid 'DumpDirectoryPath' for postmortem debugger monitor</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.zh-Hans.xlf
@@ -83,6 +83,11 @@ This test may, or may not be the source of the crash.</source>
         <target state="translated">找不到 {0}，请确保可执行文件在路径上可用，或者将 PROCDUMP_PATH 环境变量设置为包含 {0} 可执行文件的目录。</target>
         <note>0 is procDumpPath, a name of procdump executable such as procdump64.exe, 0 is used twice on purpose. PROCDUMP_PATH and PATH are literal and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter">
+        <source>Invalid 'DumpDirectoryPath' for postmortem debugger monitor</source>
+        <target state="new">Invalid 'DumpDirectoryPath' for postmortem debugger monitor</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Resources/xlf/Resources.zh-Hant.xlf
@@ -83,6 +83,11 @@ This test may, or may not be the source of the crash.</source>
         <target state="translated">找不到{0}，請確定可執行檔可在 PATH 上使用。或將 PROCDUMP_PATH 環境變數設定為包含 {0} 可執行檔的目錄。</target>
         <note>0 is procDumpPath, a name of procdump executable such as procdump64.exe, 0 is used twice on purpose. PROCDUMP_PATH and PATH are literal and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="MonitorPostmortemDebuggerInvalidDumpDirectoryPathParameter">
+        <source>Invalid 'DumpDirectoryPath' for postmortem debugger monitor</source>
+        <target state="new">Invalid 'DumpDirectoryPath' for postmortem debugger monitor</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.ObjectModel/Constants.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Constants.cs
@@ -37,6 +37,12 @@ public static class Constants
 
     /// <summary>
     /// Name of collect dump option for blame.
+    /// The internal visibility is because the new feature is not publicly exposed yet and so we can retire it.
+    /// </summary>
+    internal const string BlameCollectMonitorPostMortemDebuggerKey = "MonitorPostmortemDebugger";
+
+    /// <summary>
+    /// Name of collect dump option for blame.
     /// </summary>
     public const string BlameCollectHangDumpKey = "CollectHangDump";
 

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
@@ -966,3 +966,5 @@ virtual Microsoft.VisualStudio.TestPlatform.ObjectModel.TestObject.ProtectedSetP
 ~static Microsoft.VisualStudio.TestPlatform.ObjectModel.Resources.CommonResources.MalformedRunSettingsFile.get -> string
 ~static Microsoft.VisualStudio.TestPlatform.ObjectModel.Resources.CommonResources.NoMatchingSourcesFound.get -> string
 ~static Microsoft.VisualStudio.TestPlatform.ObjectModel.Resources.CommonResources.SourceIncompatible.get -> string
+Microsoft.VisualStudio.TestPlatform.ObjectModel.DirectoryBasedTestDiscovererAttribute
+Microsoft.VisualStudio.TestPlatform.ObjectModel.DirectoryBasedTestDiscovererAttribute.DirectoryBasedTestDiscovererAttribute() -> void

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 ﻿#nullable enable
-Microsoft.VisualStudio.TestPlatform.ObjectModel.DirectoryBasedTestDiscovererAttribute
-Microsoft.VisualStudio.TestPlatform.ObjectModel.DirectoryBasedTestDiscovererAttribute.DirectoryBasedTestDiscovererAttribute() -> void

--- a/src/vstest.console/Processors/AeDebuggerArgumentProcessor.cs
+++ b/src/vstest.console/Processors/AeDebuggerArgumentProcessor.cs
@@ -1,0 +1,226 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+
+using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors.Utilities;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
+using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
+using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
+using Microsoft.VisualStudio.TestPlatform.Utilities;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
+
+using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;
+
+namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
+
+internal class AeDebuggerArgumentProcessor : IArgumentProcessor
+{
+    public const string CommandName = "/AeDebugger";
+    private Lazy<IArgumentProcessorCapabilities>? _metadata;
+    private Lazy<IArgumentExecutor>? _executor;
+
+
+    public Lazy<IArgumentExecutor>? Executor
+    {
+        get => _executor ??= new Lazy<IArgumentExecutor>(() =>
+            new AeDebuggerArgumentExecutor(new PlatformEnvironment(), new FileHelper(), new ProcessHelper(), ConsoleOutput.Instance));
+
+        set => _executor = value;
+    }
+
+    public Lazy<IArgumentProcessorCapabilities> Metadata
+        => _metadata ??= new Lazy<IArgumentProcessorCapabilities>(() => new AeDebuggerArgumentProcessorCapabilities());
+}
+
+internal class AeDebuggerArgumentProcessorCapabilities : BaseArgumentProcessorCapabilities
+{
+    public override string CommandName => AeDebuggerArgumentProcessor.CommandName;
+
+    public override bool AllowMultiple => false;
+
+    public override bool IsAction => true;
+
+    public override ArgumentProcessorPriority Priority => ArgumentProcessorPriority.Normal;
+
+    // This feature is for internal usage at the moment, we can advertise in future when we'll have
+    // good feedback on the usage.
+    public override string? HelpContentResourceName => null;
+
+    public override HelpContentPriority HelpPriority => HelpContentPriority.EnableDiagArgumentProcessorHelpPriority;
+}
+
+internal class AeDebuggerArgumentExecutor : IArgumentExecutor
+{
+    private const int ProcDumpTimeoutSeconds = 10;
+    private const string InstallCommandArgumentName = "Install";
+    private const string UninstallCommandArgumentName = "Uninstall";
+
+    private readonly IEnvironment _environment;
+    private readonly IFileHelper _fileHelper;
+    private readonly IProcessHelper _processHelper;
+    private readonly IOutput _output;
+    private string? _argument;
+    private Dictionary<string, string>? _collectDumpParameters;
+
+    public AeDebuggerArgumentExecutor(IEnvironment environment, IFileHelper fileHelper, IProcessHelper processHelper, IOutput output)
+    {
+        _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+        _fileHelper = fileHelper ?? throw new ArgumentNullException(nameof(fileHelper));
+        _processHelper = processHelper ?? throw new ArgumentNullException(nameof(processHelper));
+        _output = output ?? throw new ArgumentNullException(nameof(output));
+    }
+
+    public void Initialize(string? argument) => _argument = argument;
+
+    public ArgumentProcessorResult Execute()
+    {
+        string exceptionMessage = string.Format(CultureInfo.CurrentCulture, CommandLineResources.InvalidAeDebuggerArgument, _argument ?? "");
+        if (StringUtils.IsNullOrEmpty(_argument))
+        {
+            _output.Error(false, exceptionMessage);
+            return ArgumentProcessorResult.Fail;
+        }
+
+        string[] aeDebuggerArgumentList = ArgumentProcessorUtilities.GetArgumentList(_argument, ArgumentProcessorUtilities.SemiColonArgumentSeparator, exceptionMessage);
+        _collectDumpParameters = ArgumentProcessorUtilities.GetArgumentParameters(
+            aeDebuggerArgumentList.Where(x => !x.Equals(InstallCommandArgumentName, StringComparison.OrdinalIgnoreCase) &&
+            !x.Equals(UninstallCommandArgumentName, StringComparison.OrdinalIgnoreCase)),
+            ArgumentProcessorUtilities.EqualNameValueSeparator, exceptionMessage);
+
+        if (aeDebuggerArgumentList.Contains(InstallCommandArgumentName, StringComparer.OrdinalIgnoreCase))
+        {
+            return InstallUnistallPostmortemDebugger(true);
+        }
+
+        if (aeDebuggerArgumentList.Contains(UninstallCommandArgumentName, StringComparer.OrdinalIgnoreCase))
+        {
+            return InstallUnistallPostmortemDebugger(false);
+        }
+
+        _output.Error(false, exceptionMessage);
+        return ArgumentProcessorResult.Fail;
+    }
+
+    private ArgumentProcessorResult InstallUnistallPostmortemDebugger(bool install)
+    {
+        if (_environment.OperatingSystem != PlatformOperatingSystem.Windows)
+        {
+            _output.Error(false, string.Format(CultureInfo.CurrentCulture, CommandLineResources.PostmortemDebuggerNotSupportedForCurrentOS));
+            return ArgumentProcessorResult.Fail;
+        }
+
+        if (_collectDumpParameters is null)
+        {
+            _output.Error(false, string.Format(CultureInfo.CurrentCulture, CommandLineResources.ProcDumpToolDirectoryPathArgumenNotFound));
+            return ArgumentProcessorResult.Fail;
+        }
+
+        // Validate ProcDumpToolDirectoryPath
+        if (!TryGetDirectoryInfo(_collectDumpParameters,
+            "ProcDumpToolDirectoryPath",
+            CommandLineResources.ProcDumpToolDirectoryPathArgumenNotFound,
+            CommandLineResources.InvalidProcDumpToolDirectoryPath,
+            out DirectoryInfo? procDumpToolDirectoryPath))
+        {
+            return ArgumentProcessorResult.Fail;
+        }
+
+        // Looking for procdump*.exe
+        FileInfo procDumpFileName = new(Path.Combine(procDumpToolDirectoryPath.FullName, ProcDumpFileName()));
+        if (!_fileHelper.Exists(procDumpFileName.FullName))
+        {
+            _output.Error(false, string.Format(CultureInfo.CurrentCulture, CommandLineResources.ProcDumpFileNameNotFound, procDumpFileName.FullName));
+            return ArgumentProcessorResult.Fail;
+        }
+
+        string procDumpInstallUnistallArgument = "";
+        if (install)
+        {
+            // Validate ProcDumpDirectoryPath
+            if (!TryGetDirectoryInfo(_collectDumpParameters,
+                "DumpDirectoryPath",
+                CommandLineResources.ProcDumpDirectoryPathArgumenNotFound,
+                CommandLineResources.InvalidProcDumpDirectoryPath,
+                out DirectoryInfo? dumpDirectoryPath))
+            {
+                return ArgumentProcessorResult.Fail;
+            }
+
+            procDumpInstallUnistallArgument = dumpDirectoryPath.FullName;
+        }
+
+        if (_processHelper.LaunchProcess(procDumpFileName.FullName, install ? "-ma -i" : "-u", procDumpInstallUnistallArgument, null,
+            (_, data) =>
+            {
+                if (data is not null && !StringUtilities.IsNullOrWhiteSpace(data))
+                {
+                    _output.Error(false, data, null);
+                }
+            },
+            null,
+            (_, data) =>
+            {
+                if (data is not null && !StringUtilities.IsNullOrWhiteSpace(data))
+                {
+                    _output.Information(false, data, null);
+                }
+            })
+            is Process process)
+        {
+            return !process.WaitForExit(TimeSpan.FromSeconds(ProcDumpTimeoutSeconds).Seconds)
+                ? ArgumentProcessorResult.Fail
+                : process.ExitCode == 0 ? ArgumentProcessorResult.Success : ArgumentProcessorResult.Fail;
+        }
+
+        // We suppose a success if the object returned by the LaunchProcess is not a Process object.
+        return ArgumentProcessorResult.Success;
+
+        string ProcDumpFileName() =>
+            _processHelper.GetCurrentProcessArchitecture() switch
+            {
+                PlatformArchitecture.X86 => "procdump.exe",
+                PlatformArchitecture.ARM64 => "procdump64a.exe",
+                _ => "procdump64.exe",
+            };
+
+        bool TryGetDirectoryInfo(Dictionary<string, string> collectDumpParameters,
+            string directoryArgumentName,
+            string invalidArgumentErrorMessage,
+            string invalidDirectoryErrorMessage,
+            [NotNullWhen(true)] out DirectoryInfo? directoryInfo)
+        {
+            directoryInfo = null;
+
+            if (!collectDumpParameters.TryGetValue(directoryArgumentName, out string? directoryPath))
+            {
+                _output.Error(false, string.Format(CultureInfo.CurrentCulture, invalidArgumentErrorMessage));
+                return false;
+            }
+
+            if (directoryPath is null)
+            {
+                _output.Error(false, string.Format(CultureInfo.CurrentCulture, invalidArgumentErrorMessage));
+                return false;
+            }
+
+            directoryInfo = new(directoryPath);
+            if (!_fileHelper.DirectoryExists(directoryInfo.FullName))
+            {
+                _output.Error(false, string.Format(CultureInfo.CurrentCulture, invalidDirectoryErrorMessage, directoryInfo.FullName));
+                directoryInfo = null;
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+}

--- a/src/vstest.console/Processors/EnableBlameArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnableBlameArgumentProcessor.cs
@@ -120,19 +120,21 @@ internal class EnableBlameArgumentExecutor : IArgumentExecutor
     {
         var enableDump = false;
         var enableHangDump = false;
+        var monitorPostMortemDebugger = false;
         var exceptionMessage = string.Format(CultureInfo.CurrentCulture, CommandLineResources.InvalidBlameArgument, argument);
         Dictionary<string, string>? collectDumpParameters = null;
-
         if (!argument.IsNullOrWhiteSpace())
         {
             // Get blame argument list.
-            var blameArgumentList = ArgumentProcessorUtilities.GetArgumentList(argument, ArgumentProcessorUtilities.SemiColonArgumentSeparator, exceptionMessage);
+            string[] blameArgumentList = ArgumentProcessorUtilities.GetArgumentList(argument, ArgumentProcessorUtilities.SemiColonArgumentSeparator, exceptionMessage);
             Func<string, bool> isDumpCollect = a => Constants.BlameCollectDumpKey.Equals(a, StringComparison.OrdinalIgnoreCase);
             Func<string, bool> isHangDumpCollect = a => Constants.BlameCollectHangDumpKey.Equals(a, StringComparison.OrdinalIgnoreCase);
+            Func<string, bool> isMonitorPostmortemDebugger = a => Constants.BlameCollectMonitorPostMortemDebuggerKey.Equals(a, StringComparison.OrdinalIgnoreCase);
 
             // Get collect dump key.
             var hasCollectDumpKey = blameArgumentList.Any(isDumpCollect);
             var hasCollectHangDumpKey = blameArgumentList.Any(isHangDumpCollect);
+            var hasMonitorPostmortemDebugger = blameArgumentList.Any(isMonitorPostmortemDebugger);
 
             // Check if dump should be enabled or not.
             enableDump = hasCollectDumpKey;
@@ -140,38 +142,41 @@ internal class EnableBlameArgumentExecutor : IArgumentExecutor
             // Check if dump should be enabled or not.
             enableHangDump = hasCollectHangDumpKey;
 
-            if (!enableDump && !enableHangDump)
+            // Check if we need to monitor the postmortem debugger folder
+            monitorPostMortemDebugger = hasMonitorPostmortemDebugger;
+
+            if (!enableDump && !enableHangDump && !monitorPostMortemDebugger)
             {
                 Output.Warning(false, string.Format(CultureInfo.CurrentCulture, CommandLineResources.BlameIncorrectOption, argument));
             }
             else
             {
                 // Get collect dump parameters.
-                var collectDumpParameterArgs = blameArgumentList.Where(a => !isDumpCollect(a) && !isHangDumpCollect(a));
+                IEnumerable<string> collectDumpParameterArgs = blameArgumentList
+                    .Where(a => !isDumpCollect(a) &&
+                    !isHangDumpCollect(a) &&
+                    !isMonitorPostmortemDebugger(a));
+
                 collectDumpParameters = ArgumentProcessorUtilities.GetArgumentParameters(collectDumpParameterArgs, ArgumentProcessorUtilities.EqualNameValueSeparator, exceptionMessage);
             }
         }
 
         // Initialize blame.
-        InitializeBlame(enableDump, enableHangDump, collectDumpParameters);
+        InitializeBlame(enableDump, enableHangDump, monitorPostMortemDebugger, collectDumpParameters);
     }
 
     /// <summary>
     /// Executes the argument processor.
     /// </summary>
     /// <returns>The <see cref="ArgumentProcessorResult"/>.</returns>
-    public ArgumentProcessorResult Execute()
-    {
-        // Nothing to do since we updated the logger and data collector list in initialize
-        return ArgumentProcessorResult.Success;
-    }
+    public ArgumentProcessorResult Execute() => ArgumentProcessorResult.Success;
 
     /// <summary>
     /// Initialize blame.
     /// </summary>
     /// <param name="enableCrashDump">Enable dump.</param>
     /// <param name="blameParameters">Blame parameters.</param>
-    private void InitializeBlame(bool enableCrashDump, bool enableHangDump, Dictionary<string, string>? collectDumpParameters)
+    private void InitializeBlame(bool enableCrashDump, bool enableHangDump, bool monitorPostMortemDebugger, Dictionary<string, string>? collectDumpParameters)
     {
         // Add Blame Logger
         LoggerUtilities.AddLoggerToRunSettings(BlameFriendlyName, null, _runSettingsManager);
@@ -193,8 +198,6 @@ internal class EnableBlameArgumentExecutor : IArgumentExecutor
         // Get data collection run settings. Create if not present.
         var dataCollectionRunSettings = XmlRunSettingsUtilities.GetDataCollectionRunSettings(settings);
         dataCollectionRunSettings ??= new DataCollectionRunSettings();
-
-        // Create blame configuration element.
         var xmlDocument = new XmlDocument();
         var outernode = xmlDocument.CreateElement("Configuration");
         var node = xmlDocument.CreateElement("ResultsDirectory");
@@ -236,6 +239,21 @@ internal class EnableBlameArgumentExecutor : IArgumentExecutor
             }
 
             AddCollectHangDumpNode(hangDumpParameters, xmlDocument, outernode);
+        }
+
+        // Check if have to monitor the post mortem debugger
+        if (monitorPostMortemDebugger)
+        {
+            if (collectDumpParameters is not null)
+            {
+                // We don't need to check if present or not if null we'll set empty dump directory path
+                collectDumpParameters.TryGetValue("DumpDirectoryPath", out string? directoryPath);
+                Dictionary<string, string> monitorPostMortemDebuggerParameters = new()
+                {
+                    { "DumpDirectoryPath", directoryPath ?? "" }
+                };
+                AddMonitorPostMortemDebuggerNode(monitorPostMortemDebuggerParameters, xmlDocument, outernode);
+            }
         }
 
         // Add blame configuration element to blame collector.
@@ -285,17 +303,7 @@ internal class EnableBlameArgumentExecutor : IArgumentExecutor
     /// <param name="outernode">Outer node.</param>
     private static void AddCollectDumpNode(Dictionary<string, string>? parameters, XmlDocument xmlDocument, XmlElement outernode)
     {
-        var dumpNode = xmlDocument.CreateElement(Constants.BlameCollectDumpKey);
-        if (parameters != null && parameters.Count > 0)
-        {
-            foreach (KeyValuePair<string, string> entry in parameters)
-            {
-                var attribute = xmlDocument.CreateAttribute(entry.Key);
-                attribute.Value = entry.Value;
-                dumpNode.Attributes.Append(attribute);
-            }
-        }
-        outernode.AppendChild(dumpNode);
+        AddNode(parameters, xmlDocument, outernode, Constants.BlameCollectDumpKey);
     }
 
     /// <summary>
@@ -306,7 +314,29 @@ internal class EnableBlameArgumentExecutor : IArgumentExecutor
     /// <param name="outernode">Outer node.</param>
     private static void AddCollectHangDumpNode(Dictionary<string, string> parameters, XmlDocument xmlDocument, XmlElement outernode)
     {
-        var dumpNode = xmlDocument.CreateElement(Constants.CollectDumpOnTestSessionHang);
+        AddNode(parameters, xmlDocument, outernode, Constants.CollectDumpOnTestSessionHang);
+    }
+
+    /// <summary>
+    /// Adds monitor postmortem debuggerNode de dump node in outer node.
+    /// </summary>
+    /// <param name="parameters">Parameters.</param>
+    /// <param name="xmlDocument">Xml document.</param>
+    /// <param name="outernode">Outer node.</param>
+    private static void AddMonitorPostMortemDebuggerNode(Dictionary<string, string> parameters, XmlDocument xmlDocument, XmlElement outernode)
+    {
+        AddNode(parameters, xmlDocument, outernode, Constants.BlameCollectMonitorPostMortemDebuggerKey);
+    }
+
+    /// <summary>
+    /// Adds node in outer node.
+    /// </summary>
+    /// <param name="parameters">Parameters.</param>
+    /// <param name="xmlDocument">Xml document.</param>
+    /// <param name="outernode">Outer node.</param>
+    private static void AddNode(Dictionary<string, string>? parameters, XmlDocument xmlDocument, XmlElement outernode, string nodeName)
+    {
+        var dumpNode = xmlDocument.CreateElement(nodeName);
         if (parameters != null && parameters.Count > 0)
         {
             foreach (KeyValuePair<string, string> entry in parameters)

--- a/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
+++ b/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
@@ -218,6 +218,7 @@ internal class ArgumentProcessorFactory
         new DisableAutoFakesArgumentProcessor(),
         new ResponseFileArgumentProcessor(),
         new EnableBlameArgumentProcessor(),
+        new AeDebuggerArgumentProcessor(),
         new UseVsixExtensionsArgumentProcessor(),
         new ListDiscoverersArgumentProcessor(),
         new ListExecutorsArgumentProcessor(),

--- a/src/vstest.console/Processors/Utilities/ArgumentProcessorUtilities.cs
+++ b/src/vstest.console/Processors/Utilities/ArgumentProcessorUtilities.cs
@@ -18,7 +18,7 @@ internal class ArgumentProcessorUtilities
     /// <param name="argumentSeparator">Argument separator.</param>
     /// <param name="exceptionMessage">Exception Message.</param>
     /// <returns>Argument list.</returns>
-    public static string[] GetArgumentList(string rawArgument, char[] argumentSeparator, string exceptionMessage)
+    public static string[] GetArgumentList(string? rawArgument, char[] argumentSeparator, string exceptionMessage)
     {
         var argumentList = rawArgument?.Split(argumentSeparator, StringSplitOptions.RemoveEmptyEntries);
 

--- a/src/vstest.console/Resources/Resources.Designer.cs
+++ b/src/vstest.console/Resources/Resources.Designer.cs
@@ -534,6 +534,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error hosting communication channel..
+        /// </summary>
+        internal static string ErrorHostingCommunicationChannel {
+            get {
+                return ResourceManager.GetString("ErrorHostingCommunicationChannel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error Message:.
         /// </summary>
         internal static string ErrorMessageBanner {
@@ -706,6 +715,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to AeDebugger argument &apos;{0}&apos; is not valid..
+        /// </summary>
+        internal static string InvalidAeDebuggerArgument {
+            get {
+                return ResourceManager.GetString("InvalidAeDebuggerArgument", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The argument {0} is invalid. Please use the /help option to check the list of valid arguments..
         /// </summary>
         internal static string InvalidArgument {
@@ -828,6 +846,24 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources {
         internal static string InvalidPortArgument {
             get {
                 return ResourceManager.GetString("InvalidPortArgument", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The directory specified is not valid: &apos;{0}&apos;.
+        /// </summary>
+        internal static string InvalidProcDumpDirectoryPath {
+            get {
+                return ResourceManager.GetString("InvalidProcDumpDirectoryPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The directory specified is not valid: &apos;{0}&apos;.
+        /// </summary>
+        internal static string InvalidProcDumpToolDirectoryPath {
+            get {
+                return ResourceManager.GetString("InvalidProcDumpToolDirectoryPath", resourceCulture);
             }
         }
         
@@ -1211,6 +1247,42 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources {
         internal static string PortArgumentHelp {
             get {
                 return ResourceManager.GetString("PortArgumentHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Postmortem debugger is not supported in the current OS..
+        /// </summary>
+        internal static string PostmortemDebuggerNotSupportedForCurrentOS {
+            get {
+                return ResourceManager.GetString("PostmortemDebuggerNotSupportedForCurrentOS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DumpDirectoryPath should be specified to install the post mortem debugger..
+        /// </summary>
+        internal static string ProcDumpDirectoryPathArgumenNotFound {
+            get {
+                return ResourceManager.GetString("ProcDumpDirectoryPathArgumenNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Procdump file name not found: &apos;{0}&apos;.
+        /// </summary>
+        internal static string ProcDumpFileNameNotFound {
+            get {
+                return ResourceManager.GetString("ProcDumpFileNameNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger..
+        /// </summary>
+        internal static string ProcDumpToolDirectoryPathArgumenNotFound {
+            get {
+                return ResourceManager.GetString("ProcDumpToolDirectoryPathArgumenNotFound", resourceCulture);
             }
         }
         
@@ -1841,15 +1913,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources {
         internal static string WarningEmulatedOnArm64 {
             get {
                 return ResourceManager.GetString("WarningEmulatedOnArm64", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Error hosting the communication channel. For better performance, please consider using the native runner vstest.console.arm64.exe..
-        /// </summary>
-        internal static string ErrorHostingCommunicationChannel {
-            get {
-                return ResourceManager.GetString("ErrorHostingCommunicationChannel", resourceCulture);
             }
         }
     }

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -748,6 +748,27 @@
   <data name="InvalidBlameArgument" xml:space="preserve">
     <value>Blame argument '{0}' is not valid.</value>
   </data>
+  <data name="InvalidAeDebuggerArgument" xml:space="preserve">
+    <value>AeDebugger argument '{0}' is not valid.</value>
+  </data>
+  <data name="ProcDumpToolDirectoryPathArgumenNotFound" xml:space="preserve">
+    <value>ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</value>
+  </data>
+  <data name="ProcDumpDirectoryPathArgumenNotFound" xml:space="preserve">
+    <value>DumpDirectoryPath should be specified to install the post mortem debugger.</value>
+  </data>
+  <data name="PostmortemDebuggerNotSupportedForCurrentOS" xml:space="preserve">
+    <value>Postmortem debugger is not supported in the current OS.</value>
+  </data>
+  <data name="InvalidProcDumpToolDirectoryPath" xml:space="preserve">
+    <value>The directory specified is not valid: '{0}'</value>
+  </data>
+  <data name="InvalidProcDumpDirectoryPath" xml:space="preserve">
+    <value>The directory specified is not valid: '{0}'</value>
+  </data>
+  <data name="ProcDumpFileNameNotFound" xml:space="preserve">
+    <value>Procdump file name not found: '{0}'</value>
+  </data>
   <data name="InvalidDiagArgument" xml:space="preserve">
     <value>Diag argument '{0}' is not valid.</value>
   </data>

--- a/src/vstest.console/Resources/xlf/Resources.cs.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.cs.xlf
@@ -1199,6 +1199,41 @@
         <target state="translated">Při hostování komunikačního kanálu došlo k chybě.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ProcDumpToolDirectoryPathArgumenNotFound">
+        <source>ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</source>
+        <target state="new">ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PostmortemDebuggerNotSupportedForCurrentOS">
+        <source>Postmortem debugger is not supported in the current OS.</source>
+        <target state="new">Postmortem debugger is not supported in the current OS.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpToolDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpFileNameNotFound">
+        <source>Procdump file name not found: '{0}'</source>
+        <target state="new">Procdump file name not found: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpDirectoryPathArgumenNotFound">
+        <source>DumpDirectoryPath should be specified to install the post mortem debugger.</source>
+        <target state="new">ProcDumpDirectoryPath should be specified to install the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidAeDebuggerArgument">
+        <source>AeDebugger argument '{0}' is not valid.</source>
+        <target state="new">Blame argument '{0}' is not valid.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.de.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.de.xlf
@@ -1199,6 +1199,41 @@
         <target state="translated">Fehler beim Hosten des Kommunikationskanals.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ProcDumpToolDirectoryPathArgumenNotFound">
+        <source>ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</source>
+        <target state="new">ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PostmortemDebuggerNotSupportedForCurrentOS">
+        <source>Postmortem debugger is not supported in the current OS.</source>
+        <target state="new">Postmortem debugger is not supported in the current OS.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpToolDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpFileNameNotFound">
+        <source>Procdump file name not found: '{0}'</source>
+        <target state="new">Procdump file name not found: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpDirectoryPathArgumenNotFound">
+        <source>DumpDirectoryPath should be specified to install the post mortem debugger.</source>
+        <target state="new">ProcDumpDirectoryPath should be specified to install the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidAeDebuggerArgument">
+        <source>AeDebugger argument '{0}' is not valid.</source>
+        <target state="new">Blame argument '{0}' is not valid.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.es.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.es.xlf
@@ -1202,6 +1202,41 @@
         <target state="translated">Error al hospedar el canal de comunicación.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ProcDumpToolDirectoryPathArgumenNotFound">
+        <source>ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</source>
+        <target state="new">ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PostmortemDebuggerNotSupportedForCurrentOS">
+        <source>Postmortem debugger is not supported in the current OS.</source>
+        <target state="new">Postmortem debugger is not supported in the current OS.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpToolDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpFileNameNotFound">
+        <source>Procdump file name not found: '{0}'</source>
+        <target state="new">Procdump file name not found: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpDirectoryPathArgumenNotFound">
+        <source>DumpDirectoryPath should be specified to install the post mortem debugger.</source>
+        <target state="new">ProcDumpDirectoryPath should be specified to install the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidAeDebuggerArgument">
+        <source>AeDebugger argument '{0}' is not valid.</source>
+        <target state="new">Blame argument '{0}' is not valid.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.fr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.fr.xlf
@@ -1199,6 +1199,41 @@ Comportements actuellement pris en charge :
         <target state="translated">Erreur lors de l’hébergement du canal de communication</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ProcDumpToolDirectoryPathArgumenNotFound">
+        <source>ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</source>
+        <target state="new">ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PostmortemDebuggerNotSupportedForCurrentOS">
+        <source>Postmortem debugger is not supported in the current OS.</source>
+        <target state="new">Postmortem debugger is not supported in the current OS.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpToolDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpFileNameNotFound">
+        <source>Procdump file name not found: '{0}'</source>
+        <target state="new">Procdump file name not found: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpDirectoryPathArgumenNotFound">
+        <source>DumpDirectoryPath should be specified to install the post mortem debugger.</source>
+        <target state="new">ProcDumpDirectoryPath should be specified to install the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidAeDebuggerArgument">
+        <source>AeDebugger argument '{0}' is not valid.</source>
+        <target state="new">Blame argument '{0}' is not valid.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.it.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.it.xlf
@@ -1199,6 +1199,41 @@
         <target state="translated">Errore nell'hosting del canale di comunicazione.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ProcDumpToolDirectoryPathArgumenNotFound">
+        <source>ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</source>
+        <target state="new">ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PostmortemDebuggerNotSupportedForCurrentOS">
+        <source>Postmortem debugger is not supported in the current OS.</source>
+        <target state="new">Postmortem debugger is not supported in the current OS.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpToolDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpFileNameNotFound">
+        <source>Procdump file name not found: '{0}'</source>
+        <target state="new">Procdump file name not found: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpDirectoryPathArgumenNotFound">
+        <source>DumpDirectoryPath should be specified to install the post mortem debugger.</source>
+        <target state="new">ProcDumpDirectoryPath should be specified to install the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidAeDebuggerArgument">
+        <source>AeDebugger argument '{0}' is not valid.</source>
+        <target state="new">Blame argument '{0}' is not valid.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.ja.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ja.xlf
@@ -1199,6 +1199,41 @@
         <target state="translated">通信チャネルをホスト中にエラーが発生しました。</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ProcDumpToolDirectoryPathArgumenNotFound">
+        <source>ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</source>
+        <target state="new">ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PostmortemDebuggerNotSupportedForCurrentOS">
+        <source>Postmortem debugger is not supported in the current OS.</source>
+        <target state="new">Postmortem debugger is not supported in the current OS.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpToolDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpFileNameNotFound">
+        <source>Procdump file name not found: '{0}'</source>
+        <target state="new">Procdump file name not found: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpDirectoryPathArgumenNotFound">
+        <source>DumpDirectoryPath should be specified to install the post mortem debugger.</source>
+        <target state="new">ProcDumpDirectoryPath should be specified to install the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidAeDebuggerArgument">
+        <source>AeDebugger argument '{0}' is not valid.</source>
+        <target state="new">Blame argument '{0}' is not valid.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.ko.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ko.xlf
@@ -1199,6 +1199,41 @@
         <target state="translated">통신 채널을 호스트하는 동안 오류가 발생했습니다.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ProcDumpToolDirectoryPathArgumenNotFound">
+        <source>ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</source>
+        <target state="new">ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PostmortemDebuggerNotSupportedForCurrentOS">
+        <source>Postmortem debugger is not supported in the current OS.</source>
+        <target state="new">Postmortem debugger is not supported in the current OS.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpToolDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpFileNameNotFound">
+        <source>Procdump file name not found: '{0}'</source>
+        <target state="new">Procdump file name not found: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpDirectoryPathArgumenNotFound">
+        <source>DumpDirectoryPath should be specified to install the post mortem debugger.</source>
+        <target state="new">ProcDumpDirectoryPath should be specified to install the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidAeDebuggerArgument">
+        <source>AeDebugger argument '{0}' is not valid.</source>
+        <target state="new">Blame argument '{0}' is not valid.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.pl.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pl.xlf
@@ -1199,6 +1199,41 @@
         <target state="translated">Błąd podczas hostowania kanału komunikacji.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ProcDumpToolDirectoryPathArgumenNotFound">
+        <source>ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</source>
+        <target state="new">ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PostmortemDebuggerNotSupportedForCurrentOS">
+        <source>Postmortem debugger is not supported in the current OS.</source>
+        <target state="new">Postmortem debugger is not supported in the current OS.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpToolDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpFileNameNotFound">
+        <source>Procdump file name not found: '{0}'</source>
+        <target state="new">Procdump file name not found: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpDirectoryPathArgumenNotFound">
+        <source>DumpDirectoryPath should be specified to install the post mortem debugger.</source>
+        <target state="new">ProcDumpDirectoryPath should be specified to install the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidAeDebuggerArgument">
+        <source>AeDebugger argument '{0}' is not valid.</source>
+        <target state="new">Blame argument '{0}' is not valid.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
@@ -1199,6 +1199,41 @@ Altere o prefixo de nível de diagnóstico do agente de console, como mostrado a
         <target state="translated">Erro ao hospedar o canal de comunicação.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ProcDumpToolDirectoryPathArgumenNotFound">
+        <source>ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</source>
+        <target state="new">ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PostmortemDebuggerNotSupportedForCurrentOS">
+        <source>Postmortem debugger is not supported in the current OS.</source>
+        <target state="new">Postmortem debugger is not supported in the current OS.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpToolDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpFileNameNotFound">
+        <source>Procdump file name not found: '{0}'</source>
+        <target state="new">Procdump file name not found: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpDirectoryPathArgumenNotFound">
+        <source>DumpDirectoryPath should be specified to install the post mortem debugger.</source>
+        <target state="new">ProcDumpDirectoryPath should be specified to install the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidAeDebuggerArgument">
+        <source>AeDebugger argument '{0}' is not valid.</source>
+        <target state="new">Blame argument '{0}' is not valid.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.ru.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ru.xlf
@@ -1199,6 +1199,41 @@
         <target state="translated">Ошибка при размещении коммуникационного канала.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ProcDumpToolDirectoryPathArgumenNotFound">
+        <source>ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</source>
+        <target state="new">ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PostmortemDebuggerNotSupportedForCurrentOS">
+        <source>Postmortem debugger is not supported in the current OS.</source>
+        <target state="new">Postmortem debugger is not supported in the current OS.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpToolDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpFileNameNotFound">
+        <source>Procdump file name not found: '{0}'</source>
+        <target state="new">Procdump file name not found: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpDirectoryPathArgumenNotFound">
+        <source>DumpDirectoryPath should be specified to install the post mortem debugger.</source>
+        <target state="new">ProcDumpDirectoryPath should be specified to install the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidAeDebuggerArgument">
+        <source>AeDebugger argument '{0}' is not valid.</source>
+        <target state="new">Blame argument '{0}' is not valid.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.tr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.tr.xlf
@@ -1199,6 +1199,41 @@ Günlükler için izleme düzeyini aşağıda gösterildiği gibi değiştirin
         <target state="translated">İletişim kanalını barındırma hatası.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ProcDumpToolDirectoryPathArgumenNotFound">
+        <source>ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</source>
+        <target state="new">ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PostmortemDebuggerNotSupportedForCurrentOS">
+        <source>Postmortem debugger is not supported in the current OS.</source>
+        <target state="new">Postmortem debugger is not supported in the current OS.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpToolDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpFileNameNotFound">
+        <source>Procdump file name not found: '{0}'</source>
+        <target state="new">Procdump file name not found: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpDirectoryPathArgumenNotFound">
+        <source>DumpDirectoryPath should be specified to install the post mortem debugger.</source>
+        <target state="new">ProcDumpDirectoryPath should be specified to install the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidAeDebuggerArgument">
+        <source>AeDebugger argument '{0}' is not valid.</source>
+        <target state="new">Blame argument '{0}' is not valid.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.xlf
@@ -993,6 +993,41 @@ Format : TestRunParameters.Parameter(name="&lt;name&gt;", value="&lt;value&gt;")
         <target state="new">Error hosting communication channel.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ProcDumpToolDirectoryPathArgumenNotFound">
+        <source>ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</source>
+        <target state="new">ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PostmortemDebuggerNotSupportedForCurrentOS">
+        <source>Postmortem debugger is not supported in the current OS.</source>
+        <target state="new">Postmortem debugger is not supported in the current OS.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpToolDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpFileNameNotFound">
+        <source>Procdump file name not found: '{0}'</source>
+        <target state="new">Procdump file name not found: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpDirectoryPathArgumenNotFound">
+        <source>DumpDirectoryPath should be specified to install the post mortem debugger.</source>
+        <target state="new">ProcDumpDirectoryPath should be specified to install the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidAeDebuggerArgument">
+        <source>AeDebugger argument '{0}' is not valid.</source>
+        <target state="new">Blame argument '{0}' is not valid.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
@@ -1199,6 +1199,41 @@
         <target state="translated">托管信道时出错。</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ProcDumpToolDirectoryPathArgumenNotFound">
+        <source>ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</source>
+        <target state="new">ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PostmortemDebuggerNotSupportedForCurrentOS">
+        <source>Postmortem debugger is not supported in the current OS.</source>
+        <target state="new">Postmortem debugger is not supported in the current OS.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpToolDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpFileNameNotFound">
+        <source>Procdump file name not found: '{0}'</source>
+        <target state="new">Procdump file name not found: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpDirectoryPathArgumenNotFound">
+        <source>DumpDirectoryPath should be specified to install the post mortem debugger.</source>
+        <target state="new">ProcDumpDirectoryPath should be specified to install the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidAeDebuggerArgument">
+        <source>AeDebugger argument '{0}' is not valid.</source>
+        <target state="new">Blame argument '{0}' is not valid.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
@@ -1199,6 +1199,41 @@
         <target state="translated">裝載通訊通道時發生錯誤。</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ProcDumpToolDirectoryPathArgumenNotFound">
+        <source>ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</source>
+        <target state="new">ProcDumpToolDirectoryPath should be specified to install or unistall the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PostmortemDebuggerNotSupportedForCurrentOS">
+        <source>Postmortem debugger is not supported in the current OS.</source>
+        <target state="new">Postmortem debugger is not supported in the current OS.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpToolDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpFileNameNotFound">
+        <source>Procdump file name not found: '{0}'</source>
+        <target state="new">Procdump file name not found: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProcDumpDirectoryPathArgumenNotFound">
+        <source>DumpDirectoryPath should be specified to install the post mortem debugger.</source>
+        <target state="new">ProcDumpDirectoryPath should be specified to install the post mortem debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidProcDumpDirectoryPath">
+        <source>The directory specified is not valid: '{0}'</source>
+        <target state="new">The directory specified is not valid: '{0}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidAeDebuggerArgument">
+        <source>AeDebugger argument '{0}' is not valid.</source>
+        <target state="new">Blame argument '{0}' is not valid.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameCollectorTests.cs
@@ -11,6 +11,7 @@ using System.Xml;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
+using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -33,6 +34,7 @@ public class BlameCollectorTests
     private readonly Mock<DataCollectionSink> _mockDataCollectionSink;
     private readonly Mock<IBlameReaderWriter> _mockBlameReaderWriter;
     private readonly Mock<IProcessDumpUtility> _mockProcessDumpUtility;
+    private readonly Mock<IProcessHelper> _mockProcessHelper;
     private readonly Mock<IInactivityTimer> _mockInactivityTimer;
     private readonly Mock<IFileHelper> _mockFileHelper;
     private readonly XmlElement? _configurationElement;
@@ -51,11 +53,13 @@ public class BlameCollectorTests
         _mockProcessDumpUtility = new Mock<IProcessDumpUtility>();
         _mockInactivityTimer = new Mock<IInactivityTimer>();
         _mockFileHelper = new Mock<IFileHelper>();
+        _mockProcessHelper = new Mock<IProcessHelper>();
         _blameDataCollector = new TestableBlameCollector(
             _mockBlameReaderWriter.Object,
             _mockProcessDumpUtility.Object,
             _mockInactivityTimer.Object,
-            _mockFileHelper.Object);
+            _mockFileHelper.Object,
+            _mockProcessHelper.Object);
 
         // Initializing members
         TestCase testcase = new() { Id = Guid.NewGuid() };
@@ -162,7 +166,8 @@ public class BlameCollectorTests
             _mockBlameReaderWriter.Object,
             _mockProcessDumpUtility.Object,
             null,
-            _mockFileHelper.Object);
+            _mockFileHelper.Object,
+            _mockProcessHelper.Object);
 
         var dumpFile = "abc_hang.dmp";
         var hangBasedDumpcollected = new ManualResetEventSlim();
@@ -197,7 +202,8 @@ public class BlameCollectorTests
             _mockBlameReaderWriter.Object,
             _mockProcessDumpUtility.Object,
             null,
-            _mockFileHelper.Object);
+            _mockFileHelper.Object,
+            _mockProcessHelper.Object);
 
         var hangBasedDumpcollected = new ManualResetEventSlim();
 
@@ -229,7 +235,8 @@ public class BlameCollectorTests
             _mockBlameReaderWriter.Object,
             _mockProcessDumpUtility.Object,
             null,
-            _mockFileHelper.Object);
+            _mockFileHelper.Object,
+            _mockProcessHelper.Object);
 
         var dumpFile = "abc_hang.dmp";
         var hangBasedDumpcollected = new ManualResetEventSlim();
@@ -755,8 +762,8 @@ public class BlameCollectorTests
         /// MockFileHelper instance.
         /// </param>
         internal TestableBlameCollector(IBlameReaderWriter blameReaderWriter, IProcessDumpUtility processDumpUtility, IInactivityTimer? inactivityTimer,
-            IFileHelper mockFileHelper)
-            : base(blameReaderWriter, processDumpUtility, inactivityTimer, mockFileHelper)
+            IFileHelper mockFileHelper, IProcessHelper mockProcessHelper)
+            : base(blameReaderWriter, processDumpUtility, inactivityTimer, mockFileHelper, mockProcessHelper)
         {
         }
     }

--- a/test/vstest.console.UnitTests/Processors/AeDebuggerArgumentProcessorTest.cs
+++ b/test/vstest.console.UnitTests/Processors/AeDebuggerArgumentProcessorTest.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+using Microsoft.VisualStudio.TestPlatform.CommandLine;
+using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
+using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
+using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
+using Microsoft.VisualStudio.TestPlatform.Utilities;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+
+namespace vstest.console.UnitTests.Processors;
+
+[TestClass]
+[TestCategory("Windows-Review")]
+public class AeDebuggerArgumentProcessorTest
+{
+    private readonly Mock<IEnvironment> _environment = new();
+    private readonly Mock<IFileHelper> _fileHelper = new();
+    private readonly Mock<IProcessHelper> _processHelper = new();
+    private readonly Mock<IOutput> _output = new();
+    private readonly AeDebuggerArgumentExecutor _executor;
+
+    public AeDebuggerArgumentProcessorTest()
+    {
+        _executor = new AeDebuggerArgumentExecutor(_environment.Object, _fileHelper.Object, _processHelper.Object, _output.Object);
+    }
+
+    [TestMethod]
+    public void AeDebuggerArgumentProcessorCommandName()
+    {
+        Assert.AreEqual("/AeDebugger", AeDebuggerArgumentProcessor.CommandName);
+    }
+
+    [TestMethod]
+    public void AeDebuggerArgumentProcessorCapabilities()
+    {
+        AeDebuggerArgumentProcessorCapabilities aeDebuggerArgumentProcessor = new();
+        Assert.IsNull(aeDebuggerArgumentProcessor.HelpContentResourceName);
+        Assert.IsTrue(aeDebuggerArgumentProcessor.IsAction);
+        Assert.AreEqual(ArgumentProcessorPriority.Normal, aeDebuggerArgumentProcessor.Priority);
+    }
+
+    [TestMethod]
+    public void AeDebuggerArgumentProcessorReturnsCorrectTypes()
+    {
+        AeDebuggerArgumentProcessor aeDebuggerArgumentProcessor = new();
+        Assert.IsInstanceOfType(aeDebuggerArgumentProcessor.Executor!.Value, typeof(AeDebuggerArgumentExecutor));
+        Assert.IsInstanceOfType(aeDebuggerArgumentProcessor.Metadata!.Value, typeof(AeDebuggerArgumentProcessorCapabilities));
+    }
+
+    [TestMethod]
+    public void AeDebuggerArgumentExecutor_InvalidCtor()
+    {
+        Assert.ThrowsException<ArgumentNullException>(() => new AeDebuggerArgumentExecutor(_environment.Object, _fileHelper.Object, _processHelper.Object, null!));
+        Assert.ThrowsException<ArgumentNullException>(() => new AeDebuggerArgumentExecutor(_environment.Object, _fileHelper.Object, null!, _output.Object));
+        Assert.ThrowsException<ArgumentNullException>(() => new AeDebuggerArgumentExecutor(_environment.Object, null!, _processHelper.Object, _output.Object));
+        Assert.ThrowsException<ArgumentNullException>(() => new AeDebuggerArgumentExecutor(null!, _fileHelper.Object, _processHelper.Object, _output.Object));
+    }
+
+    [TestMethod]
+    public void AeDebuggerArgumentExecutor_NullArgument()
+    {
+        _executor.Initialize(null);
+        Assert.AreEqual(ArgumentProcessorResult.Fail, _executor.Execute());
+        _output.Verify(x => x.WriteLine(It.IsAny<string>(), OutputLevel.Error), Times.Once());
+    }
+
+    [TestMethod]
+    [DataRow("Instal;ProcDumpToolDirectoryPath=c:\\ProcDumpToolDirectoryPath;DumpDirectoryPath=c:\\DumpDirectoryPath")]
+    [DataRow("Uninstal;ProcDumpToolDirectoryPath=c:\\ProcDumpToolDirectoryPath;DumpDirectoryPath=c:\\DumpDirectoryPath")]
+    public void AeDebuggerArgumentExecutor_WrongInstallUnistallCommand(string wrongCommand)
+    {
+        _executor.Initialize(wrongCommand);
+        Assert.ThrowsException<CommandLineException>(() => _executor.Execute());
+    }
+
+    [TestMethod]
+    public void AeDebuggerArgumentExecutor_NonWindowsOS()
+    {
+        _environment.Setup(x => x.OperatingSystem).Returns(PlatformOperatingSystem.Unix);
+        _executor.Initialize("Install;ProcDumpToolDirectoryPath=c:\\ProcDumpToolDirectoryPath;DumpDirectoryPath=c:\\DumpDirectoryPath");
+        Assert.AreEqual(ArgumentProcessorResult.Fail, _executor.Execute());
+    }
+
+    [TestMethod]
+    [DataRow("Install;{0};DumpDirectoryPath=c:\\DumpDirectoryPath", null)]
+    [DataRow("Install;{0};DumpDirectoryPath=c:\\DumpDirectoryPath", "ProcDumpToolDirectoryPath=c:\\ProcDumpToolDirectoryPat")]
+    [DataRow("Install;{0};ProcDumpToolDirectoryPath=c:\\ProcDumpToolDirectoryPath", null)]
+    [DataRow("Install;{0};ProcDumpToolDirectoryPath=c:\\ProcDumpToolDirectoryPath", "DumpDirectoryPath=c:\\DumpDirectoryPat")]
+
+    public void AeDebuggerArgumentExecutor_WrongDirectoryPaths(string command, string directoryPath)
+    {
+        _fileHelper.Setup(x => x.DirectoryExists(It.IsAny<string>()))
+            .Returns((string path) => directoryPath is null || !directoryPath.EndsWith(path));
+        _fileHelper.Setup(x => x.Exists(It.IsAny<string>()))
+            .Returns((string path) => path.EndsWith("procdump.exe"));
+        _executor.Initialize(string.Format(CultureInfo.InvariantCulture, command, directoryPath));
+        Assert.AreEqual(ArgumentProcessorResult.Fail, _executor.Execute());
+    }
+
+    [TestMethod]
+    [DataRow("Install;ProcDumpToolDirectoryPath=c:\\ProcDumpToolDirectoryPath;DumpDirectoryPath=c:\\DumpDirectoryPath", true)]
+    [DataRow("Uninstall;ProcDumpToolDirectoryPath=c:\\ProcDumpToolDirectoryPath;DumpDirectoryPath=c:\\DumpDirectoryPath", false)]
+    public void AeDebuggerArgumentExecutor_ProcdumpArgument(string command, bool install)
+    {
+        _fileHelper.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
+        _fileHelper.Setup(x => x.Exists(It.IsAny<string>())).Returns(true);
+        _processHelper.Setup(x => x.LaunchProcess(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            null,
+            It.IsAny<Action<object?, string?>>(),
+            It.IsAny<Action<object?>>(),
+            It.IsAny<Action<object?, string?>>()))
+         .Returns((string processPath, string? arguments, string? workingDirectory, IDictionary<string, string?>? envVariables, Action<object?, string?>? errorCallback, Action<object?>? exitCallBack, Action<object?, string?>? outputCallBack) =>
+         {
+             Assert.IsTrue(install ? arguments == "-ma -i" : arguments == "-u");
+             return new object();
+         });
+        _executor.Initialize(command);
+        Assert.AreEqual(ArgumentProcessorResult.Success, _executor.Execute());
+    }
+}

--- a/test/vstest.console.UnitTests/Processors/EnableBlameArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableBlameArgumentProcessorTests.cs
@@ -418,6 +418,88 @@ public class EnableBlameArgumentProcessorTests
             _settingsProvider.ActiveRunSettings.SettingsXml);
     }
 
+    [TestMethod]
+    [TestCategory("Windows-Review")]
+    public void InitializeMonitorPostmortemDebuggerShouldGenerateCorrectConfiguration()
+    {
+        var runsettingsString = string.Format(CultureInfo.CurrentCulture, _defaultRunSettings, "");
+        var runsettings = new RunSettings();
+        runsettings.LoadSettingsXml(_defaultRunSettings);
+        _settingsProvider.SetActiveRunSettings(runsettings);
+
+        _mockEnvronment.Setup(x => x.OperatingSystem)
+            .Returns(PlatformOperatingSystem.Windows);
+        _mockEnvronment.Setup(x => x.Architecture)
+            .Returns(PlatformArchitecture.X64);
+
+        _executor.Initialize("MonitorPostmortemDebugger;DumpDirectoryPath=c:\\DumpDirectoryPath");
+        Assert.IsNotNull(_settingsProvider.ActiveRunSettings);
+        Assert.AreEqual(string.Join(Environment.NewLine,
+                "<?xml version=\"1.0\" encoding=\"utf-16\"?>",
+                "<RunSettings>",
+                "  <DataCollectionRunSettings>",
+                "    <DataCollectors>",
+                "      <DataCollector friendlyName=\"blame\" enabled=\"True\">",
+                "        <Configuration>",
+                "          <ResultsDirectory>C:\\dir\\TestResults</ResultsDirectory>",
+                "          <MonitorPostmortemDebugger DumpDirectoryPath=\"c:\\DumpDirectoryPath\" />",
+                "        </Configuration>",
+                "      </DataCollector>",
+                "    </DataCollectors>",
+                "  </DataCollectionRunSettings>",
+                "  <RunConfiguration>",
+                "    <ResultsDirectory>C:\\dir\\TestResults</ResultsDirectory>",
+                "  </RunConfiguration>",
+                "  <LoggerRunSettings>",
+                "    <Loggers>",
+                "      <Logger friendlyName=\"blame\" enabled=\"True\" />",
+                "    </Loggers>",
+                "  </LoggerRunSettings>",
+                "</RunSettings>"),
+            _settingsProvider.ActiveRunSettings.SettingsXml);
+    }
+
+    [TestMethod]
+    [TestCategory("Windows-Review")]
+    public void InitializeMonitorPostmortemDebuggerShouldGenerateCorrectConfigurationAlsoIfIncomplete()
+    {
+        var runsettingsString = string.Format(CultureInfo.CurrentCulture, _defaultRunSettings, "");
+        var runsettings = new RunSettings();
+        runsettings.LoadSettingsXml(_defaultRunSettings);
+        _settingsProvider.SetActiveRunSettings(runsettings);
+
+        _mockEnvronment.Setup(x => x.OperatingSystem)
+            .Returns(PlatformOperatingSystem.Windows);
+        _mockEnvronment.Setup(x => x.Architecture)
+            .Returns(PlatformArchitecture.X64);
+
+        _executor.Initialize("MonitorPostmortemDebugger;");
+        Assert.IsNotNull(_settingsProvider.ActiveRunSettings);
+        Assert.AreEqual(string.Join(Environment.NewLine,
+                "<?xml version=\"1.0\" encoding=\"utf-16\"?>",
+                "<RunSettings>",
+                "  <DataCollectionRunSettings>",
+                "    <DataCollectors>",
+                "      <DataCollector friendlyName=\"blame\" enabled=\"True\">",
+                "        <Configuration>",
+                "          <ResultsDirectory>C:\\dir\\TestResults</ResultsDirectory>",
+                "          <MonitorPostmortemDebugger DumpDirectoryPath=\"\" />",
+                "        </Configuration>",
+                "      </DataCollector>",
+                "    </DataCollectors>",
+                "  </DataCollectionRunSettings>",
+                "  <RunConfiguration>",
+                "    <ResultsDirectory>C:\\dir\\TestResults</ResultsDirectory>",
+                "  </RunConfiguration>",
+                "  <LoggerRunSettings>",
+                "    <Loggers>",
+                "      <Logger friendlyName=\"blame\" enabled=\"True\" />",
+                "    </Loggers>",
+                "  </LoggerRunSettings>",
+                "</RunSettings>"),
+            _settingsProvider.ActiveRunSettings.SettingsXml);
+    }
+
     internal class TestableEnableBlameArgumentExecutor : EnableBlameArgumentExecutor
     {
         internal TestableEnableBlameArgumentExecutor(IRunSettingsProvider runSettingsManager, IEnvironment environment, IOutput output)


### PR DESCRIPTION
Add postmortem blame mode

// Install AeDebugger using procdump for all tests

`vstest.console.exe /AeDebugger:”Install;ProcDumpToolDirectoryPath=c:\procdump;DumpDirectoryPath=c:\DumpsDirectory”`

// Run monitoring the blame folder

`vstest.console.exe … /Blame:”MonitorPostmortemDebugger;DumpDirectoryPath=c:\DumpsDirectory”`


// Uninstall AeDebugger

`vstest.console.exe /AeDebugger:”Uninstall;ProcDumpToolDirectoryPath=c:\procdump;”`



