### PR TITLE
Fix SB ref assembly issue for System.ComponentModel.Composition

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -3,7 +3,17 @@
 
 <UsageData>
   <IgnorePatterns>
+    <!-- Caused by dependency on System.ComponentModel.Composition.4.5.0. This version is overridden in full source-build. -->
+    <UsagePattern IdentityGlob="Microsoft.NETCore.Platforms/2.0.0" />
     <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
     <UsagePattern IdentityGlob="NuGet.Frameworks/6.5.0" />
+    <!-- This version is overridden in full source-build. -->
+    <UsagePattern IdentityGlob="System.ComponentModel.Composition/4.5.0" />
+    <!-- Caused by dependency on System.ComponentModel.Composition.4.5.0. This version is overridden in full source-build. -->
+    <UsagePattern IdentityGlob="System.Security.AccessControl/4.5.0" />
+    <!-- Caused by dependency on System.ComponentModel.Composition.4.5.0. This version is overridden in full source-build. -->
+    <UsagePattern IdentityGlob="System.Security.Permissions/4.5.0" />
+    <!-- Caused by dependency on System.ComponentModel.Composition.4.5.0. This version is overridden in full source-build. -->
+    <UsagePattern IdentityGlob="System.Security.Principal.Windows/4.5.0" />
   </IgnorePatterns>
 </UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -28,6 +28,11 @@
       <Uri>https://github.com/nuget/nuget.client</Uri>
       <Sha>4ba7bfa82f894ec32a554ca8d2df143675c85735</Sha>
     </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
+    <Dependency Name="System.ComponentModel.Composition" Version="4.5.0">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>30ab651fcb4354552bd4891619a0bdd81e0ebdbf</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23364.2">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -29,9 +29,9 @@
       <Sha>4ba7bfa82f894ec32a554ca8d2df143675c85735</Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.ComponentModel.Composition" Version="7.0.0">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
+    <Dependency Name="System.ComponentModel.Composition" Version="4.5.0">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>30ab651fcb4354552bd4891619a0bdd81e0ebdbf</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -29,9 +29,9 @@
       <Sha>4ba7bfa82f894ec32a554ca8d2df143675c85735</Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.ComponentModel.Composition" Version="4.5.0">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>30ab651fcb4354552bd4891619a0bdd81e0ebdbf</Sha>
+    <Dependency Name="System.ComponentModel.Composition" Version="7.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -42,7 +42,7 @@
     <RoslynBannedApiAnalyzersVersion>3.3.3</RoslynBannedApiAnalyzersVersion>
     <RoslynPublicApiAnalyzersVersion>3.3.4-beta1.21554.2</RoslynPublicApiAnalyzersVersion>
     <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>
-    <SystemComponentModelCompositionVersion>7.0.0</SystemComponentModelCompositionVersion>
+    <SystemComponentModelCompositionVersion>4.5.0</SystemComponentModelCompositionVersion>
     <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
     <SystemNetHttpVersion>4.3.4</SystemNetHttpVersion>
     <SystemReflectionMetadataVersion>1.6.0</SystemReflectionMetadataVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -42,7 +42,7 @@
     <RoslynBannedApiAnalyzersVersion>3.3.3</RoslynBannedApiAnalyzersVersion>
     <RoslynPublicApiAnalyzersVersion>3.3.4-beta1.21554.2</RoslynPublicApiAnalyzersVersion>
     <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>
-    <SystemComponentModelCompositionVersion>4.5.0</SystemComponentModelCompositionVersion>
+    <SystemComponentModelCompositionVersion>7.0.0</SystemComponentModelCompositionVersion>
     <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
     <SystemNetHttpVersion>4.3.4</SystemNetHttpVersion>
     <SystemReflectionMetadataVersion>1.6.0</SystemReflectionMetadataVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -42,7 +42,6 @@
     <RoslynBannedApiAnalyzersVersion>3.3.3</RoslynBannedApiAnalyzersVersion>
     <RoslynPublicApiAnalyzersVersion>3.3.4-beta1.21554.2</RoslynPublicApiAnalyzersVersion>
     <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>
-    <SystemComponentModelCompositionForSourceBuildVersion>7.0.0</SystemComponentModelCompositionForSourceBuildVersion>
     <SystemComponentModelCompositionVersion>4.5.0</SystemComponentModelCompositionVersion>
     <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
     <SystemNetHttpVersion>4.3.4</SystemNetHttpVersion>

--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.csproj
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.csproj
@@ -7,7 +7,6 @@
     <When Condition=" '$(DotNetBuildFromSource)' == 'true' ">
       <PropertyGroup>
         <NuspecFile>Microsoft.TestPlatform.CLI.sourcebuild.nuspec</NuspecFile>
-        <SystemComponentModelCompositionVersion>$(SystemComponentModelCompositionForSourceBuildVersion)</SystemComponentModelCompositionVersion>
       </PropertyGroup>
     </When>
     <Otherwise>


### PR DESCRIPTION
This fixes an issue with System.ComponentModel.Composition, as described in https://github.com/dotnet/source-build/issues/3599, that is showing up as a reference assembly in the source-built SDK.

The reason a reference assembly exists in this case is because vstest has a reference to the 7.0.0 version of System.ComponentModel.Composition. When building with source-build, it loads that reference from [SBRP](https://github.com/dotnet/source-build-reference-packages) (which only contains reference assemblies) in order to fulfill compile time references. The problem is that the assembly is also getting included in the output. This should have been detected by poison leak detection [but that doesn't yet handle reference assemblies](https://github.com/dotnet/source-build/issues/2817).

It's not known whether the existence of this ref assembly causes a functional issue. But it is known that the source-built 7.0 SDK doesn't define this as a ref assembly but rather as an implementation assembly. So to maintain parity with 7.0 and avoid potential risk, it's best to ensure this is represented as an implementation assembly in the output.

This removes the special configuration that was done for source-build so that it simply reuses the existing `SystemComponentModelCompositionVersion` property. This property will get overridden by source-build as a result of the inclusion of System.ComponentModel.Composition to Version.Details.xml.