### PR TITLE
Update source-build prebuilt baseline

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,6 +9,8 @@ PublicAPI.Unshipped.txt @nohwnd @MarcoRossignoli
 TelemetryDataConstants.cs @cvpoienaru @nohwnd
 
 # Changes here might break our contracts with other adapters, and possibly
-# Visual Studio. 
-/src/Microsoft.TestPlatform.AdapterUtilities/ @haplois @Evangelink 
+# Visual Studio.
+/src/Microsoft.TestPlatform.AdapterUtilities/ @haplois @Evangelink
 /test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/  @haplois @Evangelink
+
+/src/eng/SourceBuild* @dotnet/source-build-internal

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,3 +1,5 @@
+<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+
 <Project>
 
   <PropertyGroup>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,7 +1,8 @@
+<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+<!-- See aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them. -->
+
 <UsageData>
   <IgnorePatterns>
     <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
-    <UsagePattern IdentityGlob="Microsoft.Extensions.DependencyModel/3.0.0" />
-    <UsagePattern IdentityGlob="System.Text.Json/4.6.0" />
   </IgnorePatterns>
 </UsageData>


### PR DESCRIPTION
## Description

This PR contains two changes:

1. Removed two source build prebuilt baseline entries added with https://github.com/microsoft/vstest/pull/4486.  These should not have been added as they would have caused source-build prebuilts.  Rather new reference packages were needed which I added in https://github.com/dotnet/source-build-reference-packages/pull/688 and flowed in with https://github.com/microsoft/vstest/commit/e6ea41a3100d1aaa8ea9bd048c5daf2cc084e6d6.
2. Added some comments and updated the CODEOWNERS to help ensure source-build experts review source-build related changes.  See https://github.com/dotnet/source-build/issues/3435.

## Related issue

Related to https://github.com/dotnet/source-build/issues/3435 and https://github.com/microsoft/vstest/pull/4486
