### PR TITLE
Add possibility to provide telemetry events by data collectors

### DIFF
--- a/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
+++ b/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
@@ -498,7 +498,7 @@ public class DesignModeClient : IDesignModeClient
             _communicationManager.SendMessage(MessageType.TestMessage, testMessagePayload);
             var runCompletePayload = new TestRunCompletePayload()
             {
-                TestRunCompleteArgs = new TestRunCompleteEventArgs(null, false, true, ex, null, null, TimeSpan.MinValue),
+                TestRunCompleteArgs = new TestRunCompleteEventArgs(null, false, true, ex, null, null, null, TimeSpan.MinValue),
                 LastRunTests = null
             };
 

--- a/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
+++ b/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
@@ -400,6 +400,7 @@ public class TestRunRequest : ITestRunRequest, IInternalTestRunEventsHandler
                         // This is required as TMI adapter is sending attachments as List which cannot be type casted to Collection.
                         runContextAttachments != null ? new Collection<AttachmentSet>(runContextAttachments.ToList()) : null,
                         runCompleteArgs.InvokedDataCollectors,
+                        runCompleteArgs.TelemetryEvents,
                         _runRequestTimeTracker.Elapsed);
 
                 // Add extensions discovered by vstest.console.
@@ -569,6 +570,7 @@ public class TestRunRequest : ITestRunRequest, IInternalTestRunEventsHandler
                 testRunCompletePayload.TestRunCompleteArgs.Error,
                 testRunCompletePayload.TestRunCompleteArgs.AttachmentSets,
                 testRunCompletePayload.TestRunCompleteArgs.InvokedDataCollectors,
+                testRunCompletePayload.TestRunCompleteArgs.TelemetryEvents,
                 _runRequestTimeTracker!.Elapsed);
         LoggerManager.HandleTestRunComplete(testRunCompleteArgs);
     }

--- a/src/Microsoft.TestPlatform.Common/DataCollection/AfterTestRunEndResult.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/AfterTestRunEndResult.cs
@@ -24,6 +24,7 @@ public class AfterTestRunEndResult
         AttachmentSets = null!;
         InvokedDataCollectors = null!;
         Metrics = null!;
+        TelemetryEvents = null!;
     }
 
     /// <summary>
@@ -36,7 +37,7 @@ public class AfterTestRunEndResult
     /// The metrics.
     /// </param>
     public AfterTestRunEndResult(Collection<AttachmentSet> attachmentSets, IDictionary<string, object> metrics)
-        : this(attachmentSets, new Collection<InvokedDataCollector>(), metrics)
+        : this(attachmentSets, new Collection<InvokedDataCollector>(), metrics, new Collection<TelemetryEvent>())
     { }
 
     /// <summary>
@@ -54,10 +55,34 @@ public class AfterTestRunEndResult
     public AfterTestRunEndResult(Collection<AttachmentSet> attachmentSets,
         Collection<InvokedDataCollector>? invokedDataCollectors,
         IDictionary<string, object> metrics)
+        : this(attachmentSets, invokedDataCollectors, metrics, new Collection<TelemetryEvent>())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AfterTestRunEndResult"/> class.
+    /// </summary>
+    /// <param name="attachmentSets">
+    /// The collection of attachment sets.
+    /// </param>
+    /// <param name="invokedDataCollectors">
+    /// The collection of the DataCollectors invoked during test session
+    /// </param>
+    /// <param name="metrics">
+    /// The metrics.
+    /// </param>
+    /// <param name="telemetryEvents">
+    /// The telemetry events.
+    /// </param>
+    public AfterTestRunEndResult(Collection<AttachmentSet> attachmentSets,
+        Collection<InvokedDataCollector>? invokedDataCollectors,
+        IDictionary<string, object> metrics,
+        Collection<TelemetryEvent>? telemetryEvents)
     {
         AttachmentSets = attachmentSets;
         InvokedDataCollectors = invokedDataCollectors;
         Metrics = metrics;
+        TelemetryEvents = telemetryEvents;
     }
 
     [DataMember]
@@ -68,4 +93,7 @@ public class AfterTestRunEndResult
 
     [DataMember]
     public IDictionary<string, object> Metrics { get; private set; }
+
+    [DataMember]
+    public Collection<TelemetryEvent>? TelemetryEvents { get; private set; }
 }

--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionManager.cs
@@ -267,6 +267,21 @@ internal class DataCollectionManager : IDataCollectionManager
     }
 
     /// <inheritdoc/>
+    public Collection<TelemetryEvent> GetTelemetryEvents()
+    {
+        List<TelemetryEvent> telemetryEvents = new();
+        foreach (DataCollectorInformation dataCollectorInformation in RunDataCollectors.Values)
+        {
+            if (dataCollectorInformation.DataCollector is ITelemetryEventsProvider telemetryEventsProvider)
+            {
+                telemetryEvents.AddRange(telemetryEventsProvider.GetTelemetryEvents());
+            }
+        }
+
+        return new Collection<TelemetryEvent>(telemetryEvents);
+    }
+
+    /// <inheritdoc/>
     public void TestHostLaunched(int processId)
     {
         if (!_isDataCollectionEnabled)

--- a/src/Microsoft.TestPlatform.Common/DataCollection/Interfaces/IDataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/Interfaces/IDataCollectionManager.cs
@@ -72,4 +72,10 @@ internal interface IDataCollectionManager : IDisposable
     /// </summary>
     /// <returns>Collection of data collectors.</returns>
     Collection<InvokedDataCollector> GetInvokedDataCollectors();
+
+    /// <summary>
+    /// Return a collections of the telemetry events
+    /// </summary>
+    /// <returns>Collection of telemetry events.</returns>
+    Collection<TelemetryEvent> GetTelemetryEvents();
 }

--- a/src/Microsoft.TestPlatform.Common/Logging/InternalTestLoggerEvents.cs
+++ b/src/Microsoft.TestPlatform.Common/Logging/InternalTestLoggerEvents.cs
@@ -285,11 +285,13 @@ internal class InternalTestLoggerEvents : TestLoggerEvents, IDisposable
     /// <param name="attachmentSet">Run level attachment sets</param>
     /// <param name="invokedDataCollectors">Invoked data collectors</param>
     /// <param name="elapsedTime">Time elapsed in just running the tests.</param>
