### PR TITLE
Document default value for diag trace level

### DIFF
--- a/docs/diagnose.md
+++ b/docs/diagnose.md
@@ -23,7 +23,7 @@ Trace level can be changed using below command line:
 > vstest.console testApp.dll --diag:log.txt;tracelevel=verbose
 ```
 
-Allowed values for tracelevel are: off, error, warning, info and verbose.
+Allowed values for tracelevel are: off, error, warning, info and verbose. The default value is verbose.
 
 ### Dotnet test
 


### PR DESCRIPTION
## Description
Document the default value `verbose` for the diag trace level.

See
https://github.com/microsoft/vstest/blob/2b7cec63e21713235d60bca3a1f773f74cae0f3b/src/vstest.console/Processors/EnableDiagArgumentProcessor.cs#L189-L195

## Related issue
No issue, just a documentation update.

- [ ] I have ensured that there is a previously discussed and approved issue.
