### PR TITLE
Remove explicit framework ref assembly ref

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,11 +11,6 @@
     <TargetFramework Condition=" '$(TargetFramework)' != '' ">$(NetCurrent)</TargetFramework>
   </PropertyGroup>
 
-  <!-- Allows build of .NET Framework assemblies on MacOS and Linux https://github.com/dotnet/designs/pull/33#issuecomment-489264196 -->
-  <ItemGroup>
-    <PackageReference Condition=" '$(OS)' != 'Windows_NT' " Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
-  </ItemGroup>
-
   <!-- Test project settings -->
   <Choose>
     <When Condition="$(TestProject) == 'true'">


### PR DESCRIPTION
## Description

The SDK brings this implicitly when targeting a net4* TFM. This fixes a source build filtering issue where the targeting packs were being brought in even when not building net4* outputs.