-    internal void CompleteTestRun(ITestRunStatistics? stats, bool isCanceled, bool isAborted, Exception? error, Collection<AttachmentSet>? attachmentSet, Collection<InvokedDataCollector>? invokedDataCollectors, TimeSpan elapsedTime)
+    internal void CompleteTestRun(ITestRunStatistics? stats, bool isCanceled, bool isAborted, Exception? error,
+        Collection<AttachmentSet>? attachmentSet, Collection<InvokedDataCollector>? invokedDataCollectors,
+        Collection<TelemetryEvent>? telemetryEvents, TimeSpan elapsedTime)
     {
         CheckDisposed();
 
-        var args = new TestRunCompleteEventArgs(stats, isCanceled, isAborted, error, attachmentSet, invokedDataCollectors, elapsedTime);
+        var args = new TestRunCompleteEventArgs(stats, isCanceled, isAborted, error, attachmentSet, invokedDataCollectors, telemetryEvents, elapsedTime);
 
         // Sending 0 size as this event is not expected to contain any data.
         SafeInvokeAsync(() => TestRunComplete, args, 0, "InternalTestLoggerEvents.SendTestRunComplete");

--- a/src/Microsoft.TestPlatform.Common/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.Common/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 #nullable enable
+Microsoft.VisualStudio.TestPlatform.Common.DataCollection.AfterTestRunEndResult.AfterTestRunEndResult(System.Collections.ObjectModel.Collection<Microsoft.VisualStudio.TestPlatform.ObjectModel.AttachmentSet!>! attachmentSets, System.Collections.ObjectModel.Collection<Microsoft.VisualStudio.TestPlatform.ObjectModel.InvokedDataCollector!>? invokedDataCollectors, System.Collections.Generic.IDictionary<string!, object!>! metrics, System.Collections.ObjectModel.Collection<Microsoft.VisualStudio.TestPlatform.ObjectModel.TelemetryEvent!>? telemetryEvents) -> void
+Microsoft.VisualStudio.TestPlatform.Common.DataCollection.AfterTestRunEndResult.TelemetryEvents.get -> System.Collections.ObjectModel.Collection<Microsoft.VisualStudio.TestPlatform.ObjectModel.TelemetryEvent!>?
 Microsoft.VisualStudio.TestPlatform.Common.Interfaces.ITestDiscovererCapabilities.IsDirectoryBased.get -> bool

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
@@ -410,7 +410,8 @@ internal class DataCollectionRequestHandler : IDataCollectionRequestHandler, IDi
             _requestData.MetricsCollection.Add(TelemetryDataConstants.InvokedDataCollectors, string.Join(",", invokedDataCollectorsForMetrics.ToArray()));
         }
 
-        var afterTestRunEndResult = new AfterTestRunEndResult(attachmentsets, invokedDataCollectors, _requestData.MetricsCollection.Metrics);
+        var afterTestRunEndResult = new AfterTestRunEndResult(attachmentsets, invokedDataCollectors,
+            _requestData.MetricsCollection.Metrics, _dataCollectionManager.GetTelemetryEvents());
 
         // Dispose all datacollectors before sending attachments to vstest.console process.
         // As datacollector process exits itself on parent process(vstest.console) exits.

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -682,7 +682,7 @@ public class TestRequestSender : ITestRequestSender
         LogErrorMessage(string.Format(CultureInfo.CurrentCulture, CommonResources.AbortedTestRun, reason));
 
         // notify test run abort to vstest console wrapper.
-        var completeArgs = new TestRunCompleteEventArgs(null, false, true, exception, null, null, TimeSpan.Zero);
+        var completeArgs = new TestRunCompleteEventArgs(null, false, true, exception, null, null, null, TimeSpan.Zero);
         var payload = new TestRunCompletePayload { TestRunCompleteArgs = completeArgs };
         var rawMessage = _dataSerializer.SerializePayload(MessageType.ExecutionComplete, payload);
         testRunEventsHandler.HandleRawMessage(rawMessage);

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/InProcessProxyexecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/InProcessProxyexecutionManager.cs
@@ -100,7 +100,8 @@ internal class InProcessProxyExecutionManager : IProxyExecutionManager
             eventHandler.HandleLogMessage(TestMessageLevel.Error, exception.ToString());
 
             // Send a run complete to caller.
-            var completeArgs = new TestRunCompleteEventArgs(null, false, true, exception, new Collection<AttachmentSet>(), new Collection<InvokedDataCollector>(), TimeSpan.Zero);
+            var completeArgs = new TestRunCompleteEventArgs(null, false, true, exception, new Collection<AttachmentSet>(),
+                new Collection<InvokedDataCollector>(), new Collection<TelemetryEvent>(), TimeSpan.Zero);
             eventHandler.HandleTestRunComplete(completeArgs, null, null, null);
         }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyExecutionManager.cs
@@ -462,7 +462,8 @@ internal sealed class ParallelProxyExecutionManager : IParallelProxyExecutionMan
                         // Aborted is sent to allow the current execution manager replaced with another instance
                         // Ensure that the test run aggregator in parallel run events handler doesn't add these statistics
                         // (since the test run didn't even start)
-                        var completeArgs = new TestRunCompleteEventArgs(null, false, true, null, new Collection<AttachmentSet>(), new Collection<InvokedDataCollector>(), TimeSpan.Zero);
+                        var completeArgs = new TestRunCompleteEventArgs(null, false, true, null, new Collection<AttachmentSet>(),
+                            new Collection<InvokedDataCollector>(), new Collection<TelemetryEvent>(), TimeSpan.Zero);
                         handler.HandleTestRunComplete(completeArgs, null, null, null);
                     },
                     TaskContinuationOptions.OnlyOnFaulted);

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelRunDataAggregator.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelRunDataAggregator.cs
@@ -36,6 +36,7 @@ internal class ParallelRunDataAggregator
         RunContextAttachments = new Collection<AttachmentSet>();
         RunCompleteArgsAttachments = new List<AttachmentSet>();
         InvokedDataCollectors = new Collection<InvokedDataCollector>();
+        TelemetryEvents = new Collection<TelemetryEvent>();
         Exceptions = new List<Exception>();
         DiscoveredExtensions = new Dictionary<string, HashSet<string>>();
         _executorUris = new List<string>();
@@ -54,6 +55,8 @@ internal class ParallelRunDataAggregator
     public List<AttachmentSet> RunCompleteArgsAttachments { get; }
 
     public Collection<InvokedDataCollector> InvokedDataCollectors { get; set; }
+
+    public Collection<TelemetryEvent> TelemetryEvents { get; set; }
 
     public List<Exception> Exceptions { get; }
 
@@ -143,6 +146,7 @@ internal class ParallelRunDataAggregator
         ICollection<AttachmentSet>? runContextAttachments,
         Collection<AttachmentSet>? runCompleteArgsAttachments,
         Collection<InvokedDataCollector>? invokedDataCollectors,
