### PR TITLE
Add option to not share .NET Framework testhosts

### DIFF
--- a/src/Microsoft.TestPlatform.Client/TestPlatform.cs
+++ b/src/Microsoft.TestPlatform.Client/TestPlatform.cs
@@ -87,7 +87,7 @@ internal class TestPlatform : ITestPlatform
         loggerManager.Initialize(discoveryCriteria.RunSettings);
 
         IProxyDiscoveryManager discoveryManager = _testEngine.GetDiscoveryManager(requestData, discoveryCriteria, sourceToSourceDetailMap, warningLogger);
-        discoveryManager.Initialize(options?.SkipDefaultAdapters ?? false);
+        discoveryManager.Initialize(GetSkipDefaultAdapters(options, discoveryCriteria.RunSettings));
 
         return new DiscoveryRequest(requestData, discoveryCriteria, discoveryManager, loggerManager);
     }
@@ -110,9 +110,29 @@ internal class TestPlatform : ITestPlatform
         loggerManager.Initialize(testRunCriteria.TestRunSettings);
 
         IProxyExecutionManager executionManager = _testEngine.GetExecutionManager(requestData, testRunCriteria, sourceToSourceDetailMap, warningLogger);
-        executionManager.Initialize(options?.SkipDefaultAdapters ?? false);
+        executionManager.Initialize(GetSkipDefaultAdapters(options, testRunCriteria.TestRunSettings));
 
         return new TestRunRequest(requestData, testRunCriteria, executionManager, loggerManager);
+    }
+
+    private static bool GetSkipDefaultAdapters(TestPlatformOptions? options, string? runSettings)
+    {
+        if (options?.SkipDefaultAdapters ?? false)
+        {
+            EqtTrace.Verbose($"TestPlatform.GetSkipDefaultAdapters: Skipping default adapters because of TestPlatform options SkipDefaultAdapters.");
+            return true;
+        }
+
+        RunConfiguration runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(runSettings);
+        var skipping = runConfiguration.SkipDefaultAdapters;
+        if (skipping)
+        {
+            EqtTrace.Verbose($"TestPlatform.GetSkipDefaultAdapters: Skipping default adapters because of RunConfiguration SkipDefaultAdapters.");
+            return true;
+        }
+
+        EqtTrace.Verbose($"TestPlatform.GetSkipDefaultAdapters: Not skipping default adapters SkipDefaultAdapters was false.");
+        return false;
     }
 
     /// <inheritdoc/>

--- a/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
@@ -70,7 +70,7 @@ internal partial class FeatureFlag : IFeatureFlag
     public const string VSTEST_DISABLE_STANDARD_OUTPUT_FORWARDING = nameof(VSTEST_DISABLE_STANDARD_OUTPUT_FORWARDING);
 
     // Disable not sharing .NET Framework testhosts. Which will return behavior to sharing testhosts when they are running .NET Framework dlls, and are not disabling appdomains or running in parallel.
-    public const string VSTEST_DISABLE_NOT_SHARING_NETFRAMEWORK_TESTHOST = nameof(VSTEST_DISABLE_NOT_SHARING_NETFRAMEWORK_TESTHOST);
+    public const string VSTEST_DISABLE_SHARING_NETFRAMEWORK_TESTHOST = nameof(VSTEST_DISABLE_SHARING_NETFRAMEWORK_TESTHOST);
 
 
     [Obsolete("Only use this in tests.")]

--- a/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
@@ -69,6 +69,10 @@ internal partial class FeatureFlag : IFeatureFlag
     // Disable forwarding standard output of testhost.
     public const string VSTEST_DISABLE_STANDARD_OUTPUT_FORWARDING = nameof(VSTEST_DISABLE_STANDARD_OUTPUT_FORWARDING);
 
