### PR TITLE
Fix string conversion of `Microsoft.TestPlatform.Extensions.TrxLogger.ObjectMode.TestOutcome`

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestOutcome.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestOutcome.cs
@@ -86,31 +86,5 @@ internal enum TestOutcome
     /// <summary>
     /// Test is in the execution queue, was not started yet.
     /// </summary>
-    Pending,
-
-    /// <summary>
-    /// The min value of this enum
-    /// </summary>
-    /// <remarks>
-    /// NOTE: OLD CODE WAS Min = Error
-    /// This doesn't work well with the conversion to string for the reason explained here:
-    /// https://learn.microsoft.com/dotnet/api/system.enum.tostring?view=net-7.0
-    /// Notes to Callers: If multiple enumeration members have the same underlying value and you attempt to retrieve the
-    /// string representation of an enumeration member's name based on its underlying value
-    /// We fixed removing the equality above to break less as possible. But the returned value won't be the expected Min/Max
-    /// </remarks>
-    Min,
-
-    /// <summary>
-    /// The max value of this enum
-    /// </summary>
-    /// <remarks>
-    /// NOTE: OLD CODE WAS Max = Pending
-    /// This doesn't work well with the conversion to string for the reason explained here:
-    /// https://learn.microsoft.com/dotnet/api/system.enum.tostring?view=net-7.0
-    /// Notes to Callers: If multiple enumeration members have the same underlying value and you attempt to retrieve the
-    /// string representation of an enumeration member's name based on its underlying value
-    /// We fixed removing the equality above to break less as possible. But the returned value won't be the expected Min/Max
-    /// </remarks>
-    Max
+    Pending
 }

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestOutcome.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestOutcome.cs
@@ -98,10 +98,26 @@ internal enum TestOutcome
     /// <summary>
     /// The min value of this enum
     /// </summary>
+    /// <remarks>
+    /// NOTE: OLD CODE WAS Min = Error
+    /// This doesn't work well with the conversion to string for the reason explained here:
+    /// https://learn.microsoft.com/dotnet/api/system.enum.tostring?view=net-7.0
+    /// Notes to Callers: If multiple enumeration members have the same underlying value and you attempt to retrieve the
+    /// string representation of an enumeration member's name based on its underlying value
+    /// We fixed removing the equality above to break less as possible. But the returned value won't be the expected Min/Max
+    /// </remarks>
     Min,
 
     /// <summary>
     /// The max value of this enum
     /// </summary>
+    /// <remarks>
+    /// NOTE: OLD CODE WAS Max = Pending
+    /// This doesn't work well with the conversion to string for the reason explained here:
+    /// https://learn.microsoft.com/dotnet/api/system.enum.tostring?view=net-7.0
+    /// Notes to Callers: If multiple enumeration members have the same underlying value and you attempt to retrieve the
+    /// string representation of an enumeration member's name based on its underlying value
+    /// We fixed removing the equality above to break less as possible. But the returned value won't be the expected Min/Max
+    /// </remarks>
     Max
 }

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestOutcome.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestOutcome.cs
@@ -88,13 +88,6 @@ internal enum TestOutcome
     /// </summary>
     Pending,
 
-    // NOTE: OLD CODE WAS Min = Error and Max = Pending
-    // This doesn't work well with the conversion to string for the reason explained here:
-    // https://learn.microsoft.com/dotnet/api/system.enum.tostring?view=net-7.0
-    // Notes to Callers: If multiple enumeration members have the same underlying value and you attempt to retrieve the
-    // string representation of an enumeration member's name based on its underlying value
-    // We fixed removing the equality above to break less as possible. But the returned value won't be the expected Min/Max
-
     /// <summary>
     /// The min value of this enum
     /// </summary>

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestOutcome.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestOutcome.cs
@@ -88,13 +88,20 @@ internal enum TestOutcome
     /// </summary>
     Pending,
 
+    // NOTE: OLD CODE WAS  Min = Error and Max = Pending
+    // This doesn't work well with the coversion to string for the reason explained here:
+    // https://learn.microsoft.com/en-us/dotnet/api/system.enum.tostring?view=net-7.0
+    // Notes to Callers: If multiple enumeration members have the same underlying value and you attempt to retrieve the
+    // string representation of an enumeration member's name based on its underlying value
+    // We fixed removing the equality above to break less as possible. But the returned value won't be the expected Min/Max
+
     /// <summary>
     /// The min value of this enum
     /// </summary>
-    Min = Error,
+    Min,
 
     /// <summary>
     /// The max value of this enum
     /// </summary>
-    Max = Pending
+    Max
 }

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestOutcome.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestOutcome.cs
@@ -88,7 +88,7 @@ internal enum TestOutcome
     /// </summary>
     Pending,
 
-    // NOTE: OLD CODE WAS  Min = Error and Max = Pending
+    // NOTE: OLD CODE WAS Min = Error and Max = Pending
     // This doesn't work well with the coversion to string for the reason explained here:
     // https://learn.microsoft.com/en-us/dotnet/api/system.enum.tostring?view=net-7.0
     // Notes to Callers: If multiple enumeration members have the same underlying value and you attempt to retrieve the

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestOutcome.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestOutcome.cs
@@ -90,7 +90,7 @@ internal enum TestOutcome
 
     // NOTE: OLD CODE WAS Min = Error and Max = Pending
     // This doesn't work well with the conversion to string for the reason explained here:
-    // https://learn.microsoft.com/en-us/dotnet/api/system.enum.tostring?view=net-7.0
+    // https://learn.microsoft.com/dotnet/api/system.enum.tostring?view=net-7.0
     // Notes to Callers: If multiple enumeration members have the same underlying value and you attempt to retrieve the
     // string representation of an enumeration member's name based on its underlying value
     // We fixed removing the equality above to break less as possible. But the returned value won't be the expected Min/Max

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestOutcome.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestOutcome.cs
@@ -89,7 +89,7 @@ internal enum TestOutcome
     Pending,
 
     // NOTE: OLD CODE WAS Min = Error and Max = Pending
-    // This doesn't work well with the coversion to string for the reason explained here:
+    // This doesn't work well with the conversion to string for the reason explained here:
     // https://learn.microsoft.com/en-us/dotnet/api/system.enum.tostring?view=net-7.0
     // Notes to Callers: If multiple enumeration members have the same underlying value and you attempt to retrieve the
     // string representation of an enumeration member's name based on its underlying value


### PR DESCRIPTION
By design we cannot have a "correct" value from a string conversion from enum for the same underlying value.
The behavior changed since 7.0 and now the runtime is returning `Min` and not `Error`

fixed https://github.com/microsoft/vstest/issues/4227