### PR TITLE
Take System dlls from testhost folder

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -36,7 +36,6 @@
     <MicrosoftVisualStudioEnterpriseAspNetHelper>$(MicrosoftVisualStudioDiagnosticsUtilitiesVersion)</MicrosoftVisualStudioEnterpriseAspNetHelper>
     <MicrosoftVisualStudioInteropVersion>17.3.32622.426</MicrosoftVisualStudioInteropVersion>
     <MicrosoftVSSDKBuildToolsVersion>17.4.2116</MicrosoftVSSDKBuildToolsVersion>
-    <NETStandardLibraryVersion>2.0.3</NETStandardLibraryVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <RoslynBannedApiAnalyzersVersion>3.3.3</RoslynBannedApiAnalyzersVersion>
     <RoslynPublicApiAnalyzersVersion>3.3.4-beta1.21554.2</RoslynPublicApiAnalyzersVersion>

--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -18,7 +18,7 @@ function Verify-Nuget-Packages {
         "Microsoft.NET.Test.Sdk"                      = 16;
         "Microsoft.TestPlatform"                      = 608;
         "Microsoft.TestPlatform.Build"                = 21;
-        "Microsoft.TestPlatform.CLI"                  = 493;
+        "Microsoft.TestPlatform.CLI"                  = 472;
         "Microsoft.TestPlatform.Extensions.TrxLogger" = 35;
         "Microsoft.TestPlatform.ObjectModel"          = 93;
         "Microsoft.TestPlatform.AdapterUtilities"     = 34;
@@ -34,26 +34,26 @@ function Verify-Nuget-Packages {
     $pattern = "*.$versionPrefix*.nupkg"
     $nugetPackages = @(Get-ChildItem $packageDirectory -Filter $pattern -Recurse -File | Where-Object { $_.Name -notLike "*.symbols.nupkg"})
 
-    if (0 -eq $nugetPackages.Length) { 
+    if (0 -eq $nugetPackages.Length) {
         throw "No nuget packages matching $pattern were found in '$packageDirectory'."
     }
 
     $suffixes = @($nugetPackages -replace ".*?$([regex]::Escape($versionPrefix))(.*)\.nupkg", '$1' | Sort-Object -Unique)
-    if (1 -lt $suffixes.Length) { 
+    if (1 -lt $suffixes.Length) {
         Write-Host "There are two different suffixes matching the same version prefix: '$($suffixes -join "', '")'".
 
-        $latestNuget = $nugetPackages | 
-            Where-Object { $_.Name -like "Microsoft.TestPlatform.ObjectModel.*" } | 
-            Sort-Object -Property LastWriteTime -Descending | 
+        $latestNuget = $nugetPackages |
+            Where-Object { $_.Name -like "Microsoft.TestPlatform.ObjectModel.*" } |
+            Sort-Object -Property LastWriteTime -Descending |
             Select-Object -First 1
-        
+
         $suffix = $suffixes | Where { $latestNuget.Name.Contains("$versionPrefix$_.nupkg") }
         $version = "$versionPrefix$suffix"
         Write-Host "The most recently written Microsoft.TestPlatform.ObjectModel.* nuget, is $($latestNuget.Name), which has '$suffix' suffix. Selecting only packages with that suffix."
 
         $nugetPackages = $nugetPackages | Where-Object { $_.Name -like "*$version.nupkg" }
     }
-    else { 
+    else {
         $suffix = $suffixes[0]
         $version = "$versionPrefix$suffix"
     }

--- a/src/DataCollectors/DumpMinitool.arm64/DumpMinitool.arm64.csproj
+++ b/src/DataCollectors/DumpMinitool.arm64/DumpMinitool.arm64.csproj
@@ -16,6 +16,7 @@
       or use the -\-self-contained argument.
       -->
     <MSBuildWarningsAsMessages>NETSDK1201</MSBuildWarningsAsMessages>
+    <NoWarn>$(NoWarn);NETSDK1201</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DataCollectors/DumpMinitool.x86/DumpMinitool.x86.csproj
+++ b/src/DataCollectors/DumpMinitool.x86/DumpMinitool.x86.csproj
@@ -16,6 +16,7 @@
       or use the -\-self-contained argument.
       -->
     <MSBuildWarningsAsMessages>NETSDK1201</MSBuildWarningsAsMessages>
+    <NoWarn>$(NoWarn);NETSDK1201</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DataCollectors/DumpMinitool/DumpMinitool.csproj
+++ b/src/DataCollectors/DumpMinitool/DumpMinitool.csproj
@@ -16,6 +16,7 @@
       or use the -\-self-contained argument.
       -->
     <MSBuildWarningsAsMessages>NETSDK1201</MSBuildWarningsAsMessages>
+    <NoWarn>$(NoWarn);NETSDK1201</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.csproj
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.csproj
@@ -72,10 +72,8 @@
     <PackageReference Include="Microsoft.CodeCoverage.IO" Version="$(MicrosoftCodeCoverageIOVersion)" GeneratePathProperty="true" Condition=" '$(DotNetBuildFromSource)' != 'true' " />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(MicrosoftExtensionsFileSystemGlobbingVersion)" GeneratePathProperty="true" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" GeneratePathProperty="true" />
     <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="$(MicrosoftDiagnosticsNETCoreClientVersion)" PrivateAssets="All" GeneratePathProperty="true" />
-    <PackageReference Include="NETStandard.Library" Version="$(NETStandardLibraryVersion)" PrivateAssets="All" GeneratePathProperty="true" Condition="'$(TargetFramework)'=='net472'" />
     <PackageReference Include="Microsoft.Internal.Dia" Version="$(TestPlatformMSDiaVersion)" PrivateAssets="All" GeneratePathProperty="true" Condition="'$(TargetFramework)'=='net472'" />
   </ItemGroup>
 
@@ -84,23 +82,19 @@
       <MicrosoftCodeCoverageIO Include="$(PkgMicrosoft_CodeCoverage_IO)\lib\netstandard2.0\**\*"></MicrosoftCodeCoverageIO>
       <MicrosoftExtensionsDependencyModel Include="$(PkgMicrosoft_Extensions_DependencyModel)\lib\netstandard2.0\*"></MicrosoftExtensionsDependencyModel>
       <MicrosoftExtensionsFileSystemGlobbing Include="$(PkgMicrosoft_Extensions_FileSystemGlobbing)\lib\netstandard2.0\*"></MicrosoftExtensionsFileSystemGlobbing>
-      <NewtonsoftJson Include="$(PkgNewtonsoft_Json)\lib\netstandard2.0\*"></NewtonsoftJson>
       <NuGetFrameworks Include="$(PkgNuGet_Frameworks)\lib\netstandard2.0\*"></NuGetFrameworks>
       <MicrosoftInternalDia Include="$(PkgMicrosoft_Internal_Dia)\tools\netstandard\**\*"></MicrosoftInternalDia>
       <SystemComponentModelComposition Include="$(PkgSystem_ComponentModel_Composition)\lib\netstandard2.0\**\*"></SystemComponentModelComposition>
       <MicrosoftDiagnosticsNETCoreClient Include="$(PkgMicrosoft_Diagnostics_NETCore_Client)\lib\netstandard2.0\**\*"></MicrosoftDiagnosticsNETCoreClient>
-      <NETStandardLibrary Include="$(PkgNETStandard_Library)\build\netstandard2.0\ref\**\*"></NETStandardLibrary>
       <MicrosoftInternalDia Include="$(PkgMicrosoft_Internal_Dia)\tools\net451\**\*"></MicrosoftInternalDia>
     </ItemGroup>
 
     <Copy SourceFiles="@(MicrosoftCodeCoverageIO)" DestinationFiles="$(OutDir)\Microsoft.CodeCoverage.IO\%(RecursiveDir)%(Filename)%(Extension)" Condition=" '$(DotNetBuildFromSource)' != 'true' " />
     <Copy SourceFiles="@(MicrosoftExtensionsDependencyModel)" DestinationFiles="$(OutDir)\Microsoft.Extensions.DependencyModel\%(RecursiveDir)%(Filename)%(Extension)" />
     <Copy SourceFiles="@(MicrosoftExtensionsFileSystemGlobbing)" DestinationFiles="$(OutDir)\Microsoft.Extensions.FileSystemGlobbing\%(RecursiveDir)%(Filename)%(Extension)" />
-    <Copy SourceFiles="@(NewtonsoftJson)" DestinationFiles="$(OutDir)\Newtonsoft.Json\%(RecursiveDir)%(Filename)%(Extension)" />
     <Copy SourceFiles="@(NuGetFrameworks)" DestinationFiles="$(OutDir)\NuGet.Frameworks\%(RecursiveDir)%(Filename)%(Extension)" />
     <Copy SourceFiles="@(SystemComponentModelComposition)" DestinationFiles="$(OutDir)\%(RecursiveDir)%(Filename)%(Extension)" />
     <Copy SourceFiles="@(MicrosoftDiagnosticsNETCoreClient)" DestinationFiles="$(OutDir)\Microsoft.Diagnostics.NETCore.Client\%(RecursiveDir)%(Filename)%(Extension)" />
-    <Copy SourceFiles="@(NETStandardLibrary)" DestinationFiles="$(OutDir)\NETStandard.Library\%(RecursiveDir)%(Filename)%(Extension)" />
     <Copy SourceFiles="@(MicrosoftInternalDia)" DestinationFiles="$(OutDir)\Microsoft.Internal.Dia\%(RecursiveDir)%(Filename)%(Extension)" />
   </Target>
 

--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.csproj
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.csproj
@@ -75,6 +75,7 @@
     <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="$(MicrosoftDiagnosticsNETCoreClientVersion)" PrivateAssets="All" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Internal.Dia" Version="$(TestPlatformMSDiaVersion)" PrivateAssets="All" GeneratePathProperty="true" Condition="'$(TargetFramework)'=='net472'" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" GeneratePathProperty="true" Condition="'$(TargetFramework)' != 'net472'" />
   </ItemGroup>
 
   <Target Name="CopyFiles" AfterTargets="Build">
@@ -82,6 +83,7 @@
       <MicrosoftCodeCoverageIO Include="$(PkgMicrosoft_CodeCoverage_IO)\lib\netstandard2.0\**\*"></MicrosoftCodeCoverageIO>
       <MicrosoftExtensionsDependencyModel Include="$(PkgMicrosoft_Extensions_DependencyModel)\lib\netstandard2.0\*"></MicrosoftExtensionsDependencyModel>
       <MicrosoftExtensionsFileSystemGlobbing Include="$(PkgMicrosoft_Extensions_FileSystemGlobbing)\lib\netstandard2.0\*"></MicrosoftExtensionsFileSystemGlobbing>
+      <NewtonsoftJson Include="$(PkgNewtonsoft_Json)\lib\netstandard2.0\*"></NewtonsoftJson>
       <NuGetFrameworks Include="$(PkgNuGet_Frameworks)\lib\netstandard2.0\*"></NuGetFrameworks>
       <MicrosoftInternalDia Include="$(PkgMicrosoft_Internal_Dia)\tools\netstandard\**\*"></MicrosoftInternalDia>
       <SystemComponentModelComposition Include="$(PkgSystem_ComponentModel_Composition)\lib\netstandard2.0\**\*"></SystemComponentModelComposition>
@@ -92,6 +94,7 @@
     <Copy SourceFiles="@(MicrosoftCodeCoverageIO)" DestinationFiles="$(OutDir)\Microsoft.CodeCoverage.IO\%(RecursiveDir)%(Filename)%(Extension)" Condition=" '$(DotNetBuildFromSource)' != 'true' " />
     <Copy SourceFiles="@(MicrosoftExtensionsDependencyModel)" DestinationFiles="$(OutDir)\Microsoft.Extensions.DependencyModel\%(RecursiveDir)%(Filename)%(Extension)" />
     <Copy SourceFiles="@(MicrosoftExtensionsFileSystemGlobbing)" DestinationFiles="$(OutDir)\Microsoft.Extensions.FileSystemGlobbing\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Copy SourceFiles="@(NewtonsoftJson)" DestinationFiles="$(OutDir)\Newtonsoft.Json\%(RecursiveDir)%(Filename)%(Extension)" />
     <Copy SourceFiles="@(NuGetFrameworks)" DestinationFiles="$(OutDir)\NuGet.Frameworks\%(RecursiveDir)%(Filename)%(Extension)" />
     <Copy SourceFiles="@(SystemComponentModelComposition)" DestinationFiles="$(OutDir)\%(RecursiveDir)%(Filename)%(Extension)" />
     <Copy SourceFiles="@(MicrosoftDiagnosticsNETCoreClient)" DestinationFiles="$(OutDir)\Microsoft.Diagnostics.NETCore.Client\%(RecursiveDir)%(Filename)%(Extension)" />

--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.nuspec
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.nuspec
@@ -121,8 +121,8 @@
     <file src="net48\testhost.net48.arm64.exe"          target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
     <file src="net48\testhost.net48.arm64.exe.config"   target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
 
-    <file src="net472\Newtonsoft.Json\Newtonsoft.Json.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
-    <file src="net472\NuGet.Frameworks\NuGet.Frameworks.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
+    <file src="net462\Newtonsoft.Json.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
+    <file src="net462\NuGet.Frameworks.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
 
     <file src="net462\System*.dll" exclude="net462\System.Buffers.dll;net462\System.ComponentModel.Composition.dll;net462\System.Memory.dll;net462\System.Numerics.Vectors.dll;net462\System.Runtime.CompilerServices.Unsafe.dll;net462\System.Threading.Tasks.Extensions.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
     <file src="net462\netstandard.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />

--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.nuspec
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.nuspec
@@ -124,8 +124,9 @@
     <file src="net472\Newtonsoft.Json\Newtonsoft.Json.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
     <file src="net472\NuGet.Frameworks\NuGet.Frameworks.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
 
-    <file src="net472\NETStandard.Library\**\*.dll" exclude="**\mscorlib.dll;**\*.xml" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
-    <file src="net472\System*.dll" exclude="net472\System.ComponentModel.Composition.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
+    <file src="net462\System*.dll" exclude="net462\System.Buffers.dll;net462\System.ComponentModel.Composition.dll;net462\System.Memory.dll;net462\System.Numerics.Vectors.dll;net462\System.Runtime.CompilerServices.Unsafe.dll;net462\System.Threading.Tasks.Extensions.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
+    <file src="net462\netstandard.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
+    <file src="net462\Microsoft.Win32.Primitives.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
 
     <!-- Resources -->
     <file src="netcoreapp3.1\Microsoft.CodeCoverage.IO\cs\Microsoft.CodeCoverage.IO.resources.dll" target="contentFiles\any\netcoreapp3.1\cs" />


### PR DESCRIPTION
## Description

For `TestHostNetFramework` folder, embed dlls from the various net framework folders of the testhost projects rather than from netstandard library package.

## Related issue

Relates to [AB#1843962](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1843962)
Fix #4549 