+        Collection<TelemetryEvent>? telemetryEvents,
         Dictionary<string, HashSet<string>>? discoveredExtensions)
     {
         lock (_dataUpdateSyncObject)
@@ -172,6 +176,14 @@ internal class ParallelRunDataAggregator
                     {
                         InvokedDataCollectors.Add(invokedDataCollector);
                     }
+                }
+            }
+
+            if (telemetryEvents?.Count > 0)
+            {
+                foreach (var telemetryEvent in telemetryEvents)
+                {
+                    TelemetryEvents.Add(telemetryEvent);
                 }
             }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelRunEventsHandler.cs
@@ -76,6 +76,7 @@ internal class ParallelRunEventsHandler : IInternalTestRunEventsHandler
                 _runDataAggregator.GetAggregatedException(),
                 new Collection<AttachmentSet>(_runDataAggregator.RunCompleteArgsAttachments),
                 new Collection<InvokedDataCollector>(_runDataAggregator.InvokedDataCollectors),
+                new Collection<TelemetryEvent>(_runDataAggregator.TelemetryEvents),
                 _runDataAggregator.ElapsedTime);
 
             // Collect Final RunState
@@ -124,6 +125,7 @@ internal class ParallelRunEventsHandler : IInternalTestRunEventsHandler
             runContextAttachments,
             testRunCompleteArgs.AttachmentSets,
             testRunCompleteArgs.InvokedDataCollectors,
+            testRunCompleteArgs.TelemetryEvents,
             testRunCompleteArgs.DiscoveredExtensions);
 
         // Aggregate Run Data Metrics

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -317,7 +317,7 @@ internal class ProxyExecutionManager : IProxyExecutionManager, IBaseProxy, IInte
         // message ensures another execution manager created to replace the current one.
         // This will help if the current execution manager is aborted due to irreparable
         // error and the test host is lost as well.
-        var completeArgs = new TestRunCompleteEventArgs(null, false, true, null, new Collection<AttachmentSet>(), new Collection<InvokedDataCollector>(), TimeSpan.Zero);
+        var completeArgs = new TestRunCompleteEventArgs(null, false, true, null, new Collection<AttachmentSet>(), new Collection<InvokedDataCollector>(), new Collection<TelemetryEvent>(), TimeSpan.Zero);
         var testRunCompletePayload = new TestRunCompletePayload { TestRunCompleteArgs = completeArgs };
         HandleRawMessage(_dataSerializer.SerializePayload(MessageType.ExecutionComplete, testRunCompletePayload));
         HandleTestRunComplete(completeArgs, null, null, null);

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/TestLoggerManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/TestLoggerManager.cs
@@ -247,7 +247,7 @@ internal class TestLoggerManager : ITestLoggerManager
             try
             {
                 _loggerEvents.CompleteTestRun(e.TestRunStatistics, e.IsCanceled, e.IsAborted, e.Error,
-                    e.AttachmentSets, e.InvokedDataCollectors, e.ElapsedTimeInRunningTests);
+                    e.AttachmentSets, e.InvokedDataCollectors, e.TelemetryEvents, e.ElapsedTimeInRunningTests);
             }
             finally
             {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionResult.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionResult.cs
@@ -13,9 +13,16 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection;
 public class DataCollectionResult
 {
     public DataCollectionResult(Collection<AttachmentSet>? attachments, Collection<InvokedDataCollector>? invokedDataCollectors)
+        : this(attachments, invokedDataCollectors, new Collection<TelemetryEvent>())
+    {
+    }
+
+    public DataCollectionResult(Collection<AttachmentSet>? attachments, Collection<InvokedDataCollector>? invokedDataCollectors,
+        Collection<TelemetryEvent>? telemetryEvents)
     {
         Attachments = attachments;
         InvokedDataCollectors = invokedDataCollectors;
+        TelemetryEvents = telemetryEvents;
     }
 
     /// <summary>
@@ -27,4 +34,9 @@ public class DataCollectionResult
     /// Get the list of the invoked data collectors.
     /// </summary>
     public Collection<InvokedDataCollector>? InvokedDataCollectors { get; }
+
+    /// <summary>
+    /// Get the list of the telemetry events.
+    /// </summary>
+    public Collection<TelemetryEvent>? TelemetryEvents { get; }
 }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionTestRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/DataCollectionTestRunEventsHandler.cs
@@ -31,6 +31,7 @@ internal class DataCollectionTestRunEventsHandler : IInternalTestRunEventsHandle
 
     private Collection<AttachmentSet>? _dataCollectionAttachmentSets;
     private Collection<InvokedDataCollector>? _invokedDataCollectors;
+    private Collection<TelemetryEvent>? _telemetryEvents;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DataCollectionTestRunEventsHandler"/> class.
@@ -115,6 +116,15 @@ internal class DataCollectionTestRunEventsHandler : IInternalTestRunEventsHandle
                 }
             }
 
+            _telemetryEvents = dataCollectionResult?.TelemetryEvents;
+            if (_telemetryEvents?.Count > 0)
+            {
+                foreach (var telemetryEvent in _telemetryEvents)
+                {
+                    testRunCompletePayload?.TestRunCompleteArgs?.TelemetryEvents.Add(telemetryEvent);
+                }
+            }
+
             rawMessage = _dataSerializer.SerializePayload(
                 MessageType.ExecutionComplete,
                 testRunCompletePayload);
@@ -152,6 +162,16 @@ internal class DataCollectionTestRunEventsHandler : IInternalTestRunEventsHandle
             foreach (var dataCollector in _invokedDataCollectors)
             {
                 testRunCompleteArgs.InvokedDataCollectors.Add(dataCollector);
+            }
+        }
+
+        // At the moment, we don't support running telemetry collecting inside testhost process, so it will always be empty inside "TestRunCompleteEventArgs testRunCompleteArgs".
+        // We store telementry events inside "DataCollectionTestRunEventsHandler.HandleRawMessage" method.
+        if (_telemetryEvents != null && _telemetryEvents.Count != 0)
+        {
+            foreach (var telemetryEvent in _telemetryEvents)
+            {
+                testRunCompleteArgs.TelemetryEvents.Add(telemetryEvent);
             }
         }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ParallelDataCollectionEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ParallelDataCollectionEventsHandler.cs
@@ -68,6 +68,7 @@ internal class ParallelDataCollectionEventsHandler : ParallelRunEventsHandler
             _runDataAggregator.GetAggregatedException(),
             _runDataAggregator.RunContextAttachments,
             _runDataAggregator.InvokedDataCollectors,
+            _runDataAggregator.TelemetryEvents,
             _runDataAggregator.ElapsedTime);
 
         // Add Metrics from Test Host

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
@@ -164,7 +164,7 @@ internal class ProxyDataCollectionManager : IProxyDataCollectionManager
             }
         }
 
