### PR TITLE
[rel/17.4] Fix Invalid target architecture 'S390x' error

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/Architecture.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Architecture.cs
@@ -11,5 +11,6 @@ public enum Architecture
     ARM,
     AnyCPU,
     ARM64,
-    S390x
+    S390x,
+    Ppc64le
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
@@ -113,6 +113,7 @@ Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.ARM = 3 -> Microsof
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.ARM64 = 5 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.Default = 0 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.S390x = 6 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
+Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.Ppc64le = 7 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.X64 = 2 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.X86 = 1 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
 Microsoft.VisualStudio.TestPlatform.ObjectModel.AttachmentSet

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/PlatformArchitecture.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/PlatformArchitecture.cs
@@ -13,4 +13,5 @@ public enum PlatformArchitecture
     ARM,
     ARM64,
     S390x,
+    Ppc64le,
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/PublicAPI/PublicAPI.Shipped.txt
@@ -67,6 +67,7 @@ Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture
 Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture.ARM = 2 -> Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture
 Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture.ARM64 = 3 -> Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture
 Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture.S390x = 4 -> Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture
+Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture.Ppc64le = 5 -> Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture
 Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture.X64 = 1 -> Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture
 Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture.X86 = 0 -> Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture
 Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformAssemblyExtensions

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformEnvironment.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformEnvironment.cs
@@ -28,6 +28,7 @@ public class PlatformEnvironment : IEnvironment
                 // preview 6 or later, so use the numerical value for now.
                 // case System.Runtime.InteropServices.Architecture.S390x:
                 (Architecture)5 => PlatformArchitecture.S390x,
+                (Architecture)8 => PlatformArchitecture.Ppc64le,
                 _ => throw new NotSupportedException(),
             };
         }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
@@ -41,6 +41,7 @@ public partial class ProcessHelper : IProcessHelper
             // preview 6 or later, so use the numerical value for now.
             // case System.Runtime.InteropServices.Architecture.S390x:
             (Architecture)5 => PlatformArchitecture.S390x,
+            (Architecture)8 => PlatformArchitecture.Ppc64le,
             _ => throw new NotSupportedException(),
         };
     }

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -274,6 +274,7 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
             PlatformArchitecture.ARM => Architecture.ARM,
             PlatformArchitecture.ARM64 => Architecture.ARM64,
             PlatformArchitecture.S390x => Architecture.S390x,
+            PlatformArchitecture.Ppc64le => Architecture.Ppc64le,
             _ => throw new NotSupportedException(),
         };
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -536,6 +536,10 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
                     return PlatformArchitecture.ARM;
                 case Architecture.ARM64:
                     return PlatformArchitecture.ARM64;
+                case Architecture.S390x:
+                    return PlatformArchitecture.S390x;
+                case Architecture.Ppc64le:
+                    return PlatformArchitecture.Ppc64le;
                 case Architecture.AnyCPU:
                 case Architecture.Default:
                 default:
@@ -552,6 +556,8 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
                 Architecture.X64 => platformAchitecture == PlatformArchitecture.X64,
                 Architecture.ARM => platformAchitecture == PlatformArchitecture.ARM,
                 Architecture.ARM64 => platformAchitecture == PlatformArchitecture.ARM64,
+                Architecture.S390x => platformAchitecture == PlatformArchitecture.S390x,
+                Architecture.Ppc64le => platformAchitecture == PlatformArchitecture.Ppc64le,
                 _ => throw new TestPlatformException($"Invalid target architecture '{targetArchitecture}'"),
             };
 

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -841,6 +841,8 @@ internal class TestRequestManager : ITestRequestManager
                     return Architecture.ARM64;
                 case PlatformArchitecture.S390x:
                     return Architecture.S390x;
+                case PlatformArchitecture.Ppc64le:
+                    return Architecture.Ppc64le;
                 default:
                     EqtTrace.Error($"TestRequestManager.TranslateToArchitecture: Unhandled architecture '{targetArchitecture}'.");
                     break;

--- a/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
@@ -85,7 +85,7 @@ public class PlatformArgumentProcessorTests
     {
         ExceptionUtilities.ThrowsException<CommandLineException>(
             () => _executor.Initialize("foo"),
-            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x.",
+            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x, Ppc64le.",
             "foo");
     }
 
@@ -94,7 +94,7 @@ public class PlatformArgumentProcessorTests
     {
         ExceptionUtilities.ThrowsException<CommandLineException>(
             () => _executor.Initialize("AnyCPU"),
-            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x.",
+            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x, Ppc64le.",
             "AnyCPU");
     }
 


### PR DESCRIPTION
## Description
In commit 3ae5c4aef823 ("Add support for s390x processor architecture") support for S390x architecture was provided for .NET6. This is broken in .NET7. Add missing case statements to fix this for S390x and also Power architectures.

## Related issue
https://github.com/microsoft/vstest/pull/2954
Cherry picking #4066
Cherry picking #4028
