### PR TITLE
Move SB metadata to intermediates

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,16 +9,19 @@
       <Uri>https://github.com/dotnet/diagnostics</Uri>
       <Sha>79b59c505405b9bee1d62dfa73dfb9750b2d4376</Sha>
     </Dependency>
+    <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.diagnostics" Version="8.0.0-preview.24076.1">
       <Uri>https://github.com/dotnet/diagnostics</Uri>
       <Sha>79b59c505405b9bee1d62dfa73dfb9750b2d4376</Sha>
       <SourceBuild RepoName="diagnostics" ManagedOnly="true" />
     </Dependency>
+    <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="9.0.0-alpha.1.24076.1">
       <Uri>https://github.com/dotnet/source-build-externals</Uri>
       <Sha>414a85bf970355c0e91d6a2de1ee183fafbfcecd</Sha>
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
+    <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="9.0.0-alpha.1.24075.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
       <Sha>e659f328bf255d3e17e81296117c3aed1d461f2f</Sha>
@@ -42,6 +45,11 @@
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="9.0.0-beta.24076.5">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>66c9c5397d599af40f2a94989241944f5a73442a</Sha>
+    </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="9.0.0-beta.24076.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>66c9c5397d599af40f2a94989241944f5a73442a</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />


### PR DESCRIPTION
The changes in this pull request aim to [improve the UX and guideance around the SourceBuild metadata](https://github.com/dotnet/source-build/issues/3373) by placing the metadata on explicit source-build intermediates.

The changes include:

- Removing existing SourceBuild metadata from all non-intermediate dependencies.
- Defining new explicit intermediate dependencies and adding SourceBuild metadata to those dependencies.

Related to https://github.com/dotnet/source-build/issues/3373 and https://github.com/dotnet/source-build/issues/4073