### PR TITLE
Revert making Microsoft.NET.Test.Sdk package transitive

### DIFF
--- a/src/package/nuspec/Microsoft.NET.Test.Sdk.nuspec
+++ b/src/package/nuspec/Microsoft.NET.Test.Sdk.nuspec
@@ -32,12 +32,12 @@
   <files>
     <file src="Icon.png" target="" />
     <file src="licenses\LICENSE_NET.txt" target="" />
-    <file src="netcoreapp\*" target="buildTransitive\netcoreapp3.1\" />
-    <file src="netfx\*" target="buildTransitive\net462\" />
+    <file src="netcoreapp\*" target="build\netcoreapp3.1\" />
+    <file src="netfx\*" target="build\net462\" />
 
     <file src="Microsoft.NET.Test.Sdk.props" target="buildMultiTargeting\" />
-    <file src="Microsoft.NET.Test.Sdk.props" target="buildTransitive\netcoreapp3.1\" />
-    <file src="Microsoft.NET.Test.Sdk.props" target="buildTransitive\net462\" />
+    <file src="Microsoft.NET.Test.Sdk.props" target="build\netcoreapp3.1\" />
+    <file src="Microsoft.NET.Test.Sdk.props" target="build\net462\" />
 
     <file src="_._" target="lib/netcoreapp3.1" />
     <file src="_._" target="lib/net462" />


### PR DESCRIPTION
## Description

Revert changes introduced in #3879. 

We have identified a few cases where having this package as transitive causes issue. There are also some discussion around improving UX for this package (e.g. https://github.com/dotnet/sdk/issues/25797).

Given all these information and the fact that the change was introduced in 17.4, not yet released, we decided to revert the change.

## Related issue

Fixes #4098
