### PR TITLE
Fix terminal logger encoding & error

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-alpha.1.23615.4",
+    "version": "9.0.100-alpha.1.24073.1",
     "rollForward": "minor",
     "allowPrerelease": false,
     "architecture": "x64"
@@ -29,7 +29,7 @@
     },
     "xcopy-msbuild": "17.8.1-2",
     "vswhere": "2.2.7",
-    "dotnet": "9.0.100-alpha.1.23615.4"
+    "dotnet": "9.0.100-alpha.1.24073.1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24062.5"

--- a/playground/TestPlatform.Playground/Program.cs
+++ b/playground/TestPlatform.Playground/Program.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 
+using Microsoft.TestPlatform.VsTestConsole.TranslationLayer;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
@@ -34,6 +35,7 @@ internal class Program
 
         var thisAssemblyPath = Assembly.GetEntryAssembly()!.Location;
         var here = Path.GetDirectoryName(thisAssemblyPath)!;
+        var playground = Path.GetFullPath(Path.Combine(here, "..", "..", "..", ".."));
 
         var console = Path.Combine(here, "vstest.console", "vstest.console.exe");
 
@@ -86,34 +88,75 @@ internal class Program
             """;
 
         var sources = new[] {
-@"S:\t\mstest95\bin\Debug\net9.0\mstest95ğğğ.dll"
+            Path.Combine(playground, "bin", "MSTest1", "Debug", "net472", "MSTest1.dll"),
+            Path.Combine(playground, "bin", "MSTest2", "Debug", "net472", "MSTest2.dll"),
             // The built in .NET projects don't now work right now in Playground, there is some conflict with Arcade.
             // But if you create one outside of Playground it will work. 
             //Path.Combine(playground, "bin", "MSTest1", "Debug", "net7.0", "MSTest1.dll"),
         };
 
-        // Console mode
-        // Uncomment if providing command line parameters is easier for you
-        // than converting them to settings, or when you debug command line scenario specifically.
-        var settingsFile = Path.GetTempFileName();
-        try
+        //// Console mode
+        //// Uncomment if providing command line parameters is easier for you
+        //// than converting them to settings, or when you debug command line scenario specifically.
+        //var settingsFile = Path.GetTempFileName();
+        //try
+        //{
+        //    File.WriteAllText(settingsFile, sourceSettings);
+        //    var processStartInfo = new ProcessStartInfo
+        //    {
+        //        FileName = console,
+        //        Arguments = $"{string.Join(" ", sources)} --settings:{settingsFile} --listtests",
+        //        UseShellExecute = false,
+        //    };
+        //    EnvironmentVariables.Variables.ToList().ForEach(processStartInfo.Environment.Add);
+        //    var process = Process.Start(processStartInfo);
+        //    process.WaitForExit();
+        //    if (process.ExitCode != 0)
+        //    {
+        //        throw new Exception($"Process failed with {process.ExitCode}");
+        //    }
+        //}
+        //finally
+        //{
+        //    try { File.Delete(settingsFile); } catch { }
+        //}
+
+        // design mode
+        var detailedOutput = true;
+        var consoleOptions = new ConsoleParameters
         {
-            File.WriteAllText(settingsFile, sourceSettings);
-            var processStartInfo = new ProcessStartInfo
-            {
-                FileName = console,
-                Arguments = $"{string.Join(" ", sources)} --logger:Microsoft.TestPlatform.MSBuildLogger --logger:console;verbosity=detailed",
-                UseShellExecute = false,
-            };
-            EnvironmentVariables.Variables.ToList().ForEach(processStartInfo.Environment.Add);
-            var process = Process.Start(processStartInfo);
-            process.WaitForExit();
-            Console.WriteLine(process.ExitCode);
-        }
-        finally
+            EnvironmentVariables = EnvironmentVariables.Variables,
+            // LogFilePath = Path.Combine(here, "logs", "log.txt"),
+            // TraceLevel = TraceLevel.Verbose,
+        };
+        var options = new TestPlatformOptions
         {
-            try { File.Delete(settingsFile); } catch { }
-        }
+            CollectMetrics = true,
+        };
+        var r = new VsTestConsoleWrapper(console, consoleOptions);
+        var sessionHandler = new TestSessionHandler();
+#pragma warning disable CS0618 // Type or member is obsolete
+        //// TestSessions
+        // r.StartTestSession(sources, sourceSettings, sessionHandler);
+#pragma warning restore CS0618 // Type or member is obsolete
+        var discoveryHandler = new PlaygroundTestDiscoveryHandler(detailedOutput);
+        var sw = Stopwatch.StartNew();
+        // Discovery
+        r.DiscoverTests(sources, sourceSettings, options, sessionHandler.TestSessionInfo, discoveryHandler);
+        var discoveryDuration = sw.ElapsedMilliseconds;
+        Console.WriteLine($"Discovery done in {discoveryDuration} ms");
+        sw.Restart();
+        // Run with test cases and custom testhost launcher
+        //r.RunTestsWithCustomTestHost(discoveryHandler.TestCases, sourceSettings, options, sessionHandler.TestSessionInfo, new TestRunHandler(detailedOutput), new DebuggerTestHostLauncher());
+        //// Run with test cases and without custom testhost launcher
+        r.RunTests(discoveryHandler.TestCases, sourceSettings, options, sessionHandler.TestSessionInfo, new TestRunHandler(detailedOutput));
+        //// Run with sources and custom testhost launcher and debugging
+        //r.RunTestsWithCustomTestHost(sources, sourceSettings, options, sessionHandler.TestSessionInfo, new TestRunHandler(detailedOutput), new DebuggerTestHostLauncher());
+        //// Run with sources
+        //r.RunTests(sources, sourceSettings, options, sessionHandler.TestSessionInfo, new TestRunHandler(detailedOutput));
+        var rd = sw.ElapsedMilliseconds;
+        Console.WriteLine($"Discovery: {discoveryDuration} ms, Run: {rd} ms, Total: {discoveryDuration + rd} ms");
+        // Console.WriteLine($"Settings:\n{sourceSettings}");
     }
 
     public class PlaygroundTestDiscoveryHandler : ITestDiscoveryEventsHandler, ITestDiscoveryEventsHandler2

--- a/playground/TestPlatform.Playground/Program.cs
+++ b/playground/TestPlatform.Playground/Program.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 
-using Microsoft.TestPlatform.VsTestConsole.TranslationLayer;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
@@ -35,7 +34,6 @@ internal class Program
 
         var thisAssemblyPath = Assembly.GetEntryAssembly()!.Location;
         var here = Path.GetDirectoryName(thisAssemblyPath)!;
-        var playground = Path.GetFullPath(Path.Combine(here, "..", "..", "..", ".."));
 
         var console = Path.Combine(here, "vstest.console", "vstest.console.exe");
 
@@ -88,75 +86,34 @@ internal class Program
             """;
 
         var sources = new[] {
-            Path.Combine(playground, "bin", "MSTest1", "Debug", "net472", "MSTest1.dll"),
-            Path.Combine(playground, "bin", "MSTest2", "Debug", "net472", "MSTest2.dll"),
+@"S:\t\mstest95\bin\Debug\net9.0\mstest95ğğğ.dll"
             // The built in .NET projects don't now work right now in Playground, there is some conflict with Arcade.
             // But if you create one outside of Playground it will work. 
             //Path.Combine(playground, "bin", "MSTest1", "Debug", "net7.0", "MSTest1.dll"),
         };
 
