### PR TITLE
Set NetCurrent so that it doesn't roll forward automatically

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -50,6 +50,8 @@
 
   <!-- The TFMs to build and test against. -->
   <PropertyGroup>
+    <!-- Naming is based on dotnet/runtime one -->
+    <NetFrameworkMinimum>net462</NetFrameworkMinimum>
     <!-- When not building from source, hardcode the NetCurrent TFM value as it is hardcoded in a number of places, i.e. nuspec files. -->
     <NetCurrent Condition="'$(DotNetBuildSourceOnly)' != 'true'">net9.0</NetCurrent>
     <NetCoreAppMinimum>netcoreapp3.1</NetCoreAppMinimum>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -50,8 +50,8 @@
 
   <!-- The TFMs to build and test against. -->
   <PropertyGroup>
-    <!-- Naming is based on dotnet/runtime one -->
-    <NetFrameworkMinimum>net462</NetFrameworkMinimum>
+    <!-- When not building from source, hardcode the NetCurrent TFM value as it is hardcoded in a number of places, i.e. nuspec files. -->
+    <NetCurrent Condition="'$(DotNetBuildSourceOnly)' != 'true'">net9.0</NetCurrent>
     <NetCoreAppMinimum>netcoreapp3.1</NetCoreAppMinimum>
     <!--
       Arcade is making things hard to work with. This property is unset when its value is equal to NetMinimum.


### PR DESCRIPTION
The VSTest repo can't use a floating NetCurrent value as the NetCurrent TFM is actually hardcoded in a number of places => .nuspec files. Set it to net9.0 explicitly so that the build continues to work with a .NET 10 SDK and Arcade 10 SDK (which is used inside the VMR).

Don't hardcode the value when building from source as in that configuration, the TFM needs to actually target the very latest.

## Description

Please add a meaningful description for this change.
Ensure the PR has required unit tests.

## Related issue

Kindly link any related issues. E.g. Fixes #xyz.

- [ ] I have ensured that there is a previously discussed and approved issue.
