### PR TITLE
Forward standard output of testhost

### DIFF
--- a/playground/TestPlatform.Playground/Environment.cs
+++ b/playground/TestPlatform.Playground/Environment.cs
@@ -14,7 +14,6 @@ internal class EnvironmentVariables
         ["VSTEST_RUNNER_DEBUG_ATTACHVS"] = "0",
         ["VSTEST_HOST_DEBUG_ATTACHVS"] = "0",
         ["VSTEST_DATACOLLECTOR_DEBUG_ATTACHVS"] = "0",
-        ["VSTEST_EXPERIMENTAL_FORWARD_OUTPUT_FEATURE"] = "0"
     };
 
 }

--- a/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
+++ b/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
@@ -25,7 +25,6 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Payloads;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 
 using CommunicationUtilitiesResources = Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources.Resources;
 
@@ -44,8 +43,6 @@ public class DesignModeClient : IDesignModeClient
     private readonly IEnvironment _platformEnvironment;
     private readonly TestSessionMessageLogger _testSessionMessageLogger;
     private readonly object _lockObject = new();
-    private readonly bool _isForwardingOutput;
-
     [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Part of the public API.")]
     [SuppressMessage("Design", "CA1051:Do not declare visible instance fields", Justification = "Part of the public API")]
     protected Action<Message>? onCustomTestHostLaunchAckReceived;
@@ -57,7 +54,7 @@ public class DesignModeClient : IDesignModeClient
     /// Initializes a new instance of the <see cref="DesignModeClient"/> class.
     /// </summary>
     public DesignModeClient()
-        : this(new SocketCommunicationManager(), JsonDataSerializer.Instance, new PlatformEnvironment(), new EnvironmentVariableHelper())
+        : this(new SocketCommunicationManager(), JsonDataSerializer.Instance, new PlatformEnvironment())
     {
     }
 
@@ -73,14 +70,13 @@ public class DesignModeClient : IDesignModeClient
     /// <param name="platformEnvironment">
     /// The platform Environment
     /// </param>
-    internal DesignModeClient(ICommunicationManager communicationManager, IDataSerializer dataSerializer, IEnvironment platformEnvironment, IEnvironmentVariableHelper environmentVariableHelper)
+    internal DesignModeClient(ICommunicationManager communicationManager, IDataSerializer dataSerializer, IEnvironment platformEnvironment)
     {
         _communicationManager = communicationManager;
         _dataSerializer = dataSerializer;
         _platformEnvironment = platformEnvironment;
         _testSessionMessageLogger = TestSessionMessageLogger.Instance;
         _testSessionMessageLogger.TestRunMessage += TestRunMessageHandler;
-        _isForwardingOutput = environmentVariableHelper.GetEnvironmentVariable("VSTEST_EXPERIMENTAL_FORWARD_OUTPUT_FEATURE") == "1";
     }
 
     /// <summary>
@@ -449,7 +445,7 @@ public class DesignModeClient : IDesignModeClient
             case TestMessageLevel.Informational:
                 EqtTrace.Info(e.Message);
 
-                if (_isForwardingOutput || EqtTrace.IsInfoEnabled)
+                if (EqtTrace.IsInfoEnabled)
                     SendTestMessage(e.Level, e.Message);
                 break;
 

--- a/src/Microsoft.TestPlatform.Common/ExtensionDecorators/ExtensionDecoratorFactory.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionDecorators/ExtensionDecoratorFactory.cs
@@ -16,7 +16,7 @@ internal class ExtensionDecoratorFactory
 
     public ITestExecutor Decorate(ITestExecutor originalTestExecutor)
     {
-        return _featureFlag.IsSet(FeatureFlag.DISABLE_SERIALTESTRUN_DECORATOR)
+        return _featureFlag.IsSet(FeatureFlag.VSTEST_DISABLE_SERIALTESTRUN_DECORATOR)
             ? originalTestExecutor
             : new SerialTestRunDecorator(originalTestExecutor);
     }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.cs
@@ -22,7 +22,7 @@ public class JsonDataSerializer : IDataSerializer
 {
     private static JsonDataSerializer? s_instance;
 
-    private static readonly bool DisableFastJson = FeatureFlag.Instance.IsSet(FeatureFlag.DISABLE_FASTER_JSON_SERIALIZATION);
+    private static readonly bool DisableFastJson = FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_DISABLE_FASTER_JSON_SERIALIZATION);
 
     private static readonly JsonSerializer PayloadSerializerV1; // payload serializer for version <= 1
     private static readonly JsonSerializer PayloadSerializerV2; // payload serializer for version >= 2

--- a/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
@@ -32,33 +32,42 @@ internal partial class FeatureFlag : IFeatureFlag
     // Only check the env variable once, when it is not set or is set to 0, consider it unset. When it is anything else, consider it set.
     public bool IsSet(string featureFlag) => _cache.GetOrAdd(featureFlag, f => (Environment.GetEnvironmentVariable(f)?.Trim() ?? "0") != "0");
 
-    private const string VSTEST_ = nameof(VSTEST_);
-
     // Added for artifact post-processing, it enable/disable the post processing.
     // Added in 17.2-preview 7.0-preview
-    public const string DISABLE_ARTIFACTS_POSTPROCESSING = VSTEST_ + nameof(DISABLE_ARTIFACTS_POSTPROCESSING);
+    public const string VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING = nameof(VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING);
 
     // Added for artifact post-processing, it will show old output for dotnet sdk scenario.
     // It can be useful if we need to restore old UX in case users are parsing the console output.
     // Added in 17.2-preview 7.0-preview
-    public const string DISABLE_ARTIFACTS_POSTPROCESSING_NEW_SDK_UX = VSTEST_ + nameof(DISABLE_ARTIFACTS_POSTPROCESSING_NEW_SDK_UX);
+    public const string VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING_NEW_SDK_UX = nameof(VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING_NEW_SDK_UX);
 
     // Faster JSON serialization relies on less internals of NewtonsoftJson, and on some additional caching.
-    public const string DISABLE_FASTER_JSON_SERIALIZATION = VSTEST_ + nameof(DISABLE_FASTER_JSON_SERIALIZATION);
+    public const string VSTEST_DISABLE_FASTER_JSON_SERIALIZATION = nameof(VSTEST_DISABLE_FASTER_JSON_SERIALIZATION);
 
     // Forces vstest.console to run all sources using the same target framework (TFM) and architecture, instead of allowing
     // multiple different tfms and architectures to run at the same time.
-    public const string DISABLE_MULTI_TFM_RUN = VSTEST_ + nameof(DISABLE_MULTI_TFM_RUN);
+    public const string VSTEST_DISABLE_MULTI_TFM_RUN = nameof(VSTEST_DISABLE_MULTI_TFM_RUN);
 
     // Disables setting a higher value for SetMinThreads. Setting SetMinThreads value to higher allows testhost to connect back faster
     // even though we are blocking additional threads because we don't have to wait for ThreadPool to start more threads.
-    public const string DISABLE_THREADPOOL_SIZE_INCREASE = VSTEST_ + nameof(DISABLE_THREADPOOL_SIZE_INCREASE);
+    public const string VSTEST_DISABLE_THREADPOOL_SIZE_INCREASE = nameof(VSTEST_DISABLE_THREADPOOL_SIZE_INCREASE);
 
     // Disable the SerialTestRunDecorator
-    public const string DISABLE_SERIALTESTRUN_DECORATOR = VSTEST_ + nameof(DISABLE_SERIALTESTRUN_DECORATOR);
+    public const string VSTEST_DISABLE_SERIALTESTRUN_DECORATOR = nameof(VSTEST_DISABLE_SERIALTESTRUN_DECORATOR);
 
     // Disable setting UTF8 encoding in console.
-    public const string DISABLE_UTF8_CONSOLE_ENCODING = VSTEST_ + nameof(DISABLE_UTF8_CONSOLE_ENCODING);
+    public const string VSTEST_DISABLE_UTF8_CONSOLE_ENCODING = nameof(VSTEST_DISABLE_UTF8_CONSOLE_ENCODING);
+
+    // VSTEST_EXPERIMENTAL_FORWARD_OUTPUT_FEATURE=1 replaced by the CAPTURING and FORWARDING flags, and was enabling
+    // the same behavior as what is now the default (both capture and forward set to TRUE).
+    // Because this is the new default we don't have to handle it in any special way. Setting it to 0 was not defined
+    // and so it also does not need any special treatment.
+    //
+    // Disable capturing standard output of testhost.
+    public const string VSTEST_DISABLE_STANDARD_OUTPUT_CAPTURING = nameof(VSTEST_DISABLE_STANDARD_OUTPUT_CAPTURING);
+
+    // Disable forwarding standard output of testhost.
+    public const string VSTEST_DISABLE_STANDARD_OUTPUT_FORWARDING = nameof(VSTEST_DISABLE_STANDARD_OUTPUT_FORWARDING);
 
     [Obsolete("Only use this in tests.")]
     internal static void Reset()

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/PostProcessing/ArtifactProcessingManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/PostProcessing/ArtifactProcessingManager.cs
@@ -81,7 +81,7 @@ internal class ArtifactProcessingManager : IArtifactProcessingManager
         ValidateArg.NotNull(testRunCompleteEventArgs, nameof(testRunCompleteEventArgs));
         ValidateArg.NotNull(runSettingsXml, nameof(runSettingsXml));
 
-        if (_featureFlag.IsSet(FeatureFlag.DISABLE_ARTIFACTS_POSTPROCESSING))
+        if (_featureFlag.IsSet(FeatureFlag.VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING))
         {
             EqtTrace.Verbose("ArtifactProcessingManager.CollectArtifacts: Feature disabled");
             return;
@@ -120,7 +120,7 @@ internal class ArtifactProcessingManager : IArtifactProcessingManager
 
     public async Task PostProcessArtifactsAsync()
     {
-        if (_featureFlag.IsSet(FeatureFlag.DISABLE_ARTIFACTS_POSTPROCESSING))
+        if (_featureFlag.IsSet(FeatureFlag.VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING))
         {
             EqtTrace.Verbose("ArtifactProcessingManager.PostProcessArtifacts: Feature disabled");
             return;

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
@@ -972,3 +972,5 @@ virtual Microsoft.VisualStudio.TestPlatform.ObjectModel.TestObject.ProtectedGetP
 virtual Microsoft.VisualStudio.TestPlatform.ObjectModel.TestObject.ProtectedSetPropertyValue(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestProperty! property, object? value) -> void
 virtual Microsoft.VisualStudio.TestPlatform.ObjectModel.ValidateValueCallback.Invoke(object? value) -> bool
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.RiscV64 = 8 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
+Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.CaptureStandardOutput.get -> bool
+Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.ForwardStandardOutput.get -> bool

--- a/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
@@ -9,6 +9,7 @@ using System.Xml;
 using Microsoft.VisualStudio.TestPlatform.CoreUtilities;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
+using Microsoft.VisualStudio.TestPlatform.Utilities;
 
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
@@ -92,6 +93,8 @@ public class RunConfiguration : TestRunSettings
         _shouldCollectSourceInformation = false;
         TargetDevice = null;
         ExecutionThreadApartmentState = Constants.DefaultExecutionThreadApartmentState;
+        CaptureStandardOutput = !FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_DISABLE_STANDARD_OUTPUT_CAPTURING);
+        ForwardStandardOutput = !FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_DISABLE_STANDARD_OUTPUT_FORWARDING);
     }
 
     /// <summary>
@@ -431,9 +434,26 @@ public class RunConfiguration : TestRunSettings
     /// </summary>
     public string? TestCaseFilter { get; private set; }
 
+    /// <summary>
     /// Path to dotnet executable to be used to invoke testhost.dll. Specifying this will skip looking up testhost.exe and will force usage of the testhost.dll.
     /// </summary>
     public string? DotnetHostPath { get; private set; }
+
+    /// <summary>
+    /// When true, we capture standard output of child processes. When false the standard output is not captured and it will end up in command line.
+    /// This makes the output visible to the user when running in vstest.console in-process. Such setup makes the behavior the same as in 17.6.3 and earlier.
+    /// 
+    /// The recommended way is to use this with ForwardStandardOutput=true to forward output as informational messages so the output is always visible in console and VS,
+    /// unless the logging level is set to Warning or higher.
+    ///
+    /// Lastly this can be used with ForwardStandardOutput=false, to suppress the output in console, which is behavior of 17.7.0 till now.
+    /// </summary>
+    public bool CaptureStandardOutput { get; private set; }
+
+    /// <summary>
+    /// Forward captured standard output of testhost as Informational test messages. Default is true. Needs CaptureStandardOutput to be true.
+    /// </summary>
+    public bool ForwardStandardOutput { get; private set; }
 
     /// <inheritdoc/>
     public override XmlElement ToXml()
@@ -549,6 +569,14 @@ public class RunConfiguration : TestRunSettings
             treatAsError.InnerText = TreatNoTestsAsError.ToString();
             root.AppendChild(treatAsError);
         }