-        //// Console mode
-        //// Uncomment if providing command line parameters is easier for you
-        //// than converting them to settings, or when you debug command line scenario specifically.
-        //var settingsFile = Path.GetTempFileName();
-        //try
-        //{
-        //    File.WriteAllText(settingsFile, sourceSettings);
-        //    var processStartInfo = new ProcessStartInfo
-        //    {
-        //        FileName = console,
-        //        Arguments = $"{string.Join(" ", sources)} --settings:{settingsFile} --listtests",
-        //        UseShellExecute = false,
-        //    };
-        //    EnvironmentVariables.Variables.ToList().ForEach(processStartInfo.Environment.Add);
-        //    var process = Process.Start(processStartInfo);
-        //    process.WaitForExit();
-        //    if (process.ExitCode != 0)
-        //    {
-        //        throw new Exception($"Process failed with {process.ExitCode}");
-        //    }
-        //}
-        //finally
-        //{
-        //    try { File.Delete(settingsFile); } catch { }
-        //}
-
-        // design mode
-        var detailedOutput = true;
-        var consoleOptions = new ConsoleParameters
+        // Console mode
+        // Uncomment if providing command line parameters is easier for you
+        // than converting them to settings, or when you debug command line scenario specifically.
+        var settingsFile = Path.GetTempFileName();
+        try
         {
-            EnvironmentVariables = EnvironmentVariables.Variables,
-            // LogFilePath = Path.Combine(here, "logs", "log.txt"),
-            // TraceLevel = TraceLevel.Verbose,
-        };
-        var options = new TestPlatformOptions
+            File.WriteAllText(settingsFile, sourceSettings);
+            var processStartInfo = new ProcessStartInfo
+            {
+                FileName = console,
+                Arguments = $"{string.Join(" ", sources)} --logger:Microsoft.TestPlatform.MSBuildLogger --logger:console;verbosity=detailed",
+                UseShellExecute = false,
+            };
+            EnvironmentVariables.Variables.ToList().ForEach(processStartInfo.Environment.Add);
+            var process = Process.Start(processStartInfo);
+            process.WaitForExit();
+            Console.WriteLine(process.ExitCode);
+        }
+        finally
         {
-            CollectMetrics = true,
-        };
-        var r = new VsTestConsoleWrapper(console, consoleOptions);
-        var sessionHandler = new TestSessionHandler();
-#pragma warning disable CS0618 // Type or member is obsolete
-        //// TestSessions
-        // r.StartTestSession(sources, sourceSettings, sessionHandler);
-#pragma warning restore CS0618 // Type or member is obsolete
-        var discoveryHandler = new PlaygroundTestDiscoveryHandler(detailedOutput);
-        var sw = Stopwatch.StartNew();
-        // Discovery
-        r.DiscoverTests(sources, sourceSettings, options, sessionHandler.TestSessionInfo, discoveryHandler);
-        var discoveryDuration = sw.ElapsedMilliseconds;
-        Console.WriteLine($"Discovery done in {discoveryDuration} ms");
-        sw.Restart();
-        // Run with test cases and custom testhost launcher
-        //r.RunTestsWithCustomTestHost(discoveryHandler.TestCases, sourceSettings, options, sessionHandler.TestSessionInfo, new TestRunHandler(detailedOutput), new DebuggerTestHostLauncher());
-        //// Run with test cases and without custom testhost launcher
-        r.RunTests(discoveryHandler.TestCases, sourceSettings, options, sessionHandler.TestSessionInfo, new TestRunHandler(detailedOutput));
-        //// Run with sources and custom testhost launcher and debugging
-        //r.RunTestsWithCustomTestHost(sources, sourceSettings, options, sessionHandler.TestSessionInfo, new TestRunHandler(detailedOutput), new DebuggerTestHostLauncher());
-        //// Run with sources
-        //r.RunTests(sources, sourceSettings, options, sessionHandler.TestSessionInfo, new TestRunHandler(detailedOutput));
-        var rd = sw.ElapsedMilliseconds;
-        Console.WriteLine($"Discovery: {discoveryDuration} ms, Run: {rd} ms, Total: {discoveryDuration + rd} ms");
-        // Console.WriteLine($"Settings:\n{sourceSettings}");
+            try { File.Delete(settingsFile); } catch { }
+        }
     }
 
     public class PlaygroundTestDiscoveryHandler : ITestDiscoveryEventsHandler, ITestDiscoveryEventsHandler2

