### PR TITLE
Fix feature flag name

### DIFF
--- a/src/vstest.console/CommandLine/Executor.cs
+++ b/src/vstest.console/CommandLine/Executor.cs
@@ -66,7 +66,7 @@ internal class Executor
     /// </summary>
     public Executor(IOutput output) : this(output, TestPlatformEventSource.Instance, new ProcessHelper(), new PlatformEnvironment())
     {
-        if (!FeatureFlag.Instance.IsSet(nameof(FeatureFlag.DISABLE_THREADPOOL_SIZE_INCREASE)))
+        if (!FeatureFlag.Instance.IsSet(FeatureFlag.DISABLE_THREADPOOL_SIZE_INCREASE))
         {
             // TODO: Get rid of this by making vstest.console code properly async.
             // The current implementation of vstest.console is blocking many threads that just wait


### PR DESCRIPTION
Remove using `nameof` on the flag, because that will not include the VSTEST_* prefix it has.