### PR TITLE
Backport recent fixes

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,7 @@
         is trying to parse that version and will consider any version with more than 4 `.` in it as invalid. 
     -->
     <SemanticVersioningV1>true</SemanticVersioningV1>
-    <VersionPrefix>17.7.0</VersionPrefix>
+    <VersionPrefix>17.7.1</VersionPrefix>
     <PreReleaseVersionLabel>release</PreReleaseVersionLabel>
   </PropertyGroup>
   <PropertyGroup Label="Arcade settings">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -36,7 +36,6 @@
     <MicrosoftVisualStudioEnterpriseAspNetHelper>$(MicrosoftVisualStudioDiagnosticsUtilitiesVersion)</MicrosoftVisualStudioEnterpriseAspNetHelper>
     <MicrosoftVisualStudioInteropVersion>17.3.32622.426</MicrosoftVisualStudioInteropVersion>
     <MicrosoftVSSDKBuildToolsVersion>17.4.2116</MicrosoftVSSDKBuildToolsVersion>
-    <NETStandardLibraryVersion>2.0.3</NETStandardLibraryVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <RoslynBannedApiAnalyzersVersion>3.3.3</RoslynBannedApiAnalyzersVersion>
     <RoslynPublicApiAnalyzersVersion>3.3.4-beta1.21554.2</RoslynPublicApiAnalyzersVersion>

