### PR TITLE
Deprecate releases.md

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 17.6.1 and newer
+
+Please see release notes directly in the release page: https://github.com/microsoft/vstest/releases
+
 ## 17.6.0
 
 ### Issues Fixed


### PR DESCRIPTION
Github is generating release notes for us and it is easier for people watching this repository to see release notes directly in the release page, and in their email.
