### PR TITLE
Fix executable bitness for testhost.x86

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,6 +91,8 @@ variables:
     - name: VisualStudioDropName
       value: Products/$(System.TeamProject)/$(Build.DefinitionName)/$(Build.SourceBranchName)/$(Build.BuildNumber)
     - name: _InternalBuildArgs
+      # IncludeSourceRevisionInInformationalVersion prevents ProductVersion (on file), and AssemblyInformationalVersion
+      # from appending +<commitId>, which breaks DTAAgent.
       value: /p:DotNetSignType=$(_SignType)
         /p:TeamName=$(_TeamName)
         /p:DotNetFinalVersionKind=$(_ReleaseVersionKind)
@@ -100,6 +102,7 @@ variables:
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
         /p:VisualStudioDropName=$(VisualStudioDropName)
         /p:GenerateSbom=true
+        /p:IncludeSourceRevisionInInformationalVersion=false
 
 stages:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,9 +156,11 @@ stages:
           displayName: Build
 
         # -ci is allowing to import some environment variables and some required configurations
+        # -nobl avoid overwriting binlog of the main Build
         - script: Test.cmd
             -configuration $(_BuildConfig)
             -ci
+            -nobl
             -integrationTest
             -performanceTest
           name: Test

--- a/eng/verify-nupkgs-exe-version.ps1
+++ b/eng/verify-nupkgs-exe-version.ps1
@@ -1,0 +1,8 @@
+Get-ChildItem  S:\p\vstest3\artifacts\packages\Debug\Shipping -Filter vstest.console.exe -Recurse -Force | ForEach-Object {
+    if ($_.VersionInfo.ProductVersion.Contains("+")) {
+        throw "Some files contain '+' in the ProductVersion, this breaks DTAAgent in AzDO."
+    }
+    else {
+        "$_ version $($_.VersionInfo.ProductVersion) is ok."
+    }
+} 

