### PR TITLE
Fix single quote and space in F# pretty methods

### DIFF
--- a/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/ManagedNameParser.cs
+++ b/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/ManagedNameParser.cs
@@ -82,12 +82,21 @@ public class ManagedNameParser
     {
         var i = start;
         var quoted = false;
+        char? previousChar = null;
+        // Consume all characters that are in single quotes as is. Because F# methods wrapped in `` can have any text, like ``method name``.
+        // and will be emitted into CIL  as 'method name'.
+        // Make sure you ignore \', because that is how F# will escape ' if it appears in the method name.
         for (; i < managedMethodName.Length; i++)
         {
-            var c = managedMethodName[i];
-            if (c == '\'' || quoted)
+            if ((i - 1) > 0)
             {
-                quoted = c == '\'' ? !quoted : quoted;
+                previousChar = managedMethodName[i - 1];
+            }
+
+            var c = managedMethodName[i];
+            if ((c == '\'' && previousChar != '\\') || quoted)
+            {
+                quoted = (c == '\'' && previousChar != '\\') ? !quoted : quoted;
                 continue;
             }
 

--- a/test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/ManagedNameUtilities/ManagedNameParserTests.cs
+++ b/test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/ManagedNameUtilities/ManagedNameParserTests.cs
@@ -50,6 +50,15 @@ public class ManagedNameParserTests
         AssertParse("Method", 1, new string[] { "B", "List<B>" }, "Method`1(B,List<B>)");
         AssertParse("Method", 0, new string[] { "B[]" }, "Method(B[])");
         AssertParse("Method", 0, new string[] { "A[,]", "B[,,][]" }, "Method(A[,],B[,,][])");
+
+        // An F# method that would look like this in code: member _.``method that does not pass`` () =
+        // And like this in CIL: instance void 'method that does not pass' () cil managed
+        Assert.AreEqual(("Method that does not pass", 0, null), Parse("'Method that does not pass'()"));
+
+        // An F# method that would look like this in code: member _.``method that doesn't pass`` () =
+        // And like this in CIL: instance void 'method that doesn\'t pass' () cil managed
+        // Notice the ' escaped by \.
+        Assert.AreEqual(("Method that doesn't pass", 0, null), Parse(@"'Method that doesn\'t pass'()"));
     }
 
     [TestMethod]

--- a/test/TestAssets/CILProject/OrphanMethod.il
+++ b/test/TestAssets/CILProject/OrphanMethod.il
@@ -2,24 +2,43 @@
 .assembly extern mscorlib {}
 .assembly extern System.Core {}
 
-.method static public int32 Add(int32 x, int32 y) cil managed 
+.class public CleanNamespaceName.ClassName
 {
-    .maxstack 2
+    .method static public int32 Add(int32 x, int32 y) cil managed 
+    {
+        .maxstack 2
 
-    ldarg.0
-    ldarg.1
-    add
-    ret
-}
+        ldarg.0
+        ldarg.1
+        add
+        ret
+    }
 
-.method static public int32 'An awesome method to add 𝓧➕𝓨'(int32 '𝓧', int32 '𝓨') cil managed 
-{
-    .maxstack 2
+    .method static public int32 'An awesome method to add 𝓧➕𝓨'(int32 '𝓧', int32 '𝓨') cil managed 
+    {
+        .maxstack 2
 
-    ldarg.0
-    ldarg.1
-    add
-    ret
+        ldarg.0
+        ldarg.1
+        add
+        ret
+    }
+
+    // has ' and no spaces, e.g. coming from F# method ``don't``
+    .method static public void 'don\'t'() cil managed 
+    {
+        .maxstack 1
+
+        ret
+    }
+
+    // has ' and a space, e.g. coming from F# method ``don't pass``
+    .method static public void 'don\'t pass'() cil managed 
+    {
+        .maxstack 1
+
+        ret
+    }
 }
 
 .class public CleanNamespaceName.SecondLevel.'𝐌𝐲 𝗮𝘄𝗲𝘀𝗼𝗺𝗲 𝘤𝘭𝘢𝘴𝘴 𝘢𝘯 𝒊𝒏𝒂𝒄𝒄𝒆𝒔𝒔𝒊𝒃𝒍𝒆 𝙣𝙖𝙢𝙚 😭' 


### PR DESCRIPTION
## Description
Whitespace is not valid in method names and the parser was not skipping over escaped single tick `\'`, so the method name from F# ``` ``don't pass`` ``` would be output as ` 'don\'t pass' ` in CIL. And the parser would parse `'don\'` as being quoted, and `t pass` as invalid method part because there is whitespace.

## Related issue

Fix #4313 

- [ ] I have ensured that there is a previously discussed and approved issue.
