### PR TITLE
make DataCollectorAttachmentProcessorWrapper.ProcessAttachment async

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/DataCollectorAttachmentProcessorAppDomain.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/DataCollectorAttachmentProcessorAppDomain.cs
@@ -158,7 +158,7 @@ internal class DataCollectorAttachmentProcessorAppDomain : IDataCollectorAttachm
         cancellationToken.Register(() => _wrapper.CancelProcessAttachment());
         _processAttachmentSetsLogger = logger;
         _progressReporter = progressReporter;
-        var result = await Task.Run(() => _wrapper.ProcessAttachment(configurationElement.OuterXml, JsonDataSerializer.Instance.Serialize(attachments.ToArray()))).ConfigureAwait(false);
+        var result = await _wrapper.ProcessAttachment(configurationElement.OuterXml, JsonDataSerializer.Instance.Serialize(attachments.ToArray())).ConfigureAwait(false);
         return JsonDataSerializer.Instance.Deserialize<AttachmentSet[]>(result)!;
     }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/DataCollectorAttachmentProcessorWrapper.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/DataCollectorAttachmentProcessorWrapper.cs
@@ -71,7 +71,7 @@ internal sealed class DataCollectorAttachmentProcessorRemoteWrapper : MarshalByR
                     attachmentSets,
                     progress,
                     new MessageLogger(this, nameof(ProcessAttachment)),
-                    _processAttachmentCts.Token);
+                    _processAttachmentCts.Token).ConfigureAwait(false);
 
         return JsonDataSerializer.Instance.Serialize(attachmentsResult.ToArray());
     }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/DataCollectorAttachmentProcessorWrapper.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/DataCollectorAttachmentProcessorWrapper.cs
@@ -56,7 +56,7 @@ internal sealed class DataCollectorAttachmentProcessorRemoteWrapper : MarshalByR
 
     public Uri[]? GetExtensionUris() => _dataCollectorAttachmentProcessorInstance?.GetExtensionUris()?.ToArray();
 
-    public string ProcessAttachment(
+    public async Task<string> ProcessAttachment(
         string configurationElement,
         string attachments)
     {
@@ -66,15 +66,12 @@ internal sealed class DataCollectorAttachmentProcessorRemoteWrapper : MarshalByR
         SynchronousProgress progress = new(Report);
         _processAttachmentCts = new CancellationTokenSource();
 
-        ICollection<AttachmentSet> attachmentsResult =
-            Task.Run(async () => await _dataCollectorAttachmentProcessorInstance!.ProcessAttachmentSetsAsync(
-            doc.DocumentElement,
-            attachmentSets,
-            progress,
-            new MessageLogger(this, nameof(ProcessAttachment)),
-            _processAttachmentCts.Token))
-            // We cannot marshal Task so we need to block the thread until the end of the processing
-            .ConfigureAwait(false).GetAwaiter().GetResult();
+        var attachmentsResult = await _dataCollectorAttachmentProcessorInstance!.ProcessAttachmentSetsAsync(
+                    doc.DocumentElement,
+                    attachmentSets,
+                    progress,
+                    new MessageLogger(this, nameof(ProcessAttachment)),
+                    _processAttachmentCts.Token);
 
         return JsonDataSerializer.Instance.Serialize(attachmentsResult.ToArray());
     }


### PR DESCRIPTION
to avoid the 2 `Task.Run`s and the `.GetAwaiter().GetResult()`

if there is a reason to sync this async call. let me know and i will do a new PR with a comment to that effect