### PR TITLE
[rel/17.5] Disable internal build on new pipeline

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -20,6 +20,8 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
     <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+    <add key="vs-impl-archived" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl-archived/nuget/v3/index.json" />
+    <add key="vssdk-archived" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk-archived/nuget/v3/index.json" />
   </packageSources>
   <fallbackPackageFolders>
     <clear />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,8 @@
-trigger:
-- main
-- rel/*
+# Don't trigger internal build, anything before 17.7 is built on TestPlatform.CI.Real pipeline
+# that is not YAML based.
+# trigger:
+# - main
+# - rel/*
 
 pr:
 - main


### PR DESCRIPTION
Disable build on internal pipeline because anything before 17.6 builds on TestPlatform.CI.Real pipeline.