### PR TITLE
GetTypesToLoad Attribute cant be null

### DIFF
--- a/src/Microsoft.TestPlatform.Common/Utilities/TypesToLoadUtilities.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/TypesToLoadUtilities.cs
@@ -27,9 +27,6 @@ internal static class TypesToLoadUtilities
 
     private static IEnumerable<Type> GetTypesToLoad(Attribute attribute)
     {
-        if (attribute == null)
-            return Enumerable.Empty<Type>();
-
         var type = attribute.GetType();
         var typesProperty = type.GetProperty("Types");
 


### PR DESCRIPTION
since it walks the items returned by GetCustomAttributes which will not contain nulls