-        return new DataCollectionResult(afterTestRunEnd?.AttachmentSets, afterTestRunEnd?.InvokedDataCollectors);
+        return new DataCollectionResult(afterTestRunEnd?.AttachmentSets, afterTestRunEnd?.InvokedDataCollectors, afterTestRunEnd?.TelemetryEvents);
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/DataCollection/ProxyDataCollectionManager.cs
@@ -164,7 +164,8 @@ internal class ProxyDataCollectionManager : IProxyDataCollectionManager
             }
         }
 
-        return new DataCollectionResult(afterTestRunEnd?.AttachmentSets, afterTestRunEnd?.InvokedDataCollectors, afterTestRunEnd?.TelemetryEvents);
+        return new DataCollectionResult(afterTestRunEnd?.AttachmentSets, afterTestRunEnd?.InvokedDataCollectors,
+            _requestData.IsTelemetryOptedIn ? afterTestRunEnd?.TelemetryEvents : null);
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
@@ -220,13 +220,16 @@ public class TestRequestHandler : ITestRequestHandler, IDeploymentAwareTestReque
             && testRunCompleteArgs.Error == null
             && _messageProcessingUnrecoverableError != null)
         {
-            var curentArgs = testRunCompleteArgs;
+            var currentArgs = testRunCompleteArgs;
             testRunCompleteArgs = new TestRunCompleteEventArgs(
-                curentArgs.TestRunStatistics,
-                curentArgs.IsCanceled,
-                curentArgs.IsAborted,
+                currentArgs.TestRunStatistics,
+                currentArgs.IsCanceled,
+                currentArgs.IsAborted,
                 _messageProcessingUnrecoverableError,
-                _pathConverter.UpdateAttachmentSets(curentArgs.AttachmentSets, PathConversionDirection.Send), curentArgs.InvokedDataCollectors, curentArgs.ElapsedTimeInRunningTests
+                _pathConverter.UpdateAttachmentSets(currentArgs.AttachmentSets, PathConversionDirection.Send),
+                currentArgs.InvokedDataCollectors,
+                currentArgs.TelemetryEvents,
+                currentArgs.ElapsedTimeInRunningTests
             );
         }
         var data = _dataSerializer.SerializePayload(

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -631,6 +631,7 @@ internal abstract class BaseRunTests
                 attachments,
                 // Today we don't offer an extension to run collectors for test adapters.
                 new Collection<InvokedDataCollector>(),
+                new Collection<TelemetryEvent>(),
                 elapsedTime);
 
             testRunCompleteEventArgs.DiscoveredExtensions = TestPluginCache.Instance.TestExtensions?.GetCachedExtensions();

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/ExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/ExecutionManager.cs
@@ -163,7 +163,7 @@ public class ExecutionManager : IExecutionManager
     {
         if (_activeTestRun == null)
         {
-            var testRunCompleteEventArgs = new TestRunCompleteEventArgs(null, true, false, null, null, null, TimeSpan.Zero);
+            var testRunCompleteEventArgs = new TestRunCompleteEventArgs(null, true, false, null, null, null, null, TimeSpan.Zero);
             testRunEventsHandler.HandleTestRunComplete(testRunCompleteEventArgs, null, null, null);
         }
         else
@@ -179,7 +179,7 @@ public class ExecutionManager : IExecutionManager
     {
         if (_activeTestRun == null)
         {
-            var testRunCompleteEventArgs = new TestRunCompleteEventArgs(null, false, true, null, null, null, TimeSpan.Zero);
+            var testRunCompleteEventArgs = new TestRunCompleteEventArgs(null, false, true, null, null, null, null, TimeSpan.Zero);
             testRunEventsHandler.HandleTestRunComplete(testRunCompleteEventArgs, null, null, null);
         }
         else

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection.DataCollectionResult.DataCollectionResult(System.Collections.ObjectModel.Collection<Microsoft.VisualStudio.TestPlatform.ObjectModel.AttachmentSet!>? attachments, System.Collections.ObjectModel.Collection<Microsoft.VisualStudio.TestPlatform.ObjectModel.InvokedDataCollector!>? invokedDataCollectors, System.Collections.ObjectModel.Collection<Microsoft.VisualStudio.TestPlatform.ObjectModel.TelemetryEvent!>? telemetryEvents) -> void
+Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection.DataCollectionResult.TelemetryEvents.get -> System.Collections.ObjectModel.Collection<Microsoft.VisualStudio.TestPlatform.ObjectModel.TelemetryEvent!>?

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Events/TestRunCompleteEventArgs.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Events/TestRunCompleteEventArgs.cs
@@ -22,6 +22,7 @@ public class TestRunCompleteEventArgs : EventArgs
     {
         AttachmentSets = new Collection<AttachmentSet>();
         InvokedDataCollectors = new Collection<InvokedDataCollector>();
+        TelemetryEvents = new Collection<TelemetryEvent>();
     }
 
     /// <summary>
@@ -68,6 +69,36 @@ public class TestRunCompleteEventArgs : EventArgs
         Collection<AttachmentSet>? attachmentSets,
         Collection<InvokedDataCollector>? invokedDataCollectors,
         TimeSpan elapsedTime)
+        : this(
+              stats,
+              isCanceled,
+              isAborted,
+              error,
+              attachmentSets,
+              invokedDataCollectors,
+              null,
+              elapsedTime)
+    { }
+
+    /// <summary>
+    /// Default constructor.
+    /// </summary>
+    /// <param name="stats">The final stats for the test run. This parameter is only set for communications between the test host and the clients (like VS)</param>
+    /// <param name="isCanceled">Specifies whether the test run is canceled.</param>
+    /// <param name="isAborted">Specifies whether the test run is aborted.</param>
+    /// <param name="error">Specifies the error encountered during the execution of the test run.</param>
+    /// <param name="attachmentSets">Attachment sets associated with the run.</param>
+    /// <param name="InvokedDataCollectors">Invoked data collectors</param>
+    /// <param name="elapsedTime">Time elapsed in just running tests</param>
+    public TestRunCompleteEventArgs(
+        ITestRunStatistics? stats,
+        bool isCanceled,
+        bool isAborted,
+        Exception? error,
+        Collection<AttachmentSet>? attachmentSets,
+        Collection<InvokedDataCollector>? invokedDataCollectors,
+        Collection<TelemetryEvent>? telemetryEvents,
+        TimeSpan elapsedTime)
     {
         TestRunStatistics = stats;
         IsCanceled = isCanceled;
@@ -75,6 +106,7 @@ public class TestRunCompleteEventArgs : EventArgs
         Error = error;
         AttachmentSets = attachmentSets ?? new Collection<AttachmentSet>(); // Ensuring attachmentSets are not null, so that new attachmentSets can be combined whenever required.
         InvokedDataCollectors = invokedDataCollectors ?? new Collection<InvokedDataCollector>(); // Ensuring that invoked data collectors are not null.
+        TelemetryEvents = telemetryEvents ?? new Collection<TelemetryEvent>(); // Ensuring that telemetry events are not null.
         ElapsedTimeInRunningTests = elapsedTime;
 
         DiscoveredExtensions = new Dictionary<string, HashSet<string>>();
@@ -115,6 +147,12 @@ public class TestRunCompleteEventArgs : EventArgs
     /// </summary>
     [DataMember]
     public Collection<InvokedDataCollector> InvokedDataCollectors { get; private set; }
+
+    /// <summary>
+    /// Gets the telemetry events for the test session.
+    /// </summary>
+    [DataMember]
+    public Collection<TelemetryEvent> TelemetryEvents { get; private set; }
 
     /// <summary>
     /// Gets the time elapsed in just running the tests.

--- a/src/Microsoft.TestPlatform.ObjectModel/ITelemetryEventsProvider.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/ITelemetryEventsProvider.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+/// <summary>
+/// Interface for extensions that choose to send telemetry events
+/// </summary>
+public interface ITelemetryEventsProvider
+{
+    /// <summary>
+    /// Gets telemetry events that should be propagated by Test Platform
+    /// </summary>
+    /// <returns>Telemetry events that should be propagated by Test Platform</returns>
+    IEnumerable<TelemetryEvent> GetTelemetryEvents();
+}

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 ﻿#nullable enable
+Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.TestRunCompleteEventArgs.TelemetryEvents.get -> System.Collections.ObjectModel.Collection<Microsoft.VisualStudio.TestPlatform.ObjectModel.TelemetryEvent!>!
+Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.TestRunCompleteEventArgs.TestRunCompleteEventArgs(Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.ITestRunStatistics? stats, bool isCanceled, bool isAborted, System.Exception? error, System.Collections.ObjectModel.Collection<Microsoft.VisualStudio.TestPlatform.ObjectModel.AttachmentSet!>? attachmentSets, System.Collections.ObjectModel.Collection<Microsoft.VisualStudio.TestPlatform.ObjectModel.InvokedDataCollector!>? invokedDataCollectors, System.Collections.ObjectModel.Collection<Microsoft.VisualStudio.TestPlatform.ObjectModel.TelemetryEvent!>? telemetryEvents, System.TimeSpan elapsedTime) -> void
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ITelemetryEventsProvider
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ITelemetryEventsProvider.GetTelemetryEvents() -> System.Collections.Generic.IEnumerable<Microsoft.VisualStudio.TestPlatform.ObjectModel.TelemetryEvent!>!
+Microsoft.VisualStudio.TestPlatform.ObjectModel.TelemetryEvent
+Microsoft.VisualStudio.TestPlatform.ObjectModel.TelemetryEvent.Name.get -> string!
+Microsoft.VisualStudio.TestPlatform.ObjectModel.TelemetryEvent.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
+Microsoft.VisualStudio.TestPlatform.ObjectModel.TelemetryEvent.TelemetryEvent(string! name, System.Collections.Generic.IDictionary<string!, object!>! properties) -> void

--- a/src/Microsoft.TestPlatform.ObjectModel/TelemetryEvent.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TelemetryEvent.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+public sealed class TelemetryEvent
+{
+    /// <summary>
+    /// Initialize an TelemetryEvent
+    /// </summary>
+    /// <param name="name">Telemetry event name</param>
+    /// <param name="properties">Telemetry event properties</param>
+    public TelemetryEvent(string name, IDictionary<string, object> properties)
+    {
+        Name = name;
+        Properties = properties;
+    }
+
+    /// <summary>
+    /// Telemetry event name.
+    /// </summary>
+    [DataMember]
+    public string Name { get; private set; }
+
+    /// <summary>
+    /// Telemetry event properties.
+    /// </summary>
+    [DataMember]
+    public IDictionary<string, object> Properties { get; private set; }
+}

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleRequestSender.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleRequestSender.cs
@@ -1178,7 +1178,7 @@ internal class VsTestConsoleRequestSender : ITranslationLayerRequestSender
                 TestMessageLevel.Error,
                 TranslationLayerResources.AbortedTestsRun);
             var completeArgs = new TestRunCompleteEventArgs(
-                null, false, true, exception, null, null, TimeSpan.Zero);
+                null, false, true, exception, null, null, null, TimeSpan.Zero);
             eventHandler.HandleTestRunComplete(completeArgs, null, null, null);
 
             // Earlier we were closing the connection with vstest.console in case of exceptions.
