### PR TITLE
Fix execution gets stucks on single netstandard source

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
@@ -664,7 +664,7 @@ public class TestEngine : ITestEngine
             throw new ArgumentException(null, nameof(testRuntimeProviders));
 
         // Throw when we did not find any runtime provider for any of the provided sources.
-        var shouldThrow = testRuntimeProviders.All(runtimeProvider => runtimeProvider == null);
+        var shouldThrow = testRuntimeProviders.All(runtimeProvider => runtimeProvider.Type == null);
 
         var missingRuntimeProviders = testRuntimeProviders.Where(p => p.Type == null);
         if (missingRuntimeProviders.Any())


### PR DESCRIPTION
## Description

When none of the sources that are provided for the run are runnable, we want to throw an exception. Otherwise we want a warning. The code was checking the startup info for null, which is never null. Instead we want to check the actual determined type of runtime provider, to see if none of the provided sources has one.

## Related issue

Fix  #4392

Kindly link any related issues. E.g. Fixes #xyz.

- [x] I have ensured that there is a previously discussed and approved issue.
