### PR TITLE
specify Win10 + maxversiontested to enable xaml APIs to be used in tests running under testhost.exe

### DIFF
--- a/src/testhost.x86/app.manifest
+++ b/src/testhost.x86/app.manifest
@@ -7,6 +7,9 @@
     <application>
       <!-- Windows 10 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <maxversiontested Id='10.0.18362.0'/>
+      <maxversiontested Id='10.0.19041.0'/>
+      <maxversiontested Id='10.0.22000.0'/>
       <!-- Windows 8.1 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!-- Windows Vista -->
@@ -15,11 +18,6 @@
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
       <!-- Windows 8 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-      <!-- Windows 10 -->
-      <supportedOS Id='{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}' />
-      <maxversiontested Id='10.0.18362.0'/>
-      <maxversiontested Id='10.0.19041.0'/>
-      <maxversiontested Id='10.0.22000.0'/>
     </application>
   </compatibility>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">

--- a/src/testhost.x86/app.manifest
+++ b/src/testhost.x86/app.manifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!-- Adding same as used in TPv1 Refer: /src/vset/Agile/TestPlatform/RocksteadyCLI/app.manifest -->
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <!-- The assemblyIdentity node is needed to fix a binding problem on Win2003 (PS72518) -->
@@ -15,6 +15,11 @@
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
       <!-- Windows 8 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 10 -->
+      <supportedOS Id='{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}' />
+      <maxversiontested Id='10.0.18362.0'/>
+      <maxversiontested Id='10.0.19041.0'/>
+      <maxversiontested Id='10.0.22000.0'/>
     </application>
   </compatibility>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">

--- a/src/testhost.x86/app.manifest
+++ b/src/testhost.x86/app.manifest
@@ -8,7 +8,7 @@
       <!-- Windows 10 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
       <!-- Enables Xaml Islands -->
-      <maxversiontested Id="10.0.18226.0"/>
+      <maxversiontested Id="10.0.18362.0"/>
       <!-- Windows 8.1 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!-- Windows Vista -->

--- a/src/testhost.x86/app.manifest
+++ b/src/testhost.x86/app.manifest
@@ -8,7 +8,7 @@
       <!-- Windows 10 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
       <!-- Enables Xaml Islands -->
-      <maxversiontested Id="10.0.18362.0"/>
+      <maxversiontested Id="10.0.18226.0"/>
       <!-- Windows 8.1 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!-- Windows Vista -->

--- a/src/testhost.x86/app.manifest
+++ b/src/testhost.x86/app.manifest
@@ -7,9 +7,8 @@
     <application>
       <!-- Windows 10 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
-      <maxversiontested Id='10.0.18362.0'/>
-      <maxversiontested Id='10.0.19041.0'/>
-      <maxversiontested Id='10.0.22000.0'/>
+      <!-- Enables Xaml Islands -->
+      <maxversiontested Id="10.0.18362.0"/>
       <!-- Windows 8.1 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!-- Windows Vista -->

--- a/src/testhost/app.manifest
+++ b/src/testhost/app.manifest
@@ -7,6 +7,9 @@
     <application>
       <!-- Windows 10 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <maxversiontested Id='10.0.18362.0'/>
+      <maxversiontested Id='10.0.19041.0'/>
+      <maxversiontested Id='10.0.22000.0'/>
       <!-- Windows 8.1 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!-- Windows Vista -->
@@ -15,11 +18,6 @@
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
       <!-- Windows 8 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-      <!-- Windows 10 -->
-      <supportedOS Id='{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}' />
-      <maxversiontested Id='10.0.18362.0'/>
-      <maxversiontested Id='10.0.19041.0'/>
-      <maxversiontested Id='10.0.22000.0'/>
     </application>
   </compatibility>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">

--- a/src/testhost/app.manifest
+++ b/src/testhost/app.manifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!-- Adding same as used in TPv1 Refer: /src/vset/Agile/TestPlatform/RocksteadyCLI/app.manifest -->
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <!-- The assemblyIdentity node is needed to fix a binding problem on Win2003 (PS72518) -->
@@ -15,6 +15,11 @@
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
       <!-- Windows 8 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 10 -->
