### PR TITLE
Cleanup unused usings (truly enforce ide0005 code analysis rule)

### DIFF
--- a/docs/RFCs/0029-Debugging-External-Test-Processes.md
+++ b/docs/RFCs/0029-Debugging-External-Test-Processes.md
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter
         /// Attach debugger to an already running process.
         /// </summary>
         /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
-        /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
+        /// <returns><see langword="true"/> if the debugger was successfully attached to the requested process, <see langword="false"/> otherwise.</returns>
         bool AttachDebuggerToProcess(int pid);
     }
 }
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter
         /// </summary>
         /// <param name="sources">Path to test container files to look for tests in.</param>
         /// <param name="runContext">Context to use when executing the tests.</param>
-        /// <returns><see cref="true"/> if the default test host process should be attached to, <see cref="false"/> otherwise.</returns>
+        /// <returns><see langword="true"/> if the default test host process should be attached to, <see langword="false"/> otherwise.</returns>
         bool ShouldAttachToTestHost(IEnumerable<string> sources, IRunContext runContext);
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter
         /// </summary>
         /// <param name="tests">Tests to be run.</param>
         /// <param name="runContext">Context to use when executing the tests.</param>
-        /// <returns><see cref="true"/> if the default test host process should be attached to, <see cref="false"/> otherwise.</returns>
+        /// <returns><see langword="true"/> if the default test host process should be attached to, <see langword="false"/> otherwise.</returns>
         bool ShouldAttachToTestHost(IEnumerable<TestCase> tests, IRunContext runContext);
     }
 }
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces
         /// Attach to already running custom test host process.
         /// </summary>
         /// <param name="pid">Process ID of the process to attach.</param>
-        /// <returns><see cref="true"/> if the attach was successful, <see cref="false"/> otherwise.</returns>
+        /// <returns><see langword="true"/> if the attach was successful, <see langword="false"/> otherwise.</returns>
         bool AttachToProcess(int pid);
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces
         /// </summary>
         /// <param name="pid">Process ID of the process to attach.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns><see cref="true"/> if the attach was successful, <see cref="false"/> otherwise.</returns>
+        /// <returns><see langword="true"/> if the attach was successful, <see langword="false"/> otherwise.</returns>
         bool AttachToProcess(int pid, CancellationToken cancellationToken);
     }
 }

--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -26,7 +26,7 @@
 
     <PublicSign Condition="'$(CIBuild)' == '' or '$(CIBuild)' == 'false'">true</PublicSign>
     <DelaySign Condition="'$(CIBuild)' == 'true'">true</DelaySign>
-    <!--<GenerateDocumentationFile>true</GenerateDocumentationFile>-->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>$(TestPlatformRoot)scripts/key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -82,7 +82,6 @@
   <Choose>
     <When Condition="$(TestProject) == 'true'">
       <PropertyGroup>
-        <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <!-- Suppress warnings about testhost being x64 (AMD64)/x86 when imported into AnyCPU (MSIL) test projects. -->
         <NoWarn>$(NoWarn);MSB3270</NoWarn>
       </PropertyGroup>

--- a/scripts/build/TestPlatform.targets
+++ b/scripts/build/TestPlatform.targets
@@ -3,7 +3,14 @@
   <PropertyGroup>
     <TestPlatformRoot>$(MSBuildThisFileDirectory)..\..\</TestPlatformRoot>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
-    <NoWarn>$(NoWarn);CA1416;RS0037;CS1570;CS1572;CS1573;CS1574;CS1584;CS1591;CS1658;CS1712;CS1734</NoWarn>
+    <!-- Cleanup issue: https://github.com/microsoft/vstest/issues/4236
+    CS1570: XML comment on '<construct>' has badly formed XML
+    CS1572: XML comment on 'construct' has a param tag for 'parameter', but there is no parameter by that name
+    CS1573: Parameter 'parameter' has no matching param tag in the XML comment for 'parameter' (but other parameters do)
+    CS1574: XML comment on 'construct' has syntactically incorrect cref attribute 'name'
+    CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
+    -->
+    <NoWarn>$(NoWarn);CA1416;RS0037;CS1570;CS1572;CS1573;CS1574;CS1591</NoWarn>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)TestPlatform.Localization.targets" />

