### PR TITLE
Remove source build CODEOWNER

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,5 +12,3 @@ TelemetryDataConstants.cs @cvpoienaru @nohwnd
 # Visual Studio.
 /src/Microsoft.TestPlatform.AdapterUtilities/ @nohwnd @Evangelink
 /test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/ @nohwnd @Evangelink
-
-/eng/SourceBuild* @dotnet/source-build-internal


### PR DESCRIPTION
It was discovered by @Evangelink in https://github.com/microsoft/vstest/pull/4505 that a code owner can't be a team from an external organization.