+    // Disable not sharing .NET Framework testhosts. Which will return behavior to sharing testhosts when they are running .NET Framework dlls, and are not disabling appdomains or running in parallel.
+    public const string VSTEST_DISABLE_NOT_SHARING_NETFRAMEWORK_TESTHOST = nameof(VSTEST_DISABLE_NOT_SHARING_NETFRAMEWORK_TESTHOST);
+
+
     [Obsolete("Only use this in tests.")]
     internal static void Reset()
     {

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
@@ -974,5 +974,5 @@ virtual Microsoft.VisualStudio.TestPlatform.ObjectModel.ValidateValueCallback.In
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.RiscV64 = 8 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
 Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.CaptureStandardOutput.get -> bool
 Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.ForwardStandardOutput.get -> bool
-Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.EnableSharedTestHost.get -> bool
+Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.DisableSharedTestHost.get -> bool
 Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.SkipDefaultAdapters.get -> bool

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
@@ -974,3 +974,5 @@ virtual Microsoft.VisualStudio.TestPlatform.ObjectModel.ValidateValueCallback.In
 Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.RiscV64 = 8 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture
 Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.CaptureStandardOutput.get -> bool
 Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.ForwardStandardOutput.get -> bool
+Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.EnableSharedTestHost.get -> bool
+Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.SkipDefaultAdapters.get -> bool

--- a/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
@@ -983,7 +983,7 @@ public class RunConfiguration : TestRunSettings
                         runConfiguration.ForwardStandardOutput = bForwardStandardOutput;
                         break;
 
-                    case "EnableSharedTestHost":
+                    case nameof(DisableSharedTestHost):
                         {
                             XmlRunSettingsUtilities.ThrowOnHasAttributes(reader);
                             string element = reader.ReadElementContentAsString();
@@ -999,7 +999,7 @@ public class RunConfiguration : TestRunSettings
                             break;
                         }
 
-                    case "SkipDefaultAdapters":
+                    case nameof(SkipDefaultAdapters):
                         {
                             XmlRunSettingsUtilities.ThrowOnHasAttributes(reader);
                             string element = reader.ReadElementContentAsString();

--- a/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
@@ -95,7 +95,7 @@ public class RunConfiguration : TestRunSettings
         ExecutionThreadApartmentState = Constants.DefaultExecutionThreadApartmentState;
         CaptureStandardOutput = !FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_DISABLE_STANDARD_OUTPUT_CAPTURING);
         ForwardStandardOutput = !FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_DISABLE_STANDARD_OUTPUT_FORWARDING);
-        EnableSharedTestHost = FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_DISABLE_NOT_SHARING_NETFRAMEWORK_TESTHOST);
+        DisableSharedTestHost = FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_DISABLE_SHARING_NETFRAMEWORK_TESTHOST);
     }
 
     /// <summary>
@@ -457,9 +457,9 @@ public class RunConfiguration : TestRunSettings
     public bool ForwardStandardOutput { get; private set; }
 
     /// <summary>
-    /// Enables sharing of .NET Framework testhosts.
+    /// Disables sharing of .NET Framework testhosts.
     /// </summary>
-    public bool EnableSharedTestHost { get; private set; }
+    public bool DisableSharedTestHost { get; private set; }
 
     /// <summary>
     /// Skips passing VisualStudio built in adapters to the project.
@@ -589,9 +589,9 @@ public class RunConfiguration : TestRunSettings
         forwardStandardOutput.InnerXml = ForwardStandardOutput.ToString();
         root.AppendChild(forwardStandardOutput);
 
-        XmlElement enableSharedTestHost = doc.CreateElement(nameof(EnableSharedTestHost));
-        enableSharedTestHost.InnerXml = EnableSharedTestHost.ToString();
-        root.AppendChild(enableSharedTestHost);
+        XmlElement disableSharedTesthost = doc.CreateElement(nameof(DisableSharedTestHost));
+        disableSharedTesthost.InnerXml = DisableSharedTestHost.ToString();
+        root.AppendChild(disableSharedTesthost);
 
         XmlElement skipDefaultAdapters = doc.CreateElement(nameof(SkipDefaultAdapters));
         skipDefaultAdapters.InnerXml = SkipDefaultAdapters.ToString();
@@ -995,7 +995,7 @@ public class RunConfiguration : TestRunSettings
                                     Resources.Resources.InvalidSettingsIncorrectValue, Constants.RunConfigurationSettingsName, boolValue, elementName));
                             }
 
-                            runConfiguration.EnableSharedTestHost = boolValue;
+                            runConfiguration.DisableSharedTestHost = boolValue;
                             break;
                         }
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -379,7 +379,7 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
         _targetFramework = runConfiguration.TargetFramework;
         _testHostProcess = null;
 
-        Shared = !runConfiguration.DisableAppDomain;
+        Shared = !runConfiguration.DisableAppDomain && runConfiguration.EnableSharedTestHost;
         _hostExitedEventRaised = false;
 
         IsInitialized = true;

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -384,8 +384,8 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
         // into the same process, and without appdomains we cannot safely do that.
         //
         // The OPPOSITE is not true though, disabling testhost sharing does not mean that we should not load the
-        // dll into a separate appdomain in the host.
-        Shared = !_disableAppDomain && runConfiguration.EnableSharedTestHost;
+        // dll into a separate appdomain in the host. It just means that we wish to run each dll in separate exe.
+        Shared = !_disableAppDomain && !runConfiguration.DisableSharedTestHost;
         _hostExitedEventRaised = false;
 
         IsInitialized = true;

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -58,7 +58,7 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
     private readonly IEnvironment _environment;
     private readonly IDotnetHostHelper _dotnetHostHelper;
     private readonly IEnvironmentVariableHelper _environmentVariableHelper;
