### PR TITLE
Forward error output from testhost as info

### DIFF
--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
@@ -58,7 +58,9 @@ internal class TestHostManagerCallbacks
         testHostProcessStdError.AppendSafeWithNewLine(data);
         if (_forwardOutput && _messageLogger != null && !StringUtils.IsNullOrWhiteSpace(data))
         {
-            _messageLogger.SendMessage(TestMessageLevel.Error, data);
+            // Forward the error output, but DO NOT forward it as error. Until now it was only written into logs,
+            // and applications love to write Debug messages into error stream. Which we do not want to fail the test run.
+            _messageLogger.SendMessage(TestMessageLevel.Informational, data);
         }
     }
 


### PR DESCRIPTION
## Description
Forward the error output from testhost, but as information messages, because otherwise it fails the test run, and we don't want that, because child apps can write debug or other info into the error stream.

Fix #5184 