### PR TITLE
Use stable version for Microsoft.Internal.CodeCoverage

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,10 +2,10 @@
 <Project>
   <PropertyGroup Label="Version settings">
     <!-- This repo version -->
-    <!-- 
-        Workaround for https://github.com/microsoft/vstest/issues/4544 
-        Use semantic versioning V1 because V2 will produce version like 17.7.0-preview.23280.1+94103c3f and DTAExecutionHost 
-        is trying to parse that version and will consider any version with more than 4 `.` in it as invalid. 
+    <!--
+        Workaround for https://github.com/microsoft/vstest/issues/4544
+        Use semantic versioning V1 because V2 will produce version like 17.7.0-preview.23280.1+94103c3f and DTAExecutionHost
+        is trying to parse that version and will consider any version with more than 4 `.` in it as invalid.
     -->
     <SemanticVersioningV1>true</SemanticVersioningV1>
     <VersionPrefix>17.8.0</VersionPrefix>
@@ -30,9 +30,9 @@
     <MicrosoftExtensionsDependencyModelPackageVersion>3.0.0</MicrosoftExtensionsDependencyModelPackageVersion>
     <MicrosoftExtensionsFileSystemGlobbingVersion>2.0.0</MicrosoftExtensionsFileSystemGlobbingVersion>
     <MicrosoftFakesVersion>17.4.0-beta.22478.3</MicrosoftFakesVersion>
-    <MicrosoftInternalCodeCoverageVersion>17.8.0-beta.23360.1</MicrosoftInternalCodeCoverageVersion>
+    <MicrosoftInternalCodeCoverageVersion>17.8.0</MicrosoftInternalCodeCoverageVersion>
     <MicrosoftNetCompilersToolsetVersion>4.7.0-3.23315.4</MicrosoftNetCompilersToolsetVersion>
-    <MicrosoftVisualStudioDiagnosticsUtilitiesVersion>17.6.33617.297</MicrosoftVisualStudioDiagnosticsUtilitiesVersion>
+    <MicrosoftVisualStudioDiagnosticsUtilitiesVersion>17.6.33910.51</MicrosoftVisualStudioDiagnosticsUtilitiesVersion>
     <MicrosoftVisualStudioEnterpriseAspNetHelper>$(MicrosoftVisualStudioDiagnosticsUtilitiesVersion)</MicrosoftVisualStudioEnterpriseAspNetHelper>
     <MicrosoftVisualStudioInteropVersion>17.3.32622.426</MicrosoftVisualStudioInteropVersion>
     <MicrosoftVSSDKBuildToolsVersion>17.4.2116</MicrosoftVSSDKBuildToolsVersion>

--- a/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.csproj
+++ b/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.csproj
@@ -9,8 +9,11 @@
     <!--
       Sometimes NU1702 is not suppressed correctly, so force reducing severity of the warning.
       See https://github.com/NuGet/Home/issues/9147
+      NU1605: Ignore package downgrade because Microsoft.CodeCoverage.Telemetry depends on Newtonsoft.Json
+      (>= 13.0.3) but we depend on Newtonsoft.Json (>= 13.0.1).
     -->
-    <MSBuildWarningsAsMessages>NU1702;NETSDK1023</MSBuildWarningsAsMessages>
+    <MSBuildWarningsAsMessages>NU1702;NU1605;NETSDK1023</MSBuildWarningsAsMessages>
+    <NoWarn>$(NoWarn);NU1605</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Description

Fixes symbol check issue by ensuring we use a stable version instead of beta.