@@ -1258,7 +1258,7 @@ internal class VsTestConsoleRequestSender : ITranslationLayerRequestSender
                 TestMessageLevel.Error,
                 TranslationLayerResources.AbortedTestsRun);
             var completeArgs = new TestRunCompleteEventArgs(
-                null, false, true, exception, null, null, TimeSpan.Zero);
+                null, false, true, exception, null, null, null, TimeSpan.Zero);
             eventHandler.HandleTestRunComplete(completeArgs, null, null, null);
 
             // Earlier we were closing the connection with vstest.console in case of exceptions.

--- a/src/vstest.console/InProcessVsTestConsoleWrapper.cs
+++ b/src/vstest.console/InProcessVsTestConsoleWrapper.cs
@@ -11,6 +11,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Abstraction::Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
+
 using Microsoft.TestPlatform.VsTestConsole.TranslationLayer;
 using Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.Client;
@@ -25,7 +27,6 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Payloads;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using Abstraction::Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
 using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.VsTestConsole.TranslationLayer.Interfaces;
@@ -517,7 +518,7 @@ internal class InProcessVsTestConsoleWrapper : IVsTestConsoleWrapper
         catch (Exception ex)
         {
             EqtTrace.Error("InProcessVsTestConsoleWrapper.RunTests: Exception occurred: " + ex);
-            var testRunCompleteArgs = new TestRunCompleteEventArgs(null, false, true, ex, null, null, TimeSpan.MinValue);
+            var testRunCompleteArgs = new TestRunCompleteEventArgs(null, false, true, ex, null, null, null, TimeSpan.MinValue);
 
             testRunEventsHandler.HandleLogMessage(TestMessageLevel.Error, ex.ToString());
             testRunEventsHandler.HandleTestRunComplete(testRunCompleteArgs, null, null, null);
@@ -590,7 +591,7 @@ internal class InProcessVsTestConsoleWrapper : IVsTestConsoleWrapper
         catch (Exception ex)
         {
             EqtTrace.Error("InProcessVsTestConsoleWrapper.RunTests: Exception occurred: " + ex);
-            var testRunCompleteArgs = new TestRunCompleteEventArgs(null, false, true, ex, null, null, TimeSpan.MinValue);
+            var testRunCompleteArgs = new TestRunCompleteEventArgs(null, false, true, ex, null, null, null, TimeSpan.MinValue);
 
             testRunEventsHandler.HandleLogMessage(TestMessageLevel.Error, ex.ToString());
             testRunEventsHandler.HandleTestRunComplete(testRunCompleteArgs, null, null, null);
@@ -682,7 +683,7 @@ internal class InProcessVsTestConsoleWrapper : IVsTestConsoleWrapper
         catch (Exception ex)
         {
             EqtTrace.Error("InProcessVsTestConsoleWrapper.RunTestsWithCustomTestHost: Exception occurred: " + ex);
-            var testRunCompleteArgs = new TestRunCompleteEventArgs(null, false, true, ex, null, null, TimeSpan.MinValue);
+            var testRunCompleteArgs = new TestRunCompleteEventArgs(null, false, true, ex, null, null, null, TimeSpan.MinValue);
 
             testRunEventsHandler.HandleLogMessage(TestMessageLevel.Error, ex.ToString());
             testRunEventsHandler.HandleTestRunComplete(testRunCompleteArgs, null, null, null);
@@ -774,7 +775,7 @@ internal class InProcessVsTestConsoleWrapper : IVsTestConsoleWrapper
         catch (Exception ex)
         {
             EqtTrace.Error("InProcessVsTestConsoleWrapper.RunTestsWithCustomTestHost: Exception occurred: " + ex);
-            var testRunCompleteArgs = new TestRunCompleteEventArgs(null, false, true, ex, null, null, TimeSpan.MinValue);
+            var testRunCompleteArgs = new TestRunCompleteEventArgs(null, false, true, ex, null, null, null, TimeSpan.MinValue);
 
             testRunEventsHandler.HandleLogMessage(TestMessageLevel.Error, ex.ToString());
             testRunEventsHandler.HandleTestRunComplete(testRunCompleteArgs, null, null, null);

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/EventHandler/RunEventHandler.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/EventHandler/RunEventHandler.cs
@@ -30,6 +30,11 @@ public class RunEventHandler : ITestRunEventsHandler
     public List<InvokedDataCollector> InvokedDataCollectors { get; private set; }
 
     /// <summary>
+    /// Gets the list of the telemetry events.
+    /// </summary>
+    public List<TelemetryEvent> TelemetryEvents { get; private set; }
+
+    /// <summary>
     /// Gets the metrics.
     /// </summary>
     public IDictionary<string, object>? Metrics { get; private set; }
@@ -52,6 +57,7 @@ public class RunEventHandler : ITestRunEventsHandler
         Errors = new List<string?>();
         Attachments = new List<AttachmentSet>();
         InvokedDataCollectors = new List<InvokedDataCollector>();
+        TelemetryEvents = new List<TelemetryEvent>();
     }
 
     public void EnsureSuccess()
@@ -91,6 +97,11 @@ public class RunEventHandler : ITestRunEventsHandler
         if (testRunCompleteArgs.InvokedDataCollectors != null)
         {
             InvokedDataCollectors.AddRange(testRunCompleteArgs.InvokedDataCollectors);
+        }
+
+        if (testRunCompleteArgs.TelemetryEvents != null)
+        {
+            TelemetryEvents.AddRange(testRunCompleteArgs.TelemetryEvents);
         }
 
         Metrics = testRunCompleteArgs.Metrics;

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Logging/InternalTestLoggerEventsTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Logging/InternalTestLoggerEventsTests.cs
@@ -129,7 +129,7 @@ public class InternalTestLoggerEventsBehaviors
 
         _loggerEvents.EnableEvents();
         // Send the test run complete event.
-        _loggerEvents.CompleteTestRun(null, false, false, null, null, null, new TimeSpan());
+        _loggerEvents.CompleteTestRun(null, false, false, null, null, null, null, new TimeSpan());
 
         var waitSuccess = waitHandle.WaitOne(500);
         Assert.IsTrue(waitSuccess, "Event must be raised within timeout.");
@@ -187,7 +187,7 @@ public class InternalTestLoggerEventsBehaviors
     {
         var loggerEvents = GetDisposedLoggerEvents();
 
-        Assert.ThrowsException<ObjectDisposedException>(() => loggerEvents.CompleteTestRun(null, true, false, null, null, null, new TimeSpan()));
+        Assert.ThrowsException<ObjectDisposedException>(() => loggerEvents.CompleteTestRun(null, true, false, null, null, null, null, new TimeSpan()));
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/DataCollectionTestRunEventsHandlerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/DataCollectionTestRunEventsHandlerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
@@ -113,12 +114,17 @@ public class DataCollectionTestRunEventsHandlerTests
             new InvokedDataCollector(new Uri("datacollector://sample"), "sample", typeof(string).AssemblyQualifiedName!, typeof(string).Assembly.Location, true)
         };
 
+        var telemetryEvents = new Collection<TelemetryEvent>()
+        {
+            new TelemetryEvent("event", new Dictionary<string, object>() { { "a", "b" } })
+        };
+
         var testRunCompleteEventArgs = new TestRunCompleteEventArgs(null, false, false, null, new Collection<AttachmentSet>(), new Collection<InvokedDataCollector>(), new TimeSpan());
         _mockDataSerializer.Setup(x => x.DeserializeMessage(It.IsAny<string>())).Returns(new Message() { MessageType = MessageType.ExecutionComplete });
         _mockDataSerializer.Setup(x => x.DeserializePayload<TestRunCompletePayload>(It.IsAny<Message>()))
             .Returns(new TestRunCompletePayload() { TestRunCompleteArgs = testRunCompleteEventArgs });
         _proxyDataCollectionManager.Setup(p => p.AfterTestRunEnd(It.IsAny<bool>(), It.IsAny<ITestMessageEventHandler>()))
-            .Returns(new DataCollectionResult(null, invokedDataCollectors));
+            .Returns(new DataCollectionResult(null, invokedDataCollectors, telemetryEvents));
         _mockDataSerializer.Setup(r => r.SerializePayload(It.IsAny<string>(), It.IsAny<object>())).Callback((string message, object o) =>
         {
             var testRunCompleteArgs = o as TestRunCompletePayload;

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
@@ -222,6 +222,7 @@ public class ProxyDataCollectionManagerTests
     {
         var attachments = new Collection<AttachmentSet>();
         var invokedDataCollectors = new Collection<InvokedDataCollector>();
+        var telemetryEvents = new Collection<TelemetryEvent>();
         var dispName = "MockAttachments";
         var uri = new Uri("Mock://Attachments");
         var attachmentSet = new AttachmentSet(uri, dispName);
@@ -233,7 +234,7 @@ public class ProxyDataCollectionManagerTests
             {"key", "value"}
         };
 
-        _mockDataCollectionRequestSender.Setup(x => x.SendAfterTestRunEndAndGetResult(It.IsAny<ITestRunEventsHandler>(), It.IsAny<bool>())).Returns(new AfterTestRunEndResult(attachments, invokedDataCollectors, metrics));
+        _mockDataCollectionRequestSender.Setup(x => x.SendAfterTestRunEndAndGetResult(It.IsAny<ITestRunEventsHandler>(), It.IsAny<bool>())).Returns(new AfterTestRunEndResult(attachments, invokedDataCollectors, metrics, telemetryEvents));
 
         var result = _proxyDataCollectionManager.AfterTestRunEnd(false, null);
 

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameLoggerTests.cs
@@ -75,7 +75,7 @@ public class BlameLoggerTests
 
         // Setup and Raise event
         _mockBlameReaderWriter.Setup(x => x.ReadTestSequence(It.IsAny<string>()));
-        loggerEvents.CompleteTestRun(null, false, false, null, null, null, new TimeSpan(1, 0, 0, 0));
+        loggerEvents.CompleteTestRun(null, false, false, null, null, null, null, new TimeSpan(1, 0, 0, 0));
 
         // Verify Call
         _mockBlameReaderWriter.Verify(x => x.ReadTestSequence(It.IsAny<string>()), Times.Never);
@@ -97,7 +97,7 @@ public class BlameLoggerTests
         _blameLogger.Initialize(loggerEvents, null);
 
         // Setup and Raise event
-        loggerEvents.CompleteTestRun(null, false, true, null, new Collection<AttachmentSet>(attachmentSetList), new Collection<InvokedDataCollector>(), new TimeSpan(1, 0, 0, 0));
+        loggerEvents.CompleteTestRun(null, false, true, null, new Collection<AttachmentSet>(attachmentSetList), new Collection<InvokedDataCollector>(), new Collection<TelemetryEvent>(), new TimeSpan(1, 0, 0, 0));
 
         // Verify Call
         _mockBlameReaderWriter.Verify(x => x.ReadTestSequence(It.IsAny<string>()), Times.Never);
@@ -135,7 +135,7 @@ public class BlameLoggerTests
 
         // Setup and Raise event
         _mockBlameReaderWriter.Setup(x => x.ReadTestSequence(It.IsAny<string>())).Returns(testCaseList);
-        loggerEvents.CompleteTestRun(null, false, true, null, new Collection<AttachmentSet>(attachmentSetList), new Collection<InvokedDataCollector>(), new TimeSpan(1, 0, 0, 0));
+        loggerEvents.CompleteTestRun(null, false, true, null, new Collection<AttachmentSet>(attachmentSetList), new Collection<InvokedDataCollector>(), new Collection<TelemetryEvent>(), new TimeSpan(1, 0, 0, 0));
 
         // Verify Call
         _mockBlameReaderWriter.Verify(x => x.ReadTestSequence(It.Is<string>(str => str.EndsWith(".xml"))), Times.Exactly(count));

--- a/test/datacollector.UnitTests/DataCollectionManagerTests.cs
+++ b/test/datacollector.UnitTests/DataCollectionManagerTests.cs
@@ -348,6 +348,17 @@ public class DataCollectionManagerTests
     }
 
     [TestMethod]
+    public void GetTelemetryEventsShouldReturnCorrectEvent()
+    {
+        var dataCollectorSettingsWithNullFriendlyName = string.Format(CultureInfo.InvariantCulture, _defaultRunSettings, string.Format(CultureInfo.InvariantCulture, _defaultDataCollectionSettings, string.Empty, _uri, _mockDataCollector.Object.GetType().AssemblyQualifiedName, typeof(DataCollectionManagerTests).Assembly.Location, string.Empty).Replace("friendlyName=\"\"", string.Empty));
+        _dataCollectionManager.InitializeDataCollectors(dataCollectorSettingsWithNullFriendlyName);
+        var telemetryEvents = _dataCollectionManager.GetTelemetryEvents();
+        Assert.AreEqual(1, telemetryEvents.Count);
+        Assert.AreEqual("testevent", telemetryEvents[0].Name);
+        Assert.AreEqual("value", telemetryEvents[0].Properties["prop"]);
+    }
+
+    [TestMethod]
     public void SessionEndedShouldReturnAttachments()
     {
         var attachment = new AttachmentSet(new Uri("my://custom/datacollector"), "CustomDataCollector");
@@ -558,8 +569,12 @@ internal class TestableDataCollectionManager : DataCollectionManager
 [DataCollectorFriendlyName("CustomDataCollector")]
 [DataCollectorTypeUri("my://custom/datacollector")]
 [DataCollectorAttachmentProcessor(typeof(AttachmentProcessorDataCollector2))]
-public abstract class DataCollector2 : ObjectModel.DataCollection.DataCollector
+public abstract class DataCollector2 : ObjectModel.DataCollection.DataCollector, ITelemetryEventsProvider
 {
+    public IEnumerable<TelemetryEvent> GetTelemetryEvents()
+    {
+        yield return new TelemetryEvent("testevent", new Dictionary<string, object>() { { "prop", "value" } });
+    }
 }
 
 [DataCollectorFriendlyName("Code Coverage")]

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 
 using Microsoft.Extensions.FileSystemGlobbing;
+using Microsoft.TestPlatform.TestUtilities;
 using Microsoft.VisualStudio.TestPlatform.CommandLine.Internal;
 using Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 using Microsoft.VisualStudio.TestPlatform.Common.Logging;
@@ -19,7 +20,6 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
 using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.TestPlatform.TestUtilities;
 
 using Moq;
 
@@ -853,7 +853,7 @@ public class ConsoleLoggerTests
         loggerEvents.RaiseTestResult(new(new(new("FQN6", new Uri("some://uri"), @"\\MyApp6\Tests\MyApp6.Tests\MyApp6.Tests.dll"))));
 
         // Act
-        loggerEvents.CompleteTestRun(null, false, false, null, null, null, new TimeSpan(1, 0, 0, 0));
+        loggerEvents.CompleteTestRun(null, false, false, null, null, null, null, new TimeSpan(1, 0, 0, 0));
 
         // Assert
         VerifyCall("MyApp1.Tests.dll");
@@ -889,7 +889,7 @@ public class ConsoleLoggerTests
         {
             loggerEvents.RaiseTestResult(new TestResultEventArgs(testResult));
         }
-        loggerEvents.CompleteTestRun(null, false, false, null, null, null, new TimeSpan(1, 0, 0, 0));
+        loggerEvents.CompleteTestRun(null, false, false, null, null, null, null, new TimeSpan(1, 0, 0, 0));
 
         _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryTotalTests, 1), OutputLevel.Information), Times.Once());
         _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryPassedTests, 1), OutputLevel.Information), Times.Once());
