### PR TITLE
Fix trace in DataCollectionRequestSender.cs

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestSender.cs
@@ -103,7 +103,7 @@ public sealed class DataCollectionRequestSender : IDataCollectionRequestSender
         var isDataCollectionStarted = false;
         BeforeTestRunStartResult? result = null;
 
-        EqtTrace.Verbose("DataCollectionRequestSender.SendBeforeTestRunStartAndGetResult: Send BeforeTestRunStart message with settingsXml {0} and sources {1}: ", settingsXml, sources.ToString());
+        EqtTrace.Verbose("DataCollectionRequestSender.SendBeforeTestRunStartAndGetResult: Send BeforeTestRunStart message with settingsXml {0} and sources {1}: ", settingsXml, string.Join(" ", sources));
 
         var payload = new BeforeTestRunStartPayload
         {


### PR DESCRIPTION
String join:

```
..., vstest.console.exe, DataCollectionRequestSender.SendBeforeTestRunStartAndGetResult: Send BeforeTestRunStart message with settingsXml <RunSettings>...</RunSettings> and sources System.Collections.Generic.List`1[System.String]: 
```

## Description

Please add a meaningful description for this change.
Ensure the PR has required unit tests.

## Related issue

Kindly link any related issues. E.g. Fixes #xyz.

- [ ] I have ensured that there is a previously discussed and approved issue.