+
+        XmlElement captureStandardOutput = doc.CreateElement(nameof(CaptureStandardOutput));
+        captureStandardOutput.InnerXml = CaptureStandardOutput.ToString();
+        root.AppendChild(captureStandardOutput);
+
+        XmlElement forwardStandardOutput = doc.CreateElement(nameof(ForwardStandardOutput));
+        forwardStandardOutput.InnerXml = ForwardStandardOutput.ToString();
+        root.AppendChild(forwardStandardOutput);
 
         return root;
     }
@@ -907,6 +935,35 @@ public class RunConfiguration : TestRunSettings
                     case "TargetFrameworkTestHostDemultiplexer":
                         reader.Skip();
                         break;
+
+                    case "CaptureStandardOutput":
+                        XmlRunSettingsUtilities.ThrowOnHasAttributes(reader);
+                        string captureStandardOutputStr = reader.ReadElementContentAsString();
+
+                        bool bCaptureStandardOutput;
+                        if (!bool.TryParse(captureStandardOutputStr, out bCaptureStandardOutput))
+                        {
+                            throw new SettingsException(string.Format(CultureInfo.CurrentCulture,
+                                Resources.Resources.InvalidSettingsIncorrectValue, Constants.RunConfigurationSettingsName, bCaptureStandardOutput, elementName));
+                        }
+
+                        runConfiguration.CaptureStandardOutput = bCaptureStandardOutput;
+                        break;
+
+                    case "ForwardStandardOutput":
+                        XmlRunSettingsUtilities.ThrowOnHasAttributes(reader);
+                        string forwardStandardOutputStr = reader.ReadElementContentAsString();
+
+                        bool bForwardStandardOutput;
+                        if (!bool.TryParse(forwardStandardOutputStr, out bForwardStandardOutput))
+                        {
+                            throw new SettingsException(string.Format(CultureInfo.CurrentCulture,
+                                Resources.Resources.InvalidSettingsIncorrectValue, Constants.RunConfigurationSettingsName, bForwardStandardOutput, elementName));
+                        }
+
+                        runConfiguration.ForwardStandardOutput = bForwardStandardOutput;
+                        break;
+
                     default:
                         // Ignore a runsettings element that we don't understand. It could occur in the case
                         // the test runner is of a newer version, but the test host is of an earlier version.

