### PR TITLE
Fix IDE0090 warning

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcessCodeMethods.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcessCodeMethods.cs
@@ -68,7 +68,7 @@ internal static class ProcessCodeMethods
         var limit = 10;
         ResolveChildren(process, acc, level, limit);
 
-        return new List<ProcessTreeNode> { new ProcessTreeNode { Process = process, Level = 0 } }.Concat(acc.Where(a => a.Level > 0)).ToList();
+        return new List<ProcessTreeNode> { new() { Process = process, Level = 0 } }.Concat(acc.Where(a => a.Level > 0)).ToList();
     }
 
     /// <summary>


### PR DESCRIPTION
When building the repo with a recent build of the .NET 8 RC2 SDK, it produces the following warning (treated as an error):

```
/vmr/src/vstest/artifacts/source-build/self/src/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcessCodeMethods.cs(71,48): error IDE0090: 'new' expression can be simplified (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090) [/vmr/src/vstest/artifacts/source-build/self/src/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Microsoft.TestPlatform.Extensions.BlameDataCollector.csproj::TargetFramework=net8.0]
```

Fixed the code to remove the explicit type usage.