### PR TITLE
[rel/17.6] Update Nuget.Frameworks

### DIFF
--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -55,7 +55,7 @@
 
 
     <!-- This version also needs to be updated in src\package\nuspec\TestPlatform.ObjectModel.nuspec -->
-    <NuGetFrameworksVersion>5.11.0</NuGetFrameworksVersion>
+    <NuGetFrameworksVersion>6.2.1</NuGetFrameworksVersion>
     <ILAsmPackageVersion>5.0.0</ILAsmPackageVersion>
     <JsonNetVersion>13.0.1</JsonNetVersion>
 

--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -55,7 +55,7 @@
 
 
     <!-- This version also needs to be updated in src\package\nuspec\TestPlatform.ObjectModel.nuspec -->
-    <NuGetFrameworksVersion>6.2.1</NuGetFrameworksVersion>
+    <NuGetFrameworksVersion>6.6.0</NuGetFrameworksVersion>
     <ILAsmPackageVersion>5.0.0</ILAsmPackageVersion>
     <JsonNetVersion>13.0.1</JsonNetVersion>
 

--- a/src/package/nuspec/TestPlatform.ObjectModel.nuspec
+++ b/src/package/nuspec/TestPlatform.ObjectModel.nuspec
@@ -22,17 +22,17 @@
     <dependencies>
       <group targetFramework="net462">
         <dependency id="System.Reflection.Metadata" version="[1.6.0, )" />
-        <dependency id="NuGet.Frameworks" version="[6.2.1, )" />
+        <dependency id="NuGet.Frameworks" version="[6.6.0, )" />
       </group>
 
       <group targetFramework="netcoreapp3.1">
         <dependency id="System.Reflection.Metadata" version="[1.6.0, )" />
-        <dependency id="NuGet.Frameworks" version="[6.2.1, )" />
+        <dependency id="NuGet.Frameworks" version="[6.6.0, )" />
       </group>
 
       <group targetFramework="netstandard2.0">
         <dependency id="System.Reflection.Metadata" version="[1.6.0, )" />
-        <dependency id="NuGet.Frameworks" version="[6.2.1, )" />
+        <dependency id="NuGet.Frameworks" version="[6.6.0, )" />
       </group>
     </dependencies>
 

--- a/src/package/nuspec/TestPlatform.ObjectModel.nuspec
+++ b/src/package/nuspec/TestPlatform.ObjectModel.nuspec
@@ -22,17 +22,17 @@
     <dependencies>
       <group targetFramework="net462">
         <dependency id="System.Reflection.Metadata" version="[1.6.0, )" />
-        <dependency id="NuGet.Frameworks" version="[5.11.0, )" />
+        <dependency id="NuGet.Frameworks" version="[6.2.1, )" />
       </group>
 
       <group targetFramework="netcoreapp3.1">
         <dependency id="System.Reflection.Metadata" version="[1.6.0, )" />
-        <dependency id="NuGet.Frameworks" version="[5.11.0, )" />
+        <dependency id="NuGet.Frameworks" version="[6.2.1, )" />
       </group>
 
       <group targetFramework="netstandard2.0">
         <dependency id="System.Reflection.Metadata" version="[1.6.0, )" />
-        <dependency id="NuGet.Frameworks" version="[5.11.0, )" />
+        <dependency id="NuGet.Frameworks" version="[6.2.1, )" />
       </group>
     </dependencies>
 


### PR DESCRIPTION
Bumping nuget.frameworks to the version that we are bundled with in 7.0.302 sdk, so we know we work with it.

Related #4409