### PR TITLE
Update Microsoft.NET.Test.Sdk.targets

### DIFF
--- a/src/package/nuspec/netcoreapp/Microsoft.NET.Test.Sdk.targets
+++ b/src/package/nuspec/netcoreapp/Microsoft.NET.Test.Sdk.targets
@@ -16,7 +16,7 @@
     Output type for .NET Core test projects should be exe.
     https://devdiv.visualstudio.com/DevDiv/_workitems?id=375688&_a=edit
   -->
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(OutputType)' != 'WinExe' And '$(OutputType)' != 'Exe'" >
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 


### PR DESCRIPTION
Support WinExe project to avoid changing the OutputType to Exe

## Description

Please add a meaningful description for this change.
Ensure the PR has required unit tests.

## Related issue

Kindly link any related issues. E.g. Fixes #xyz.

- [ ] I have ensure that there a previously discussed and approved issue.
