### PR TITLE
fix(#4125): Order enumerate files to return deterministic result among different operating and file systems

### DIFF
--- a/src/Microsoft.TestPlatform.CoreUtilities/Helpers/FileHelper.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Helpers/FileHelper.cs
@@ -55,9 +55,12 @@ public class FileHelper : IFileHelper
 
         var files = Directory.EnumerateFiles(directory, "*", searchOption);
 
-        return files.Where(
-            file => endsWithSearchPatterns.Any(
-                pattern => file.EndsWith(pattern, StringComparison.OrdinalIgnoreCase)));
+        return files
+            .Where(
+                file => endsWithSearchPatterns.Any(
+                    pattern => file.EndsWith(pattern, StringComparison.OrdinalIgnoreCase)))
+            .OrderBy(
+                file => file, StringComparer.Ordinal);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Description

As MSDN [describes](https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.getfiles?view=net-7.0), enumerate files does not guarantee the order of the returned files. Sorting the files makes the behaviour consistent across all systems and improves the cross platform experience.

## Related issue

- Relates #4125
