### PR TITLE
Add aborted tests to TRX summary

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestRunSummary.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestRunSummary.cs
@@ -91,6 +91,7 @@ internal class TestRunSummary : IXmlTestStore
         int executed,
         int pass,
         int fail,
+        int abort,
         TestOutcome outcome,
         List<RunInfo> runMessages,
         string stdOut,
@@ -102,7 +103,7 @@ internal class TestRunSummary : IXmlTestStore
         _passedTests = pass;
         _failedTests = fail;
         int countForNonExistingResults = 0; // if below values are assigned constants 0, compiler gives warning CS0414
-        _abortedTests = countForNonExistingResults;
+        _abortedTests = abort;
         _errorTests = countForNonExistingResults;
         _timeoutTests = countForNonExistingResults;
         _inconclusiveTests = countForNonExistingResults;

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -175,6 +175,8 @@ public class TrxLogger : ITestLoggerWithParameters
 
     internal int FailedTestCount { get; private set; }
 
+    internal int AbortedTestCount { get; private set; }
+
     internal int TestResultCount
     {
         get
@@ -293,14 +295,18 @@ public class TrxLogger : ITestLoggerWithParameters
 
         // Set various counts (passed tests, failed tests, total tests)
         TotalTestCount++;
-        if (testResult.Outcome == TrxLoggerObjectModel.TestOutcome.Failed)
+        switch (testResult.Outcome)
         {
-            TestResultOutcome = TrxLoggerObjectModel.TestOutcome.Failed;
-            FailedTestCount++;
-        }
-        else if (testResult.Outcome == TrxLoggerObjectModel.TestOutcome.Passed)
-        {
-            PassedTestCount++;
+            case TrxLoggerObjectModel.TestOutcome.Failed:
+                TestResultOutcome = TrxLoggerObjectModel.TestOutcome.Failed;
+                FailedTestCount++;
+                break;
+            case TrxLoggerObjectModel.TestOutcome.Passed:
+                PassedTestCount++;
+                break;
+            case TrxLoggerObjectModel.TestOutcome.Aborted:
+                AbortedTestCount++;
+                break;
         }
     }
 
@@ -379,6 +385,7 @@ public class TrxLogger : ITestLoggerWithParameters
             PassedTestCount + FailedTestCount,
             PassedTestCount,
             FailedTestCount,
+            AbortedTestCount,
             TestResultOutcome,
             _runLevelErrorsAndWarnings,
             _runLevelStdOut.ToString(),

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
@@ -159,6 +159,9 @@ internal class Converter
             case Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.NotFound:
                 outcome = TrxObjectModel.TestOutcome.NotExecuted;
                 break;
+            case Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Aborted:
+                outcome = TrxObjectModel.TestOutcome.Aborted;
+                break;
             default:
                 Debug.Fail("Unexpected Outcome.");
                 break;

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 ﻿#nullable enable
+Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Aborted = 5 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome

--- a/src/Microsoft.TestPlatform.ObjectModel/TestOutcome.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TestOutcome.cs
@@ -32,4 +32,9 @@ public enum TestOutcome
     /// Test Case Not found
     /// </summary>
     NotFound = 4,
+
+    /// <summary>
+    /// Test Case Aborted
+    /// </summary>
+    Aborted,
 }

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -191,6 +191,21 @@ public class TrxLoggerTests
     }
 
     [TestMethod]
+    public void TestResultHandlerKeepingTheTrackOfAbortedTests()
+    {
+        TestCase abortTestCase1 = CreateTestCase("Abort");
+
+        VisualStudio.TestPlatform.ObjectModel.TestResult passResult1 = new(abortTestCase1);
+        passResult1.Outcome = TestOutcome.Aborted;
+
+        Mock<TestResultEventArgs> pass1 = new(passResult1);
+
+        _testableTrxLogger.TestResultHandler(new object(), pass1.Object);
+
+        Assert.AreEqual(1, _testableTrxLogger.AbortedTestCount, "Aborted Tests");
+    }
+
+    [TestMethod]
     public void TestResultHandlerKeepingTheTrackOfTotalTests()
     {
         TestCase passTestCase1 = CreateTestCase("Pass1");

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/Utility/ConverterTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/Utility/ConverterTests.cs
@@ -68,6 +68,12 @@ public class ConverterTests
     }
 
     [TestMethod]
+    public void ToOutcomeShouldMapAbortedToAborted()
+    {
+        Assert.AreEqual(TrxLoggerOutcome.Aborted, Converter.ToOutcome(TestOutcome.Aborted));
+    }
+
+    [TestMethod]
     public void ToCollectionEntriesShouldRenameAttachmentUriIfTheAttachmentNameIsSame()
     {
         SetupForToCollectionEntries(out var tempDir, out var attachmentSets, out var testRun, out var testResultsDirectory);


### PR DESCRIPTION
## Description

The current TRX report summary is missing information about various test status, such as aborted, timeout, inconclusive, etc.

Full list is here https://github.com/microsoft/vstest/blob/458e90e8e310b71629953e380ebabcb1546a0ced/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestRunSummary.cs#L105-L116

Public repro here https://github.com/mfkl/trx-missing-attributes-repro

It would be nice to have this information as part of the TRX summary, which currently only reports failed/passed test information.

I've started by adding the aborted test result info to the TRX summary. If the approach seems fine with you, I'll add the other properties so that the TRX summary is completely filled.

To write the test, I had to modify the following public API `src/Microsoft.TestPlatform.ObjectModel/TestOutcome.cs` which does not match the internal API `src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestOutcome.cs`

## Related issue

Contribution towards https://github.com/microsoft/vstest/issues/2506
