### PR TITLE
[rel/17.6] Disable internal build on new pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,8 @@
-trigger:
-- main
-- rel/*
+# Don't trigger internal build, anything before 17.7 is built on TestPlatform.CI.Real pipeline
+# that is not YAML based.
+# trigger:
+# - main
+# - rel/*
 
 pr:
 - main


### PR DESCRIPTION
Disable build on internal pipeline because anything before 17.6 build it on TestPlatform.CI.Real pipeline.