@@ -914,7 +914,7 @@ public class ConsoleLoggerTests
         {
             loggerEvents.RaiseTestResult(new TestResultEventArgs(testResult));
         }
-        loggerEvents.CompleteTestRun(null, false, false, null, null, null, new TimeSpan(1, 0, 0, 0));
+        loggerEvents.CompleteTestRun(null, false, false, null, null, null, null, new TimeSpan(1, 0, 0, 0));
 
         _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryTotalTests, 1), OutputLevel.Information), Times.Once());
         _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryFailedTests, 1), OutputLevel.Information), Times.Once());
@@ -938,7 +938,7 @@ public class ConsoleLoggerTests
         {
             loggerEvents.RaiseTestResult(new TestResultEventArgs(testResult));
         }
-        loggerEvents.CompleteTestRun(null, true, false, null, null, null, new TimeSpan(1, 0, 0, 0));
+        loggerEvents.CompleteTestRun(null, true, false, null, null, null, null, new TimeSpan(1, 0, 0, 0));
 
         _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryForCanceledOrAbortedRun), OutputLevel.Information), Times.Once());
         _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryFailedTests, 1), OutputLevel.Information), Times.Once());
@@ -958,7 +958,7 @@ public class ConsoleLoggerTests
         };
         _consoleLogger.Initialize(loggerEvents, parameters);
 
