### PR TITLE
Enable native debugging for vstest.console

### DIFF
--- a/src/Microsoft.TestPlatform.Execution.Shared/WellKnownDebugEnvironmentVariables.cs
+++ b/src/Microsoft.TestPlatform.Execution.Shared/WellKnownDebugEnvironmentVariables.cs
@@ -13,4 +13,5 @@ internal static class WellKnownDebugEnvironmentVariables
     public const string VSTEST_HOST_DEBUG_ATTACHVS = nameof(VSTEST_HOST_DEBUG_ATTACHVS);
     public const string VSTEST_RUNNER_DEBUG_ATTACHVS = nameof(VSTEST_RUNNER_DEBUG_ATTACHVS);
     public const string VSTEST_HOST_NATIVE_DEBUG = nameof(VSTEST_HOST_NATIVE_DEBUG);
+    public const string VSTEST_RUNNER_NATIVE_DEBUG = nameof(VSTEST_RUNNER_NATIVE_DEBUG);
 }

--- a/src/vstest.console/CommandLine/Executor.cs
+++ b/src/vstest.console/CommandLine/Executor.cs
@@ -91,6 +91,7 @@ internal class Executor
     internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment)
     {
         DebuggerBreakpoint.AttachVisualStudioDebugger(WellKnownDebugEnvironmentVariables.VSTEST_RUNNER_DEBUG_ATTACHVS);
+        DebuggerBreakpoint.WaitForNativeDebugger(WellKnownDebugEnvironmentVariables.VSTEST_RUNNER_NATIVE_DEBUG);
         DebuggerBreakpoint.WaitForDebugger(WellKnownDebugEnvironmentVariables.VSTEST_RUNNER_DEBUG);
 
         Output = output;


### PR DESCRIPTION
## Description
With environment variable `VSTEST_HOST_NATIVE_DEBUG`, we can use a native debugger to debug tests but it requires `--InIsolation` flag.
When using the argument `--tests:` to run a specific test, testhost.exe is spawned twice and we must attach twice to properly debug.

When the environment variable `VSTEST_RUNNER_DEBUG` is set, vstest.console only waits for a managed debugger.

I propose to add new environment variable `VSTEST_RUNNER_NATIVE_DEBUG` to enable native debugging of vstest.conssole.
This will enable native debugging of tests without the `--InIsolation` flag.

## Related issue
Fixes #10393

- [x] I have ensured that there is a previously discussed and approved issue.