### PR TITLE
Add msdia for arm64 into nuget

### DIFF
--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -19,7 +19,7 @@ function Verify-Nuget-Packages {
     $expectedNumOfFiles = @{
         "Microsoft.CodeCoverage"                      = 59;
         "Microsoft.NET.Test.Sdk"                      = 15;
-        "Microsoft.TestPlatform"                      = 608;
+        "Microsoft.TestPlatform"                      = 609;
         "Microsoft.TestPlatform.Build"                = 20;
         "Microsoft.TestPlatform.CLI"                  = 471;
         "Microsoft.TestPlatform.Extensions.TrxLogger" = 34;

--- a/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.nuspec
+++ b/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.nuspec
@@ -284,6 +284,7 @@
     <file src="net472\Microsoft.Internal.TestPlatform.Extensions\Extensions\Cpp\arm64\dbghelp.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\Extensions\Cpp\arm64\dbghelp.dll" />
     <file src="net472\Microsoft.Internal.Dia\x64\msdia140.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\Extensions\TestImpact\ComComponents\x64\msdia140.dll" />
     <file src="net472\Microsoft.Internal.Dia\x64\msdia140.dll.manifest" target="tools\net462\Common7\IDE\Extensions\TestPlatform\Extensions\TestImpact\ComComponents\x64\msdia140.dll.manifest" />
+    <file src="net472\CodeCoverage\arm64\msdia140.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\Extensions\TestImpact\ComComponents\arm64\msdia140.dll" />
     <file src="net472\Microsoft.Internal.Dia\x86\msdia140.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\Extensions\TestImpact\ComComponents\x86\msdia140.dll" />
     <file src="net472\Microsoft.Internal.Dia\x86\msdia140.dll.manifest" target="tools\net462\Common7\IDE\Extensions\TestPlatform\Extensions\TestImpact\ComComponents\x86\msdia140.dll.manifest" />
     <file src="net472\Microsoft.VisualStudio.QualityTools.DataCollectors\Extensions\V1\Microsoft.VisualStudio.QualityTools.Plugins.CodeCoverage.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\Extensions\V1\Microsoft.VisualStudio.QualityTools.Plugins.CodeCoverage.dll" />


### PR DESCRIPTION
## Description
Ship arm64 dia in more folders so it is available when running c++ tests. 
