### PR TITLE
[rel/17.6] Downgrade Nuget.Frameworks to 6.5.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <!-- This repo version -->
-    <VersionPrefix>17.6.1</VersionPrefix>
+    <VersionPrefix>17.6.2</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>

--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -12,7 +12,7 @@
     and because during the test `dotnet test` will run and re-build some of the test projects and at that time the version
     from a build parameter would not be available, so I am writing this version from the build.ps1 script to keep it in sync -->
 		<!-- Note that before bumping this version, you need to have one NuGet package available -->
-    <NETTestSdkVersion>17.6.1-dev</NETTestSdkVersion>
+    <NETTestSdkVersion>17.6.2-dev</NETTestSdkVersion>
 
     <!-- These versions are used for running unit tests, and running acceptance tests. They are also used as the default version for projects
     in TestAssets.sln to allow running and debugging tests in that solution directly in VS without having to run them via AcceptanceTests. -->

--- a/scripts/build/TestPlatform.Dependencies.props
+++ b/scripts/build/TestPlatform.Dependencies.props
@@ -55,7 +55,8 @@
 
 
     <!-- This version also needs to be updated in src\package\nuspec\TestPlatform.ObjectModel.nuspec -->
-    <NuGetFrameworksVersion>6.6.0</NuGetFrameworksVersion>
+    <!-- This version needs to be the same or lower than <NuGetFrameworksPackageVersion> https://github.com/dotnet/sdk/blob/release/7.0.3xx/eng/Versions.props, it also needs to be on nuget.org -->
+    <NuGetFrameworksVersion>6.5.0</NuGetFrameworksVersion>
     <ILAsmPackageVersion>5.0.0</ILAsmPackageVersion>
     <JsonNetVersion>13.0.1</JsonNetVersion>
 

--- a/scripts/build/TestPlatform.Settings.targets
+++ b/scripts/build/TestPlatform.Settings.targets
@@ -5,7 +5,7 @@
     <!-- This version is read by vsts-prebuild.ps1 and is a base for the current version, this should be updated
     at the start of new iteration to the goal number. This is also used to version the local packages. This version needs to be statically
     readable when we read the file as xml, don't move it to a .props file, unless you change the build server process -->
-    <TPVersionPrefix>17.6.1</TPVersionPrefix>
+    <TPVersionPrefix>17.6.2</TPVersionPrefix>
     <LangVersion>preview</LangVersion>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>preview</AnalysisLevel>

--- a/src/package/nuspec/TestPlatform.ObjectModel.nuspec
+++ b/src/package/nuspec/TestPlatform.ObjectModel.nuspec
@@ -22,17 +22,17 @@
     <dependencies>
       <group targetFramework="net462">
         <dependency id="System.Reflection.Metadata" version="[1.6.0, )" />
-        <dependency id="NuGet.Frameworks" version="[6.6.0, )" />
+        <dependency id="NuGet.Frameworks" version="[6.5.0, )" />
       </group>
 
       <group targetFramework="netcoreapp3.1">
         <dependency id="System.Reflection.Metadata" version="[1.6.0, )" />
-        <dependency id="NuGet.Frameworks" version="[6.6.0, )" />
+        <dependency id="NuGet.Frameworks" version="[6.5.0, )" />
       </group>
 
       <group targetFramework="netstandard2.0">
         <dependency id="System.Reflection.Metadata" version="[1.6.0, )" />
-        <dependency id="NuGet.Frameworks" version="[6.6.0, )" />
+        <dependency id="NuGet.Frameworks" version="[6.5.0, )" />
       </group>
     </dependencies>
 


### PR DESCRIPTION
Downgrade Nuget.Frameworks to 6.5.0, because dotnet SDK ships with nuget version 6.6.0-preview.3 which contains 6.6.0.61, but we upgraded to 6.6.0 which requires 6.6.0.62. During build SDK will replace our version with the newest one to keep us up to date, but this time we got ahead of it and this breaks the insertion. 


https://github.com/dotnet/sdk/runs/13951675455


```
> C:\h\w\B8C009BA\p\d\dotnet.exe msbuild /t:Restore C:\h\w\B8C009BA\t\dotnetSdkTests\th1jboi0.34o\82fd8ac8-1635---0705B68C\VSTestCore.csproj
MSBuild version 17.6.3+07e294721 for .NET
  Determining projects to restore...
  Restored C:\h\w\B8C009BA\t\dotnetSdkTests\th1jboi0.34o\82fd8ac8-1635---0705B68C\VSTestCore.csproj (in 540 ms).
> C:\h\w\B8C009BA\p\d\dotnet.exe test --results-directory C:\h\w\B8C009BA\t\dotnetSdkTests\th1jboi0.34o\82fd8ac8-1635---0705B68C\flag-dir///
  Determining projects to restore...
  All projects are up-to-date for restore.
  VSTestCore -> C:\h\w\B8C009BA\t\dotnetSdkTests\th1jboi0.34o\82fd8ac8-1635---0705B68C\bin\Debug\net7.0\VSTestCore.dll
Test run for C:\h\w\B8C009BA\t\dotnetSdkTests\th1jboi0.34o\82fd8ac8-1635---0705B68C\bin\Debug\net7.0\VSTestCore.dll (.NETCoreApp,Version=v7.0)
Microsoft (R) Test Execution Command Line Tool Version 17.6.1 (x64)
Copyright (c) Microsoft Corporation.  All rights reserved.

StdErr:
Unhandled exception. System.TypeInitializationException: The type initializer for 'Microsoft.VisualStudio.TestPlatform.ObjectModel.Framework' threw an exception.
 ---> System.IO.FileNotFoundException: Could not load file or assembly 'NuGet.Frameworks, Version=6.6.0.62, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified.
File name: 'NuGet.Frameworks, Version=6.6.0.62, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
   at Microsoft.VisualStudio.TestPlatform.ObjectModel.Framework.FromString(String frameworkString)
   at Microsoft.VisualStudio.TestPlatform.ObjectModel.Framework..cctor()
   --- End of inner exception stack trace ---
   at Microsoft.VisualStudio.TestPlatform.ObjectModel.Framework.get_DefaultFramework()
   at Microsoft.VisualStudio.TestPlatform.Common.Utilities.RunSettingsProviderExtensions.AddDefaultRunSettings(String runSettings)
   at Microsoft.VisualStudio.TestPlatform.Common.Utilities.RunSettingsProviderExtensions.AddDefaultRunSettings(IRunSettingsProvider runSettingsProvider)
   at Microsoft.VisualStudio.TestPlatform.CommandLine.Executor.GetArgumentProcessors(String[] args, List`1& processors)
   at Microsoft.VisualStudio.TestPlatform.CommandLine.Executor.Execute(String[] args)
   at Microsoft.VisualStudio.TestPlatform.CommandLine.Program.Run(String[] args, UiLanguageOverride uiLanguageOverride)
   at Microsoft.VisualStudio.TestPlatform.CommandLine.Program.Main(String[] args)
Exit Code: 1
``` 