--- a/scripts/build/TestPlatform.targets
+++ b/scripts/build/TestPlatform.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TestPlatformRoot>$(MSBuildThisFileDirectory)..\..\</TestPlatformRoot>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
-    <NoWarn>$(NoWarn);CA1416;RS0037</NoWarn>
+    <NoWarn>$(NoWarn);CA1416;RS0037;CS1570;CS1572;CS1573;CS1574;CS1584;CS1591;CS1658;CS1712;CS1734</NoWarn>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)TestPlatform.Localization.targets" />

--- a/scripts/verify-nupkgs.ps1
+++ b/scripts/verify-nupkgs.ps1
@@ -16,7 +16,7 @@ function Verify-Nuget-Packages($packageDirectory, $version)
         "Microsoft.NET.Test.Sdk" = 16;
         "Microsoft.TestPlatform" = 603;
         "Microsoft.TestPlatform.Build" = 21;
-        "Microsoft.TestPlatform.CLI" = 477;
+        "Microsoft.TestPlatform.CLI" = 476;
         "Microsoft.TestPlatform.Extensions.TrxLogger" = 35;
         "Microsoft.TestPlatform.ObjectModel" = 93;
         "Microsoft.TestPlatform.AdapterUtilities" = 34;

--- a/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/ManagedNameParser.cs
+++ b/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/ManagedNameParser.cs
@@ -57,7 +57,7 @@ public class ManagedNameParser
     /// </param>
     /// <param name="parameterTypes">
     /// When this method returns, contains the parsed parameter types of the <paramref name="managedMethodName"/>.
-    /// If there are no parameter types in <paramref name="managedMethodName"/>, <paramref name="parameterTypes"/> is set to <c>null</c>.
+    /// If there are no parameter types in <paramref name="managedMethodName"/>, <paramref name="parameterTypes"/> is set to <see langword="null"/>.
     /// This parameter is passed uninitialized; any value originally supplied in result will be overwritten.
     /// </param>
     /// <exception cref="InvalidManagedNameException">

--- a/src/Microsoft.TestPlatform.AdapterUtilities/TestIdProvider.cs
+++ b/src/Microsoft.TestPlatform.AdapterUtilities/TestIdProvider.cs
@@ -36,7 +36,7 @@ public class TestIdProvider
     /// </summary>
     /// <param name="str">String to append to the id seed.</param>
     /// <exception cref="InvalidOperationException">Thrown if <see cref="GetHash"/> or <see cref="GetId"/> is called already.</exception>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="str"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="str"/> is <see langword="null"/>.</exception>
     public void AppendString(string str)
     {
         if (_hash != null)
@@ -55,7 +55,7 @@ public class TestIdProvider
     /// </summary>
     /// <param name="bytes">Array to append to the id seed.</param>
     /// <exception cref="InvalidOperationException">Thrown if <see cref="GetHash"/> or <see cref="GetId"/> is called already.</exception>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="bytes"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="bytes"/> is <see langword="null"/>.</exception>
     public void AppendBytes(byte[] bytes)
     {
         if (_hash != null)

--- a/src/Microsoft.TestPlatform.Client/DesignMode/IDesignModeClient.cs
+++ b/src/Microsoft.TestPlatform.Client/DesignMode/IDesignModeClient.cs
@@ -35,7 +35,7 @@ public interface IDesignModeClient : IDisposable
     /// </summary>
     /// <param name="attachDebuggerInfo">Process Id and other information about the process that IDE should attach to.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if the debugger was successfully attached to the requested process, <see langword="false"/> otherwise.</returns>
     bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo, CancellationToken cancellationToken);
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestDiscoveryExtensionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestDiscoveryExtensionManager.cs
@@ -185,8 +185,8 @@ internal class TestDiscovererMetadata : ITestDiscovererCapabilities
     }
 
     /// <summary>
