### PR TITLE
Fix Invalid target architecture 'S390x' error

### DIFF
--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -536,6 +536,10 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
                     return PlatformArchitecture.ARM;
                 case Architecture.ARM64:
                     return PlatformArchitecture.ARM64;
+                case Architecture.S390x:
+                    return PlatformArchitecture.S390x;
+                case Architecture.Ppc64le:
+                    return PlatformArchitecture.Ppc64le;
                 case Architecture.AnyCPU:
                 case Architecture.Default:
                 default:
@@ -552,6 +556,8 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
                 Architecture.X64 => platformAchitecture == PlatformArchitecture.X64,
                 Architecture.ARM => platformAchitecture == PlatformArchitecture.ARM,
                 Architecture.ARM64 => platformAchitecture == PlatformArchitecture.ARM64,
+                Architecture.S390x => platformAchitecture == PlatformArchitecture.S390x,
+                Architecture.Ppc64le => platformAchitecture == PlatformArchitecture.Ppc64le,
                 _ => throw new TestPlatformException($"Invalid target architecture '{targetArchitecture}'"),
             };
 


### PR DESCRIPTION
## Description
In commit 3ae5c4aef823 ("Add support for s390x processor architecture") support for S390x architecture was provided for .NET6. This is broken in .NET7. Add missing case statements to fix this for S390x and also Power architectures.

## Related issue
https://github.com/microsoft/vstest/pull/2954
