### PR TITLE
Improve test script output

### DIFF
--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -206,7 +206,7 @@ function Invoke-Test
             }
             else
             {
-                Write-Log ".. . $testContainerName test container found. ($testOutputPath)"
+                Write-Log ".. . $testContainerName test container found. ($testContainerPath)"
                 $testContainers += ,"$testContainerPath"
             }
         }


### PR DESCRIPTION
## Description

Fix output to no longer display `Microsoft.TestPlatform.Build.UnitTests test container found. (C:\src\vstest\test\Microsoft.TestPlatform.Build.UnitTests\bin\Debug\{0})` but now correctly display `Microsoft.TestPlatform.Build.UnitTests test container found. (C:\src\vstest\test\Microsoft.TestPlatform.Build.UnitTests\bin\Debug\Microsoft.TestPlatform.Build.UnitTests)`
