### PR TITLE
Ensure to send a session complete event

### DIFF
--- a/src/Microsoft.TestPlatform.Client/TestPlatform.cs
+++ b/src/Microsoft.TestPlatform.Client/TestPlatform.cs
@@ -142,7 +142,6 @@ internal class TestPlatform : ITestPlatform
             // sources tells us we should run in-process (i.e. in vstest.console). Because
             // of this no session will be created because there's no testhost to be launched.
             // Expecting a subsequent call to execute tests with the same set of parameters.
-            eventsHandler.HandleStartTestSessionComplete(new());
             return false;
         }
 

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -525,6 +525,10 @@ internal class TestRequestManager : ITestRequestManager
                 var testSessionStarted = _testPlatform.StartTestSession(requestData, criteria, eventsHandler, sourceToSourceDetailMap, new NullWarningLogger());
                 if (!testSessionStarted)
                 {
+                    // Note: StartTestSession will invoke the HandleStartTestSessionComplete event
+                    // if the test session is started successfully. If it is not started, we need
+                    // to invoke the event here.
+                    eventsHandler.HandleStartTestSessionComplete(new());
                     EqtTrace.Warning("TestRequestManager.StartTestSession: Unable to start test session.");
                 }
             }

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -525,9 +525,12 @@ internal class TestRequestManager : ITestRequestManager
                 var testSessionStarted = _testPlatform.StartTestSession(requestData, criteria, eventsHandler, sourceToSourceDetailMap, new NullWarningLogger());
                 if (!testSessionStarted)
                 {
-                    // Note: StartTestSession will invoke the HandleStartTestSessionComplete event
-                    // if the test session is started successfully. If it is not started, we need
-                    // to invoke the event here.
+                    // Note: We need to send back a TestSessionComplete event, so that the caller
+                    // completes a session start request.
+                    // StartTestSession will invoke the HandleStartTestSessionComplete event
+                    // if the test session is started successfully. However, if it is not started,
+                    // HandleStartTestSessionComplete will not send an event. That's why we need
+                    // to do it here.
                     eventsHandler.HandleStartTestSessionComplete(new());
                     EqtTrace.Warning("TestRequestManager.StartTestSession: Unable to start test session.");
                 }

--- a/test/Microsoft.TestPlatform.Client.UnitTests/TestPlatformTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/TestPlatformTests.cs
@@ -494,10 +494,6 @@ public class TestPlatformTests
                 testSessionCriteria,
                 mockEventsHandler.Object,
                 It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>()));
-
-        mockEventsHandler.Verify(
-            eh => eh.HandleStartTestSessionComplete(It.IsAny<StartTestSessionCompleteEventArgs>()),
-            Times.Once);
     }
 
     [TestMethod]


### PR DESCRIPTION
Fixes the issue that if starting sessions fails, vstest console will not receive a completion event, thus will keep waiting on the StartSession call indefinitely.