### PR TITLE
Fix arm64 build

### DIFF
--- a/src/datacollector.arm64/datacollector.arm64.csproj
+++ b/src/datacollector.arm64/datacollector.arm64.csproj
@@ -13,6 +13,9 @@
     <TargetFrameworks Condition=" '$(OS)' == 'WINDOWS_NT' ">$(TargetFrameworks);net472;$(NetFrameworkMinimum)</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'WINDOWS_NT' ">$(TargetFrameworks);$(NetFrameworkMinimum)</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);net7.0;net6.0;</TargetFrameworks>
+    <RuntimeIdentifier Condition="$(TargetFramework.StartsWith('net4'))">win10-arm64</RuntimeIdentifier>
+    <!-- Setting both RuntimeIdentifier and PlatformTarget ends up building as AnyCPU and selecting the default x86 architecture, irregardles of RuntimeIdentifier,
+    so order here matters. -->
     <PlatformTarget Condition=" $(TargetFramework.StartsWith('net4')) AND '$(RuntimeIdentifier)' == '' ">AnyCPU</PlatformTarget>
     <OutputType>Exe</OutputType>
     <!-- Prevent the creation of the ".exe" for .NET Core. This was the default on .NET Core 2.1, behavior changed for .NET Core 3.1 -->
@@ -21,10 +24,6 @@
     <IsTestProject>false</IsTestProject>
     <!-- MSB3276 Suppress warnings about conflicts between different versions of the same dependent assembly -->
     <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB3276</MSBuildWarningsAsMessages>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/vstest.console.arm64/vstest.console.arm64.csproj
+++ b/src/vstest.console.arm64/vstest.console.arm64.csproj
@@ -9,6 +9,9 @@
     <UseAppHost>false</UseAppHost>
     <RollForward>Major</RollForward>
     <IsTestProject>false</IsTestProject>
+    <RuntimeIdentifier Condition="'$(TargetFramework)' == '$(NetFrameworkMinimum)'">win10-arm64</RuntimeIdentifier>
+    <!-- Setting both RuntimeIdentifier and PlatformTarget ends up building as AnyCPU and selecting the default x86 architecture, irregardles of RuntimeIdentifier,
+    so order here matters. -->
     <PlatformTarget Condition="'$(TargetFramework)' == '$(NetFrameworkMinimum)' AND '$(RuntimeIdentifier)' == '' ">AnyCPU</PlatformTarget>
     <ApplicationManifest>..\vstest.console\app.manifest</ApplicationManifest>
     <RootNamespace>Microsoft.VisualStudio.TestPlatform.CommandLine</RootNamespace>
@@ -25,9 +28,6 @@
     <MSBuildWarningsAsMessages>
       $(MSBuildWarningsAsMessages);MSB3276;
     </MSBuildWarningsAsMessages>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == '$(NetFrameworkMinimum)'">
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkMinimum)' ">
     <Reference Include="System" />


### PR DESCRIPTION
## Description

Setting both `RuntimeIdentifier` and `PlatformTarget` ends up building as `AnyCPU` and selecting the default x86 architecture, irregardles of `RuntimeIdentifier`. Moving the `RuntimeIdentifier` property before the `PlatformTarget` property that checks for presence of it in condition.

Testhost.arm64 is not affected because it does not set `PlatformTarget`.
