### PR TITLE
Dispose IDisosables in HtmlTransformer

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlTransformer.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlTransformer.cs
@@ -20,7 +20,8 @@ internal class HtmlTransformer : IHtmlTransformer
     public HtmlTransformer()
     {
         _xslTransform = new XslCompiledTransform();
-        _xslTransform.Load(XmlReader.Create(GetType().Assembly.GetManifestResourceStream("Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger.Html.xslt") ?? throw new InvalidOperationException(), new XmlReaderSettings { CheckCharacters = false }));
+        using var reader = XmlReader.Create(GetType().Assembly.GetManifestResourceStream("Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger.Html.xslt") ?? throw new InvalidOperationException(), new XmlReaderSettings { CheckCharacters = false, CloseInput = true });
+        _xslTransform.Load(reader);
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

There's two IDisposables being used in HtmlTransformer (a `Stream` and an `XmlReader`). We should Dispose() both of them.

I think this is mostly a hygiene issue. Assembly.GetManifestResourceStream() allocates memory only, not an some non-memory resource that has to be Dispose()d correctly. Same thing for XmlReader too. So I don't think not disposing these has any real impact.

This was flagged by a static analysis too.

## Related issue

Kindly link any related issues. E.g. Fixes #xyz.   -- Shall I file one?

- [ ] I have ensured that there is a previously discussed and approved issue.
