### PR TITLE
Add letter number among valid identifiers in class name

### DIFF
--- a/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/ManagedNameHelper.Reflection.cs
+++ b/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/ManagedNameHelper.Reflection.cs
@@ -563,7 +563,7 @@ public static partial class ManagedNameHelper
         }
 
         if (c == '_'
-            // 'Digit' does not include letter numbers, which are valid identifiers as per docs https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/identifier-names'.
+            // 'Digit' does not include letter numbers, which are valid identifiers as per docs https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/identifier-names'.
             || char.IsLetterOrDigit(c) // Lu, Ll, Lt, Lm, Lo, or Nd
             )
         {

--- a/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/ManagedNameHelper.Reflection.cs
+++ b/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/ManagedNameHelper.Reflection.cs
@@ -563,7 +563,8 @@ public static partial class ManagedNameHelper
         }
 
         if (c == '_'
-            || char.IsLetterOrDigit(c) // Lu, Ll, Lt, Lm, Lo, or Nl
+            // 'Digit' does not include letter numbers, which are valid identifiers as per docs https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/identifier-names'.
+            || char.IsLetterOrDigit(c) // Lu, Ll, Lt, Lm, Lo, or Nd
             )
         {
             return false;
@@ -571,7 +572,8 @@ public static partial class ManagedNameHelper
 
         var category = CharUnicodeInfo.GetUnicodeCategory(c);
         return category
-            is not UnicodeCategory.NonSpacingMark         // Mn
+            is not UnicodeCategory.LetterNumber           // Nl
+            and not UnicodeCategory.NonSpacingMark        // Mn
             and not UnicodeCategory.SpacingCombiningMark  // Mc
             and not UnicodeCategory.ConnectorPunctuation  // Pc
             and not UnicodeCategory.Format;               // Cf

--- a/test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/ManagedNameUtilities/ManagedNameGeneratorTests.cs
+++ b/test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/ManagedNameUtilities/ManagedNameGeneratorTests.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using TestClasses;
+
 namespace Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities.UnitTests;
 
 [TestClass]
@@ -123,4 +125,19 @@ public class ManagedNameGeneratorTests
         Assert.AreEqual("Method0", managedMethodName);
         Assert.IsNull(hierarchyValues[HierarchyConstants.Levels.NamespaceIndex]);
     }
+
+    [TestMethod]
+    public void SpecialCharacters_HierarchyShouldNotWrapMembersWithSpecialCharactersInSingleQuotes()
+    {
+        var methodBase = typeof(Class狧麱狵錋狾龍龪啊阿埃挨哎唉0u㐀㐁㐂㐃㐄㐅㐆㐇6ⅶ０ǒoU1U2U38丂丄丅丆丏丒丟).GetMethod("Method0")!;
+
+        // Act
+        ManagedNameHelper.GetManagedName(methodBase, out var managedTypeName, out var managedMethodName, out var _);
+
+        // Assert
+        Assert.AreEqual("TestClasses.Class狧麱狵錋狾龍龪啊阿埃挨哎唉0u㐀㐁㐂㐃㐄㐅㐆㐇6ⅶ０ǒoU1U2U38丂丄丅丆丏丒丟", managedTypeName);
+        Assert.AreEqual("Method0", managedMethodName);
+    }
+
+
 }

--- a/test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/ManagedNameUtilities/ManagedNameGeneratorTests.cs
+++ b/test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/ManagedNameUtilities/ManagedNameGeneratorTests.cs
@@ -139,5 +139,4 @@ public class ManagedNameGeneratorTests
         Assert.AreEqual("Method0", managedMethodName);
     }
 
-
 }

--- a/test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/TestClasses.cs
+++ b/test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/TestClasses.cs
@@ -144,7 +144,6 @@ namespace TestClasses
 }
 
 
-
 #pragma warning restore IDE0161 // Convert to file-scoped namespace
 #pragma warning restore IDE0060 // Remove unused parameter
 #pragma warning restore CA1822 // Mark members as static

--- a/test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/TestClasses.cs
+++ b/test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/TestClasses.cs
@@ -133,7 +133,17 @@ namespace TestClasses
         public void Overload0(Tuple<Tuple<string>, Tuple<int>> t) { }
         public void Overload0<U>(Tuple<Tuple<Outer<U>.Inner<U>>> t) { }
     }
+
+    public class Class狧麱狵錋狾龍龪啊阿埃挨哎唉0u㐀㐁㐂㐃㐄㐅㐆㐇6ⅶ０ǒoU1U2U38丂丄丅丆丏丒丟
+    {
+        public void Method0()
+        {
+
+        }
+    }
 }
+
+
 
 #pragma warning restore IDE0161 // Convert to file-scoped namespace
 #pragma warning restore IDE0060 // Remove unused parameter


### PR DESCRIPTION
## Description

IsLetterOrDigit is not considering LetterNumbers to be a digit (as defined here in remarks: https://learn.microsoft.com/en-us/dotnet/api/system.char.isletterordigit?view=net-9.0 )

But spec considers them as valid, this mismatch was causing the identifier to be wrapped in `'`.

## Related issue
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2285943
