### PR TITLE
Declare version.details.xml dependency for source-build

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -24,6 +24,10 @@
       <Sha>4a3b4b6b37bdafe501477bf2e564380e1962ce61</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
+    <Dependency Name="NuGet.Frameworks" Version="5.5.0">
+      <Uri>https://github.com/nuget/nuget.client</Uri>
+      <Sha>4ba7bfa82f894ec32a554ca8d2df143675c85735</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23262.5">


### PR DESCRIPTION
## Description

Source-build needs the NuGet.Client dependency expressed in Version.Details.xml.

## Related issue

Related to https://github.com/dotnet/source-build/issues/3043