--- a/src/Microsoft.TestPlatform.ObjectModel/TestProperty/TestProperty.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TestProperty/TestProperty.cs
@@ -19,7 +19,7 @@ public class TestProperty : IEquatable<TestProperty>
 {
     private static readonly ConcurrentDictionary<string, Type> TypeCache = new();
 
-    private static bool DisableFastJson { get; set; } = FeatureFlag.Instance.IsSet(FeatureFlag.DISABLE_FASTER_JSON_SERIALIZATION);
+    private static bool DisableFastJson { get; set; } = FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_DISABLE_FASTER_JSON_SERIALIZATION);
 
     private Type _valueType;
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
@@ -29,11 +29,11 @@ internal class TestHostManagerCallbacks
             {
                 but = " But logger is null, so it won't forward any output.";
             }
-            EqtTrace.Verbose($"TestHostManagerCallbacks.ctor: Experimental forwarding output is enabled.{but}");
+            EqtTrace.Verbose($"TestHostManagerCallbacks.ctor: Forwarding output is enabled.{but}");
         }
         else
         {
-            EqtTrace.Verbose($"TestHostManagerCallbacks.ctor: Experimental forwarding output is disabled.");
+            EqtTrace.Verbose($"TestHostManagerCallbacks.ctor: Forwarding output is disabled.");
         }
         _forwardOutput = forwardOutput;
         _messageLogger = logger;

