### PR TITLE
Exclude old branches from new pipeline trigger (#4388)Co-authored-by: Jakub Jareš <me@jakubjares.com>

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,8 +5,8 @@ trigger:
     - main
     - rel/*
     exclude:
-    - rel/15*
-    - rel/16*
+    - rel/15.*
+    - rel/16.*
     - rel/17.0
     - rel/17.1
     - rel/17.2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,19 @@
 # Branches that trigger a build on commit
 trigger:
-- main
-- rel/*
+  branches:
+    include:
+    - main
+    - rel/*
+    exclude:
+    - rel/15*
+    - rel/16*
+    - rel/17.0
+    - rel/17.1
+    - rel/17.2
+    - rel/17.3
+    - rel/17.4
+    - rel/17.5
+    - rel/17.6
 
 # Branch(es) that trigger(s) build(s) on PR
 pr:


### PR DESCRIPTION
Avoid triggering builds on the dnceng pipeline after we moved to Arcade. Still trigger build for PR, that defintion is in yaml and runs on the same pipeline as the public Arcade build.