--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.csproj
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.csproj
@@ -29,6 +29,7 @@
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
     <PackageId>Microsoft.TestPlatform.Build</PackageId>
     <PackageTags>vstest visual-studio unittest testplatform mstest microsoft test testing</PackageTags>
+    <PackageProjectUrl>https://github.com/microsoft/vstest</PackageProjectUrl>
     <PackageDescription>
       Build tasks and targets for running tests with Test Platform
     </PackageDescription>

--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.csproj
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.csproj
@@ -29,8 +29,8 @@
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
     <PackageId>Microsoft.TestPlatform.Build</PackageId>
     <PackageTags>vstest visual-studio unittest testplatform mstest microsoft test testing</PackageTags>
-    <PackageProjectUrl>https://github.com/microsoft/vstest</PackageProjectUrl>
     <RepositoryUrl>https://github.com/microsoft/vstest</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/microsoft/vstest</PackageProjectUrl>
     <PackageDescription>
       Build tasks and targets for running tests with Test Platform
     </PackageDescription>

--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.csproj
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.csproj
@@ -30,6 +30,7 @@
     <PackageId>Microsoft.TestPlatform.Build</PackageId>
     <PackageTags>vstest visual-studio unittest testplatform mstest microsoft test testing</PackageTags>
     <PackageProjectUrl>https://github.com/microsoft/vstest</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/microsoft/vstest</RepositoryUrl>
     <PackageDescription>
       Build tasks and targets for running tests with Test Platform
     </PackageDescription>

