### PR TITLE
Use SemVer1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,9 +2,11 @@
 <Project>
   <PropertyGroup Label="Version settings">
     <!-- This repo version -->
-    <!-- Workaround for https://github.com/microsoft/vstest/issues/4544 
-    Use semantic versioning V1 because V2 will produce version like 17.7.0-preview.23280.1+94103c3f and DTAExecutionHost 
-    is trying to parse that version and will consider any version with more than 4 `.` in it as invalid. -->
+    <!-- 
+        Workaround for https://github.com/microsoft/vstest/issues/4544 
+        Use semantic versioning V1 because V2 will produce version like 17.7.0-preview.23280.1+94103c3f and DTAExecutionHost 
+        is trying to parse that version and will consider any version with more than 4 `.` in it as invalid. 
+    -->
     <SemanticVersioningV1>true</SemanticVersioningV1>
     <VersionPrefix>17.7.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,6 +2,10 @@
 <Project>
   <PropertyGroup Label="Version settings">
     <!-- This repo version -->
+    <!-- Workaround for https://github.com/microsoft/vstest/issues/4544 
+    Use semantic versioning V1 because V2 will produce version like 17.7.0-preview.23280.1+94103c3f and DTAExecutionHost 
+    is trying to parse that version and will consider any version with more than 4 `.` in it as invalid. -->
+    <SemanticVersioningV1>true</SemanticVersioningV1>
     <VersionPrefix>17.7.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
   </PropertyGroup>


### PR DESCRIPTION
## Description


When using TestPlatformInstaller task we can install a preview version, and deep in DTAAgent the version we provide in ProductVersion on vstest.console.exe is parsed and split into sections. Semver1 is assumed, and maximum of 4 dots in the whole version string is also assumed. Semver2 has more dots (`.`), and the parsing breaks.

## Related issue

Fix #4544