-    /// <c>true</c> if the discoverer plugin is decorated with <see cref="DirectoryBasedTestDiscovererAttribute"/>,
-    /// <c>false</c> otherwise.
+    /// <see langword="true"/> if the discoverer plugin is decorated with <see cref="DirectoryBasedTestDiscovererAttribute"/>,
+    /// <see langword="false"/> otherwise.
     /// </summary>
     public bool IsDirectoryBased
     {

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginManager.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginManager.cs
@@ -88,11 +88,16 @@ internal class TestPluginManager
     /// <summary>
     /// Retrieves the test extension collections of given extension type.
     /// </summary>
+    /// <typeparam name="TPluginInfo">
+    /// </typeparam>
     /// <typeparam name="TExtension">
     /// Type of the required extensions
     /// </typeparam>
-    /// <typeparam name="TMetadata">
+    /// <typeparam name="IMetadata">
     /// Type of metadata of required extensions
+    /// </typeparam>
+    /// <typeparam name="TMetadata">
+    /// Concrete type of metadata
     /// </typeparam>
     /// <param name="endsWithPattern">
     /// Pattern used to select files using String.EndsWith
@@ -124,8 +129,11 @@ internal class TestPluginManager
     /// <typeparam name="TExtension">
     /// Type of the required extensions
     /// </typeparam>
-    /// <typeparam name="TMetadata">
+    /// <typeparam name="IMetadata">
     /// Type of metadata of required extensions
+    /// </typeparam>
+    /// <typeparam name="TMetadata">
+    /// Concrete type of metadata
     /// </typeparam>
     /// <param name="unfiltered">
     /// Receives unfiltered list of test extensions
@@ -173,8 +181,11 @@ internal class TestPluginManager
     /// <typeparam name="TExtension">
     /// Type of the required extensions
     /// </typeparam>
-    /// <typeparam name="TMetadata">
+    /// <typeparam name="IMetadata">
     /// Type of metadata of required extensions
+    /// </typeparam>
+    /// <typeparam name="TMetadata">
+    /// Concrete type of metadata
     /// </typeparam>
     /// <param name="testPluginInfo">
     /// The test extension dictionary.

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginManager.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginManager.cs
@@ -94,9 +94,6 @@ internal class TestPluginManager
     /// <typeparam name="TMetadata">
     /// Type of metadata of required extensions
     /// </typeparam>
-    /// <typeparam name="TMetadata">
-    /// Concrete type of metadata
-    /// </typeparam>
     /// <param name="endsWithPattern">
     /// Pattern used to select files using String.EndsWith
     /// </param>
@@ -129,9 +126,6 @@ internal class TestPluginManager
     /// </typeparam>
     /// <typeparam name="TMetadata">
     /// Type of metadata of required extensions
-    /// </typeparam>
-    /// <typeparam name="TMetadata">
-    /// Concrete type of metadata
     /// </typeparam>
     /// <param name="unfiltered">
     /// Receives unfiltered list of test extensions
@@ -181,9 +175,6 @@ internal class TestPluginManager
     /// </typeparam>
     /// <typeparam name="TMetadata">
     /// Type of metadata of required extensions
-    /// </typeparam>
-    /// <typeparam name="TMetadata">
-    /// Concrete type of metadata
     /// </typeparam>
     /// <param name="testPluginInfo">
     /// The test extension dictionary.

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestDiscovererPluginInformation.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/Utilities/TestDiscovererPluginInformation.cs
@@ -72,8 +72,8 @@ internal class TestDiscovererPluginInformation : TestPluginInformation
     }
 
     /// <summary>
-    /// <c>true</c> if the discoverer plugin is decorated with <see cref="DirectoryBasedTestDiscovererAttribute"/>,
-    /// <c>false</c> otherwise.
+    /// <see langword="true"/> if the discoverer plugin is decorated with <see cref="DirectoryBasedTestDiscovererAttribute"/>,
+    /// <see langword="false"/> otherwise.
     /// </summary>
     public bool IsDirectoryBased
     {
@@ -107,7 +107,7 @@ internal class TestDiscovererPluginInformation : TestPluginInformation
     }
 
     /// <summary>
-    /// Returns the value of default executor Uri on this type. <c>null</c> if not present.
+    /// Returns the value of default executor Uri on this type. <see langword="null"/> if not present.
     /// </summary>
     /// <param name="testDiscovererType"> The test discoverer Type. </param>
     /// <returns> The default executor URI. </returns>
@@ -147,8 +147,8 @@ internal class TestDiscovererPluginInformation : TestPluginInformation
     }
 
     /// <summary>
