### PR TITLE
Fix formatting in two files

### DIFF
--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestLogsTask.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestLogsTask.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.TestPlatform.Build.Tasks;
+
 public class VSTestLogsTask : Task
 {
     public string? LogType { get; set; }

--- a/src/Microsoft.TestPlatform.Common/ExtensionDecorators/ExtensionDecoratorFactory.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionDecorators/ExtensionDecoratorFactory.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
 
 namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionDecorators;
+
 internal class ExtensionDecoratorFactory
 {
     private readonly IFeatureFlag _featureFlag;

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/ProtocolVersioning.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/ProtocolVersioning.cs
@@ -4,6 +4,7 @@
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
 
 namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
+
 internal static class ProtocolVersioning
 {
     public const int HighestSupportedVersion = Version7;

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/NullPathConverter.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/NullPathConverter.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 
 namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
+
 internal class NullPathConverter : IPathConverter
 {
     private static readonly Lazy<NullPathConverter> LazyInstance = new(() => new NullPathConverter());

--- a/src/vstest.console/Processors/ShowDeprecateDotnetVStestMessageArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ShowDeprecateDotnetVStestMessageArgumentProcessor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
+
 internal class ShowDeprecateDotnetVStestMessageArgumentProcessor : IArgumentProcessor
 {
     public const string CommandName = "/ShowDeprecateDotnetVSTestMessage";

--- a/test/TestAssets/NetStandard2Library/Class1.cs
+++ b/test/TestAssets/NetStandard2Library/Class1.cs
@@ -4,6 +4,7 @@
 using System;
 
 namespace NetStandard2Library;
+
 public class Class1
 {
 

--- a/test/vstest.ProgrammerTests/Fakes/FakeTestHost.cs
+++ b/test/vstest.ProgrammerTests/Fakes/FakeTestHost.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace vstest.ProgrammerTests.Fakes;
+
 internal class FakeTestHostFixture : IDisposable
 {
     public int Id { get; }


### PR DESCRIPTION
Unblocks https://github.com/dotnet/sdk/pull/48088

Resolves the following VMR failures:

    /__w/1/vmr/src/vstest/src/Microsoft.TestPlatform.Build/Tasks/VSTestLogsTask.cs(10,1): error IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [/__w/1/vmr/src/vstest/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.csproj::TargetFramework=net10.0]
    /__w/1/vmr/src/vstest/src/Microsoft.TestPlatform.Common/ExtensionDecorators/ExtensionDecoratorFactory.cs(8,1): error IDE0055: Fix formatting (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055) [/__w/1/vmr/src/vstest/src/Microsoft.TestPlatform.Common/Microsoft.TestPlatform.Common.csproj::TargetFramework=net10.0]

This is due to a new analyzer or an analyzer fix with latest roslyn.