### PR TITLE
Exclude .signature.p7s from nupkg file count

### DIFF
--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -84,7 +84,7 @@ function Verify-Nuget-Packages {
             $packageKey = $packageBaseName.Replace([string]".$version", [string]"")
             Write-Host "Verifying package '$packageBaseName'."
 
-            $actualNumOfFiles = (Get-ChildItem -Recurse -File -Path $unzipNugetPackageDir).Count
+            $actualNumOfFiles = (Get-ChildItem -Recurse -File -Path $unzipNugetPackageDir | Where-Object { $_.Name -ne '.signature.p7s' }).Count
             if (-not $expectedNumOfFiles.ContainsKey($packageKey)) {
                 $errors += "Package '$packageKey' is not present in file expectedNumOfFiles table. Is that package known?"
                 continue


### PR DESCRIPTION
Fixes https://github.com/microsoft/vstest/issues/10414

This PR adds logic to exclude `.signature.p7s` files from the file count when verifying nupkgs in `verify-nupkgs.ps1`. This allows the verification to still pass when the artifacts are signed.