### PR TITLE
Add missing copyright header

### DIFF
--- a/src/Microsoft.TestPlatform.CoreUtilities/GlobalSuppressions.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.


### PR DESCRIPTION
This file was added with https://github.com/microsoft/vstest/pull/4970 and the copyright header was missed.

This breaks source-build and is blocking the [sdk->installer dependency flow](https://github.com/dotnet/installer/pull/19634).  I will pull in this change as a patch to unblock.

```
    /vmr/src/vstest/src/Microsoft.TestPlatform.CoreUtilities/GlobalSuppressions.cs(1,1): error IDE0073: A source file contains a header that does not match the required text (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0073) [/vmr/src/vstest/src/Microsoft.TestPlatform.CoreUtilities/Microsoft.TestPlatform.CoreUtilities.csproj::TargetFramework=net9.0]
##[error]/vmr/src/vstest/src/Microsoft.TestPlatform.CoreUtilities/GlobalSuppressions.cs(1,1): error IDE0073: (NETCORE_ENGINEERING_TELEMETRY=Build) A source file contains a header that does not match the required text (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0073)
 ```
 
 cc @nohwnd 