### PR TITLE
Fix XmlException when writing Html log with certain test names

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlTransformer.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlTransformer.cs
@@ -28,6 +28,13 @@ internal class HtmlTransformer : IHtmlTransformer
     /// </summary>
     public void Transform(string xmlFile, string htmlFile)
     {
-        _xslTransform.Transform(xmlFile, htmlFile);
+
+        // DCS happily serializes characters into character references that are not strictly valid XML,
+        // for example &#xFFFF;. DCS will load them, but for XSL to load them here we need to pass it
+        // a reader that we've configured to be tolerant of such references.
+        using XmlReader xr = XmlReader.Create(xmlFile, new XmlReaderSettings() { CheckCharacters = false });
+        using XmlWriter xw = XmlWriter.Create(htmlFile, new XmlWriterSettings() { CheckCharacters = false });
+
+        _xslTransform.Transform(xr, xw);
     }
 }

--- a/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
@@ -591,32 +591,6 @@ public class HtmlLoggerTests
         Assert.AreEqual(0, _htmlLogger.TestRunDetails.Summary.PassPercentage);
     }
 
-    [TestMethod]
-    public void TestCompleteHandlerShouldHandleInvalidCharReferences()
-    {
-        System.Diagnostics.Debugger.Break();
-        VisualStudio.TestPlatform.Extensions.HtmlLogger.HtmlLogger hl = new(_mockFileHelper.Object, new Mock<IHtmlTransformer>().Object, new DataContractSerializer(typeof(TestRunDetails)));
-        hl.Initialize(_events.Object, _parameters);
-
-        MemoryStream xmlStream = new();
-        _mockFileHelper.Setup(x => x.GetStream(It.IsAny<string>(), FileMode.Open, FileAccess.Read)).Returns(xmlStream);
-        _mockFileHelper.Setup(x => x.Exists(It.IsAny<string>())).Returns(false);
-
-        MemoryStream htmlStream = new();
-        _mockFileHelper.Setup(x => x.GetStream(It.IsAny<string>(), FileMode.OpenOrCreate, FileAccess.ReadWrite)).Returns(htmlStream);
-        _mockFileHelper.Setup(x => x.Exists(It.IsAny<string>())).Returns(false);
-
-        var testCase = new TestCase("TestName", new Uri("some://uri"), "TestSource");
-        var testResult = new ObjectModel.TestResult(testCase) { Outcome = TestOutcome.Failed };
-        testResult.Messages.Add(new(TestResultMessage.StandardErrorCategory, "\uFFFF"));
-
-        hl.TestResultHandler(new object(), new TestResultEventArgs(testResult));
-
-        hl.TestRunCompleteHandler(new object(), new TestRunCompleteEventArgs(null, false, true, null, null, null, TimeSpan.Zero));
-
-        //Assert.AreEqual(htmlFileContent, new StreamReader(htmlStream).ReadToEnd());
-    }
-
     private static TestCase CreateTestCase(string testCaseName)
     {
         return new TestCase(testCaseName, new Uri("some://uri"), "DummySourceFileName");


### PR DESCRIPTION
Fix https://github.com/microsoft/vstest/issues/3136

Bug: In the repro case, the test metadata (display name here) contains characters like `&#xFFFF;` that are not valid in XML (outside of CDATA perhaps) per spec:
<html>
<body>
<!--StartFragment--><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><a href="https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Char" rel="nofollow" style="box-sizing: border-box; background-color: transparent; color: var(--color-accent-fg); text-decoration: none;">https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Char</a></p>

[2] | Char | ::= | #x9 \| #xA \| #xD \| [#x20-#xD7FF] \| [#xE000-#xFFFD] \| [#x10000-#x10FFFF] | /* any Unicode character, excluding the surrogate blocks, FFFE, and FFFF. */
-- | -- | -- | -- | --


<!--EndFragment-->
</body>
</html>

The HtmlLogger serializes the TestResult to XML using DCS. DCS is tolerant of these invalid characters -- it will serialize as eg `&#xFFFF;` and read that too. XmlTextWriter will by default serialize the same way. But in default configuration XmlReader will not read it, and throw XmlException causing the production of the Html log to fail.

Fix: set XmlWriterSettings.CheckCharacters to false.

I **verified that this fixes the problem locally**. I tried hard to make a unit test (see first commit) but concluded that it's not mockable using public API: HtmlTransformer is internal. I guess it could be mocked using reflection or we could use an end to end test instead? I don't have more time to spend, so perhaps it's acceptable without a test.