--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -18,7 +18,7 @@ function Verify-Nuget-Packages {
         "Microsoft.NET.Test.Sdk"                      = 16;
         "Microsoft.TestPlatform"                      = 608;
         "Microsoft.TestPlatform.Build"                = 21;
-        "Microsoft.TestPlatform.CLI"                  = 493;
+        "Microsoft.TestPlatform.CLI"                  = 472;
         "Microsoft.TestPlatform.Extensions.TrxLogger" = 35;
         "Microsoft.TestPlatform.ObjectModel"          = 93;
         "Microsoft.TestPlatform.AdapterUtilities"     = 34;
@@ -34,26 +34,26 @@ function Verify-Nuget-Packages {
     $pattern = "*.$versionPrefix*.nupkg"
     $nugetPackages = @(Get-ChildItem $packageDirectory -Filter $pattern -Recurse -File | Where-Object { $_.Name -notLike "*.symbols.nupkg"})
 
-    if (0 -eq $nugetPackages.Length) { 
+    if (0 -eq $nugetPackages.Length) {
         throw "No nuget packages matching $pattern were found in '$packageDirectory'."
     }
 
     $suffixes = @($nugetPackages -replace ".*?$([regex]::Escape($versionPrefix))(.*)\.nupkg", '$1' | Sort-Object -Unique)
-    if (1 -lt $suffixes.Length) { 
+    if (1 -lt $suffixes.Length) {
         Write-Host "There are two different suffixes matching the same version prefix: '$($suffixes -join "', '")'".
 
-        $latestNuget = $nugetPackages | 
-            Where-Object { $_.Name -like "Microsoft.TestPlatform.ObjectModel.*" } | 
-            Sort-Object -Property LastWriteTime -Descending | 
+        $latestNuget = $nugetPackages |
+            Where-Object { $_.Name -like "Microsoft.TestPlatform.ObjectModel.*" } |
+            Sort-Object -Property LastWriteTime -Descending |
             Select-Object -First 1
-        
+
         $suffix = $suffixes | Where { $latestNuget.Name.Contains("$versionPrefix$_.nupkg") }
         $version = "$versionPrefix$suffix"
         Write-Host "The most recently written Microsoft.TestPlatform.ObjectModel.* nuget, is $($latestNuget.Name), which has '$suffix' suffix. Selecting only packages with that suffix."
 
         $nugetPackages = $nugetPackages | Where-Object { $_.Name -like "*$version.nupkg" }
     }
-    else { 
+    else {
         $suffix = $suffixes[0]
         $version = "$versionPrefix$suffix"
     }

--- a/src/DataCollectors/DumpMinitool.arm64/DumpMinitool.arm64.csproj
+++ b/src/DataCollectors/DumpMinitool.arm64/DumpMinitool.arm64.csproj
@@ -10,6 +10,13 @@
     <RuntimeIdentifier Condition=" '$(DotNetBuildFromSource)' != 'true' ">win10-arm64</RuntimeIdentifier>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <!--
+      NETSDK1201: For projects targeting .NET 8.0 and higher, specifying a RuntimeIdentifier will no longer produce a
+      self contained app by default. To continue building self-contained apps, set the SelfContained property to true
+      or use the -\-self-contained argument.
+      -->
+    <MSBuildWarningsAsMessages>NETSDK1201</MSBuildWarningsAsMessages>
+    <NoWarn>$(NoWarn);NETSDK1201</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DataCollectors/DumpMinitool.x86/DumpMinitool.x86.csproj
+++ b/src/DataCollectors/DumpMinitool.x86/DumpMinitool.x86.csproj
@@ -10,6 +10,13 @@
     <RuntimeIdentifier Condition=" '$(DotNetBuildFromSource)' != 'true' ">win7-x86</RuntimeIdentifier>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <!--
+      NETSDK1201: For projects targeting .NET 8.0 and higher, specifying a RuntimeIdentifier will no longer produce a
+      self contained app by default. To continue building self-contained apps, set the SelfContained property to true
+      or use the -\-self-contained argument.
+      -->
+    <MSBuildWarningsAsMessages>NETSDK1201</MSBuildWarningsAsMessages>
+    <NoWarn>$(NoWarn);NETSDK1201</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DataCollectors/DumpMinitool/DumpMinitool.csproj
+++ b/src/DataCollectors/DumpMinitool/DumpMinitool.csproj
@@ -10,6 +10,13 @@
     <RuntimeIdentifier Condition=" '$(DotNetBuildFromSource)' != 'true' ">win7-x64</RuntimeIdentifier>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <!--
+      NETSDK1201: For projects targeting .NET 8.0 and higher, specifying a RuntimeIdentifier will no longer produce a
+      self contained app by default. To continue building self-contained apps, set the SelfContained property to true
+      or use the -\-self-contained argument.
+      -->
+    <MSBuildWarningsAsMessages>NETSDK1201</MSBuildWarningsAsMessages>
+    <NoWarn>$(NoWarn);NETSDK1201</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelOperationManager.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 
 namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client;
 
@@ -63,6 +64,8 @@ internal sealed class ParallelOperationManager<TManager, TEventHandler, TWorkloa
 
     private void ClearSlots(bool acceptMoreWork)
     {
+        EqtTrace.Verbose($"ParallelOperationManager.ClearSlots: Clearing all slots. Slots should accept more work: {acceptMoreWork}");
+
         lock (_lock)
         {
             _acceptMoreWork = acceptMoreWork;
@@ -76,6 +79,13 @@ internal sealed class ParallelOperationManager<TManager, TEventHandler, TWorkloa
     {
         AvailableSlotCount = _managerSlots.Count(s => !s.HasWork);
         OccupiedSlotCount = _managerSlots.Count - AvailableSlotCount;
+
+        if (EqtTrace.IsVerboseEnabled)
+        {
+            EqtTrace.Verbose($"ParallelOperationManager.SetOccupiedSlotCount: Setting slot counts AvailableSlotCount = {AvailableSlotCount}, OccupiedSlotCount = {OccupiedSlotCount}.");
+            EqtTrace.Verbose($"Occupied slots:\n{(string.Join("\n", _managerSlots.Where(s => s.HasWork).Select((slot) => $"{slot.Index}: {GetSourcesForSlotExpensive(slot)}").ToArray()))}");
+
+        }
     }
 
     public void StartWork(
@@ -91,6 +101,7 @@ internal sealed class ParallelOperationManager<TManager, TEventHandler, TWorkloa
         _initializeWorkload = initializeWorkload ?? throw new ArgumentNullException(nameof(initializeWorkload));
         _runWorkload = runWorkload ?? throw new ArgumentNullException(nameof(runWorkload));
 
+        EqtTrace.Verbose($"ParallelOperationManager.StartWork: Starting adding {workloads.Count} workloads.");
         _workloads.AddRange(workloads);
 
         ClearSlots(acceptMoreWork: true);
@@ -123,7 +134,10 @@ internal sealed class ParallelOperationManager<TManager, TEventHandler, TWorkloa
             // so when it is allowed to enter it will try to add more work, but we already cancelled,
             // so we should not start more work.
             if (!_acceptMoreWork)
+            {
+                EqtTrace.Verbose($"ParallelOperationManager.RunWorkInParallel: We don't accept more work, returning false.");
                 return false;
+            }
 
             // We grab all empty slots.
             var availableSlots = _managerSlots.Where(slot => !slot.HasWork).ToImmutableArray();
@@ -136,11 +150,10 @@ internal sealed class ParallelOperationManager<TManager, TEventHandler, TWorkloa
             var workloadsToAdd = availableWorkloads.Take(amount).ToImmutableArray();
 
             // We associate each workload to a slot, if we reached the max parallel
-            // level, then we will run only initalize step of the given workload.
+            // level, then we will run only initialize step of the given workload.
             for (int i = 0; i < amount; i++)
             {
                 var slot = availableSlots[i];
-                slot.HasWork = true;
                 var workload = workloadsToAdd[i];
                 slot.ShouldPreStart = occupiedSlots + i + 1 > MaxParallelLevel;
 
@@ -152,6 +165,13 @@ internal sealed class ParallelOperationManager<TManager, TEventHandler, TWorkloa
                 slot.Work = workload.Work;
 
                 _workloads.Remove(workload);
+
+                EqtTrace.Verbose($"ParallelOperationManager.RunWorkInParallel: Adding 1 workload to slot, remaining workloads {_workloads.Count}.");
+
+                // This must be set last, every loop below looks at this property,
+                // and they can do so from a different thread. So if we mark it as HasWork before actually assigning the work
+                // we can pick up the slot, but it has no associated work yet.
+                slot.HasWork = true;
             }
 
             slots = _managerSlots.ToArray();
@@ -172,12 +192,16 @@ internal sealed class ParallelOperationManager<TManager, TEventHandler, TWorkloa
         {
             startedWork++;
             slot.IsRunning = true;
-            EqtTrace.Verbose($"ParallelOperationManager.RunWorkInParallel: Running on pre-started host: {(DateTime.Now.TimeOfDay - slot.PreStartTime).TotalMilliseconds}ms {slot.InitTask?.Status}");
+            if (EqtTrace.IsVerboseEnabled)
+            {
+                EqtTrace.Verbose($"ParallelOperationManager.RunWorkInParallel: Running on pre-started host for work (source) {GetSourcesForSlotExpensive(slot)}: {(DateTime.Now.TimeOfDay - slot.PreStartTime).TotalMilliseconds}ms {slot.InitTask?.Status}");
+            }
             _runWorkload(slot.Manager!, slot.EventHandler!, slot.Work!, slot.IsPreStarted, slot.InitTask);
 
             // We already started as many as we were allowed, jump out;
             if (startedWork == MaxParallelLevel)
             {
+                EqtTrace.Verbose($"ParallelOperationManager.RunWorkInParallel: We started {startedWork} work items, which is the max parallel level. Won't start more work.");
                 break;
             }
         }
@@ -194,7 +218,10 @@ internal sealed class ParallelOperationManager<TManager, TEventHandler, TWorkloa
                     {
                         startedWork++;
                         slot.IsRunning = true;
-                        EqtTrace.Verbose("ParallelOperationManager.RunWorkInParallel: Started work on a host.");
+                        if (EqtTrace.IsVerboseEnabled)
+                        {
+                            EqtTrace.Verbose($"ParallelOperationManager.RunWorkInParallel: Started host in slot number {slot.Index} for work (source): {GetSourcesForSlotExpensive(slot)}.");
+                        }
                         _runWorkload(slot.Manager!, slot.EventHandler!, slot.Work!, slot.IsPreStarted, slot.InitTask);
                     }
                 }
@@ -202,6 +229,7 @@ internal sealed class ParallelOperationManager<TManager, TEventHandler, TWorkloa
                 // We already started as many as we were allowed, jump out;
                 if (startedWork == MaxParallelLevel)
                 {
+                    EqtTrace.Verbose($"ParallelOperationManager.RunWorkInParallel: We started {startedWork} work items, which is the max parallel level. Won't start more work.");
                     break;
                 }
             }
@@ -215,14 +243,19 @@ internal sealed class ParallelOperationManager<TManager, TEventHandler, TWorkloa
                 preStartedWork++;
                 slot.PreStartTime = DateTime.Now.TimeOfDay;
                 slot.IsPreStarted = true;
-                EqtTrace.Verbose("ParallelOperationManager.RunWorkInParallel: Pre-starting a host.");
+                if (EqtTrace.IsVerboseEnabled)
+                {
+                    EqtTrace.Verbose($"ParallelOperationManager.RunWorkInParallel: Pre-starting a host for work (source): {GetSourcesForSlotExpensive(slot)}.");
+                }
                 slot.InitTask = _initializeWorkload!(slot.Manager!, slot.EventHandler!, slot.Work!);
             }
         }
 
         // Return true when we started more work. Or false, when there was nothing more to do.
         // This will propagate to handling of partial discovery or partial run.
-        return preStartedWork + startedWork > 0;
+        var weAddedMoreWork = preStartedWork + startedWork > 0;
+        EqtTrace.Verbose($"ParallelOperationManager.RunWorkInParallel: We started {preStartedWork + startedWork} work items in here, returning {weAddedMoreWork}.");
+        return weAddedMoreWork;
     }
 
     public bool RunNextWork(TManager completedManager)
@@ -258,6 +291,10 @@ internal sealed class ParallelOperationManager<TManager, TEventHandler, TWorkloa
                 throw new InvalidOperationException("The provided manager was found in multiple slots.");
             }
 
+            if (EqtTrace.IsVerboseEnabled)
+            {
+                EqtTrace.Verbose($"ParallelOperationManager.ClearCompletedSlot: Clearing slot number {completedSlot[0].Index} with work (source): {GetSourcesForSlotExpensive(completedSlot[0])}.");
+            }
             var slot = completedSlot[0];
             slot.PreStartTime = TimeSpan.Zero;
             slot.Work = default(TWorkload);
@@ -273,8 +310,14 @@ internal sealed class ParallelOperationManager<TManager, TEventHandler, TWorkloa
         }
     }
 
