### PR TITLE
Enable ngen of testhost*.exe in VSIX

### DIFF
--- a/src/package/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI.csproj
+++ b/src/package/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI.csproj
@@ -108,7 +108,7 @@
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net472\win*\testhost.net472.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net472.x86.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net48\win*\testhost.net48.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net48.x86.exe" />
 
-      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net4*\win*\*.*" Exclude="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net4*\win*\testhost*" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net4*\win*\*.*" Exclude="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net4*\win*\testhost*.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\$(NetFrameworkMinimum)\win*\testhost.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.arm64.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net47\win*\testhost.net47.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net47.arm64.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net471\win*\testhost.net471.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net471.arm64.exe" />

--- a/src/package/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI.csproj
+++ b/src/package/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI.csproj
@@ -94,13 +94,23 @@
     <!-- Test host dependencies -->
     <ItemGroup>
       <!-- We still need to manually include artifacts from the other tfms -->
-      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\net4*\win*\*.*" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\net4*\win*\*.*" Exclude="$(ArtifactsBinDir)\testhost\$(Configuration)\net4*\win*\testhost*.exe" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\net47\win*\testhost.net47.exe" Ngen="true" NgenArchitecture="X64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net47.exe" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\net471\win*\testhost.net471.exe" Ngen="true" NgenArchitecture="X64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net471.exe" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\net472\win*\testhost.net472.exe" Ngen="true" NgenArchitecture="X64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net472.exe" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\net48\win*\testhost.net48.exe" Ngen="true" NgenArchitecture="X64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net48.exe" />
 
-      <!-- We still need to manually include dlls artifacts the other tfms -->
-      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net4*\win*\*.*" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net4*\win*\*.*" Exclude="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net4*\win*\testhost*x86.exe" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net47\win*\testhost.net47.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net47.x86.exe" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net471\win*\testhost.net471.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net471.x86.exe" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net472\win*\testhost.net472.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net472.x86.exe" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net48\win*\testhost.net48.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net48.x86.exe" />
 
-      <!-- We still need to manually include dlls artifacts the other tfms -->
-      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net4*\win*\*.*" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net4*\win*\*.*" Exclude="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net4*\win*\testhost*" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net47\win*\testhost.net47.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net47.arm64.exe" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net471\win*\testhost.net471.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net471.arm64.exe" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net472\win*\testhost.net472.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net472.arm64.exe" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net48\win*\testhost.net48.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net48.arm64.exe" />
     </ItemGroup>
 
     <!-- Cpp Extensions -->

--- a/src/package/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI.csproj
+++ b/src/package/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI.csproj
@@ -94,21 +94,21 @@
     <!-- Test host dependencies -->
     <ItemGroup>
       <!-- We still need to manually include artifacts from the other tfms -->
-      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\net4*\win*\*.*" Exclude="$(ArtifactsBinDir)\testhost\$(Configuration)\net4*\win*\testhost*.exe" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\net4*\win*\*.*" Exclude="$(ArtifactsBinDir)\testhost\$(Configuration)\net4*\win*\testhost.exe;$(ArtifactsBinDir)\testhost\$(Configuration)\net4*\win*\testhost.net4*.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\$(NetFrameworkMinimum)\win*\testhost.exe" Ngen="true" NgenArchitecture="X64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\net47\win*\testhost.net47.exe" Ngen="true" NgenArchitecture="X64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net47.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\net471\win*\testhost.net471.exe" Ngen="true" NgenArchitecture="X64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net471.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\net472\win*\testhost.net472.exe" Ngen="true" NgenArchitecture="X64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net472.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\net48\win*\testhost.net48.exe" Ngen="true" NgenArchitecture="X64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net48.exe" />
 
-      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net4*\win*\*.*" Exclude="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net4*\win*\testhost*x86.exe" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net4*\win*\*.*" Exclude="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net4*\win*\testhost.x86.exe;$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net4*\win*\testhost.net4*.x86.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\$(NetFrameworkMinimum)\win*\testhost.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.x86.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net47\win*\testhost.net47.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net47.x86.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net471\win*\testhost.net471.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net471.x86.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net472\win*\testhost.net472.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net472.x86.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net48\win*\testhost.net48.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net48.x86.exe" />
 
-      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net4*\win*\*.*" Exclude="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net4*\win*\testhost*.exe" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net4*\win*\*.*" Exclude="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net4*\win*\testhost.arm64.exe;$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net4*\win*\testhost.net4*.arm64.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\$(NetFrameworkMinimum)\win*\testhost.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.arm64.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net47\win*\testhost.net47.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net47.arm64.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net471\win*\testhost.net471.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net471.arm64.exe" />

--- a/src/package/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI.csproj
+++ b/src/package/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI.csproj
@@ -95,18 +95,21 @@
     <ItemGroup>
       <!-- We still need to manually include artifacts from the other tfms -->
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\net4*\win*\*.*" Exclude="$(ArtifactsBinDir)\testhost\$(Configuration)\net4*\win*\testhost*.exe" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\$(NetFrameworkMinimum)\win*\testhost.exe" Ngen="true" NgenArchitecture="X64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\net47\win*\testhost.net47.exe" Ngen="true" NgenArchitecture="X64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net47.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\net471\win*\testhost.net471.exe" Ngen="true" NgenArchitecture="X64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net471.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\net472\win*\testhost.net472.exe" Ngen="true" NgenArchitecture="X64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net472.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost\$(Configuration)\net48\win*\testhost.net48.exe" Ngen="true" NgenArchitecture="X64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net48.exe" />
 
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net4*\win*\*.*" Exclude="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net4*\win*\testhost*x86.exe" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\$(NetFrameworkMinimum)\win*\testhost.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.x86.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net47\win*\testhost.net47.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net47.x86.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net471\win*\testhost.net471.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net471.x86.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net472\win*\testhost.net472.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net472.x86.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.x86\$(Configuration)\net48\win*\testhost.net48.x86.exe" Ngen="true" NgenArchitecture="X86" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net48.x86.exe" />
 
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net4*\win*\*.*" Exclude="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net4*\win*\testhost*" />
+      <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\$(NetFrameworkMinimum)\win*\testhost.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.arm64.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net47\win*\testhost.net47.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net47.arm64.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net471\win*\testhost.net471.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net471.arm64.exe" />
       <VsixSourceItem Include="$(ArtifactsBinDir)\testhost.arm64\$(Configuration)\net472\win*\testhost.net472.arm64.exe" Ngen="true" NgenArchitecture="Arm64" NgenPriority="2" NgenApplication="$(ExtensionInstallationRelativeToVS)\testhost.net472.arm64.exe" />
@@ -327,15 +330,6 @@
       <Ngen>false</Ngen>
     </ProjectReference>
     <ProjectReference Include="..\..\SettingsMigrator\SettingsMigrator.csproj">
-      <Ngen>false</Ngen>
-    </ProjectReference>
-    <ProjectReference Include="..\..\testhost\testhost.csproj">
-      <Ngen>false</Ngen>
-    </ProjectReference>
-    <ProjectReference Include="..\..\testhost.arm64\testhost.arm64.csproj">
-      <Ngen>false</Ngen>
-    </ProjectReference>
-    <ProjectReference Include="..\..\testhost.x86\testhost.x86.csproj">
       <Ngen>false</Ngen>
     </ProjectReference>
     <ProjectReference Include="..\..\vstest.console.arm64\vstest.console.arm64.csproj">


### PR DESCRIPTION
## Description

At the moment, there is still an issue with having ngen for `testhost.exe`, `testhost.x86.exe` and `testhost.arm64.exe`.
