### PR TITLE
Revert "Downgrade msbuild sdk (#4864)"

### DIFF
--- a/global.json
+++ b/global.json
@@ -27,7 +27,7 @@
     "vs": {
       "version": "17.8.0"
     },
-    "xcopy-msbuild": "17.8.3",
+    "xcopy-msbuild": "17.8.5",
     "vswhere": "2.2.7",
     "dotnet": "9.0.100-alpha.1.24073.1"
   },

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-alpha.1.23615.4",
+    "version": "9.0.100-alpha.1.24073.1",
     "rollForward": "minor",
     "allowPrerelease": false,
     "architecture": "x64"
@@ -27,9 +27,9 @@
     "vs": {
       "version": "17.8.0"
     },
-    "xcopy-msbuild": "17.8.1-2",
+    "xcopy-msbuild": "17.8.3",
     "vswhere": "2.2.7",
-    "dotnet": "9.0.100-alpha.1.23615.4"
+    "dotnet": "9.0.100-alpha.1.24073.1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24076.5"

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestMSBuildOutputTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestMSBuildOutputTests.cs
@@ -12,13 +12,6 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 /// Running dotnet test + csproj and using MSBuild for the output.
 /// </summary>
 [TestClass]
-[Ignore(
-"""
-    Ignored because we need to update to dotnet SDK 9.0.100-alpha.1.24073.1 or newer,
-    but that depends on newer version of MSBuild sdk that is not published yet, and so our build fails in Signing validation.
-    We need that upgrade because older SDK is hardcoding the same ENV variable that we are using to disable this functionality.
-    So when we patch the targets and build dll in the current SDK this new functionality is always disabled and we cannot test it with older SDK.
-""")]
 public class DotnetTestMSBuildOutputTests : AcceptanceTestBase
 {
     [TestMethod]


### PR DESCRIPTION
Upgrade the dotnet SDK and msbuild-sdk, to allow using the new features of msbuild logger.