### PR TITLE
Updating version of Microsoft.VisualStudio.Interop to 17.10

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -7,6 +7,7 @@
     <clear />
     <!-- When building TestAssets we read the keys from here and provide them directly to dotnet restore together with path to artifacts/packages/<configuration>/Shipping,
     because the path to packages contains configuration and we don't want to modify a checked-in file in our repo to be able to build. -->
+    <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
     <add key="vssdk-archived" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk-archived/nuget/v3/index.json" />
     <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,7 +33,7 @@
     <MicrosoftInternalCodeCoverageVersion>17.10.2-preview.24080.2</MicrosoftInternalCodeCoverageVersion>
     <MicrosoftVisualStudioDiagnosticsUtilitiesVersion>17.8.34518.129</MicrosoftVisualStudioDiagnosticsUtilitiesVersion>
     <MicrosoftVisualStudioEnterpriseAspNetHelper>$(MicrosoftVisualStudioDiagnosticsUtilitiesVersion)</MicrosoftVisualStudioEnterpriseAspNetHelper>
-    <MicrosoftVisualStudioInteropVersion>17.3.32622.426</MicrosoftVisualStudioInteropVersion>
+    <MicrosoftVisualStudioInteropVersion>17.10.525-preview.1</MicrosoftVisualStudioInteropVersion>
     <MicrosoftVSTelemetryVersion>17.6.46</MicrosoftVSTelemetryVersion>
     <MicrosoftVSUtilitiesInternalVersion>16.3.42</MicrosoftVSUtilitiesInternalVersion>
     <MicrosoftVSSDKBuildToolsVersion>17.4.2124</MicrosoftVSSDKBuildToolsVersion>


### PR DESCRIPTION
## Description

Updating package version of Microsoft.VisualStudio.Interop to a recent 17.10 build.  This is required to fix a MEF composition issue caused by a new interface in 17.10.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1948166
