### PR TITLE
Fix two source-build poison leaks

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -33,6 +33,16 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>30ab651fcb4354552bd4891619a0bdd81e0ebdbf</Sha>
     </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="3.0.0">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
+    </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
+    <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="2.0.0">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23364.2">


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/3670

This fixes 2 source-build poison leaks: Microsoft.Extensions.DependencyModel.dll and Microsoft.Extensions.FileSystemGlobbing.dll that come from this repo. This was caused by missing package dependencies, which causes source-build to consume reference packages from SBRP repo.

The fix is a simple addition of explicit package dependencies, for versions used by VSTest repo. Source-build will automatically bump these package versions to latest, built in source-build.