### PR TITLE
Fix parent directory

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -271,14 +271,14 @@ extends:
               - task:  1ES.PublishNuget@1
                 displayName: 'Publish NuGet packages to dotnet-tools feed'
                 inputs:
-                  packageParentPath: '$(Build.SourcesDirectory)'
+                  packageParentPath: '$(Build.SourcesDirectory)/artifacts/packages/Release'
                   packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/Release/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/packages/Release/**/*.symbols.nupkg'
                   publishVstsFeed: 'public/dotnet-tools'
 
               - task:  1ES.PublishNuget@1
                 displayName: 'Publish NuGet packages to test-tools feed'
                 inputs:
-                  packageParentPath: '$(Build.SourcesDirectory)'
+                  packageParentPath: '$(Build.SourcesDirectory)/artifacts/packages/Release'
                   packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/Release/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/packages/Release/**/*.symbols.nupkg'
                   publishVstsFeed: 'public/test-tools'
 


### PR DESCRIPTION
Set parent directory closer to nugets, to avoid sdl checks on files we don't publish