-
+    private bool _disableAppDomain;
     private Architecture _architecture;
     private Framework? _targetFramework;
     private ITestHostLauncher? _customTestHostLauncher;
@@ -199,10 +199,10 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
             testhostProcessPath = Path.Combine(currentWorkingDirectory, "..", testHostProcessName);
         }
 
-        if (!Shared)
+        if (_disableAppDomain)
         {
-            // Not sharing the host which means we need to pass the test assembly path as argument
-            // so that the test host can create an appdomain on startup (Main method) and set appbase
+            // When host appdomains are disabled (in that case host is not shared) we need to pass the test assembly path as argument
+            // so that the test host can create one appdomain on startup (Main method) and set appbase.
             argumentsString += " --testsourcepath " + sources.FirstOrDefault()?.AddDoubleQuote();
         }
 
@@ -379,7 +379,13 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
         _targetFramework = runConfiguration.TargetFramework;
         _testHostProcess = null;
 
-        Shared = !runConfiguration.DisableAppDomain && runConfiguration.EnableSharedTestHost;
+        _disableAppDomain = runConfiguration.DisableAppDomain;
+        // If appdomains are disabled the host cannot be shared, because sharing means loading multiple assemblies
+        // into the same process, and without appdomains we cannot safely do that.
+        //
+        // The OPPOSITE is not true though, disabling testhost sharing does not mean that we should not load the
+        // dll into a separate appdomain in the host.
+        Shared = !_disableAppDomain && runConfiguration.EnableSharedTestHost;
         _hostExitedEventRaised = false;
 
         IsInitialized = true;

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DifferentTestFrameworkSimpleTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DifferentTestFrameworkSimpleTests.cs
@@ -163,7 +163,7 @@ public class DifferentTestFrameworkSimpleTests : AcceptanceTestBase
 
         var arguments = PrepareArguments(
             GetAssetFullPath("NUTestProject.dll"),
-            GetTestAdapterPath(UnitTestFramework.NUnit),
+            null, // GetTestAdapterPath(UnitTestFramework.NUnit),
             string.Empty, FrameworkArgValue,
             runnerInfo.InIsolationValue, TempDirectory.Path);
         InvokeVsTest(arguments);

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -111,7 +111,27 @@ public class DefaultTestHostManagerTests
     }
 
     [TestMethod]
-    public void GetTestHostProcessStartInfoShouldIncludeConnectionInfo()
+    public void GetTestHostProcessStartInfoShouldIncludeConnectionInfo_WhenShared()
+    {
+        var connectionInfo = new TestRunnerConnectionInfo { Port = 123, ConnectionInfo = new TestHostConnectionInfo { Endpoint = "127.0.0.0:123", Role = ConnectionRole.Client, Transport = Transport.Sockets }, RunnerProcessId = 101 };
+        _testHostManager.Initialize(_mockMessageLogger.Object, $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <RunSettings>
+            <RunConfiguration>
+                <EnableSharedTestHost>{true}</EnableSharedTestHost>
+            </RunConfiguration>
+            </RunSettings>
+            """);
+        var info = _testHostManager.GetTestHostProcessStartInfo(
+            Enumerable.Empty<string>(),
+            null,
+            connectionInfo);
+
+        Assert.AreEqual(" --port 123 --endpoint 127.0.0.0:123 --role client --parentprocessid 101", info.Arguments);
+    }
+
+    [TestMethod]
+    public void GetTestHostProcessStartInfoShouldIncludeConnectionInfo_WhenNotShared()
     {
         var connectionInfo = new TestRunnerConnectionInfo { Port = 123, ConnectionInfo = new TestHostConnectionInfo { Endpoint = "127.0.0.0:123", Role = ConnectionRole.Client, Transport = Transport.Sockets }, RunnerProcessId = 101 };
         var info = _testHostManager.GetTestHostProcessStartInfo(
@@ -119,7 +139,7 @@ public class DefaultTestHostManagerTests
             null,
             connectionInfo);
 
-        Assert.AreEqual(" --port 123 --endpoint 127.0.0.0:123 --role client --parentprocessid 101", info.Arguments);
+        Assert.AreEqual(" --port 123 --endpoint 127.0.0.0:123 --role client --parentprocessid 101 --testsourcepath ", info.Arguments);
     }
 
     [TestMethod]
@@ -395,9 +415,23 @@ public class DefaultTestHostManagerTests
     }
 
     [TestMethod]
-    public void DefaultTestHostManagerShouldBeShared()
+    public void DefaultTestHostManagerShouldBeSharedWhenOptedIn()
     {
+        _testHostManager.Initialize(_mockMessageLogger.Object, $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <RunSettings>
+            <RunConfiguration>
+                <EnableSharedTestHost>{true}</EnableSharedTestHost>
+            </RunConfiguration>
+            </RunSettings>
+            """);
         Assert.IsTrue(_testHostManager.Shared);
+    }
+
+    [TestMethod]
+    public void DefaultTestHostManagerShouldNotBeShared()
+    {
+        Assert.IsFalse(_testHostManager.Shared);
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -395,23 +395,23 @@ public class DefaultTestHostManagerTests
     }
 
     [TestMethod]
