### PR TITLE
Condition property on .NET FX MSBuild

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -133,8 +133,6 @@
     <DebugType>embedded</DebugType>
     <!-- Default to all packages generating a corresponding symbol package -->
     <IncludeSymbols>true</IncludeSymbols>
-    <!-- Workaround for AD0001 in analyzers with .NET 9. See https://github.com/dotnet/arcade/issues/14311 -->
-    <BuildWithNetFrameworkHostedCompiler Condition="'$(MSBuildRuntimeType)' == 'Full'">true</BuildWithNetFrameworkHostedCompiler>
   </PropertyGroup>
 
   <!-- Sign config -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -79,9 +79,9 @@
     <NetPortableTargetFrameworks>$(NetCoreAppMinimum)</NetPortableTargetFrameworks>
     <NetRunnerTargetFrameworks>$(NetSDKTargetFramework);$(NetPortableTargetFrameworks)</NetRunnerTargetFrameworks>
     <RunnerTargetFrameworks>$(NetFrameworkRunnerTargetFramework);$(NetRunnerTargetFrameworks)</RunnerTargetFrameworks>
-    
+
     <!--
-      
+
     -->
     <BundledExtensionTargetFrameworks>$(RunnerTargetFrameworks)</BundledExtensionTargetFrameworks>
     <!--
@@ -112,7 +112,7 @@
       https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks
     -->
     <TestHostAllTargetFrameworks>$(TestHostMinimumTargetFrameworks);net47;net471;net472;net48;net481</TestHostAllTargetFrameworks>
-    
+
     <!--
       Library that is loaded by others and by us. We don't know where it will run (e.b. TranslationLayer),
       we need to support all frameworks from minimum, and also netstandard2.0.
@@ -134,7 +134,7 @@
     <!-- Default to all packages generating a corresponding symbol package -->
     <IncludeSymbols>true</IncludeSymbols>
     <!-- Workaround for AD0001 in analyzers with .NET 9. See https://github.com/dotnet/arcade/issues/14311 -->
-    <BuildWithNetFrameworkHostedCompiler>true</BuildWithNetFrameworkHostedCompiler>
+    <BuildWithNetFrameworkHostedCompiler Condition="'$(MSBuildRuntimeType)' == 'Full'">true</BuildWithNetFrameworkHostedCompiler>
   </PropertyGroup>
 
   <!-- Sign config -->


### PR DESCRIPTION
The `BuildWithNetFrameworkHostedCompiler` property forces a .NET Framework specific compiler package to be used. This property was being unconditionally set which meant it loaded inside of `dotnet build`. In that environment the build task is invalid / unsupported.

In this particular case the task ended up throwing errors trying to connect to the compiler server. That is an expected failure path in the build task and it will fallback silently to csc.exe. That meant this went unnoticed as builds remained functional, just significantly slower.

Related: https://github.com/dotnet/sdk/pull/48557
