### PR TITLE
Deprecate serialization ctor for .NET8 onward

### DIFF
--- a/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/InvalidManagedNameException.cs
+++ b/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/InvalidManagedNameException.cs
@@ -12,7 +12,7 @@ public class InvalidManagedNameException : Exception, ISerializable
     public InvalidManagedNameException(string? message) : base(message) { }
 
 #if NET8_0_OR_GREATER
-    [Obsolete(DiagnosticId = "SYSLIB0051")]
+    [Obsolete(DiagnosticId = "SYSLIB0051", "Serialization constructors are deprecated in .NET8+")]
 #endif
     protected InvalidManagedNameException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 }

--- a/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/InvalidManagedNameException.cs
+++ b/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/InvalidManagedNameException.cs
@@ -12,7 +12,7 @@ public class InvalidManagedNameException : Exception, ISerializable
     public InvalidManagedNameException(string? message) : base(message) { }
 
 #if NET8_0_OR_GREATER
-    [Obsolete(DiagnosticId = "SYSLIB0051", "Serialization constructors are deprecated in .NET8+")]
+    [Obsolete("Serialization constructors are deprecated in .NET8+", DiagnosticId = "SYSLIB0051")]
 #endif
     protected InvalidManagedNameException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 }

--- a/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/InvalidManagedNameException.cs
+++ b/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/InvalidManagedNameException.cs
@@ -11,5 +11,8 @@ public class InvalidManagedNameException : Exception, ISerializable
 {
     public InvalidManagedNameException(string? message) : base(message) { }
 
+#if NET8_0_OR_GREATER
+    [Obsolete(DiagnosticId = "SYSLIB0051")]
+#endif
     protected InvalidManagedNameException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 }


### PR DESCRIPTION
## Description

Comply to .NET 8 Preview 4+ concepts by deprecating the serialization ctor for exceptions.

## Related issue

Fixes #4424
