### PR TITLE
Consume localized resources in source-build

### DIFF
--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.sourcebuild.nuspec
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.sourcebuild.nuspec
@@ -61,5 +61,202 @@
     <file src="$SourceBuildTfm$\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions" />
     <file src="$SourceBuildTfm$\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions" />
 
+    <!-- Resources -->
+    <file src="$SourceBuildTfm$\cs\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\cs" />
+    <file src="$SourceBuildTfm$\de\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\de" />
+    <file src="$SourceBuildTfm$\es\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\es" />
+    <file src="$SourceBuildTfm$\fr\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\fr" />
+    <file src="$SourceBuildTfm$\it\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\it" />
+    <file src="$SourceBuildTfm$\ja\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ja" />
+    <file src="$SourceBuildTfm$\ko\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ko" />
+    <file src="$SourceBuildTfm$\pl\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\pl" />
+    <file src="$SourceBuildTfm$\pt-BR\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"   target="contentFiles\any\$SourceBuildTfm$\pt-BR" />
+    <file src="$SourceBuildTfm$\ru\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ru" />
+    <file src="$SourceBuildTfm$\tr\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\tr" />
+    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hans" />
+    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hant" />
+
+    <file src="$SourceBuildTfm$\cs\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\cs" />
+    <file src="$SourceBuildTfm$\de\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\de" />
+    <file src="$SourceBuildTfm$\es\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\es" />
+    <file src="$SourceBuildTfm$\fr\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\fr" />
+    <file src="$SourceBuildTfm$\it\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\it" />
+    <file src="$SourceBuildTfm$\ja\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ja" />
+    <file src="$SourceBuildTfm$\ko\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ko" />
+    <file src="$SourceBuildTfm$\pl\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\pl" />
+    <file src="$SourceBuildTfm$\pt-BR\Microsoft.TestPlatform.CoreUtilities.resources.dll"   target="contentFiles\any\$SourceBuildTfm$\pt-BR" />
+    <file src="$SourceBuildTfm$\ru\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ru" />
+    <file src="$SourceBuildTfm$\tr\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\tr" />
+    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hans" />
+    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hant" />
+
+    <file src="$SourceBuildTfm$\cs\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\cs" />
+    <file src="$SourceBuildTfm$\de\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\de" />
+    <file src="$SourceBuildTfm$\es\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\es" />
+    <file src="$SourceBuildTfm$\fr\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\fr" />
+    <file src="$SourceBuildTfm$\it\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\it" />
+    <file src="$SourceBuildTfm$\ja\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ja" />
+    <file src="$SourceBuildTfm$\ko\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ko" />
+    <file src="$SourceBuildTfm$\pl\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\pl" />
+    <file src="$SourceBuildTfm$\pt-BR\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"   target="contentFiles\any\$SourceBuildTfm$\pt-BR" />
+    <file src="$SourceBuildTfm$\ru\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ru" />
+    <file src="$SourceBuildTfm$\tr\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\tr" />
+    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.TestPlatform.CrossPlatEngine.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hans" />
+    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.TestPlatform.CrossPlatEngine.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hant" />
+
+    <file src="$SourceBuildTfm$\cs\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\cs" />
+    <file src="$SourceBuildTfm$\de\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\de" />
+    <file src="$SourceBuildTfm$\es\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\es" />
+    <file src="$SourceBuildTfm$\fr\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\fr" />
+    <file src="$SourceBuildTfm$\it\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\it" />
+    <file src="$SourceBuildTfm$\ja\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ja" />
+    <file src="$SourceBuildTfm$\ko\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ko" />
+    <file src="$SourceBuildTfm$\pl\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\pl" />
+    <file src="$SourceBuildTfm$\pt-BR\Microsoft.TestPlatform.Utilities.resources.dll"   target="contentFiles\any\$SourceBuildTfm$\pt-BR" />
+    <file src="$SourceBuildTfm$\ru\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ru" />
+    <file src="$SourceBuildTfm$\tr\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\tr" />
+    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.TestPlatform.Utilities.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hans" />
+    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.TestPlatform.Utilities.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hant" />
+
+    <file src="$SourceBuildTfm$\cs\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\cs" />
+    <file src="$SourceBuildTfm$\de\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\de" />
+    <file src="$SourceBuildTfm$\es\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\es" />
+    <file src="$SourceBuildTfm$\fr\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\fr" />
+    <file src="$SourceBuildTfm$\it\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\it" />
+    <file src="$SourceBuildTfm$\ja\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\ja" />
+    <file src="$SourceBuildTfm$\ko\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\ko" />
+    <file src="$SourceBuildTfm$\pl\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\pl" />
+    <file src="$SourceBuildTfm$\pt-BR\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\pt-BR" />
+    <file src="$SourceBuildTfm$\ru\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\ru" />
+    <file src="$SourceBuildTfm$\tr\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\tr" />
+    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hans" />
+    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hant" />
+
+    <file src="$SourceBuildTfm$\cs\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\cs" />
+    <file src="$SourceBuildTfm$\de\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\de" />
+    <file src="$SourceBuildTfm$\es\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\es" />
+    <file src="$SourceBuildTfm$\fr\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\fr" />
+    <file src="$SourceBuildTfm$\it\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\it" />
+    <file src="$SourceBuildTfm$\ja\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\ja" />
+    <file src="$SourceBuildTfm$\ko\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\ko" />
+    <file src="$SourceBuildTfm$\pl\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\pl" />
+    <file src="$SourceBuildTfm$\pt-BR\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\pt-BR" />
+    <file src="$SourceBuildTfm$\ru\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\ru" />
+    <file src="$SourceBuildTfm$\tr\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\tr" />
+    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hans" />
+    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hant" />
+
+    <file src="$SourceBuildTfm$\cs\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\cs" />
+    <file src="$SourceBuildTfm$\de\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\de" />
+    <file src="$SourceBuildTfm$\es\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\es" />
+    <file src="$SourceBuildTfm$\fr\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\fr" />
+    <file src="$SourceBuildTfm$\it\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\it" />
+    <file src="$SourceBuildTfm$\ja\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ja" />
+    <file src="$SourceBuildTfm$\ko\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ko" />
+    <file src="$SourceBuildTfm$\pl\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\pl" />
+    <file src="$SourceBuildTfm$\pt-BR\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"   target="contentFiles\any\$SourceBuildTfm$\pt-BR" />
+    <file src="$SourceBuildTfm$\ru\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ru" />
+    <file src="$SourceBuildTfm$\tr\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\tr" />
+    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hans" />
+    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hant" />
+
+    <file src="$SourceBuildTfm$\cs\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\cs" />
+    <file src="$SourceBuildTfm$\de\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\de" />
+    <file src="$SourceBuildTfm$\es\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\es" />
+    <file src="$SourceBuildTfm$\fr\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\fr" />
+    <file src="$SourceBuildTfm$\it\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\it" />
+    <file src="$SourceBuildTfm$\ja\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ja" />
+    <file src="$SourceBuildTfm$\ko\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ko" />
+    <file src="$SourceBuildTfm$\pl\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\pl" />
+    <file src="$SourceBuildTfm$\pt-BR\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"   target="contentFiles\any\$SourceBuildTfm$\pt-BR" />
+    <file src="$SourceBuildTfm$\ru\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ru" />
+    <file src="$SourceBuildTfm$\tr\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\tr" />
+    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hans" />
+    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hant" />
+
+    <file src="$SourceBuildTfm$\cs\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\cs" />
+    <file src="$SourceBuildTfm$\de\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\de" />
+    <file src="$SourceBuildTfm$\es\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\es" />
+    <file src="$SourceBuildTfm$\fr\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\fr" />
+    <file src="$SourceBuildTfm$\it\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\it" />
+    <file src="$SourceBuildTfm$\ja\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\ja" />
+    <file src="$SourceBuildTfm$\ko\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\ko" />
+    <file src="$SourceBuildTfm$\pl\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\pl" />
+    <file src="$SourceBuildTfm$\pt-BR\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\pt-BR" />
+    <file src="$SourceBuildTfm$\ru\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\ru" />
+    <file src="$SourceBuildTfm$\tr\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\tr" />
+    <file src="$SourceBuildTfm$\zh-Hans\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hans" />
+    <file src="$SourceBuildTfm$\zh-Hant\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hant" />
+
+    <file src="$SourceBuildTfm$\cs\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\cs" />
+    <file src="$SourceBuildTfm$\de\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\de" />
+    <file src="$SourceBuildTfm$\es\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\es" />
+    <file src="$SourceBuildTfm$\fr\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\fr" />
+    <file src="$SourceBuildTfm$\it\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\it" />
+    <file src="$SourceBuildTfm$\ja\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ja" />
+    <file src="$SourceBuildTfm$\ko\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ko" />
+    <file src="$SourceBuildTfm$\pl\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pl" />
+    <file src="$SourceBuildTfm$\pt-BR\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pt-BR" />
+    <file src="$SourceBuildTfm$\ru\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ru" />
+    <file src="$SourceBuildTfm$\tr\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\tr" />
+    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hans" />
+    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hant" />
+
+    <file src="$SourceBuildTfm$\cs\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\cs" />
+    <file src="$SourceBuildTfm$\de\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\de" />
+    <file src="$SourceBuildTfm$\es\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\es" />
+    <file src="$SourceBuildTfm$\fr\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\fr" />
+    <file src="$SourceBuildTfm$\it\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\it" />
+    <file src="$SourceBuildTfm$\ja\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ja" />
+    <file src="$SourceBuildTfm$\ko\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ko" />
+    <file src="$SourceBuildTfm$\pl\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pl" />
+    <file src="$SourceBuildTfm$\pt-BR\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pt-BR" />
+    <file src="$SourceBuildTfm$\ru\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ru" />
+    <file src="$SourceBuildTfm$\tr\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\tr" />
+    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hans" />
+    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hant" />
+
+    <file src="$SourceBuildTfm$\cs\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\cs" />
+    <file src="$SourceBuildTfm$\de\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\de" />
+    <file src="$SourceBuildTfm$\es\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\es" />
+    <file src="$SourceBuildTfm$\fr\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\fr" />
+    <file src="$SourceBuildTfm$\it\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\it" />
+    <file src="$SourceBuildTfm$\ja\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ja" />
+    <file src="$SourceBuildTfm$\ko\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ko" />
+    <file src="$SourceBuildTfm$\pl\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pl" />
+    <file src="$SourceBuildTfm$\pt-BR\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pt-BR" />
+    <file src="$SourceBuildTfm$\ru\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ru" />
+    <file src="$SourceBuildTfm$\tr\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\tr" />
+    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hans" />
+    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hant" />
+
+    <file src="$SourceBuildTfm$\cs\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\cs" />
+    <file src="$SourceBuildTfm$\de\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\de" />
+    <file src="$SourceBuildTfm$\es\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\es" />
+    <file src="$SourceBuildTfm$\fr\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\fr" />
+    <file src="$SourceBuildTfm$\it\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\it" />
+    <file src="$SourceBuildTfm$\ja\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ja" />
+    <file src="$SourceBuildTfm$\ko\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ko" />
+    <file src="$SourceBuildTfm$\pl\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pl" />
+    <file src="$SourceBuildTfm$\pt-BR\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pt-BR" />
+    <file src="$SourceBuildTfm$\ru\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ru" />
+    <file src="$SourceBuildTfm$\tr\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\tr" />
+    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hans" />
+    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hant" />
+
+    <file src="$SourceBuildTfm$\cs\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\cs" />
+    <file src="$SourceBuildTfm$\de\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\de" />
+    <file src="$SourceBuildTfm$\es\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\es" />
+    <file src="$SourceBuildTfm$\fr\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\fr" />
+    <file src="$SourceBuildTfm$\it\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\it" />
+    <file src="$SourceBuildTfm$\ja\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ja" />
+    <file src="$SourceBuildTfm$\ko\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ko" />
+    <file src="$SourceBuildTfm$\pl\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pl" />
+    <file src="$SourceBuildTfm$\pt-BR\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pt-BR" />
+    <file src="$SourceBuildTfm$\ru\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ru" />
+    <file src="$SourceBuildTfm$\tr\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\tr" />
+    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hans" />
+    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hant" />
+
   </files>
 </package>


### PR DESCRIPTION
## Description

Microsoft.TestPlatform.CLI package, built in source-build, should include localized resources. Localization was enabled on Linux few months ago. This PR adds resources to source-built CLI package.

## Related issue

https://github.com/dotnet/source-build/issues/3517