--- a/src/vstest.console/CommandLine/Executor.cs
+++ b/src/vstest.console/CommandLine/Executor.cs
@@ -66,7 +66,7 @@ internal class Executor
     /// </summary>
     public Executor(IOutput output) : this(output, TestPlatformEventSource.Instance, new ProcessHelper(), new PlatformEnvironment())
     {
-        if (!FeatureFlag.Instance.IsSet(FeatureFlag.DISABLE_THREADPOOL_SIZE_INCREASE))
+        if (!FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_DISABLE_THREADPOOL_SIZE_INCREASE))
         {
             // TODO: Get rid of this by making vstest.console code properly async.
             // The current implementation of vstest.console is blocking many threads that just wait

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -680,9 +680,9 @@ internal class ConsoleLogger : ITestLoggerWithParameters
         if (runLevelAttachmentsCount > 0)
         {
             // If ARTIFACTS_POSTPROCESSING is disabled
-            if (_featureFlag.IsSet(FeatureFlag.DISABLE_ARTIFACTS_POSTPROCESSING) ||
+            if (_featureFlag.IsSet(FeatureFlag.VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING) ||
                 // DISABLE_ARTIFACTS_POSTPROCESSING_NEW_SDK_UX(new UX) is disabled
-                _featureFlag.IsSet(FeatureFlag.DISABLE_ARTIFACTS_POSTPROCESSING_NEW_SDK_UX) ||
+                _featureFlag.IsSet(FeatureFlag.VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING_NEW_SDK_UX) ||
                 // TestSessionCorrelationId is null(we're not running through the dotnet SDK).
                 CommandLineOptions.Instance.TestSessionCorrelationId is null)
             {

--- a/src/vstest.console/Processors/ArtifactProcessingPostProcessModeProcessor.cs
+++ b/src/vstest.console/Processors/ArtifactProcessingPostProcessModeProcessor.cs
@@ -45,7 +45,7 @@ internal class ArtifactProcessingPostProcessModeProcessor : IArgumentProcessor
     }
 
     public static bool ContainsPostProcessCommand(string[]? args, IFeatureFlag? featureFlag = null)
-        => !(featureFlag ?? FeatureFlag.Instance).IsSet(FeatureFlag.DISABLE_ARTIFACTS_POSTPROCESSING) &&
+        => !(featureFlag ?? FeatureFlag.Instance).IsSet(FeatureFlag.VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING) &&
             (args?.Contains("--artifactsProcessingMode-postprocess", StringComparer.OrdinalIgnoreCase) == true ||
             args?.Contains(CommandName, StringComparer.OrdinalIgnoreCase) == true);
 }

--- a/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
+++ b/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
@@ -51,7 +51,7 @@ internal class ArgumentProcessorFactory
     {
         var defaultArgumentProcessor = DefaultArgumentProcessors;
 
-        if (!(featureFlag ?? FeatureFlag.Instance).IsSet(FeatureFlag.DISABLE_ARTIFACTS_POSTPROCESSING))
+        if (!(featureFlag ?? FeatureFlag.Instance).IsSet(FeatureFlag.VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING))
         {
             defaultArgumentProcessor.Add(new ArtifactProcessingCollectModeProcessor());
             defaultArgumentProcessor.Add(new ArtifactProcessingPostProcessModeProcessor());

--- a/src/vstest.console/Program.cs
+++ b/src/vstest.console/Program.cs
@@ -23,7 +23,7 @@ public static class Program
 
     internal static int Run(string[]? args, UiLanguageOverride uiLanguageOverride)
     {
-        if (!FeatureFlag.Instance.IsSet(FeatureFlag.DISABLE_UTF8_CONSOLE_ENCODING))
+        if (!FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_DISABLE_UTF8_CONSOLE_ENCODING))
         {
             Console.OutputEncoding = Encoding.UTF8;
         }

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -710,7 +710,7 @@ internal class TestRequestManager : ITestRequestManager
         // After MULTI_TFM  sourceToArchitectureMap and sourceToFrameworkMap are the source of truth, and are propagated forward,
         // so when we want to revert to the older behavior we need to re-enable the check, and unify all the architecture and
         // framework entries to the same chosen value.
-        var disableMultiTfm = FeatureFlag.Instance.IsSet(FeatureFlag.DISABLE_MULTI_TFM_RUN);
+        var disableMultiTfm = FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_DISABLE_MULTI_TFM_RUN);
 
         // Choose default architecture based on the framework.
         // For a run with mixed tfms enabled, or .NET "Core", the default platform architecture should be based on the process.

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestTests.cs
@@ -98,4 +98,22 @@ public class DotnetTestTests : AcceptanceTestBase
         ValidateSummaryStatus(1, 1, 0);
         ExitCodeEquals(1);
     }
+
+    [TestMethod]
+    // patched dotnet is not published on non-windows systems
+    [TestCategory("Windows-Review")]
+    [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
+    [Ignore("TODO: This scenario is broken in real environment as well (running with shipped `dotnet test`. Old tests (before arcade) use location of vstest.console that have more dlls in place than what we ship, and they make it work.")]
+    public void RunDotnetTestAndSeeOutputFromConsoleWriteLine(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var assemblyPath = GetAssetFullPath("OutputtingTestProject.dll");
+        InvokeDotnetTest($@"{assemblyPath} --logger:""Console;Verbosity=normal"" ");
+
+        StdOutputContains("MY OUTPUT FROM TEST");
+
+        ValidateSummaryStatus(1, 0, 0);
+        ExitCodeEquals(0);
+    }
 }

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestTests.cs
@@ -103,7 +103,6 @@ public class DotnetTestTests : AcceptanceTestBase
     // patched dotnet is not published on non-windows systems
     [TestCategory("Windows-Review")]
     [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
-    [Ignore("TODO: This scenario is broken in real environment as well (running with shipped `dotnet test`. Old tests (before arcade) use location of vstest.console that have more dlls in place than what we ship, and they make it work.")]
     public void RunDotnetTestAndSeeOutputFromConsoleWriteLine(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);

--- a/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeClientTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeClientTests.cs
@@ -22,7 +22,6 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Payloads;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 
 using Moq;
 
@@ -42,15 +41,13 @@ public class DesignModeClientTests
     private readonly int _protocolVersion = 7;
     private readonly AutoResetEvent _completeEvent;
     private readonly Mock<IEnvironment> _mockPlatformEnvironment;
-    private readonly Mock<IEnvironmentVariableHelper> _mockEnvironmentVariableHelper;
 
     public DesignModeClientTests()
     {
         _mockTestRequestManager = new Mock<ITestRequestManager>();
         _mockCommunicationManager = new Mock<ICommunicationManager>();
         _mockPlatformEnvironment = new Mock<IEnvironment>();
-        _mockEnvironmentVariableHelper = new Mock<IEnvironmentVariableHelper>();
-        _designModeClient = new DesignModeClient(_mockCommunicationManager.Object, JsonDataSerializer.Instance, _mockPlatformEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        _designModeClient = new DesignModeClient(_mockCommunicationManager.Object, JsonDataSerializer.Instance, _mockPlatformEnvironment.Object);
         _completeEvent = new AutoResetEvent(false);
     }
 
@@ -295,7 +292,7 @@ public class DesignModeClientTests
     [TestMethod]
     public void DesignModeClientLaunchCustomHostMustReturnIfAckComes()
     {
-        var testableDesignModeClient = new TestableDesignModeClient(_mockCommunicationManager.Object, JsonDataSerializer.Instance, _mockPlatformEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testableDesignModeClient = new TestableDesignModeClient(_mockCommunicationManager.Object, JsonDataSerializer.Instance, _mockPlatformEnvironment.Object);
 
         _mockCommunicationManager.Setup(cm => cm.WaitForServerConnection(It.IsAny<int>())).Returns(true);
 
@@ -315,7 +312,7 @@ public class DesignModeClientTests
     [ExpectedException(typeof(TestPlatformException))]
     public void DesignModeClientLaunchCustomHostMustThrowIfInvalidAckComes()
     {
-        var testableDesignModeClient = new TestableDesignModeClient(_mockCommunicationManager.Object, JsonDataSerializer.Instance, _mockPlatformEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testableDesignModeClient = new TestableDesignModeClient(_mockCommunicationManager.Object, JsonDataSerializer.Instance, _mockPlatformEnvironment.Object);
 
         _mockCommunicationManager.Setup(cm => cm.WaitForServerConnection(It.IsAny<int>())).Returns(true);
 
@@ -334,7 +331,7 @@ public class DesignModeClientTests
     [ExpectedException(typeof(TestPlatformException))]
     public void DesignModeClientLaunchCustomHostMustThrowIfCancellationOccursBeforeHostLaunch()
     {
-        var testableDesignModeClient = new TestableDesignModeClient(_mockCommunicationManager.Object, JsonDataSerializer.Instance, _mockPlatformEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testableDesignModeClient = new TestableDesignModeClient(_mockCommunicationManager.Object, JsonDataSerializer.Instance, _mockPlatformEnvironment.Object);
 
         var info = new TestProcessStartInfo();
         var cancellationTokenSource = new CancellationTokenSource();
@@ -635,9 +632,8 @@ public class DesignModeClientTests
         internal TestableDesignModeClient(
             ICommunicationManager communicationManager,
             IDataSerializer dataSerializer,
-            IEnvironment platformEnvironment,
-            IEnvironmentVariableHelper environmentVariableHelper)
-            : base(communicationManager, dataSerializer, platformEnvironment, environmentVariableHelper)
+            IEnvironment platformEnvironment)
+            : base(communicationManager, dataSerializer, platformEnvironment)
         {
         }
 

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/ExtensionDecoratorTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/ExtensionDecoratorTests.cs
@@ -38,7 +38,7 @@ public class ExtensionDecoratorTests
     public void ExtensionDecoratorFactory_DisabledByFlag()
     {
         // Arrange
-        _featureFlagMock.Setup(x => x.IsSet(FeatureFlag.DISABLE_SERIALTESTRUN_DECORATOR)).Returns(true);
+        _featureFlagMock.Setup(x => x.IsSet(FeatureFlag.VSTEST_DISABLE_SERIALTESTRUN_DECORATOR)).Returns(true);
 
         // Run test and assert
         ExtensionDecoratorFactory extensionDecoratorFactory = new(_featureFlagMock.Object);

--- a/test/TestAssets/OutputtingTestProject/OutputtingTestProject.csproj
+++ b/test/TestAssets/OutputtingTestProject/OutputtingTestProject.csproj
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(NetFrameworkMinimum);$(NetCoreAppMinimum)</TargetFrameworks>
+    <OutputType Condition="$(NetCoreAppTargetFrameWork) == 'true' ">Exe</OutputType>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestFrameworkVersion)" />
+    <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestTestAdapterVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(PackageVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkMinimum)' ">
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkMinimum)' ">
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)"/>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/test/TestAssets/OutputtingTestProject/UnitTest1.cs
+++ b/test/TestAssets/OutputtingTestProject/UnitTest1.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System;
+using System.IO;
+
+namespace OutputtingTestProject;
+
+[TestClass]
+public class UnitTest1
+{
+    [TestMethod]
+    public void TestThatWritesOutput()
+    {
+        // This is a trick to bypass the console output capturing that MSTest does, and write directly
+        // to console output. The same bypass can be configured by <MSTest><CaptureTraceOutput>false</CaptureTraceOutput></MSTest>
+        // in MSTest 3.3.2 and newer.
+        using StreamWriter writer = new StreamWriter(Console.OpenStandardOutput());
+        writer.WriteLine("MY OUTPUT FROM TEST");
+    }
+}

--- a/test/TestAssets/TestAssets.sln
+++ b/test/TestAssets/TestAssets.sln
@@ -134,6 +134,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetStandard2Library", "NetS
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TerminalLoggerTestProject", "TerminalLoggerTestProject\TerminalLoggerTestProject.csproj", "{C69BEEA4-BE37-4155-8DD0-130C62D8BF6D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OutputtingTestProject", "OutputtingTestProject\OutputtingTestProject.csproj", "{A83CE873-2536-4795-B601-5816294ED0B8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -384,6 +386,10 @@ Global
 		{C69BEEA4-BE37-4155-8DD0-130C62D8BF6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C69BEEA4-BE37-4155-8DD0-130C62D8BF6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C69BEEA4-BE37-4155-8DD0-130C62D8BF6D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A83CE873-2536-4795-B601-5816294ED0B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A83CE873-2536-4795-B601-5816294ED0B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A83CE873-2536-4795-B601-5816294ED0B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A83CE873-2536-4795-B601-5816294ED0B8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/test/vstest.ProgrammerTests/MultiTFMRunAndDiscovery.cs
+++ b/test/vstest.ProgrammerTests/MultiTFMRunAndDiscovery.cs
@@ -561,7 +561,7 @@ public class MultiTFMRunAndDiscoveryCompatibilityMode
             {
                 FeatureFlags = new Dictionary<string, bool>
                 {
-                    [FeatureFlag.DISABLE_MULTI_TFM_RUN] = true
+                    [FeatureFlag.VSTEST_DISABLE_MULTI_TFM_RUN] = true
                 }
             }
         );


### PR DESCRIPTION
## Description

When Tests write output using `Console.WriteLine` it may or might not be seen by the user, depending on which target framework they are using, which OS, and which testing framework.

### When it is seen: 

User is running .NET Framework tests in-process, is using vstest.console 17.6.3 or earlier, and is not using MSTest.
User is running tests on Linux.

### When it is not seen:

- User uses .NET on Windows.
- User uses MSTest pre 3.3.2, or 3.3.2+ without `<MSTest><CaptureTraceOutput>false</CaptureTraceOutput></MSTest>` option.
- User uses vstest.console 17.7.0 or newer with .NET Framework in-process or out of process.
- User is running in isolation on Windows: 
   - always under dotnet test
   - always under Visual Studio
   - for .NET workloads under vstest.console
 
 ## Solution

This pull request standardizes the output capturing and passing to parent processes via Informational `TestMessage`. This same mechanism is used by xUnit to send their `[xUnit.net 00:00:00.11]   Starting:    xunit001` messages. 

Two options are added and enabled by default: 

```xml
<RunSettings>
    <RunConfiguration>
        <CaptureStandardOutput>true</CaptureStandardOutput>
        <ForwardStandardOutput>true</ForwardStandardOutput>
    </RunConfiguration>
</RunSettings>
```

`CaptureStandardOutput` enables output capturing by VSTest. When disabled the behavior returns to the one of 17.6.3 and earlier.
`ForwardStandardOutput` enables output forwarding. When enabled it forwards output to VS. 

When disabled, but CaptureStandardOutput is enabled it will suppress all output and return to behavior in 17.7.0 and newer.

Additionally two feature flags are added to allow easier global opt-out: 

```
VSTEST_DISABLE_STANDARD_OUTPUT_CAPTURING
VSTEST_DISABLE_STANDARD_OUTPUT_FORWARDING
```

Setting them to 1 has the same effect as setting the above options to FALSE.


## Related issue
Fix https://github.com/microsoft/vstest/issues/799
Fix https://github.com/microsoft/vstest/issues/4828
Fix https://github.com/microsoft/vstest/issues/4947

