### PR TITLE
[rel/17.11] Forward error output from testhost as info

### DIFF
--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/TestHostManagerCallbacks.cs
@@ -58,7 +58,9 @@ internal class TestHostManagerCallbacks
         testHostProcessStdError.AppendSafeWithNewLine(data);
         if (_forwardOutput && _messageLogger != null && !StringUtils.IsNullOrWhiteSpace(data))
         {
-            _messageLogger.SendMessage(TestMessageLevel.Error, data);
+            // Forward the error output, but DO NOT forward it as error. Until now it was only written into logs,
+            // and applications love to write Debug messages into error stream. Which we do not want to fail the test run.
+            _messageLogger.SendMessage(TestMessageLevel.Informational, data);
         }
     }
 


### PR DESCRIPTION
## Description

Forward error but as info, so we don't fail run when application writes logs to error output.

Fix #5184 
