### PR TITLE
[rel/17.6] Fix no-suitable provider found

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyDiscoveryManager.cs
@@ -99,7 +99,17 @@ internal sealed class ParallelProxyDiscoveryManager : IParallelProxyDiscoveryMan
         // marked as NotDiscovered.
         _dataAggregator.MarkSourcesWithStatus(discoveryCriteria.Sources, DiscoveryStatus.NotDiscovered);
 
-        _parallelOperationManager.StartWork(workloads, eventHandler, GetParallelEventHandler, InitializeDiscoverTestsOnConcurrentManager, DiscoverTestsOnConcurrentManager);
+        if (nonRunnableWorkloads.Count > 0)
+        {
+            // We found some sources that don't associate to any runtime provider and so they cannot run.
+            // Mark the sources as skipped.
+
+            _dataAggregator.MarkSourcesWithStatus(nonRunnableWorkloads.SelectMany(w => w.Work.Sources), DiscoveryStatus.SkippedDiscovery);
+            // TODO: in strict mode keep them as non-discovered, and mark the run as aborted.
+            // _dataAggregator.MarkAsAborted();
+        }
+
+        _parallelOperationManager.StartWork(runnableWorkloads, eventHandler, GetParallelEventHandler, InitializeDiscoverTestsOnConcurrentManager, DiscoverTestsOnConcurrentManager);
     }
 
     private ITestDiscoveryEventsHandler2 GetParallelEventHandler(ITestDiscoveryEventsHandler2 eventHandler, IProxyDiscoveryManager concurrentManager)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyExecutionManager.cs
@@ -115,7 +115,7 @@ internal sealed class ParallelProxyExecutionManager : IParallelProxyExecutionMan
             // _currentRunDataAggregator.MarkAsAborted();
         }
 
-        _parallelOperationManager.StartWork(workloads, eventHandler, GetParallelEventHandler, PrepareTestRunOnConcurrentManager, StartTestRunOnConcurrentManager);
+        _parallelOperationManager.StartWork(runnableWorkloads, eventHandler, GetParallelEventHandler, PrepareTestRunOnConcurrentManager, StartTestRunOnConcurrentManager);
 
         // Why 1? Because this is supposed to be a processId, and that is just the default that was chosen by someone before me,
         // and maybe is checked somewhere, but I don't see it checked in our codebase.


### PR DESCRIPTION
## Description

Add fixes that were not correctly merged in 17.6 in PR . This will pass only runnable sources (sources that have some test runtime provider) to the proxy execution/discovery manager, so when it tries to execute the source (and instantiate a new runtime provider for it) it will succeed rather than fail to resolve the provider.

https://github.com/microsoft/vstest/pull/3666/files#diff-1a8bafa7d283356b53d249b58c8c118f9e811003c7ddfa8e906a8fc4de1bef27L102-L112.

## Related issue

Kindly link any related issues. E.g. Fixes #xyz.

Related https://github.com/microsoft/vstest/issues/4467 (not marking as fix, too keep it active for fix in 17.7)
