### PR TITLE
Revert "Build TestPlatform packages in VMR"

### DIFF
--- a/src/package/Microsoft.TestPlatform.Portable/Microsoft.TestPlatform.Portable.csproj
+++ b/src/package/Microsoft.TestPlatform.Portable/Microsoft.TestPlatform.Portable.csproj
@@ -16,7 +16,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <IsPackable>true</IsPackable>
+    <!-- Don't produce this package when building from source or inside the VMR as it relies on a VS license. -->
+    <IsPackable Condition="'$(DotNetBuild)' != 'true'">true</IsPackable>
     <NuspecFile>Microsoft.TestPlatform.Portable.nuspec</NuspecFile>
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
     <PackageId>Microsoft.TestPlatform.Portable</PackageId>
@@ -31,9 +32,7 @@
     </PackageDescription>
     <!-- Override default license -->
     <PackageLicenseFile>LICENSE_VS.txt</PackageLicenseFile>
-    <!-- Use the MIT license when building from the VMR as the VS license is cloaked out. -->
-    <PackageLicenseFile Condition="'$(DotNetBuild)' == 'true'">LICENSE_MIT.txt</PackageLicenseFile>
-    <PackageLicenseFullPath>$(SrcPackageFolder)licenses/$(PackageLicenseFile)</PackageLicenseFullPath>
+    <PackageLicenseFullPath>$(SrcPackageFolder)licenses/LICENSE_VS.txt</PackageLicenseFullPath>
   </PropertyGroup>
 
   <ItemGroup Label="NuGet">

--- a/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.csproj
+++ b/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.csproj
@@ -15,7 +15,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <IsPackable>true</IsPackable>
+    <!-- Don't produce this package when building from source or inside the VMR as it relies on a VS license. -->
+    <IsPackable Condition="'$(DotNetBuild)' != 'true'">true</IsPackable>
     <NuspecFile>Microsoft.TestPlatform.nuspec</NuspecFile>
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
     <PackageId>Microsoft.TestPlatform</PackageId>
@@ -33,9 +34,7 @@
     </PackageDescription>
     <!-- Override default license -->
     <PackageLicenseFile>LICENSE_VS.txt</PackageLicenseFile>
-    <!-- Use the MIT license when building from the VMR as the VS license is cloaked out. -->
-    <PackageLicenseFile Condition="'$(DotNetBuild)' == 'true'">LICENSE_MIT.txt</PackageLicenseFile>
-    <PackageLicenseFullPath>$(SrcPackageFolder)licenses/$(PackageLicenseFile)</PackageLicenseFullPath>
+    <PackageLicenseFullPath>$(SrcPackageFolder)licenses/LICENSE_VS.txt</PackageLicenseFullPath>
   </PropertyGroup>
 
   <ItemGroup Label="NuGet">


### PR DESCRIPTION
Reverts microsoft/vstest#15055

The packages don't build successfully on non-Windows:

```
  Microsoft.TestPlatform failed with 1 error(s) (0.1s)
    /home/vihofer/git/vstest/.dotnet/sdk/9.0.104/Sdks/NuGet.Build.Tasks.Pack/buildCrossTargeting/NuGet.Build.Tasks.Pack.targets(221,5): error NU5019: File not found: 'net48\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.xml'.
  Microsoft.TestPlatform.Portable failed with 1 error(s) (0.1s)
    /home/vihofer/git/vstest/.dotnet/sdk/9.0.104/Sdks/NuGet.Build.Tasks.Pack/buildCrossTargeting/NuGet.Build.Tasks.Pack.targets(221,5): error NU5019: File not found: 'net48\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.xml'.
```

I'm a bit suprised that vstest's CI doesn't build packages on non-Windows. Also, the checked-in nuspecs with the hundreds of lines of assets to include are horrible. They made me open this revert PR instead of attempting to fix the build issue.