-        loggerEvents.CompleteTestRun(null, true, false, null, null, null, new TimeSpan(1, 0, 0, 0));
+        loggerEvents.CompleteTestRun(null, true, false, null, null, null, null, new TimeSpan(1, 0, 0, 0));
 
         _mockOutput.Verify(o => o.WriteLine(CommandLineResources.TestRunCanceled, OutputLevel.Error), Times.Once());
     }
@@ -978,7 +978,7 @@ public class ConsoleLoggerTests
         {
             loggerEvents.RaiseTestResult(new TestResultEventArgs(testResult));
         }
-        loggerEvents.CompleteTestRun(null, false, true, null, null, null, new TimeSpan(1, 0, 0, 0));
+        loggerEvents.CompleteTestRun(null, false, true, null, null, null, null, new TimeSpan(1, 0, 0, 0));
 
         _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryForCanceledOrAbortedRun), OutputLevel.Information), Times.Once());
         _mockOutput.Verify(o => o.WriteLine(CommandLineResources.TestRunAborted, OutputLevel.Error), Times.Once());
@@ -995,7 +995,7 @@ public class ConsoleLoggerTests
         };
         _consoleLogger.Initialize(loggerEvents, parameters);
 
-        loggerEvents.CompleteTestRun(null, false, true, null, null, null, new TimeSpan(1, 0, 0, 0));
+        loggerEvents.CompleteTestRun(null, false, true, null, null, null, null, new TimeSpan(1, 0, 0, 0));
 
         _mockOutput.Verify(o => o.WriteLine(CommandLineResources.TestRunAborted, OutputLevel.Error), Times.Once());
     }
