### PR TITLE
Addressing System.Private.Uri source-build prebuilt in testhost

### DIFF
--- a/src/testhost.arm64/testhost.arm64.csproj
+++ b/src/testhost.arm64/testhost.arm64.csproj
@@ -37,7 +37,7 @@
     </ProjectReference>
 
     <!-- CVE-2019-0657, CVE-2019-0980 and CVE-2019-0981 mitigation -->
-    <PackageReference Include="System.Private.Uri" Version="$(SystemUriVersion)" />
+    <PackageReference Include="System.Private.Uri" Version="$(SystemUriVersion)" Condition="'$(DotNetBuildFromSource)' != 'true'" />
     <PackageReference Include="Microsoft.NETCore.Targets" Version="1.1.4" Condition=" $(TargetFramework.StartsWith('net4')) " />
     <!-- CVE-2019-0657, CVE-2019-0980 and CVE-2019-0981 mitigation -->
   </ItemGroup>


### PR DESCRIPTION
Related to https://github.com/microsoft/vstest/issues/4403.

I noticed a discrepancy between [testhost.csproj](https://github.com/microsoft/vstest/blob/main/src/testhost/testhost.csproj#L40), [testhost.x86.csproj](https://github.com/microsoft/vstest/blob/main/src/testhost.x86/testhost.x86.csproj#L40) and [testhost.arm64.csproj](https://github.com/microsoft/vstest/blob/main/src/testhost.arm64/testhost.arm64.csproj#L40).   I'm not sure why testhost.arm64.csproj is the only one to not include the source build condition on System.Private.Uri.  This is causing a prebuilt.

@nohwnd
@Evangelink