+      <supportedOS Id='{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}' />
+      <maxversiontested Id='10.0.18362.0'/>
+      <maxversiontested Id='10.0.19041.0'/>
+      <maxversiontested Id='10.0.22000.0'/>
     </application>
   </compatibility>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">

--- a/src/testhost/app.manifest
+++ b/src/testhost/app.manifest
@@ -8,7 +8,7 @@
       <!-- Windows 10 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
       <!-- Enables Xaml Islands -->
-      <maxversiontested Id="10.0.18226.0"/>
+      <maxversiontested Id="10.0.18362.0"/>
       <!-- Windows 8.1 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!-- Windows Vista -->

--- a/src/testhost/app.manifest
+++ b/src/testhost/app.manifest
@@ -8,7 +8,7 @@
       <!-- Windows 10 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
       <!-- Enables Xaml Islands -->
-      <maxversiontested Id="10.0.18362.0"/>
+      <maxversiontested Id="10.0.18226.0"/>
       <!-- Windows 8.1 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!-- Windows Vista -->

--- a/src/testhost/app.manifest
+++ b/src/testhost/app.manifest
@@ -7,9 +7,8 @@
     <application>
       <!-- Windows 10 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
-      <maxversiontested Id='10.0.18362.0'/>
-      <maxversiontested Id='10.0.19041.0'/>
-      <maxversiontested Id='10.0.22000.0'/>
+      <!-- Enables Xaml Islands -->
+      <maxversiontested Id="10.0.18362.0"/>
       <!-- Windows 8.1 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!-- Windows Vista -->

--- a/src/vstest.console/app.manifest
+++ b/src/vstest.console/app.manifest
@@ -15,6 +15,11 @@
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
       <!-- Windows 8 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 10 -->
+      <supportedOS Id='{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}' />
+      <maxversiontested Id='10.0.18362.0'/>
+      <maxversiontested Id='10.0.19041.0'/>
+      <maxversiontested Id='10.0.22000.0'/>
     </application>
   </compatibility>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">

--- a/src/vstest.console/app.manifest
+++ b/src/vstest.console/app.manifest
@@ -7,6 +7,9 @@
     <application>
       <!-- Windows 10 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <maxversiontested Id='10.0.18362.0'/>
+      <maxversiontested Id='10.0.19041.0'/>
+      <maxversiontested Id='10.0.22000.0'/>
       <!-- Windows 8.1 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!-- Windows Vista -->
@@ -15,11 +18,6 @@
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
       <!-- Windows 8 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-      <!-- Windows 10 -->
-      <supportedOS Id='{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}' />
-      <maxversiontested Id='10.0.18362.0'/>
-      <maxversiontested Id='10.0.19041.0'/>
-      <maxversiontested Id='10.0.22000.0'/>
     </application>
   </compatibility>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">

--- a/src/vstest.console/app.manifest
+++ b/src/vstest.console/app.manifest
@@ -8,7 +8,7 @@
       <!-- Windows 10 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
       <!-- Enables Xaml Islands -->
-      <maxversiontested Id="10.0.18226.0"/>
+      <maxversiontested Id="10.0.18362.0"/>
       <!-- Windows 8.1 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!-- Windows Vista -->

--- a/src/vstest.console/app.manifest
+++ b/src/vstest.console/app.manifest
@@ -8,7 +8,7 @@
       <!-- Windows 10 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
       <!-- Enables Xaml Islands -->
-      <maxversiontested Id="10.0.18362.0"/>
+      <maxversiontested Id="10.0.18226.0"/>
       <!-- Windows 8.1 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!-- Windows Vista -->

--- a/src/vstest.console/app.manifest
+++ b/src/vstest.console/app.manifest
@@ -7,9 +7,8 @@
     <application>
       <!-- Windows 10 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
-      <maxversiontested Id='10.0.18362.0'/>
-      <maxversiontested Id='10.0.19041.0'/>
-      <maxversiontested Id='10.0.22000.0'/>
+      <!-- Enables Xaml Islands -->
+      <maxversiontested Id="10.0.18362.0"/>
       <!-- Windows 8.1 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!-- Windows Vista -->


### PR DESCRIPTION
## Description

Resolves #4887 

## Related issue

Kindly link any related issues. E.g. Fixes #xyz.

- [ ] I have ensured that there is a previously discussed and approved issue.