-    /// Returns <c>true</c> if the discoverer plugin is decorated with
-    /// <see cref="DirectoryBasedTestDiscovererAttribute"/>, <c>false</c> otherwise.
+    /// Returns <see langword="true"/> if the discoverer plugin is decorated with
+    /// <see cref="DirectoryBasedTestDiscovererAttribute"/>, <see langword="false"/> otherwise.
     /// </summary>
     /// <param name="testDiscovererType">Data type of the test discoverer</param>
     private static bool GetIsDirectoryBased(Type testDiscovererType)

--- a/src/Microsoft.TestPlatform.Common/Interfaces/ITestDiscovererCapabilities.cs
+++ b/src/Microsoft.TestPlatform.Common/Interfaces/ITestDiscovererCapabilities.cs
@@ -29,8 +29,8 @@ public interface ITestDiscovererCapabilities
     AssemblyType AssemblyType { get; }
 
     /// <summary>
-    /// <c>true</c> if the discoverer plugin is decorated with <see cref="DirectoryBasedTestDiscovererAttribute"/>,
-    /// <c>false</c> otherwise.
+    /// <see langword="true"/> if the discoverer plugin is decorated with <see cref="DirectoryBasedTestDiscovererAttribute"/>,
+    /// <see langword="false"/> otherwise.
     /// </summary>
     bool IsDirectoryBased { get; }
 }

--- a/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs
@@ -2,13 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/ITestRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/ITestRequestHandler.cs
@@ -92,6 +92,6 @@ public interface ITestRequestHandler : IDisposable
     /// Attach debugger to an already running process.
     /// </summary>
     /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
-    /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if the debugger was successfully attached to the requested process, <see langword="false"/> otherwise.</returns>
     bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo);
 }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.cs
@@ -291,7 +291,7 @@ public class JsonDataSerializer : IDataSerializer
     /// <param name="json">JSON string.</param>
     /// <param name="version">Version of serializer to be used.</param>
     /// <typeparam name="T">Target type to deserialize.</typeparam>