-    public void DefaultTestHostManagerShouldBeSharedWhenOptedIn()
+    public void DefaultTestHostManagerShouldNotBeSharedWhenOptedIn()
     {
         _testHostManager.Initialize(_mockMessageLogger.Object, $"""
             <?xml version="1.0" encoding="utf-8"?>
             <RunSettings>
             <RunConfiguration>
-                <EnableSharedTestHost>{true}</EnableSharedTestHost>
+                <DisableSharedTestHost>{true}</DisableSharedTestHost>
             </RunConfiguration>
             </RunSettings>
             """);
-        Assert.IsTrue(_testHostManager.Shared);
+        Assert.IsFalse(_testHostManager.Shared);
     }
 
     [TestMethod]
-    public void DefaultTestHostManagerShouldNotBeShared()
+    public void DefaultTestHostManagerShouldBeShared()
     {
-        Assert.IsFalse(_testHostManager.Shared);
+        Assert.IsTrue(_testHostManager.Shared);
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -111,35 +111,15 @@ public class DefaultTestHostManagerTests
     }
 
     [TestMethod]
-    public void GetTestHostProcessStartInfoShouldIncludeConnectionInfo_WhenShared()
+    public void GetTestHostProcessStartInfoShouldIncludeConnectionInfo()
     {
         var connectionInfo = new TestRunnerConnectionInfo { Port = 123, ConnectionInfo = new TestHostConnectionInfo { Endpoint = "127.0.0.0:123", Role = ConnectionRole.Client, Transport = Transport.Sockets }, RunnerProcessId = 101 };
-        _testHostManager.Initialize(_mockMessageLogger.Object, $"""
-            <?xml version="1.0" encoding="utf-8"?>
-            <RunSettings>
-            <RunConfiguration>
-                <EnableSharedTestHost>{true}</EnableSharedTestHost>
-            </RunConfiguration>
-            </RunSettings>
-            """);
         var info = _testHostManager.GetTestHostProcessStartInfo(
             Enumerable.Empty<string>(),
             null,
             connectionInfo);
 
         Assert.AreEqual(" --port 123 --endpoint 127.0.0.0:123 --role client --parentprocessid 101", info.Arguments);
-    }
-
-    [TestMethod]
-    public void GetTestHostProcessStartInfoShouldIncludeConnectionInfo_WhenNotShared()
-    {
-        var connectionInfo = new TestRunnerConnectionInfo { Port = 123, ConnectionInfo = new TestHostConnectionInfo { Endpoint = "127.0.0.0:123", Role = ConnectionRole.Client, Transport = Transport.Sockets }, RunnerProcessId = 101 };
-        var info = _testHostManager.GetTestHostProcessStartInfo(
-            Enumerable.Empty<string>(),
-            null,
-            connectionInfo);
-
-        Assert.AreEqual(" --port 123 --endpoint 127.0.0.0:123 --role client --parentprocessid 101 --testsourcepath ", info.Arguments);
     }
 
     [TestMethod]


### PR DESCRIPTION
Adds runsettings option to disable sharing testhosts:

```xml

<DisableSharedTestHost>true</DisableSharedTestHost>
```

and ENV: 

```
VSTEST_DISABLE_SHARING_NETFRAMEWORK_TESTHOST=1
```

This is useful when solution is using both MSTest v2 and MSTest v3 and would like to run each project in isolated process even when they are not running in parallel, or not disabling appdomains. Otherwise the extension logic will send both extension dlls to the host for initialization and it will fail to find the extension and to run the tests. 

This option only affects .NET Framework test projects that don't enable parallelization, or don't disable app domains. Such projects are sharing host, others are not.



Adds option to skip default adapters (the extensions that are place in Extensions folder in our VisualStudio folder).

```xml
<SkipDefaultAdapters>true</SkipDefaultAdapters>
```

This allows projects to run even if external extensions (such as Chutzpah) add dependencies that are incompatible with the projects. Without this option all extensions from the built in folder are always included in the run.

Fix https://github.com/microsoft/vstest/issues/3475
