### PR TITLE
Use outputs

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -177,19 +177,19 @@ extends:
               displayName: Test
 
             templateContext:
-                outputs:
-                # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
-                # through the console or trx
-                - output: pipelineArtifact
-                  targetPath: $(System.DefaultWorkingDirectory)/out
-                  artifactName: TestResults
-                  displayName: 'Publish Test Results folders'
-                  condition: failed()
+              outputs:
+              # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
+              # through the console or trx
+              - output: pipelineArtifact
+                targetPath: $(System.DefaultWorkingDirectory)/out
+                artifactName: TestResults
+                displayName: 'Publish Test Results folders'
+                condition: failed()
 
-                - output: pipelineArtifact
-                  displayName: 'Publish VSSetup'
-                  targetPath: '$(Build.SourcesDirectory)/artifacts/VSSetup/Release'
-                  artifactName: VSSetupArtifacts 
+              - output: pipelineArtifact
+                displayName: 'Publish VSSetup'
+                targetPath: '$(Build.SourcesDirectory)/artifacts/VSSetup/Release'
+                artifactName: VSSetupArtifacts 
           
           - ${{ each pool in parameters.otherOsPools }}:
             - job: ${{ pool.os }}

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -144,6 +144,7 @@ extends:
             timeoutInMinutes: 120
             pool:
               name: netcore1espool-internal
+              image: 1es-windows-2022-pt
               demands: ImageOverride -equals 1es-windows-2022-pt
             steps:
             # This steps help to understand versions of .NET runtime installed on the machine,
@@ -175,20 +176,20 @@ extends:
               name: Test
               displayName: Test
 
-            # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
-            # through the console or trx
-            - task: 1ES.PublishBuildArtifacts@1
-              displayName: 'Publish Test Results folders'
-              inputs:
-                PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/Release'
-                ArtifactName: TestResults
-              condition: failed()
+            templateContext:
+                outputs:
+                # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
+                # through the console or trx
+                - output: pipelineArtifact
+                  targetPath: $(System.DefaultWorkingDirectory)/out
+                  artifactName: TestResults
+                  displayName: 'Publish Test Results folders'
+                  condition: failed()
 
-            - task: 1ES.PublishBuildArtifacts@1
-              displayName: 'Publish VSSetup'
-              inputs:
-                PathtoPublish: '$(Build.SourcesDirectory)/artifacts/VSSetup/Release'
-                ArtifactName: VSSetupArtifacts
+                - output: pipelineArtifact
+                  displayName: 'Publish VSSetup'
+                  targetPath: '$(Build.SourcesDirectory)/artifacts/VSSetup/Release'
+                  artifactName: VSSetupArtifacts 
           
           - ${{ each pool in parameters.otherOsPools }}:
             - job: ${{ pool.os }}
@@ -226,22 +227,24 @@ extends:
                 name: Test
                 displayName: Test
 
-              # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
-              # through the console or trx
-              - task: 1ES.PublishBuildArtifacts@1
-                displayName: 'Publish Test Results folders'
-                inputs:
-                  PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/Release'
-                  ArtifactName: TestResults
-                condition: failed()
+              templateContext:
+                outputs:
+                # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
+                # through the console or trx
+                - output: pipelineArtifact
+                  targetPath: $(System.DefaultWorkingDirectory)/out
+                  artifactName: TestResults
+                  displayName: 'Publish Test Results folders'
+                  condition: failed()
 
           - job: Publish
             dependsOn: 
               - ${{ each pool in parameters.otherOsPools }}:
                 - ${{ pool.os }}
             pool:
-                name: $(DncEngInternalBuildPool)
+                name: netcore1espool-internal
                 demands: ImageOverride -equals 1es-windows-2022-pt
+                image: 1es-windows-2022-pt
                 os: windows
             steps:
               # The template job needs a log, otherwise it writes a warning. We can disable log uploading only for
@@ -261,39 +264,42 @@ extends:
                   artifactName: VSSetupArtifacts
                   targetPath: '$(Build.SourcesDirectory)/artifacts/VSSetup/Release'
 
-              - task: NuGetAuthenticate@1
-                displayName: 'NuGet Authenticate to dotnet-tools and test-tools feeds'
+              templateContext:
+                outputs:
+                # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
+                # through the console or trx
+                - output: pipelineArtifact
+                  targetPath: $(System.DefaultWorkingDirectory)/out
+                  artifactName: TestResults
+                  displayName: 'Publish Test Results folders'
+                  condition: failed()
 
-              - task:  1ES.PublishNuget@1
-                displayName: 'Publish NuGet packages to dotnet-tools feed'
-                inputs:
+                - output: nuget
+                  displayName: 'Publish NuGet packages to dotnet-tools feed'
                   packageParentPath: '$(Build.SourcesDirectory)'
                   packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/Release/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/packages/Release/**/*.symbols.nupkg'
                   publishVstsFeed: 'public/dotnet-tools'
 
