### PR TITLE
[rel/17.6] Disable pre-start of testhosts

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelOperationManager.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client;
 /// </summary>
 internal sealed class ParallelOperationManager<TManager, TEventHandler, TWorkload> : IDisposable
 {
-    private const int PreStart = 2;
+    private const int PreStart = 0;
     private readonly static int VSTEST_HOSTPRESTART_COUNT =
         int.TryParse(
                 Environment.GetEnvironmentVariable(nameof(VSTEST_HOSTPRESTART_COUNT)),

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelProxyExecutionManagerTests.cs
@@ -285,11 +285,7 @@ public class ParallelProxyExecutionManagerTests
 
         Assert.IsTrue(_executionCompleted.Wait(Timeout3Seconds), "Test run not completed.");
 
-        // Even though we start the test run for two sources, because of the current setup where
-        // we initialize a proxy if no more slots are available, we end up with abort notice being
-        // sent only to the running manager. This leaves the initialized manager in limbo and the
-        // assert will fail because of this.
-        Assert.AreEqual(1, _processedSources.Count, "Abort should stop all sources execution.");
+        Assert.AreEqual(2, _processedSources.Count, "Abort should stop all sources execution.");
     }
 
     [TestMethod]


### PR DESCRIPTION
When testhost is pre-started, we will set up communication with it, and then we hand over to parallel proxy manager, this will cause NotifyDataAvailable to have no subscribers, but some data pending on the wire, which causes communication to Poll in a tight loop, consuming a lot of CPU. 

Not prestarting testhosts is a workaround, while a better solution is found. 


## Related issue

Workaround for #4553
