### PR TITLE
Build TestPlatform packages in VMR

### DIFF
--- a/src/package/Microsoft.TestPlatform.Portable/Microsoft.TestPlatform.Portable.csproj
+++ b/src/package/Microsoft.TestPlatform.Portable/Microsoft.TestPlatform.Portable.csproj
@@ -16,8 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Don't produce this package when building from source or inside the VMR as it relies on a VS license. -->
-    <IsPackable Condition="'$(DotNetBuild)' != 'true'">true</IsPackable>
+    <IsPackable>true</IsPackable>
     <NuspecFile>Microsoft.TestPlatform.Portable.nuspec</NuspecFile>
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
     <PackageId>Microsoft.TestPlatform.Portable</PackageId>
@@ -32,7 +31,9 @@
     </PackageDescription>
     <!-- Override default license -->
     <PackageLicenseFile>LICENSE_VS.txt</PackageLicenseFile>
-    <PackageLicenseFullPath>$(SrcPackageFolder)licenses/LICENSE_VS.txt</PackageLicenseFullPath>
+    <!-- Use the MIT license when building from the VMR as the VS license is cloaked out. -->
+    <PackageLicenseFile Condition="'$(DotNetBuild)' == 'true'">LICENSE_MIT.txt</PackageLicenseFile>
+    <PackageLicenseFullPath>$(SrcPackageFolder)licenses/$(PackageLicenseFile)</PackageLicenseFullPath>
   </PropertyGroup>
 
   <ItemGroup Label="NuGet">

--- a/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.csproj
+++ b/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.csproj
@@ -15,8 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Don't produce this package when building from source or inside the VMR as it relies on a VS license. -->
-    <IsPackable Condition="'$(DotNetBuild)' != 'true'">true</IsPackable>
+    <IsPackable>true</IsPackable>
     <NuspecFile>Microsoft.TestPlatform.nuspec</NuspecFile>
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
     <PackageId>Microsoft.TestPlatform</PackageId>
@@ -34,7 +33,9 @@
     </PackageDescription>
     <!-- Override default license -->
     <PackageLicenseFile>LICENSE_VS.txt</PackageLicenseFile>
-    <PackageLicenseFullPath>$(SrcPackageFolder)licenses/LICENSE_VS.txt</PackageLicenseFullPath>
+    <!-- Use the MIT license when building from the VMR as the VS license is cloaked out. -->
+    <PackageLicenseFile Condition="'$(DotNetBuild)' == 'true'">LICENSE_MIT.txt</PackageLicenseFile>
+    <PackageLicenseFullPath>$(SrcPackageFolder)licenses/$(PackageLicenseFile)</PackageLicenseFullPath>
   </PropertyGroup>
 
   <ItemGroup Label="NuGet">


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4996

Build TestPlatform packages in VMR but with the MIT license instead of the VS one, as discussed in the issue. We don't ship those packages so that should be fine.

Validation build: https://github.com/dotnet/sdk/pull/48571