### PR TITLE
Set console encoding to UTF8

### DIFF
--- a/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
@@ -57,6 +57,9 @@ internal partial class FeatureFlag : IFeatureFlag
     // Disable the SerialTestRunDecorator
     public const string DISABLE_SERIALTESTRUN_DECORATOR = VSTEST_ + nameof(DISABLE_SERIALTESTRUN_DECORATOR);
 
+    // Disable setting UTF8 encoding in console.
+    public const string DISABlE_UTF8_CONSOLE_ENCODING = VSTEST_ + nameof(DISABlE_UTF8_CONSOLE_ENCODING);
+
     [Obsolete("Only use this in tests.")]
     internal static void Reset()
     {

--- a/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
@@ -58,7 +58,7 @@ internal partial class FeatureFlag : IFeatureFlag
     public const string DISABLE_SERIALTESTRUN_DECORATOR = VSTEST_ + nameof(DISABLE_SERIALTESTRUN_DECORATOR);
 
     // Disable setting UTF8 encoding in console.
-    public const string DISABlE_UTF8_CONSOLE_ENCODING = VSTEST_ + nameof(DISABlE_UTF8_CONSOLE_ENCODING);
+    public const string DISABLE_UTF8_CONSOLE_ENCODING = VSTEST_ + nameof(DISABLE_UTF8_CONSOLE_ENCODING);
 
     [Obsolete("Only use this in tests.")]
     internal static void Reset()

--- a/src/vstest.console/Program.cs
+++ b/src/vstest.console/Program.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+using System;
+
 using Microsoft.VisualStudio.TestPlatform.Execution;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
 
@@ -20,6 +23,10 @@ public static class Program
 
     internal static int Run(string[]? args, UiLanguageOverride uiLanguageOverride)
     {
+        if (!FeatureFlag.Instance.IsSet(FeatureFlag.DISABlE_UTF8_CONSOLE_ENCODING))
+        {
+            Console.OutputEncoding = Encoding.UTF8;
+        }
         uiLanguageOverride.SetCultureSpecifiedByUser();
         return new Executor(ConsoleOutput.Instance).Execute(args);
     }

--- a/src/vstest.console/Program.cs
+++ b/src/vstest.console/Program.cs
@@ -23,7 +23,7 @@ public static class Program
 
     internal static int Run(string[]? args, UiLanguageOverride uiLanguageOverride)
     {
-        if (!FeatureFlag.Instance.IsSet(FeatureFlag.DISABlE_UTF8_CONSOLE_ENCODING))
+        if (!FeatureFlag.Instance.IsSet(FeatureFlag.DISABLE_UTF8_CONSOLE_ENCODING))
         {
             Console.OutputEncoding = Encoding.UTF8;
         }


### PR DESCRIPTION
Set console encoding to UTF8. 

Fix #4605