--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
@@ -29,7 +29,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <Target Name="VSTest" DependsOnTargets="ShowInfoMessageIfProjectHasNoIsTestProjectProperty">
     <!-- Unloggable colorized output (cf. https://github.com/microsoft/vstest/issues/680) -->
-    <CallTarget Targets="_VSTestConsole" Condition="!$(VsTestUseMSBuildOutput) || $(MSBUILDENSURESTDOUTFORTASKPROCESSES) == '1'" />
+    <CallTarget Targets="_VSTestConsole" Condition="!$(VsTestUseMSBuildOutput) OR $(MSBUILDENSURESTDOUTFORTASKPROCESSES) == '1'" />
     <!-- Proper MSBuild integration, but no custom colorization -->
     <CallTarget Targets="_VSTestMSBuild" Condition="$(VsTestUseMSBuildOutput)" />
   </Target>

--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
@@ -29,7 +29,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <Target Name="VSTest" DependsOnTargets="ShowInfoMessageIfProjectHasNoIsTestProjectProperty">
     <!-- Unloggable colorized output (cf. https://github.com/microsoft/vstest/issues/680) -->
-    <CallTarget Targets="_VSTestConsole" Condition="!$(VsTestUseMSBuildOutput)" />
+    <CallTarget Targets="_VSTestConsole" Condition="!$(VsTestUseMSBuildOutput) || $(MSBUILDENSURESTDOUTFORTASKPROCESSES) == '1'" />
     <!-- Proper MSBuild integration, but no custom colorization -->
     <CallTarget Targets="_VSTestMSBuild" Condition="$(VsTestUseMSBuildOutput)" />
   </Target>

--- a/src/Microsoft.TestPlatform.Build/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.Build/PublicAPI/PublicAPI.Unshipped.txt
@@ -116,6 +116,8 @@ override Microsoft.TestPlatform.Build.Tasks.VSTestTask.Execute() -> bool
 override Microsoft.TestPlatform.Build.Tasks.VSTestTask2.GenerateCommandLineCommands() -> string?
 override Microsoft.TestPlatform.Build.Tasks.VSTestTask2.GenerateFullPathToTool() -> string?
 override Microsoft.TestPlatform.Build.Tasks.VSTestTask2.LogEventsFromTextOutput(string! singleLine, Microsoft.Build.Framework.MessageImportance messageImportance) -> void
+override Microsoft.TestPlatform.Build.Tasks.VSTestTask2.StandardErrorEncoding.get -> System.Text.Encoding!
+override Microsoft.TestPlatform.Build.Tasks.VSTestTask2.StandardOutputEncoding.get -> System.Text.Encoding!
 override Microsoft.TestPlatform.Build.Tasks.VSTestTask2.ToolName.get -> string?
 static Microsoft.TestPlatform.Build.Trace.Tracing.Trace(string! message) -> void
 static Microsoft.TestPlatform.Build.Trace.Tracing.traceEnabled -> bool

--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask2.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask2.cs
@@ -141,8 +141,14 @@ public class VSTestTask2 : ToolTask, ITestTask
                 return;
             }
         }
+        else
+        {
+            Log.LogMessage(MessageImportance.Low, singleLine);
+        }
 
-        base.LogEventsFromTextOutput(singleLine, messageImportance);
+        // Do not call the base, it parses out the output, and if it sees "error" in any place it will log it as error
+        // we don't want this, we only want to log errors from the text messages we receive that start error splitter.
+        // base.LogEventsFromTextOutput(singleLine, messageImportance);
     }
 
     protected override string? GenerateCommandLineCommands()

