### PR TITLE
Add missing runtimeconfig.json file for 8.0

### DIFF
--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -19,9 +19,9 @@ function Verify-Nuget-Packages {
     $expectedNumOfFiles = @{
         "Microsoft.CodeCoverage"                      = 59;
         "Microsoft.NET.Test.Sdk"                      = 16;
-        "Microsoft.TestPlatform"                      = 605;
+        "Microsoft.TestPlatform"                      = 606;
         "Microsoft.TestPlatform.Build"                = 21;
-        "Microsoft.TestPlatform.CLI"                  = 470;
+        "Microsoft.TestPlatform.CLI"                  = 471;
         "Microsoft.TestPlatform.Extensions.TrxLogger" = 35;
         "Microsoft.TestPlatform.ObjectModel"          = 93;
         "Microsoft.TestPlatform.AdapterUtilities"     = 34;

--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.nuspec
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.nuspec
@@ -44,6 +44,7 @@
     <file src="$TesthostRuntimeconfig$\testhost-5.0.runtimeconfig.json" target="contentFiles\any\netcoreapp3.1" />
     <file src="$TesthostRuntimeconfig$\testhost-6.0.runtimeconfig.json" target="contentFiles\any\netcoreapp3.1" />
     <file src="$TesthostRuntimeconfig$\testhost-7.0.runtimeconfig.json" target="contentFiles\any\netcoreapp3.1" />
+    <file src="$TesthostRuntimeconfig$\testhost-8.0.runtimeconfig.json" target="contentFiles\any\netcoreapp3.1" />
     <file src="$TesthostRuntimeconfig$\testhost-latest.runtimeconfig.json" target="contentFiles\any\netcoreapp3.1" />
     <file src="netcoreapp3.1\testhost.dll" target="contentFiles\any\netcoreapp3.1" />
     <file src="netcoreapp3.1\testhost.deps.json" target="contentFiles\any\netcoreapp3.1" />

--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.sourcebuild.nuspec
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.sourcebuild.nuspec
@@ -43,6 +43,7 @@
     <file src="$TesthostRuntimeconfig$\testhost-5.0.runtimeconfig.json" target="contentFiles\any\$SourceBuildTfm$" />
     <file src="$TesthostRuntimeconfig$\testhost-6.0.runtimeconfig.json" target="contentFiles\any\$SourceBuildTfm$" />
     <file src="$TesthostRuntimeconfig$\testhost-7.0.runtimeconfig.json" target="contentFiles\any\$SourceBuildTfm$" />
+    <file src="$TesthostRuntimeconfig$\testhost-8.0.runtimeconfig.json" target="contentFiles\any\$SourceBuildTfm$" />
     <file src="$TesthostRuntimeconfig$\testhost-latest.runtimeconfig.json" target="contentFiles\any\$SourceBuildTfm$" />
     <file src="$SourceBuildTfm$\testhost.dll" target="contentFiles\any\$SourceBuildTfm$" />
     <file src="$SourceBuildTfm$\testhost.deps.json" target="contentFiles\any\$SourceBuildTfm$" />

--- a/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.nuspec
+++ b/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.nuspec
@@ -539,6 +539,7 @@
     <file src="$TesthostRuntimeconfig$\testhost-5.0.runtimeconfig.json" target="tools\net462\Common7\IDE\Extensions\TestPlatform\TestHostNet\testhost-5.0.runtimeconfig.json" />
     <file src="$TesthostRuntimeconfig$\testhost-6.0.runtimeconfig.json" target="tools\net462\Common7\IDE\Extensions\TestPlatform\TestHostNet\testhost-6.0.runtimeconfig.json" />
     <file src="$TesthostRuntimeconfig$\testhost-7.0.runtimeconfig.json" target="tools\net462\Common7\IDE\Extensions\TestPlatform\TestHostNet\testhost-7.0.runtimeconfig.json" />
+    <file src="$TesthostRuntimeconfig$\testhost-8.0.runtimeconfig.json" target="tools\net462\Common7\IDE\Extensions\TestPlatform\TestHostNet\testhost-8.0.runtimeconfig.json" />
     <file src="$TesthostRuntimeconfig$\testhost-latest.runtimeconfig.json" target="tools\net462\Common7\IDE\Extensions\TestPlatform\TestHostNet\testhost-latest.runtimeconfig.json" />
     <file src="netcoreapp3.1\testhost.deps.json" target="tools\net462\Common7\IDE\Extensions\TestPlatform\TestHostNet\testhost.deps.json" />
     <file src="netcoreapp3.1\testhost.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\TestHostNet\testhost.dll" />

--- a/temp/testhost/testhost-8.0.runtimeconfig.json
+++ b/temp/testhost/testhost-8.0.runtimeconfig.json
@@ -1,0 +1,9 @@
+{
+  "runtimeOptions": {
+    "tfm": "net8.0",
+    "framework": {
+      "name": "Microsoft.NETCore.App",
+      "version": "8.0.0-preview.0"
+    }
+  }
+}


### PR DESCRIPTION

We have a fallback for the corner case scenario where for some reason the runtimeconfig is not close to the test dll as expected(file moved post processing for instance without the runtime config file).
We ship the fallback configuration directly inside the sdk, for 8.0 was missing failing the above scenario.

fixes https://github.com/microsoft/vscode/issues/198748

cc: @pavelhorak @cvpoienaru @Evangelink 