### PR TITLE
Update source-build.yml

### DIFF
--- a/eng/common/templates-official/steps/source-build.yml
+++ b/eng/common/templates-official/steps/source-build.yml
@@ -94,6 +94,8 @@ steps:
       $baseOsArgs \
       /p:SourceBuildNonPortable=${{ parameters.platform.nonPortable }} \
       /p:ArcadeBuildFromSource=true \
+      /p:DotNetBuildSourceOnly=true \
+      /p:DotNetBuildRepo=true \
       /p:AssetManifestFileName=$assetManifestFileName
   displayName: Build
 


### PR DESCRIPTION
This should fix the failing source-build leg in the official build. Reason is that the source-build.yml in the "templates-official" folder is too old.