### PR TITLE
Fix Microsoft.TestPlatform.Build sourcebuild nuspec

### DIFF
--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.sourcebuild.product.nuspec
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.sourcebuild.product.nuspec
@@ -11,7 +11,7 @@
   <files>
     $CommonFileElements$
 
-    <file src="$SourceBuildTfmPrevious$/Microsoft.TestPlatform.targets" target="runtimes/any/native" />
+    <file src="$SourceBuildTfmCurrent$/Microsoft.TestPlatform.targets" target="runtimes/any/native" />
     <file src="$SourceBuildTfmCurrent$/Microsoft.TestPlatform.Build.dll" target="lib/$SourceBuildTfmCurrent$" />
 
     <!-- Add localized resources -->


### PR DESCRIPTION
The line should be referencing net current and not net previous.

Fixes https://github.com/dotnet/installer/pull/18449
