### PR TITLE
Add platform guard

### DIFF
--- a/src/Microsoft.TestPlatform.CoreUtilities/Output/OutputExtensions.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Output/OutputExtensions.cs
@@ -118,7 +118,8 @@ public static class OutputExtensions
 
 #if NET5_0_OR_GREATER
         if (OperatingSystem.IsAndroid() || OperatingSystem.IsIOS() || OperatingSystem.IsBrowser() || OperatingSystem.IsTvOS())
-            return; // Console color not supported on these platforms.
+            // Console color not supported on these platforms.
+            action.Invoke();
 #endif
 
         var previousForegroundColor = Console.ForegroundColor;

--- a/src/Microsoft.TestPlatform.CoreUtilities/Output/OutputExtensions.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Output/OutputExtensions.cs
@@ -118,8 +118,11 @@ public static class OutputExtensions
 
 #if NET5_0_OR_GREATER
         if (OperatingSystem.IsAndroid() || OperatingSystem.IsIOS() || OperatingSystem.IsBrowser() || OperatingSystem.IsTvOS())
+        {
             // Console color not supported on these platforms.
             action.Invoke();
+            return;
+        }
 #endif
 
         var previousForegroundColor = Console.ForegroundColor;

--- a/src/Microsoft.TestPlatform.CoreUtilities/Output/OutputExtensions.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Output/OutputExtensions.cs
@@ -116,6 +116,11 @@ public static class OutputExtensions
             return;
         }
 
+#if NET5_0_OR_GREATER
+        if (OperatingSystem.IsAndroid() || OperatingSystem.IsIOS() || OperatingSystem.IsBrowser() || OperatingSystem.IsTvOS())
+            return; // Console color not supported on these platforms.
+#endif
+
         var previousForegroundColor = Console.ForegroundColor;
         try
         {


### PR DESCRIPTION
## Description

Allows the use of the TRX Logger on other platforms where test runners are being created.

## Related issue

Fixes #4736.

- [ ] I have ensured that there is a previously discussed and approved issue.
