### PR TITLE
Fix broken source build path

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,4 +13,4 @@ TelemetryDataConstants.cs @cvpoienaru @nohwnd
 /src/Microsoft.TestPlatform.AdapterUtilities/ @haplois @Evangelink
 /test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/  @haplois @Evangelink
 
-/src/eng/SourceBuild* @dotnet/source-build-internal
+/eng/SourceBuild* @dotnet/source-build-internal


### PR DESCRIPTION
The CODEOWNERS path for source build specified in https://github.com/microsoft/vstest/pull/4503 was incorrect and I unfortunately didn't catch it.  