### PR TITLE
Don't print socket transport error in console

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TcpClientExtensions.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TcpClientExtensions.cs
@@ -71,7 +71,11 @@ internal static class TcpClientExtensions
                         ioException,
                         remoteEndPoint,
                         localEndPoint);
-                    error = ioException;
+                    // Do not pass the error to the caller, the transport was torn down because testhost
+                    // disconnected, in 99% of the cases. This error ends up confusing developers
+                    // even though it just means "testhost crashed", look at testhost to see what happened.
+                    // https://github.com/microsoft/vstest/issues/4461
+                    // error = ioException;
                     break;
                 }
             }


### PR DESCRIPTION
## Description
Avoid forwarding stack error when testhost disconnects unexpectedly. This error steals developer focus from the other more important error, which is either the testhost error message, or simply "testhost crashed" without any additional info.

## Related issue
Fix #4461

Kindly link any related issues. E.g. Fixes #xyz.

- [x] I have ensured that there is a previously discussed and approved issue.
