### PR TITLE
Fix invalid cert issue

### DIFF
--- a/scripts/verify-sign.ps1
+++ b/scripts/verify-sign.ps1
@@ -54,6 +54,9 @@ function Verify-Assemblies
                 if ($signature.SignerCertificate.Subject -eq "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US") {
                     Write-Debug "Valid ($($signature.SignerCertificate.Thumbprint)): $Path"
                 }
+                elseif ($signature.SignerCertificate.Subject -eq "CN=.NET, O=Microsoft Corporation, L=Redmond, S=Washington, C=US") {
+                    Write-Debug "Valid ($($signature.SignerCertificate.Thumbprint)): $Path"
+                }
                 elseif ($signature.SignerCertificate.Subject -eq "CN=Microsoft 3rd Party Application Component, O=Microsoft Corporation, L=Redmond, S=Washington, C=US") {
                     Write-Debug "Valid ($($signature.SignerCertificate.Thumbprint)): $Path [3rd Party]"
                 }


### PR DESCRIPTION
## Description

Fix issue in Real.CI:
```
2023-02-10T18:54:01.0775189Z ##[debug]Pattern: Microsoft.DiaSymReader.dll
2023-02-10T18:54:01.1058730Z ##[task.logissue type=error]Invalid (921263EA40B2C7592E8CC1C1A4EF66E64D511674). File: D:\a\_work\1\s\artifacts\release\Microsoft.CodeCoverage\Microsoft.DiaSymReader.dll. [CN=.NET, O=Microsoft Corporation, L=Redmond, S=Washington, C=US]
2023-02-10T18:54:01.1676838Z ##[debug]Valid (5A257D333718C4B468A5DBC6643348AF667AEE3D): D:\a\_work\1\s\artifacts\release\net462\win7-x64\Microsoft.DiaSymReader.dll
```