### PR TITLE
Remove Microsoft.SourceBuild.Intermediate from prebuilt baseline

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -5,7 +5,6 @@
   <IgnorePatterns>
     <!-- Caused by dependency on System.ComponentModel.Composition.4.5.0. This version is overridden in full source-build. -->
     <UsagePattern IdentityGlob="Microsoft.NETCore.Platforms/2.0.0" />
-    <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
     <!-- This version is overridden in full source-build. -->
     <UsagePattern IdentityGlob="System.ComponentModel.Composition/4.5.0" />
     <!-- Caused by dependency on System.ComponentModel.Composition.4.5.0. This version is overridden in full source-build. -->


### PR DESCRIPTION
Prebuilt detection no longer detects Microsoft.SourceBuild.Intermediates as prebuilts due to https://github.com/dotnet/arcade/pull/13935.

Addresses https://github.com/dotnet/source-build/issues/3010