### PR TITLE
Add option to overwrite trx without warning

### DIFF
--- a/playground/TestPlatform.Playground/Program.cs
+++ b/playground/TestPlatform.Playground/Program.cs
@@ -105,7 +105,7 @@ internal class Program
         //    var processStartInfo = new ProcessStartInfo
         //    {
         //        FileName = console,
-        //        Arguments = $"{string.Join(" ", sources)} --settings:{settingsFile} --listtests",
+        //        Arguments = $"{string.Join(" ", sources)} --settings:{settingsFile} --logger:trx;LogFileName=my.trx;WarnOnFileOverwrite=false",
         //        UseShellExecute = false,
         //    };
         //    EnvironmentVariables.Variables.ToList().ForEach(processStartInfo.Environment.Add);

--- a/playground/TestPlatform.Playground/TestPlatform.Playground.csproj
+++ b/playground/TestPlatform.Playground/TestPlatform.Playground.csproj
@@ -32,6 +32,7 @@
     <ProjectReference Include="$(RepoRoot)src\AttachVS\AttachVS.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Microsoft.TestPlatform.Build\Microsoft.TestPlatform.Build.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Microsoft.TestPlatform.Extensions.HtmlLogger\Microsoft.TestPlatform.Extensions.HtmlLogger.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.TestPlatform.Extensions.TrxLogger\Microsoft.TestPlatform.Extensions.TrxLogger.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) AND '$(OS)' != 'Windows_NT' ">
     <Reference Include="System" />
@@ -74,6 +75,7 @@
 
       <!-- copy loggers -->
       <FileToCopy Include="$(SourcePath)bin\Microsoft.TestPlatform.Extensions.HtmlLogger\$(Configuration)\$(NetFrameworkMinimum)\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger*" SubFolder="netfx\Extensions\" />
+      <FileToCopy Include="$(SourcePath)bin\Microsoft.TestPlatform.Extensions.TrxLogger\$(Configuration)\$(NetFrameworkMinimum)\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger*" SubFolder="netfx\Extensions\" />
 
       <!-- .NET console -->
       <FileToCopy Include="$(SourcePath)bin\vstest.console\$(Configuration)\$(NetCoreAppMinimum)\**\*.*" SubFolder="net" />

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Constants.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Constants.cs
@@ -76,6 +76,11 @@ internal static class Constants
     public const string TmiTestIdPropertyIdentifier = "MSTestDiscoverer.TmiTestId";
 
     /// <summary>
+    /// Warn when overwriting the trx file.
+    /// </summary>
+    public static string WarnOnFileOverwrite = "WarnOnFileOverwrite";
+
+    /// <summary>
     /// Mstest adapter string
     /// </summary>
     public const string MstestAdapterString = "mstestadapter";


### PR DESCRIPTION
Fix #5132

## Description

Add option to not warn on trx overwrite. 

`WarnOnFileOverwrite=false`

Usage from commandline or from csproj: 
```
--logger:trx;LogFileName=my.trx;WarnOnFileOverwrite=false
```
```xml
<VSTestLogger>trx%3bLogFileName=$(MSBuildProjectName).trx%3bWarnOnFileOverwrite=false</VSTestLogger>
```

## Related issue

Kindly link any related issues. E.g. Fixes #xyz.

- [x] I have ensured that there is a previously discussed and approved issue.
