### PR TITLE
Fix issue #14993 about forward slashes not working on windows when globbing sources

### DIFF
--- a/src/vstest.console/Internal/FilePatternParser.cs
+++ b/src/vstest.console/Internal/FilePatternParser.cs
@@ -28,6 +28,7 @@ public class FilePatternParser
     private readonly Matcher _matcher;
     private readonly IFileHelper _fileHelper;
     private readonly char[] _wildCardCharacters = ['*'];
+    private readonly char[] _directorySeparatorCharacters = [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar];
 
     public FilePatternParser()
         : this(new Matcher(), new FileHelper())
@@ -96,7 +97,7 @@ public class FilePatternParser
     {
         // Split the pattern based on first wild card character found.
         var splitOnWildCardIndex = filePattern.IndexOfAny(_wildCardCharacters);
-        var directorySeparatorIndex = filePattern.Substring(0, splitOnWildCardIndex).LastIndexOf(Path.DirectorySeparatorChar);
+        var directorySeparatorIndex = filePattern.Substring(0, splitOnWildCardIndex).LastIndexOfAny(_directorySeparatorCharacters);
 
         string searchDir = filePattern.Substring(0, directorySeparatorIndex);
         string pattern = filePattern.Substring(directorySeparatorIndex + 1);

--- a/test/vstest.console.UnitTests/Internal/FilePatternParserTests.cs
+++ b/test/vstest.console.UnitTests/Internal/FilePatternParserTests.cs
@@ -44,6 +44,18 @@ public class FilePatternParserTests
     }
 
     [TestMethod]
+    public void FilePatternParserShouldCorrectlySplitPatternAndDirectoryWithAlternateSeparator()
+    {
+        var patternMatchingResult = new PatternMatchingResult(new List<FilePatternMatch>());
+        _mockMatcherHelper.Setup(x => x.Execute(It.IsAny<DirectoryInfoWrapper>())).Returns(patternMatchingResult);
+        _filePatternParser.GetMatchingFiles(TranslatePath(@"C:/Users/vanidhi/Desktop/a/c/*bc.dll"));
+
+        // Assert
+        _mockMatcherHelper.Verify(x => x.AddInclude(TranslatePath(@"*bc.dll")));
+        _mockMatcherHelper.Verify(x => x.Execute(It.Is<DirectoryInfoWrapper>(y => y.FullName.Equals(TranslatePath(@"C:\Users\vanidhi\Desktop\a\c")))));
+    }
+
+    [TestMethod]
     public void FilePatternParserShouldCorrectlySplitWithArbitraryDirectoryDepth()
     {
         var patternMatchingResult = new PatternMatchingResult(new List<FilePatternMatch>());


### PR DESCRIPTION
🐛: Using a list of allowed separators (alternate + normal) to search for instead of only using the main separators

## Description

To retrieve the source where we start the globbing pattern, the pattern is first split, then we search for the first Directory separator.

In this search, we only allow for the the principal separator, however, some platforms have alternate separators.

So we use `LastIndexOfAny` instead of `LastIndexOf`

## Related issue

Issue being fixed is here https://github.com/microsoft/vstest/issues/14993 and is flagged as a bug


- [x] I have ensured that there is a previously discussed and approved issue.