--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask2.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask2.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -40,6 +42,9 @@ public class VSTestTask2 : ToolTask, ITestTask
     public string? VSTestArtifactsProcessingMode { get; set; }
     public string? VSTestSessionCorrelationId { get; set; }
 
+    protected override Encoding StandardErrorEncoding => !_disableUtf8ConsoleEncoding ? Encoding.UTF8 : base.StandardErrorEncoding;
+    protected override Encoding StandardOutputEncoding => !_disableUtf8ConsoleEncoding ? Encoding.UTF8 : base.StandardOutputEncoding;
+
     private readonly string _testResultSplitter = "++++";
     private readonly string[] _testResultSplitterArray = new[] { "++++" };
 
@@ -50,6 +55,7 @@ public class VSTestTask2 : ToolTask, ITestTask
     private readonly string[] _fullErrorSplitterArray = new[] { "~~~~" };
 
     private readonly string _fullErrorNewlineSplitter = "!!!!";
+    private readonly bool _disableUtf8ConsoleEncoding;
 
     protected override string? ToolName
     {
@@ -64,12 +70,15 @@ public class VSTestTask2 : ToolTask, ITestTask
 
     public VSTestTask2()
     {
+        // Unless user opted out, use UTF encoding, which we force in vstest.console.
+        _disableUtf8ConsoleEncoding = Environment.GetEnvironmentVariable("VSTEST_DISABLE_UTF8_CONSOLE_ENCODING") == "1";
         LogStandardErrorAsError = false;
         StandardOutputImportance = "Normal";
     }
 
     protected override void LogEventsFromTextOutput(string singleLine, MessageImportance messageImportance)
     {
+        Debug.WriteLine($"vstestTask2: received output {singleLine}, importance {messageImportance}");
         if (singleLine.StartsWith(_errorSplitter))
         {
             var parts = singleLine.Split(_errorSplitterArray, StringSplitOptions.None);

--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask2.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask2.cs
@@ -42,8 +42,8 @@ public class VSTestTask2 : ToolTask, ITestTask
     public string? VSTestArtifactsProcessingMode { get; set; }
     public string? VSTestSessionCorrelationId { get; set; }
 
-    protected override Encoding StandardErrorEncoding => !_disableUtf8ConsoleEncoding ? Encoding.UTF8 : base.StandardErrorEncoding;
-    protected override Encoding StandardOutputEncoding => !_disableUtf8ConsoleEncoding ? Encoding.UTF8 : base.StandardOutputEncoding;
+    protected override Encoding StandardErrorEncoding => _disableUtf8ConsoleEncoding ? base.StandardErrorEncoding ? Encoding.UTF8;
+    protected override Encoding StandardOutputEncoding => _disableUtf8ConsoleEncoding ? base.StandardOutputEncoding : Encoding.UTF8;
 
     private readonly string _testResultSplitter = "++++";
     private readonly string[] _testResultSplitterArray = new[] { "++++" };

--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask2.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask2.cs
@@ -42,7 +42,7 @@ public class VSTestTask2 : ToolTask, ITestTask
     public string? VSTestArtifactsProcessingMode { get; set; }
     public string? VSTestSessionCorrelationId { get; set; }
 
-    protected override Encoding StandardErrorEncoding => _disableUtf8ConsoleEncoding ? base.StandardErrorEncoding ? Encoding.UTF8;
+    protected override Encoding StandardErrorEncoding => _disableUtf8ConsoleEncoding ? base.StandardErrorEncoding : Encoding.UTF8;
     protected override Encoding StandardOutputEncoding => _disableUtf8ConsoleEncoding ? base.StandardOutputEncoding : Encoding.UTF8;
 
     private readonly string _testResultSplitter = "++++";

--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.csproj
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.csproj
@@ -23,6 +23,8 @@
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
     <PackageId>Microsoft.TestPlatform.CLI</PackageId>
     <PackageTags>vstest visual-studio unittest testplatform mstest microsoft test testing</PackageTags>
+    <PackageProjectUrl>https://github.com/microsoft/vstest</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/microsoft/vstest</RepositoryUrl>
     <PackageDescription>
       The cross platform Microsoft Test Platform.
     </PackageDescription>

--- a/src/vstest.console/Internal/MSBuildLogger.cs
+++ b/src/vstest.console/Internal/MSBuildLogger.cs
@@ -112,8 +112,9 @@ internal class MSBuildLogger : ITestLoggerWithParameters
                 Output.Information(false, info);
                 break;
             case TestOutcome.Failed:
-
                 var result = e.Result;
+                Debug.WriteLine(">>>>ERR:" + result.ErrorMessage);
+                Debug.WriteLine(">>>>STK:" + result.ErrorStackTrace);
                 if (!StringUtils.IsNullOrWhiteSpace(result.ErrorStackTrace))
                 {
                     var maxLength = 1000;

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestMSBuildOutputTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestMSBuildOutputTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.TestPlatform.TestUtilities;
@@ -20,7 +20,7 @@ public class DotnetTestMSBuildOutputTests : AcceptanceTestBase
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        var projectPath = GetIsolatedTestAsset("SimpleTestProject.csproj");
+        var projectPath = GetIsolatedTestAsset("TerminalLoggerTestProject.csproj");
         InvokeDotnetTest($@"{projectPath} /p:VsTestUseMSBuildOutput=true /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}");
 
         // The output:
@@ -31,7 +31,7 @@ public class DotnetTestMSBuildOutputTests : AcceptanceTestBase
         // C:\Users\nohwnd\AppData\Local\Temp\vstest\xvoVt\UnitTest1.cs(41): error VSTEST1: (FailingTest) SampleUnitTestProject.UnitTest1.FailingTest() Assert.AreEqual failed. Expected:<2>. Actual:<3>.  [C:\Users\nohwnd\AppData\Local\Temp\vstest\xvoVt\SimpleTestProject.csproj::TargetFramework=net462]
         // C:\Users\nohwnd\AppData\Local\Temp\vstest\xvoVt\UnitTest1.cs(41): error VSTEST1: (FailingTest) SampleUnitTestProject.UnitTest1.FailingTest() Assert.AreEqual failed. Expected:<2>. Actual:<3>.  [C:\Users\nohwnd\AppData\Local\Temp\vstest\xvoVt\SimpleTestProject.csproj::TargetFramework=netcoreapp3.1]
 
-        StdOutputContains("error VSTEST1: (FailingTest) SampleUnitTestProject.UnitTest1.FailingTest() Assert.AreEqual failed. Expected:<2>. Actual:<3>.");
+        StdOutputContains("TerminalLoggerUnitTests.UnitTest1.FailingTest() Assert.AreEqual failed. Expected:<ğğğ𦮙我們剛才從𓋴𓅓𓏏𓇏𓇌𓀀 (System.String)>. Actual:<3 (System.Int32)>.");
         // We are sending those as low prio messages, they won't show up on screen but will be in binlog.
         //StdOutputContains("passed PassingTest");
         //StdOutputContains("skipped SkippingTest");

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestMSBuildOutputTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestMSBuildOutputTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 using Microsoft.TestPlatform.TestUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -16,12 +18,12 @@ public class DotnetTestMSBuildOutputTests : AcceptanceTestBase
     // patched dotnet is not published on non-windows systems
     [TestCategory("Windows-Review")]
     [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
-    public void RunDotnetTestWithCsproj(RunnerInfo runnerInfo)
+    public void MSBuildLoggerCanBeEnabledByBuildPropertyAndDoesNotEatSpecialChars(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
         var projectPath = GetIsolatedTestAsset("TerminalLoggerTestProject.csproj");
-        InvokeDotnetTest($@"{projectPath} /p:VsTestUseMSBuildOutput=true /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}");
+        InvokeDotnetTest($@"{projectPath} -nodereuse:false /p:VsTestUseMSBuildOutput=true /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}");
 
         // The output:
         // Determining projects to restore...
@@ -35,6 +37,43 @@ public class DotnetTestMSBuildOutputTests : AcceptanceTestBase
         // We are sending those as low prio messages, they won't show up on screen but will be in binlog.
         //StdOutputContains("passed PassingTest");
         //StdOutputContains("skipped SkippingTest");
+        ExitCodeEquals(1);
+    }
+
+    [TestMethod]
+    // patched dotnet is not published on non-windows systems
+    [TestCategory("Windows-Review")]
+    [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
+    public void MSBuildLoggerCanBeDisabledByBuildProperty(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var projectPath = GetIsolatedTestAsset("TerminalLoggerTestProject.csproj");
+        InvokeDotnetTest($@"{projectPath} -nodereuse:false /p:VsTestUseMSBuildOutput=false /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}");
+
+        // Check that we see the summary that is printed from the console logger, meaning the new output is disabled.
+        StdOutputContains("Failed! - Failed: 1, Passed: 1, Skipped: 1, Total: 3, Duration:");
+        // We are sending those as low prio messages, they won't show up on screen but will be in binlog.
+        //StdOutputContains("passed PassingTest");
+        //StdOutputContains("skipped SkippingTest");
+        ExitCodeEquals(1);
+    }
+
+
+    [TestMethod]
+    // patched dotnet is not published on non-windows systems
+    [TestCategory("Windows-Review")]
+    [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
+    public void MSBuildLoggerCanBeDisabledByEnvironmentVariableProperty(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var projectPath = GetIsolatedTestAsset("TerminalLoggerTestProject.csproj");
+        InvokeDotnetTest($@"{projectPath} -nodereuse:false /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}", environmentVariables: new Dictionary<string, string?> { ["MSBUILDENSURESTDOUTFORTASKPROCESSES"] = "1" });
+
+        // Check that we see the summary that is printed from the console logger, meaning the new output is disabled.
+        StdOutputContains("Failed! - Failed: 1, Passed: 1, Skipped: 1, Total: 3, Duration:");
+
         ExitCodeEquals(1);
     }
 }

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestTests.cs
@@ -26,7 +26,7 @@ public class DotnetTestTests : AcceptanceTestBase
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
         var projectPath = GetIsolatedTestAsset("SimpleTestProject.csproj");
-        InvokeDotnetTest($@"{projectPath} --logger:""Console;Verbosity=normal"" /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}");
+        InvokeDotnetTest($@"{projectPath} -p:VSTestUseMSBuildOutput=false --logger:""Console;Verbosity=normal"" /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}");
 
         // ensure our dev version is used
         StdOutputContains(GetFinalVersion(IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion));
@@ -60,7 +60,7 @@ public class DotnetTestTests : AcceptanceTestBase
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
         var projectPath = GetIsolatedTestAsset("ParametrizedTestProject.csproj");
-        InvokeDotnetTest($@"{projectPath} --logger:""Console;Verbosity=normal"" /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion} -- TestRunParameters.Parameter(name =\""weburl\"", value=\""http://localhost//def\"")");
+        InvokeDotnetTest($@"{projectPath} --logger:""Console;Verbosity=normal"" -p:VSTestUseMSBuildOutput=false /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion} -- TestRunParameters.Parameter(name =\""weburl\"", value=\""http://localhost//def\"")");
 
         ValidateSummaryStatus(1, 0, 0);
         ExitCodeEquals(0);

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/RunsettingsTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/RunsettingsTests.cs
@@ -522,7 +522,7 @@ public class RunsettingsTests : AcceptanceTestBase
         // are honored by dotnet test, instead of just using the default, which would produce the same
         // result
         var settingsPath = GetProjectAssetFullPath(projectName, "inconclusive.runsettings");
-        InvokeDotnetTest($@"{projectPath} --settings {settingsPath} --logger:""Console;Verbosity=normal"" /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}");
+        InvokeDotnetTest($@"{projectPath} --settings {settingsPath} /p:VSTestUseMSBuildOutput=false --logger:""Console;Verbosity=normal"" /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}");
         ValidateSummaryStatus(0, 0, 1);
     }
 

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/RunsettingsTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/RunsettingsTests.cs
@@ -514,7 +514,7 @@ public class RunsettingsTests : AcceptanceTestBase
 
         var projectName = "ProjectFileRunSettingsTestProject.csproj";
         var projectPath = GetIsolatedTestAsset(projectName);
-        InvokeDotnetTest($@"{projectPath} --logger:""Console;Verbosity=normal"" /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}");
+        InvokeDotnetTest($@"{projectPath} /p:VSTestUseMSBuildOutput=false --logger:""Console;Verbosity=normal"" /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}");
         ValidateSummaryStatus(0, 1, 0);
 
         // make sure that we can revert the project settings back by providing a config from command line

--- a/test/TestAssets/TerminalLoggerTestProject/TerminalLoggerTestProject.csproj
+++ b/test/TestAssets/TerminalLoggerTestProject/TerminalLoggerTestProject.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>SimpleTestProject</AssemblyName>
+    <TargetFrameworks>$(NetFrameworkMinimum);$(NetCoreAppMinimum)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestFramework">
+      <Version>$(MSTestTestFrameworkVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="MSTest.TestAdapter">
+      <Version>$(MSTestTestAdapterVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk">
+      <Version>$(PackageVersion)</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkMinimum)' ">
+    <Reference Include="System.Runtime" />
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/test/TestAssets/TerminalLoggerTestProject/UnitTest1.cs
+++ b/test/TestAssets/TerminalLoggerTestProject/UnitTest1.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETFRAMEWORK
+using System;
+using System.IO;
+#endif
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TerminalLoggerUnitTests
+{
+    /// <summary>
+    /// The unit test 1.
+    /// </summary>
+    [TestClass]
+    public class UnitTest1
+    {
+        /// <summary>
+        /// The passing test.
+        /// </summary>
+        [TestMethod]
+        public void PassingTest()
+        {
+            Assert.AreEqual(2, 2);
+        }
+
+        /// <summary>
+        /// The failing test.
+        /// </summary>
+        [TestMethod]
+        public void FailingTest()
+        {
+            // test characters taken from https://pages.ucsd.edu/~dkjordan/chin/unitestuni.html
+            Assert.AreEqual("ğğğ𦮙我們剛才從𓋴𓅓𓏏𓇏𓇌𓀀", 3);
+        }
+
+        /// <summary>
+        /// The skipping test.
+        /// </summary>
+        [Ignore]
+        [TestMethod]
+        public void SkippingTest()
+        {
+        }
+    }
+}

--- a/test/TestAssets/TestAssets.sln
+++ b/test/TestAssets/TestAssets.sln
@@ -132,7 +132,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MultiHostTestExecutionProje
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NonDll.TestAdapter", "NonDll.TestAdapter\NonDll.TestAdapter.csproj", "{429552A4-4C18-4355-94C5-80DC88C48405}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetStandard2Library", "NetStandard2Library\NetStandard2Library.csproj", "{080F0AD2-E7AE-42C8-B867-56D78576735D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetStandard2Library", "NetStandard2Library\NetStandard2Library.csproj", "{080F0AD2-E7AE-42C8-B867-56D78576735D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TerminalLoggerTestProject", "TerminalLoggerTestProject\TerminalLoggerTestProject.csproj", "{C69BEEA4-BE37-4155-8DD0-130C62D8BF6D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -384,6 +386,10 @@ Global
 		{080F0AD2-E7AE-42C8-B867-56D78576735D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{080F0AD2-E7AE-42C8-B867-56D78576735D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{080F0AD2-E7AE-42C8-B867-56D78576735D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C69BEEA4-BE37-4155-8DD0-130C62D8BF6D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C69BEEA4-BE37-4155-8DD0-130C62D8BF6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C69BEEA4-BE37-4155-8DD0-130C62D8BF6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C69BEEA4-BE37-4155-8DD0-130C62D8BF6D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Description

- Use UTF8 encoding for the output that we force in vstest.console unless the user opts out. 
- Don't forward unrecognized messages to the parser, instead write them as message. Otherwise any message with "error" in it will be written as error, including passed tests that say "Standard Error: <empty>"
- Allow suppressing the logger also by MSBUILDENSURESTDOUTFORTASKPROCESSES=1

This PR is updating the dotnet SDK because the new SDK is NOT forcing MSBUILDENSURESTDOUTFORTASKPROCESSES=1 when the new logger is enabled. The old SDK was forcing it, and it would always disable the new task in our tests.

## Related issue

Fix https://github.com/dotnet/msbuild/issues/9674
Fix https://github.com/microsoft/vstest/issues/4852