### PR TITLE
methodParameterTypes cant be null

### DIFF
--- a/test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/ManagedNameUtilities/FindMethodExtensions.cs
+++ b/test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/ManagedNameUtilities/FindMethodExtensions.cs
@@ -39,7 +39,7 @@ internal static class FindMethodExtensions
             }
         }
 
-        if (methodParameterTypes != null && methodParameterTypes.Length >= 0)
+        if (methodParameterTypes.Length > 0)
         {
             candidates = candidates.Where(m => m.Parameters.Length == methodParameterTypes.Length);
             if (candidates.Any() && !candidates.Skip(1).Any())


### PR DESCRIPTION
and i assume the check should be for non empty?

so `methodParameterTypes.Length >= 0` becomes `methodParameterTypes.Length > 0`
