### PR TITLE
Remove unused variable

### DIFF
--- a/src/Microsoft.TestPlatform.Utilities/XmlUtilities.cs
+++ b/src/Microsoft.TestPlatform.Utilities/XmlUtilities.cs
@@ -93,7 +93,7 @@ internal class XmlUtilities
 
     internal static void RemoveChildNode(XPathNavigator? parentNavigator, string nodeXPath, string childName)
     {
-        if (parentNavigator?.SelectSingleNode(nodeXPath) is { } childNodeNavigator)
+        if (parentNavigator?.SelectSingleNode(nodeXPath) is { })
         {
             parentNavigator.MoveToChild(childName, string.Empty);
             parentNavigator.DeleteSelf();


### PR DESCRIPTION
When using the latest build of .NET 8 Preview 4 SDK to build the vstest repo, it results in the following analyzer error:

```
/repos/dotnet/src/vstest/artifacts/source-build/self/src/src/Microsoft.TestPlatform.Utilities/XmlUtilities.cs(96,65): error IDE0059: Unnecessary assignment of a value to 'childNodeNavigator' (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059) [/repos/dotnet/src/vstest/artifacts/source-build/self/src/src/Microsoft.TestPlatform.Utilities/Microsoft.TestPlatform.Utilities.csproj::TargetFramework=net8.0]
```

This was caught by the Source-build bootstrapping build workflow which uses a source-built version of the latest SDK to build the product's repos.

Fixed by removing the unused variable.