@@ -1111,10 +1111,10 @@ public class ConsoleLoggerTests
         {
             loggerEvents.RaiseTestResult(new TestResultEventArgs(testResult));
         }
-        loggerEvents.CompleteTestRun(null, false, false, null, null, null, new TimeSpan(1, 0, 0, 0));
-        loggerEvents.CompleteTestRun(null, false, false, null, null, null, new TimeSpan(0, 1, 0, 0));
-        loggerEvents.CompleteTestRun(null, false, false, null, null, null, new TimeSpan(0, 0, 1, 0));
-        loggerEvents.CompleteTestRun(null, false, false, null, null, null, new TimeSpan(0, 0, 0, 1));
+        loggerEvents.CompleteTestRun(null, false, false, null, null, null, null, new TimeSpan(1, 0, 0, 0));
+        loggerEvents.CompleteTestRun(null, false, false, null, null, null, null, new TimeSpan(0, 1, 0, 0));
+        loggerEvents.CompleteTestRun(null, false, false, null, null, null, null, new TimeSpan(0, 0, 1, 0));
+        loggerEvents.CompleteTestRun(null, false, false, null, null, null, null, new TimeSpan(0, 0, 0, 1));
 
         // Verify PrintTimeSpan with different formats
         _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.ExecutionTimeFormatString, 1, CommandLineResources.Days), OutputLevel.Information), Times.Once());
@@ -1232,7 +1232,7 @@ public class ConsoleLoggerTests
         {
             attachmentSet
         };
-        loggerEvents.CompleteTestRun(null, false, false, null, new Collection<AttachmentSet>(attachmentSetList), new Collection<InvokedDataCollector>(), new TimeSpan(1, 0, 0, 0));
+        loggerEvents.CompleteTestRun(null, false, false, null, new Collection<AttachmentSet>(attachmentSetList), new Collection<InvokedDataCollector>(), new Collection<TelemetryEvent>(), new TimeSpan(1, 0, 0, 0));
 
         _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.AttachmentOutputFormat, uriDataAttachment.Uri.LocalPath), OutputLevel.Information), Times.Once());
         _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.AttachmentOutputFormat, uriDataAttachment1.Uri.LocalPath), OutputLevel.Information), Times.Once());
@@ -1273,7 +1273,7 @@ public class ConsoleLoggerTests
         loggerEvents.RaiseTestResult(new TestResultEventArgs(result2));
         loggerEvents.RaiseTestResult(new TestResultEventArgs(result3));
 
-        loggerEvents.CompleteTestRun(null, false, false, null, null, null, new TimeSpan(1, 0, 0, 0));
+        loggerEvents.CompleteTestRun(null, false, false, null, null, null, null, new TimeSpan(1, 0, 0, 0));
 
         _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryFailedTests, 1), OutputLevel.Information), Times.Once());
         _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestRunSummaryPassedTests, 1), OutputLevel.Information), Times.Once());


### PR DESCRIPTION
## Description

This PR adds possibility for data collectors to provide its owned telemetry events. Telemetry events are passed back to Test Window and are published to VS.

Example:
![image](https://github.com/microsoft/vstest/assets/59966772/f92b88ae-ef7c-4a94-8261-cbbd929c72d5)

## Related issue

No collector telemetry in Visual Studio.
