### PR TITLE
Bump to macos-12 build image

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -50,7 +50,7 @@ parameters:
     image: 1es-ubuntu-2204
     os: linux
   - name: Azure Pipelines
-    image: macOS-11
+    image: macOS-12
     os: macOS
 
 variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,8 +156,8 @@ stages:
             Ubuntu_22_04:
               vmImage: ubuntu-22.04
               pwsh: true
-            macOS_11:
-              vmImage: macOS-11
+            macOS_12:
+              vmImage: macOS-12
               pwsh: true
         pool:
           vmImage: $[ variables['vmImage'] ]


### PR DESCRIPTION
AzDO will remove macos-11 in about two weeks: https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#recent-updates