--- a/eng/verify-nupkgs-exe.ps1
+++ b/eng/verify-nupkgs-exe.ps1
@@ -1,0 +1,90 @@
+$exclusions = @{
+    "CodeCoverage\CodeCoverage.exe"                = "x86"
+    "Dynamic Code Coverage Tools\CodeCoverage.exe" = "x86"
+    "amd64\CodeCoverage.exe"                       = "x64"
+
+    "IntelliTrace.exe"                             = "x86"
+    "ProcessSnapshotCleanup.exe"                   = "x86-64"
+    "TDEnvCleanup.exe"                             = "x86"
+
+    "TestPlatform\SettingsMigrator.exe"            = "x86"
+
+    "dump\DumpMinitool.exe"                        = "x86-64"
+
+    "QTAgent32.exe"                                = "x86"
+    "QTAgent32_35.exe"                             = "x86"
+    "QTAgent32_40.exe"                             = "x86"
+    "QTDCAgent32.exe"                              = "x86"
+
+    "V1\VSTestVideoRecorder.exe"                   = "x86"
+    "VideoRecorder\VSTestVideoRecorder.exe"        = "x86"
+}
+
+$errs = @()
+Get-ChildItem  S:\p\vstest3\artifacts\packages\Debug\Shipping -Filter *.exe -Recurse -Force | ForEach-Object {
+    $m = & "C:\Program Files\Microsoft Visual Studio\2022\IntPreview\VC\Tools\MSVC\14.38.32919\bin\HostX86\x86\dumpbin.exe" /headers $_.FullName | Select-String "machine \((.*)\)"
+    if (-not $m.Matches.Success) {
+        $err = "Did not find the platform of the exe $fullName)."
+    }
+
+    $platform = $m.Matches.Groups[1].Value
+    $fullName = $_.FullName
+    $name = $_.Name
+
+    if ("x86" -eq $platform) { 
+        $corFlags = "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\CorFlags.exe"
+        $corFlagsOutput = & $corFlags $fullName
+        # this is an native x86 exe or a .net x86 that requires of prefers 32bit
+        $platform = if ($corFlagsOutput -like "*does not have a valid managed header*" -or $corFlagsOutput -like "*32BITREQ  : 1*" -or $corFlagsOutput -like "*32BITPREF : 1*") {
+            # this is an native x86 exe or a .net x86 that requires of prefers 32bit
+            "x86" } else {
+            # this is a x86 executable that is built as AnyCpu and does not prefer 32-bit so it will run as x64 on 64-bit system.
+            "x86-64" }
+    }
+
+    if (($pair = $exclusions.GetEnumerator() | Where-Object { $fullName -like "*$($_.Name)" })) {
+        if (1 -lt $($pair).Count) {
+            $err = "Too many paths matched the query, only one match is allowed. Matches: $($pair.Name)"
+            $errs += $err
+            Write-Host -ForegroundColor Red Error: $err
+        }
+
+        if ($platform -ne $pair.Value) {
+            $err = "$fullName must have architecture $($pair.Value), but it was $platform."
+            $errs += $err
+            Write-Host -ForegroundColor Red Error: $err
+        }
+    }
+    elseif ("x86" -eq $platform) {
+        if ($name -notlike "*x86*") {
+            $err = "$fullName has architecture $platform, and must contain x86 in the name of the executable."
+            $errs += $err
+            Write-Host -ForegroundColor Red Error: $err
+        }
+    }
+    elseif ($platform -in  "x64", "x86-64") {
+        if ($name -like "*x86*" -or $name -like "*arm64*") {
+            $err = "$fullName has architecture $platform, and must NOT contain x86 or arm64 in the name of the executable."
+            $errs += $err
+            Write-Host -ForegroundColor Red Error: $err
+        }
+    }
+    elseif ("arm64" -eq $platform) {
+        if ($name -notlike "*arm64*") {
+            $err = "$fullName has architecture $platform, and must contain arm64 in the name of the executable."
+            $errs += $err
+            Write-Host -ForegroundColor Red Error: $err
+        }
+    }
+    else {
+        $err = "$fullName has unknown architecture $platform."
+        $errs += $err
+        Write-Host -ForegroundColor Red $err
+    }
+
+    "Success: $name is $platform - $fullName"
+}
+
+if ($errs) { 
+    throw "Fail!:`n$($errs -join "`n")"
+}

--- a/src/DataCollectors/DumpMinitool.arm64/DumpMinitool.arm64.csproj
+++ b/src/DataCollectors/DumpMinitool.arm64/DumpMinitool.arm64.csproj
@@ -3,11 +3,13 @@
 
   <PropertyGroup>
     <TargetFrameworks>net7.0;net6.0;$(NetFrameworkMinimum)</TargetFrameworks>
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <Prefer32Bit Condition="'$(TargetFramework)' == '$(NetFrameworkMinimum)'">false</Prefer32Bit>
     <OutputType>Exe</OutputType>
     <IsTestProject>false</IsTestProject>
     <RuntimeIdentifier Condition=" '$(DotNetBuildFromSource)' != 'true' ">win10-arm64</RuntimeIdentifier>
+    <!-- Setting both RuntimeIdentifier and PlatformTarget ends up building as AnyCPU and selecting the default x86 architecture, irregardles of RuntimeIdentifier,
+    so order here matters. -->
+    <PlatformTarget Condition=" '$(RuntimeIdentifier)' == '' ">AnyCPU</PlatformTarget>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <!--

--- a/src/DataCollectors/DumpMinitool.arm64/DumpMinitool.arm64.csproj
+++ b/src/DataCollectors/DumpMinitool.arm64/DumpMinitool.arm64.csproj
@@ -7,7 +7,7 @@
     <OutputType>Exe</OutputType>
     <IsTestProject>false</IsTestProject>
     <RuntimeIdentifier Condition=" '$(DotNetBuildFromSource)' != 'true' ">win10-arm64</RuntimeIdentifier>
-    <!-- Setting both RuntimeIdentifier and PlatformTarget ends up building as AnyCPU and selecting the default x86 architecture, irregardles of RuntimeIdentifier,
+    <!-- Setting both RuntimeIdentifier and PlatformTarget ends up building as AnyCPU and selecting the default x86 architecture, irregardless of RuntimeIdentifier,
     so order here matters. -->
     <PlatformTarget Condition=" '$(RuntimeIdentifier)' == '' ">AnyCPU</PlatformTarget>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>

--- a/src/testhost.x86/testhost.x86.csproj
+++ b/src/testhost.x86/testhost.x86.csproj
@@ -17,6 +17,13 @@
     <OutputType>Exe</OutputType>
     <IsTestProject>false</IsTestProject>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <!--
+    NETSDK1201: For projects targeting .NET 8.0 and higher, specifying a RuntimeIdentifier will no longer produce a
+    self contained app by default. To continue building self-contained apps, set the SelfContained property to true
+    or use the -\-self-contained argument.
+    -->
+    <MSBuildWarningsAsMessages>NETSDK1201</MSBuildWarningsAsMessages>
+    <NoWarn>$(NoWarn);NETSDK1201</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>

--- a/src/testhost.x86/testhost.x86.csproj
+++ b/src/testhost.x86/testhost.x86.csproj
@@ -13,7 +13,7 @@
     <TargetFrameworks>net7.0;$(NetCoreAppMinimum);$(NetFrameworkMinimum);net47;net471;net472;net48</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <RuntimeIdentifier Condition="'$(DotNetBuildFromSource)' != 'true'">win7-x86</RuntimeIdentifier>
-    <Prefer32Bit>true</Prefer32Bit>
+    <Prefer32Bit Condition=" $(TargetFramework.StartsWith('net4')) ">true</Prefer32Bit>
     <OutputType>Exe</OutputType>
     <IsTestProject>false</IsTestProject>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/testhost.x86/testhost.x86.csproj
+++ b/src/testhost.x86/testhost.x86.csproj
@@ -12,13 +12,13 @@
     <AssemblyName>testhost.x86</AssemblyName>
     <TargetFrameworks>net7.0;$(NetCoreAppMinimum);$(NetFrameworkMinimum);net47;net471;net472;net48</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <Prefer32Bit Condition=" $(TargetFramework.StartsWith('net4')) ">true</Prefer32Bit>
+    <RuntimeIdentifier Condition="'$(DotNetBuildFromSource)' != 'true'">win7-x86</RuntimeIdentifier>
+    <Prefer32Bit>true</Prefer32Bit>
     <OutputType>Exe</OutputType>
     <IsTestProject>false</IsTestProject>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
-    <RuntimeIdentifier Condition="'$(DotNetBuildFromSource)' != 'true'">win7-x86</RuntimeIdentifier>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <TargetName Condition="'$(TargetFramework)' != '$(NetFrameworkMinimum)'">$(AssemblyName.Replace('.x86', '')).$(TargetFramework).x86</TargetName>
   </PropertyGroup>

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Build.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Build.cs
@@ -42,6 +42,7 @@ public class Build : IntegrationTestBase
 #pragma warning disable RS0030 // Do not used banned APIs
         Environment.SetEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0");
         Environment.SetEnvironmentVariable("DOTNET_ROOT", DotnetDir);
+        Environment.SetEnvironmentVariable("DOTNET_ROOT(x86)", Path.Combine(DotnetDir, "dotnet-sdk-x86"));
         Environment.SetEnvironmentVariable("PATH", $"{DotnetDir};{Environment.GetEnvironmentVariable("PATH")}");
 #pragma warning restore RS0030 // Do not used banned APIs
     }


### PR DESCRIPTION
Fixes those issues in 17.8.0 but we need to backport and release 17.7.1:

Related #4650
Related [AB#1866640](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1866640)'
Related #4645 


Remove + from the final version.
Fix the bitness of our executables. Will plug that script later into build, IDK if both those tools are on hosted images, and on everyones computers.