-              - task:  1ES.PublishNuget@1
-                displayName: 'Publish NuGet packages to test-tools feed'
-                inputs:
+                - output: nuget
+                  displayName: 'Publish NuGet packages to test-tools feed'
                   packageParentPath: '$(Build.SourcesDirectory)'
                   packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/Release/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/packages/Release/**/*.symbols.nupkg'
                   publishVstsFeed: 'public/test-tools'
 
-              # Publishes setup VSIXes to a drop.
-              # Note: The insertion tool looks for the display name of this task in the logs.
-              - task: 1ES.MicroBuildVstsDrop@1
-                displayName: Upload VSTS Drop
-                inputs:
+                # Publishes setup VSIXes to a drop.
+                # Note: The insertion tool looks for the display name of this task in the logs.
+                - output: microBuildVstsDrop
+                  displayName: Upload VSTS Drop
                   dropName: $(VisualStudioDropName)
                   dropFolder: 'artifacts\VSSetup\Release\Insertion'
                   accessToken: $(_DevDivDropAccessToken)
-                condition: succeeded()
+                  condition: succeeded()
 
-              - task: 1ES.PublishBuildArtifacts@1
-                displayName: Publish Artifact VSSetup
-                inputs:
-                  PathtoPublish: 'artifacts\VSSetup\Release'
-                  ArtifactName: 'VSSetup'
-                condition: succeeded()
+                - output: pipelineArtifact
+                  displayName: Publish Artifact VSSetup
+                  targetPath: 'artifacts\VSSetup\Release'
+                  artifactName: 'VSSetup'
+                  condition: succeeded()
 
       - template: /eng/common/templates-official/job/onelocbuild.yml@self
         parameters:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -264,42 +264,42 @@ extends:
                   artifactName: VSSetupArtifacts
                   targetPath: '$(Build.SourcesDirectory)/artifacts/VSSetup/Release'
 
-              templateContext:
-                outputs:
-                # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
-                # through the console or trx
-                - output: pipelineArtifact
-                  targetPath: $(System.DefaultWorkingDirectory)/out
-                  artifactName: TestResults
-                  displayName: 'Publish Test Results folders'
-                  condition: failed()
+            templateContext:
+              outputs:
+              # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
+              # through the console or trx
+              - output: pipelineArtifact
+                targetPath: $(System.DefaultWorkingDirectory)/out
+                artifactName: TestResults
+                displayName: 'Publish Test Results folders'
+                condition: failed()
 
-                - output: nuget
-                  displayName: 'Publish NuGet packages to dotnet-tools feed'
-                  packageParentPath: '$(Build.SourcesDirectory)'
-                  packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/Release/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/packages/Release/**/*.symbols.nupkg'
-                  publishVstsFeed: 'public/dotnet-tools'
+              - output: nuget
+                displayName: 'Publish NuGet packages to dotnet-tools feed'
+                packageParentPath: '$(Build.SourcesDirectory)'
+                packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/Release/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/packages/Release/**/*.symbols.nupkg'
+                publishVstsFeed: 'public/dotnet-tools'
 
-                - output: nuget
-                  displayName: 'Publish NuGet packages to test-tools feed'
-                  packageParentPath: '$(Build.SourcesDirectory)'
-                  packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/Release/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/packages/Release/**/*.symbols.nupkg'
-                  publishVstsFeed: 'public/test-tools'
+              - output: nuget
+                displayName: 'Publish NuGet packages to test-tools feed'
+                packageParentPath: '$(Build.SourcesDirectory)'
+                packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/Release/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/packages/Release/**/*.symbols.nupkg'
+                publishVstsFeed: 'public/test-tools'
 
-                # Publishes setup VSIXes to a drop.
-                # Note: The insertion tool looks for the display name of this task in the logs.
-                - output: microBuildVstsDrop
-                  displayName: Upload VSTS Drop
-                  dropName: $(VisualStudioDropName)
-                  dropFolder: 'artifacts\VSSetup\Release\Insertion'
-                  accessToken: $(_DevDivDropAccessToken)
-                  condition: succeeded()
+              # Publishes setup VSIXes to a drop.
+              # Note: The insertion tool looks for the display name of this task in the logs.
+              - output: microBuildVstsDrop
+                displayName: Upload VSTS Drop
+                dropName: $(VisualStudioDropName)
+                dropFolder: 'artifacts\VSSetup\Release\Insertion'
+                accessToken: $(_DevDivDropAccessToken)
+                condition: succeeded()
 
-                - output: pipelineArtifact
-                  displayName: Publish Artifact VSSetup
-                  targetPath: 'artifacts\VSSetup\Release'
-                  artifactName: 'VSSetup'
-                  condition: succeeded()
+              - output: pipelineArtifact
+                displayName: Publish Artifact VSSetup
+                targetPath: 'artifacts\VSSetup\Release'
+                artifactName: 'VSSetup'
+                condition: succeeded()
 
       - template: /eng/common/templates-official/job/onelocbuild.yml@self
         parameters:


### PR DESCRIPTION
Use outputs to eventually reduce the number of SDL checks.