### PR TITLE
Use arcade managed images and pools from variables

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -47,7 +47,7 @@ parameters:
   type: object
   default:
   - name: $(DncEngInternalBuildPool)
-    image: build.ubuntu.2204.amd64
+    image: 1es-ubuntu-2204-pt
     os: linux
   - name: Azure Pipelines
     image: macOS-11

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -46,8 +46,8 @@ parameters:
 - name: otherOsPools
   type: object
   default:
-  - name: netcore1espool-internal
-    image: 1es-ubuntu-2204-pt
+  - name: $(DncEngInternalBuildPool)
+    image: build.ubuntu.2204.amd64
     os: linux
   - name: Azure Pipelines
     image: macOS-11
@@ -119,8 +119,8 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
-      name: netcore1espool-internal
-      image: 1es-windows-2022-pt
+      name: $(DncEngInternalBuildPool)
+      image: windows.vs2022.amd64
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling
@@ -143,8 +143,8 @@ extends:
           - job: Windows
             timeoutInMinutes: 120
             pool:
-              name: netcore1espool-internal
-              demands: ImageOverride -equals 1es-windows-2022-pt
+              name: $(DncEngInternalBuildPool)
+              demands: ImageOverride -equals windows.vs2022.amd64
             steps:
             # This steps help to understand versions of .NET runtime installed on the machine,
             # which is useful to diagnose some governance issues.
@@ -245,7 +245,7 @@ extends:
                 - ${{ pool.os }}
             pool:
                 name: $(DncEngInternalBuildPool)
-                demands: ImageOverride -equals 1es-windows-2022-pt
+                demands: ImageOverride -equals windows.vs2022.amd64
                 os: windows
             steps:
               # The template job needs a log, otherwise it writes a warning. We can disable log uploading only for

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -144,7 +144,8 @@ extends:
             timeoutInMinutes: 120
             pool:
               name: $(DncEngInternalBuildPool)
-              demands: ImageOverride -equals windows.vs2022.amd64
+              image: windows.vs2022.amd64
+              os: windows
             steps:
             # This steps help to understand versions of .NET runtime installed on the machine,
             # which is useful to diagnose some governance issues.
@@ -245,7 +246,7 @@ extends:
                 - ${{ pool.os }}
             pool:
                 name: $(DncEngInternalBuildPool)
-                demands: ImageOverride -equals windows.vs2022.amd64
+                image: windows.vs2022.amd64
                 os: windows
             steps:
               # The template job needs a log, otherwise it writes a warning. We can disable log uploading only for


### PR DESCRIPTION
The windows image is updated by Arcade team, unlike the one we used until now, this prevents errors on Arcade updates.