### PR TITLE
Remove specific handling for MSTest in trx logger

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -608,27 +608,13 @@ public class TrxLogger : ITestLoggerWithParameters
         TestCase testCase = rockSteadyTestResult.TestCase;
         Guid testId = Converter.GetTestId(testCase);
 
-        // Scenario for inner test case when parent test element is not present.
-        string? testName = testCase.DisplayName;
-        var adapter = testCase.ExecutorUri.ToString();
-        if (adapter.Contains(TrxLoggerConstants.MstestAdapterString) &&
-            parentTestElement == null &&
-            !string.IsNullOrEmpty(rockSteadyTestResult.DisplayName))
-        {
-            // Note: For old mstest adapters hierarchical support was not present. Thus inner result of data driven was identified using test result display name.
-            // Non null test result display name means its a inner result of data driven/ordered test.
-            // Changing GUID to keep supporting old mstest adapters.
-            testId = Guid.NewGuid();
-            testName = rockSteadyTestResult.DisplayName;
-        }
-
         // Get test element
         testElement = GetTestElement(testId);
 
         // Create test element
         if (testElement == null)
         {
-            testElement = Converter.ToTestElement(testId, executionId, parentExecutionId, testName!, testType, testCase);
+            testElement = Converter.ToTestElement(testId, executionId, parentExecutionId, testCase.DisplayName, testType, testCase);
             _testElements.TryAdd(testId, testElement);
         }
 

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -328,15 +328,9 @@ public class TrxLoggerTests
     }
 
     [TestMethod]
-    public void TestResultHandlerShouldChangeGuidAndDisplayNameForMsTestResultIfParentNotPresentButTestResultNamePresent()
+    public void TestResultHandlerShouldNotChangeGuidAndDisplayNameForTestResultIfParentNotPresentButTestResultNamePresent()
     {
-        ValidateTestIdAndNameInTrx(true);
-    }
-
-    [TestMethod]
-    public void TestResultHandlerShouldNotChangeGuidAndDisplayNameForNonMsTestResultIfParentNotPresentButTestResultNamePresent()
-    {
-        ValidateTestIdAndNameInTrx(false);
+        ValidateTestIdAndNameInTrx();
     }
 
     [TestMethod]
@@ -863,42 +857,30 @@ public class TrxLoggerTests
         Assert.ThrowsException<ArgumentException>(() => _testableTrxLogger.Initialize(_events.Object, _parameters));
     }
 
-    private void ValidateTestIdAndNameInTrx(bool isMstestAdapter)
+    private void ValidateTestIdAndNameInTrx()
     {
         TestCase testCase = CreateTestCase("TestCase");
-        testCase.ExecutorUri = isMstestAdapter ? new Uri("some://mstestadapteruri") : new Uri("some://uri");
+        testCase.ExecutorUri = new Uri("some://uri");
 
         VisualStudio.TestPlatform.ObjectModel.TestResult result = new(testCase);
         result.SetPropertyValue(TrxLoggerConstants.ExecutionIdProperty, Guid.NewGuid());
-        if (isMstestAdapter)
-        {
-            result.DisplayName = "testDisplayName";
-        }
 
         Mock<TestResultEventArgs> resultEventArg = new(result);
         _testableTrxLogger.TestResultHandler(new object(), resultEventArg.Object);
         var testRunCompleteEventArgs = CreateTestRunCompleteEventArgs();
         _testableTrxLogger.TestRunCompleteHandler(new object(), testRunCompleteEventArgs);
 
-        ValidateResultAttributesInTrx(_testableTrxLogger.TrxFile!, testCase.Id, testCase.DisplayName, isMstestAdapter);
+        ValidateResultAttributesInTrx(_testableTrxLogger.TrxFile!, testCase.Id, testCase.DisplayName);
     }
 
-    private static void ValidateResultAttributesInTrx(string trxFileName, Guid testId, string testName, bool isMstestAdapter)
+    private static void ValidateResultAttributesInTrx(string trxFileName, Guid testId, string testName)
     {
         using FileStream file = File.OpenRead(trxFileName);
         using XmlReader reader = XmlReader.Create(file);
         XDocument document = XDocument.Load(reader);
         var resultNode = document.Descendants(document.Root!.GetDefaultNamespace() + "UnitTestResult").First();
-        if (isMstestAdapter)
-        {
-            Assert.AreNotEqual(resultNode.Attributes("testId").First().Value, testId.ToString());
-            Assert.AreNotEqual(resultNode.Attributes("testName").First().Value, testName);
-        }
-        else
-        {
-            Assert.AreEqual(resultNode.Attributes("testId").First().Value, testId.ToString());
-            Assert.AreEqual(resultNode.Attributes("testName").First().Value, testName);
-        }
+        Assert.AreEqual(resultNode.Attributes("testId").First().Value, testId.ToString());
+        Assert.AreEqual(resultNode.Attributes("testName").First().Value, testName);
     }
 
     private static void ValidateTimeWithinUtcLimits(DateTimeOffset dateTime)


### PR DESCRIPTION
## Description

Remove specific handling for MSTest in trx logger. It's not clear why this specific code was added as it seems that older versions of MSTest don't reach that place.

## Related issue

See #1784 where specific handling for mstest was added. See https://github.com/microsoft/testfx/issues/1149 where issue was detected.
