### PR TITLE
Check for null Path

### DIFF
--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -777,7 +777,10 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
                             }
                         }
 
-                        testHostPath = Path.Combine(testhostPackage.Path, testHostPath);
+                        if (testhostPackage.Path is not null)
+                        {
+                            testHostPath = Path.Combine(testhostPackage.Path, testHostPath);
+                        }
                         _hostPackageVersion = testhostPackage.Version;
                         IsVersionCheckRequired = !_hostPackageVersion.StartsWith("15.0.0");
                         EqtTrace.Verbose("DotnetTestHostmanager: Relative path of testhost.dll with respect to package folder is {0}", testHostPath);


### PR DESCRIPTION
## Description

Fix nullability error in DotnetTestManager that is breaking sourcebuild in dotnet/installer with the latest versions of vstest

## Related issue

fixes https://github.com/microsoft/vstest/issues/4394
https://github.com/dotnet/installer/pull/16005#issuecomment-1500588135

- [ ] I have ensured that there is a previously discussed and approved issue.