+    private static string GetSourcesForSlotExpensive(ParallelOperationManager<TManager, TEventHandler, TWorkload>.Slot slot)
+    {
+        return string.Join(", ", (slot.Work as DiscoveryCriteria)?.Sources ?? (slot.Work as TestRunCriteria)?.Sources ?? Array.Empty<string>());
+    }
+
     public void DoActionOnAllManagers(Action<TManager> action, bool doActionsInParallel = false)
     {
+        EqtTrace.Verbose($"ParallelOperationManager.DoActionOnAllManagers: Calling an action on all managers.");
         // We don't need to lock here, we just grab the current list of
         // slots that are occupied (have managers) and run action on each one of them.
         var managers = _managerSlots.Where(slot => slot.HasWork).Select(slot => slot.Manager).ToImmutableArray();
@@ -320,11 +363,13 @@ internal sealed class ParallelOperationManager<TManager, TEventHandler, TWorkloa
 
     internal void StopAllManagers()
     {
+        EqtTrace.Verbose($"ParallelOperationManager.StopAllManagers: Stopping all managers.");
         ClearSlots(acceptMoreWork: false);
     }
 
     public void Dispose()
     {
+        EqtTrace.Verbose($"ParallelOperationManager.Dispose: Disposing all managers.");
         ClearSlots(acceptMoreWork: false);
     }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyDiscoveryManager.cs
@@ -287,6 +287,12 @@ internal sealed class ParallelProxyDiscoveryManager : IParallelProxyDiscoveryMan
         bool initialized,
         Task? task)
     {
+        // If we do the scheduling incorrectly this will get null. It should not happen, but it has happened before.
+        if (discoveryCriteria == null)
+        {
+            throw new ArgumentNullException(nameof(discoveryCriteria));
+        }
+
         // Kick off another discovery task for the next source
         Task.Run(() =>
             {

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelRunEventsHandler.cs
@@ -66,10 +66,12 @@ internal class ParallelRunEventsHandler : IInternalTestRunEventsHandler
         ICollection<AttachmentSet>? runContextAttachments,
         ICollection<string>? executorUris)
     {
+        EqtTrace.Verbose($"ParallelRunEventsHandler.HandleTestRunComplete: Handling a run completion, this can be either one part of parallel run completing, or the whole parallel run completing.");
         var parallelRunComplete = HandleSingleTestRunComplete(testRunCompleteArgs, lastChunkArgs, runContextAttachments, executorUris);
 
         if (parallelRunComplete)
         {
+            EqtTrace.Verbose($"ParallelRunEventsHandler.HandleTestRunComplete: Whole parallel run completed.");
             var completedArgs = new TestRunCompleteEventArgs(_runDataAggregator.GetAggregatedRunStats(),
                 _runDataAggregator.IsCanceled,
                 _runDataAggregator.IsAborted,
@@ -95,6 +97,10 @@ internal class ParallelRunEventsHandler : IInternalTestRunEventsHandler
             completedArgs.Metrics = aggregatedRunDataMetrics;
 
             HandleParallelTestRunComplete(completedArgs);
+        }
+        else
+        {
+            EqtTrace.Verbose($"ParallelRunEventsHandler.HandleTestRunComplete: Single part of parallel run completed, but whole run is not complete yet.");
         }
     }
 

--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.csproj
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.csproj
@@ -72,11 +72,10 @@
     <PackageReference Include="Microsoft.CodeCoverage.IO" Version="$(MicrosoftCodeCoverageIOVersion)" GeneratePathProperty="true" Condition=" '$(DotNetBuildFromSource)' != 'true' " />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(MicrosoftExtensionsFileSystemGlobbingVersion)" GeneratePathProperty="true" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" GeneratePathProperty="true" />
     <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="$(MicrosoftDiagnosticsNETCoreClientVersion)" PrivateAssets="All" GeneratePathProperty="true" />
-    <PackageReference Include="NETStandard.Library" Version="$(NETStandardLibraryVersion)" PrivateAssets="All" GeneratePathProperty="true" Condition="'$(TargetFramework)'=='net472'" />
     <PackageReference Include="Microsoft.Internal.Dia" Version="$(TestPlatformMSDiaVersion)" PrivateAssets="All" GeneratePathProperty="true" Condition="'$(TargetFramework)'=='net472'" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" GeneratePathProperty="true" Condition="'$(TargetFramework)' != 'net472'" />
   </ItemGroup>
 
   <Target Name="CopyFiles" AfterTargets="Build">
@@ -89,7 +88,6 @@
       <MicrosoftInternalDia Include="$(PkgMicrosoft_Internal_Dia)\tools\netstandard\**\*"></MicrosoftInternalDia>
       <SystemComponentModelComposition Include="$(PkgSystem_ComponentModel_Composition)\lib\netstandard2.0\**\*"></SystemComponentModelComposition>
       <MicrosoftDiagnosticsNETCoreClient Include="$(PkgMicrosoft_Diagnostics_NETCore_Client)\lib\netstandard2.0\**\*"></MicrosoftDiagnosticsNETCoreClient>
-      <NETStandardLibrary Include="$(PkgNETStandard_Library)\build\netstandard2.0\ref\**\*"></NETStandardLibrary>
       <MicrosoftInternalDia Include="$(PkgMicrosoft_Internal_Dia)\tools\net451\**\*"></MicrosoftInternalDia>
     </ItemGroup>
 
@@ -100,7 +98,6 @@
     <Copy SourceFiles="@(NuGetFrameworks)" DestinationFiles="$(OutDir)\NuGet.Frameworks\%(RecursiveDir)%(Filename)%(Extension)" />
     <Copy SourceFiles="@(SystemComponentModelComposition)" DestinationFiles="$(OutDir)\%(RecursiveDir)%(Filename)%(Extension)" />
     <Copy SourceFiles="@(MicrosoftDiagnosticsNETCoreClient)" DestinationFiles="$(OutDir)\Microsoft.Diagnostics.NETCore.Client\%(RecursiveDir)%(Filename)%(Extension)" />
-    <Copy SourceFiles="@(NETStandardLibrary)" DestinationFiles="$(OutDir)\NETStandard.Library\%(RecursiveDir)%(Filename)%(Extension)" />
     <Copy SourceFiles="@(MicrosoftInternalDia)" DestinationFiles="$(OutDir)\Microsoft.Internal.Dia\%(RecursiveDir)%(Filename)%(Extension)" />
   </Target>
 

--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.nuspec
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.nuspec
@@ -121,11 +121,12 @@
     <file src="net48\testhost.net48.arm64.exe"          target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
     <file src="net48\testhost.net48.arm64.exe.config"   target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
 
-    <file src="net472\Newtonsoft.Json\Newtonsoft.Json.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
-    <file src="net472\NuGet.Frameworks\NuGet.Frameworks.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
+    <file src="net462\Newtonsoft.Json.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
+    <file src="net462\NuGet.Frameworks.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
 
-    <file src="net472\NETStandard.Library\**\*.dll" exclude="**\mscorlib.dll;**\*.xml" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
-    <file src="net472\System*.dll" exclude="net472\System.ComponentModel.Composition.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
+    <file src="net462\System*.dll" exclude="net462\System.Buffers.dll;net462\System.ComponentModel.Composition.dll;net462\System.Memory.dll;net462\System.Numerics.Vectors.dll;net462\System.Runtime.CompilerServices.Unsafe.dll;net462\System.Threading.Tasks.Extensions.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
+    <file src="net462\netstandard.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
+    <file src="net462\Microsoft.Win32.Primitives.dll" target="contentFiles\any\netcoreapp3.1\TestHostNetFramework" />
 
     <!-- Resources -->
     <file src="netcoreapp3.1\Microsoft.CodeCoverage.IO\cs\Microsoft.CodeCoverage.IO.resources.dll" target="contentFiles\any\netcoreapp3.1\cs" />


### PR DESCRIPTION
Backporting recent simple fixes to have then in 7.0.4xx SDK

- Take System dlls from testhost folder (#4610) to fix running .NET Framework dlls on mono and under VS on Mac
- [Fix timing issue in parallel execution (#4629)
