### PR TITLE
Update docker to the latest tagging schema

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -221,5 +221,5 @@ jobs:
   parameters:
     platform:
       name: Managed
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343
+      container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7
       buildScript: eng/common/build.sh


### PR DESCRIPTION
As a part of https://github.com/dotnet/dnceng/issues/1313, we are moving all docker containers to the new tagging schema