-    /// <returns>An instance of <see cref="T"/>.</returns>
+    /// <returns>An instance of <typeparamref name="T"/>.</returns>
     [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Part of the public API")]
     public T? Deserialize<T>(string json, int version = 1)
     {

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
-using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/DiscoveryDataAggregator.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/DiscoveryDataAggregator.cs
@@ -164,7 +164,7 @@ internal sealed class DiscoveryDataAggregator
     /// Handles race conditions as this aggregator is shared across various event handler for the
     /// same discovery request but we want to notify only once.
     /// </remarks>
-    /// <returns><c>true</c> if first to send the message; <c>false</c> otherwise.</returns>
+    /// <returns><see langword="true"/> if first to send the message; <see langword="false"/> otherwise.</returns>
     public bool TryAggregateIsMessageSent()
         => Interlocked.CompareExchange(ref _isMessageSent, 1, 0) == 0;
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscovererEnumerator.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscovererEnumerator.cs
@@ -118,7 +118,8 @@ internal class DiscovererEnumerator
     /// </summary>
     /// <param name="extensionAssembly"> The extension Assembly. </param>
     /// <param name="sources"> The sources.   </param>
-    /// <param name="settings"> The test case filter. </param>
+    /// <param name="settings"> The settings.   </param>
+    /// <param name="testCaseFilter"> The test case filter. </param>
     /// <param name="logger"> The logger.  </param>
     private void LoadTestsFromAnExtension(string extensionAssembly, IEnumerable<string> sources, IRunSettings? settings, string? testCaseFilter, IMessageLogger logger)
     {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscovererEnumerator.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscovererEnumerator.cs
@@ -118,7 +118,6 @@ internal class DiscovererEnumerator
     /// </summary>
     /// <param name="extensionAssembly"> The extension Assembly. </param>
     /// <param name="sources"> The sources.   </param>
-    /// <param name="settings"> The settings.   </param>
     /// <param name="settings"> The test case filter. </param>
     /// <param name="logger"> The logger.  </param>
     private void LoadTestsFromAnExtension(string extensionAssembly, IEnumerable<string> sources, IRunSettings? settings, string? testCaseFilter, IMessageLogger logger)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -297,8 +297,8 @@ internal abstract class BaseRunTests
     /// <param name="executorUriExtensionTuple">The executor URI.</param>
     /// <param name="runContext">The run context.</param>
     /// <returns>
-    /// <see cref="true"/> if must attach the debugger to the default test host,
-    /// <see cref="false"/> otherwise.
+    /// <see langword="true"/> if must attach the debugger to the default test host,
+    /// <see langword="false"/> otherwise.
     /// </returns>
     protected abstract bool ShouldAttachDebuggerToTestHost(
         LazyExtension<ITestExecutor, ITestExecutorCapabilities> executor,

--- a/src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/IFrameworkHandle2.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/IFrameworkHandle2.cs
@@ -12,6 +12,6 @@ public interface IFrameworkHandle2 : IFrameworkHandle
     /// Attach debugger to an already running process.
     /// </summary>
     /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
-    /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if the debugger was successfully attached to the requested process, <see langword="false"/> otherwise.</returns>
     bool AttachDebuggerToProcess(int pid);
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/ITestExecutor.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/ITestExecutor.cs
@@ -9,8 +9,8 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 /// Defines the test executor which provides capability to run tests.
 ///
 /// A class that implements this interface will be available for use if its containing
-//  assembly is either placed in the Extensions folder or is marked as a 'UnitTestExtension' type
-//  in the vsix package.
+///  assembly is either placed in the Extensions folder or is marked as a 'UnitTestExtension' type
+///  in the vsix package.
 /// </summary>
 public interface ITestExecutor
 {

--- a/src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/ITestExecutor2.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/ITestExecutor2.cs
@@ -20,8 +20,8 @@ public interface ITestExecutor2 : ITestExecutor
     /// <param name="sources">Path to test container files to look for tests in.</param>
     /// <param name="runContext">Context to use when executing the tests.</param>
     /// <returns>
-    /// <see cref="true"/> if the default test host process should be attached to,
-    /// <see cref="false"/> otherwise.
+    /// <see langword="true"/> if the default test host process should be attached to,
+    /// <see langword="false"/> otherwise.
     /// </returns>
     bool ShouldAttachToTestHost(IEnumerable<string>? sources, IRunContext runContext);
 
@@ -31,8 +31,8 @@ public interface ITestExecutor2 : ITestExecutor
     /// <param name="tests">Tests to be run.</param>
     /// <param name="runContext">Context to use when executing the tests.</param>
     /// <returns>
-    /// <see cref="true"/> if the default test host process should be attached to,
-    /// <see cref="false"/> otherwise.
+    /// <see langword="true"/> if the default test host process should be attached to,
+    /// <see langword="false"/> otherwise.
     /// </returns>
     bool ShouldAttachToTestHost(IEnumerable<TestCase>? tests, IRunContext runContext);
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/FilterOptions.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/FilterOptions.cs
@@ -20,8 +20,8 @@ public class FilterOptions
     public string? FilterRegEx { get; set; }
 
     /// <summary>
-    /// Gets or sets the optional regular expression replacement string. When this property is set, <see cref="System.Text.RegularExpressions.Regex.Replace"/>
-    /// will be called upon property value instead of <see cref="System.Text.RegularExpressions.Regex.Match"/> before matching.
+    /// Gets or sets the optional regular expression replacement string. When this property is set, <see cref="System.Text.RegularExpressions.Regex.Replace(string)"/>
+    /// will be called upon property value instead of <see cref="System.Text.RegularExpressions.Regex.Match(string)"/> before matching.
     /// </summary>
     [DataMember]
     public string? FilterRegExReplacement { get; set; }

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/IInternalTestRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/IInternalTestRunEventsHandler.cs
@@ -40,7 +40,7 @@ public interface IInternalTestRunEventsHandler : ITestMessageEventHandler
     /// Attach debugger to an already running process.
     /// </summary>
     /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
-    /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if the debugger was successfully attached to the requested process, <see langword="false"/> otherwise.</returns>
     bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo);
 }
 

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher2.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher2.cs
@@ -14,7 +14,7 @@ public interface ITestHostLauncher2 : ITestHostLauncher
     /// Attach debugger to already running custom test host process.
     /// </summary>
     /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
-    /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if the debugger was successfully attached to the requested process, <see langword="false"/> otherwise.</returns>
     bool AttachDebuggerToProcess(int pid);
 
     /// <summary>
@@ -22,6 +22,6 @@ public interface ITestHostLauncher2 : ITestHostLauncher
     /// </summary>
     /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if the debugger was successfully attached to the requested process, <see langword="false"/> otherwise.</returns>
     bool AttachDebuggerToProcess(int pid, CancellationToken cancellationToken);
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher3.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher3.cs
@@ -12,6 +12,6 @@ public interface ITestHostLauncher3 : ITestHostLauncher2
     /// </summary>
     /// <param name="attachDebuggerInfo">Process ID and target framework of the process to which the debugger should be attached.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if the debugger was successfully attached to the requested process, <see langword="false"/> otherwise.</returns>
     bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo, CancellationToken cancellationToken);
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestRunEventsHandler2.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestRunEventsHandler2.cs
@@ -16,7 +16,7 @@ public interface ITestRunEventsHandler2 : ITestRunEventsHandler
     /// Attach debugger to an already running process.
     /// </summary>
     /// <param name="pid">Process ID of the process to which the debugger should be attached.</param>
-    /// <returns><see cref="true"/> if the debugger was successfully attached to the requested process, <see cref="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if the debugger was successfully attached to the requested process, <see langword="false"/> otherwise.</returns>
     [Obsolete("You don't have to implement this it is never called back. To attach to debugger implement ITestHostLauncher2 or ITestHostLauncher3.")]
     bool AttachDebuggerToProcess(int pid);
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/Host/ITestRuntimeProvider2.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Host/ITestRuntimeProvider2.cs
@@ -13,8 +13,8 @@ public interface ITestRuntimeProvider2 : ITestRuntimeProvider
     /// Attach the debugger to an already running testhost process.
     /// </summary>
     /// <returns>
-    /// <see cref="true"/> if the debugger was successfully attached to the running testhost
-    /// process, <see cref="false"/> otherwise.
+    /// <see langword="true"/> if the debugger was successfully attached to the running testhost
+    /// process, <see langword="false"/> otherwise.
     /// </returns>
     bool AttachDebuggerToTestHost();
 }

--- a/src/Microsoft.TestPlatform.Utilities/CodeCoverageRunSettingsProcessor.cs
+++ b/src/Microsoft.TestPlatform.Utilities/CodeCoverageRunSettingsProcessor.cs
@@ -157,7 +157,7 @@ public class CodeCoverageRunSettingsProcessor
     /// </param>
     /// <param name="pathComponents">The path components.</param>
     ///
-    /// <returns>The requested node if successful, <see cref="null"/> otherwise.</returns>
+    /// <returns>The requested node if successful, <see langword="null"/> otherwise.</returns>
     private static XmlNode? SelectNodeOrAddDefaults(
         XmlNode currentRootNode,
         XmlNode? defaultRootNode,
@@ -215,7 +215,7 @@ public class CodeCoverageRunSettingsProcessor
     /// <param name="node">The current exclusion node.</param>
     ///
     /// <returns>
-    /// <see cref="true"/> if the node should be processed, <see cref="false"/> otherwise.
+    /// <see langword="true"/> if the node should be processed, <see langword="false"/> otherwise.
     /// </returns>
     private static bool ShouldProcessCurrentExclusion(XmlNode node)
     {
@@ -258,7 +258,7 @@ public class CodeCoverageRunSettingsProcessor
     /// <param name="node">The root to be used for extraction.</param>
     /// <param name="path">The path used to specify the requested node.</param>
     ///
-    /// <returns>The extracted node if successful, <see cref="null"/> otherwise.</returns>
+    /// <returns>The extracted node if successful, <see langword="null"/> otherwise.</returns>
     private static XmlNode? ExtractNode(XmlNode? node, string path)
     {
         try

--- a/src/Microsoft.TestPlatform.Utilities/MSTestSettingsUtilities.cs
+++ b/src/Microsoft.TestPlatform.Utilities/MSTestSettingsUtilities.cs
@@ -21,7 +21,7 @@ public static class MSTestSettingsUtilities
     /// Imports the parameter settings file in the default runsettings.
     /// </summary>
     /// <param name="settingsFile">
-    /// Settings file which need to be imported. The file extension of the settings file will be specified by <paramref name="SettingsFileExtension"/> property.
+    /// Settings file which need to be imported. The file extension of the settings file will be specified by <c>SettingsFileExtension</c> property.
     /// </param>
     /// <param name="defaultRunSettings"> Input RunSettings document to which settings file need to be imported. </param>
     /// <returns> Updated RunSetting Xml document with imported settings. </returns>

--- a/src/package/nuspec/TestPlatform.CLI.nuspec
+++ b/src/package/nuspec/TestPlatform.CLI.nuspec
@@ -14,11 +14,11 @@
     <projectUrl>https://github.com/microsoft/vstest/</projectUrl>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>vstest visual-studio unittest testplatform mstest microsoft test testing</tags>
-    <repository type="git" 
-                url="https://github.com/microsoft/vstest" 
-                branch="$BranchName$" 
+    <repository type="git"
+                url="https://github.com/microsoft/vstest"
+                branch="$BranchName$"
                 commit="$CommitId$" />
-                
+
     <contentFiles>
       <files include="**/*.*" copyToOutput="true" flatten="false" buildAction="None" />
     </contentFiles>
@@ -28,8 +28,8 @@
     <file src="licenses\LICENSE_NET.txt" target="" />
     <!-- Add a third party notice file -->
     <file src="ThirdPartyNotices.txt" target="" />
-    
+
     <!-- excluding dbghelp and cpp as they cannot be re-distributed with sdk, but need to be distributed with VS -->
-    <file src="$TargetFramework$\**\*.*" exclude="**\*.pdb;**\dbghelp.dll;**\*TestTools.CppUnitTestFramework*" target="contentFiles\any\$TargetFramework$" />
+    <file src="$TargetFramework$\**\*.*" exclude="**\*.pdb;**\*.xml;**\dbghelp.dll;**\*TestTools.CppUnitTestFramework*" target="contentFiles\any\$TargetFramework$" />
   </files>
 </package>

--- a/src/vstest.console/Internal/ProgressIndicator.cs
+++ b/src/vstest.console/Internal/ProgressIndicator.cs
@@ -62,9 +62,9 @@ internal sealed class ProgressIndicator : IProgressIndicator, IDisposable
     }
 
     /// <summary>
-    // Get the current cursor position
-    // Clear the console starting given position
-    // Reset the cursor position back
+    /// Get the current cursor position
+    /// Clear the console starting given position
+    /// Reset the cursor position back
     /// </summary>
     /// <param name="startPos">the starting position</param>
     private void Clear(int startPos)

--- a/src/vstest.console/Processors/ListTestsTargetPathArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ListTestsTargetPathArgumentProcessor.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
 
 /// <summary>
-//  An argument processor to provide path to the file for listing fully qualified tests.
+///  An argument processor to provide path to the file for listing fully qualified tests.
 /// To be used only with ListFullyQualifiedTests
 /// </summary>
 internal class ListTestsTargetPathArgumentProcessor : IArgumentProcessor

--- a/test/vstest.ProgrammerTests/Fakes/FakeTestHostBuilder.cs
+++ b/test/vstest.ProgrammerTests/Fakes/FakeTestHostBuilder.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-
 namespace vstest.ProgrammerTests.Fakes;
 
 internal class FakeTestHostFixtureBuilder

--- a/test/vstest.ProgrammerTests/Fakes/FakeTestHostBuilder.cs
+++ b/test/vstest.ProgrammerTests/Fakes/FakeTestHostBuilder.cs
@@ -1,6 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+# if DEBUG
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+# endif
+
 namespace vstest.ProgrammerTests.Fakes;
 
 internal class FakeTestHostFixtureBuilder

--- a/test/vstest.ProgrammerTests/Fakes/FakeTestHostBuilder.cs
+++ b/test/vstest.ProgrammerTests/Fakes/FakeTestHostBuilder.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 namespace vstest.ProgrammerTests.Fakes;

--- a/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
@@ -358,7 +358,7 @@ public class RunSettingsArgumentProcessorTests
     {
         var settingsXml = @"<RunSettings><RunConfiguration></RunConfiguration></RunSettings>";
 
-        /// Arrange.
+        // Arrange.
         var fileName = "C:\\temp\\r.runsettings";
 
         var executor = new TestableRunSettingsArgumentExecutor(


### PR DESCRIPTION
Ensure unused `using`s are caught at the build time.

## Description

Unused `using`s are part of unused code analysis rules: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0005
Applie the suggestion from https://github.com/dotnet/roslyn/issues/41640#issuecomment-985780130 and cleaned up doc-related warnings.

## Related issue

Follows up on #3299 to clean up the repo from unused `using`s. With that in mind, the ide0005 rule being on-but-not-enforced:

- [x] I have ensured that there is a previously discussed and approved issue.
