### PR TITLE
Update RunSettingsArguments.md

### DIFF
--- a/docs/RunSettingsArguments.md
+++ b/docs/RunSettingsArguments.md
@@ -52,8 +52,11 @@ Starting from .NET SDK 5.0 you can also set `TestRunParameters` using command li
 # cmd
 dotnet test  -- TestRunParameters.Parameter(name=\"myParam\", value=\"value\")
 
-# powershell
-dotnet test --%  -- TestRunParameters.Parameter(name=\"myParam\", value=\"value\") 
+# powershell (prior 7.3, or with $PSNativeCommandArgumentPassing = "legacy")
+dotnet test --%  -- TestRunParameters.Parameter(name=\"myParam\", value=\"value\")
+
+# powershell (7.3+)
+dotnet test --%  -- TestRunParameters.Parameter(name="myParam", value="value") 
 
 # bash
 dotnet test -- TestRunParameters.Parameter\(name=\"myParam\",\ value=\"value\"\) 


### PR DESCRIPTION
Fix syntax for PowerShell 7.3 where they changed how native command arguments are parsed.

Fix #4637

