### PR TITLE
Warning on unsupported tfms

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -52,7 +52,7 @@
     <MicrosoftExtensionsDependencyModelPackageVersion>6.0.2</MicrosoftExtensionsDependencyModelPackageVersion>
     <MicrosoftExtensionsFileSystemGlobbingVersion>6.0.0</MicrosoftExtensionsFileSystemGlobbingVersion>
     <MicrosoftFakesVersion>17.12.0</MicrosoftFakesVersion>
-    <MicrosoftInternalCodeCoverageVersion>17.14.3-preview.25164.1</MicrosoftInternalCodeCoverageVersion>
+    <MicrosoftInternalCodeCoverageVersion>17.14.2</MicrosoftInternalCodeCoverageVersion>
     <!--
       Make sure you are taking a version from a release branch (rel/d*) in VS. Otherwise there won't be symbols for the dlls in package,
       a and it will create a symcheck bug on re-insertion into VS.

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
       from appending +<commitId>, which breaks DTAAgent.
     -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
-    <VersionPrefix>17.14.0</VersionPrefix>
+    <VersionPrefix>17.14.1</VersionPrefix>
     <PreReleaseVersionLabel>release</PreReleaseVersionLabel>
   </PropertyGroup>
   <PropertyGroup Label="Arcade settings">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -52,7 +52,7 @@
     <MicrosoftExtensionsDependencyModelPackageVersion>6.0.2</MicrosoftExtensionsDependencyModelPackageVersion>
     <MicrosoftExtensionsFileSystemGlobbingVersion>6.0.0</MicrosoftExtensionsFileSystemGlobbingVersion>
     <MicrosoftFakesVersion>17.12.0</MicrosoftFakesVersion>
-    <MicrosoftInternalCodeCoverageVersion>17.14.2</MicrosoftInternalCodeCoverageVersion>
+    <MicrosoftInternalCodeCoverageVersion>17.14.3-preview.25164.1</MicrosoftInternalCodeCoverageVersion>
     <!--
       Make sure you are taking a version from a release branch (rel/d*) in VS. Otherwise there won't be symbols for the dlls in package,
       a and it will create a symcheck bug on re-insertion into VS.

--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -18,7 +18,7 @@ function Verify-Nuget-Packages {
     Write-Host "Starting Verify-Nuget-Packages."
     $expectedNumOfFiles = @{
         "Microsoft.CodeCoverage"                      = 59;
-        "Microsoft.NET.Test.Sdk"                      = 15;
+        "Microsoft.NET.Test.Sdk"                      = 20;
         "Microsoft.TestPlatform"                      = 619;
         "Microsoft.TestPlatform.Build"                = 20;
         "Microsoft.TestPlatform.CLI"                  = 481;

--- a/src/package/Microsoft.NET.Test.Sdk/Microsoft.NET.Test.Sdk.csproj
+++ b/src/package/Microsoft.NET.Test.Sdk/Microsoft.NET.Test.Sdk.csproj
@@ -29,6 +29,9 @@
     <None Update="Microsoft.NET.Test.Sdk.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Microsoft.NET.Test.Sdk.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="netcoreapp\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/package/Microsoft.NET.Test.Sdk/Microsoft.NET.Test.Sdk.nuspec
+++ b/src/package/Microsoft.NET.Test.Sdk/Microsoft.NET.Test.Sdk.nuspec
@@ -21,9 +21,16 @@
     <file src="netstandard2.0\netcoreapp\*" target="build\net8.0\" />
     <file src="netstandard2.0\netfx\*" target="build\net462\" />
 
-    <file src="netstandard2.0\Microsoft.NET.Test.Sdk.props" target="buildMultiTargeting\" />
+    <file src="netstandard2.0\Microsoft.NET.Test.Sdk.props" target="buildMultiTargeting\net462\" />
+    <file src="netstandard2.0\Microsoft.NET.Test.Sdk.props" target="buildMultiTargeting\net8.0\" />
     <file src="netstandard2.0\Microsoft.NET.Test.Sdk.props" target="build\net8.0\" />
     <file src="netstandard2.0\Microsoft.NET.Test.Sdk.props" target="build\net462\" />
+
+    <!-- Add incompatibility warning. -->
+    <file src="netstandard2.0\Microsoft.NET.Test.Sdk.targets" target="buildMultiTargeting\netcoreapp2.0\" />
+    <file src="netstandard2.0\Microsoft.NET.Test.Sdk.targets" target="build\netcoreapp2.0\" />
+    <file src="netstandard2.0\Microsoft.NET.Test.Sdk.targets" target="buildMultiTargeting\netstandard2.0\" />
+    <file src="netstandard2.0\Microsoft.NET.Test.Sdk.targets" target="build\netstandard2.0\" />
 
     <file src="netstandard2.0\_._" target="lib/net8.0" />
     <file src="netstandard2.0\_._" target="lib/net462" />

--- a/src/package/Microsoft.NET.Test.Sdk/Microsoft.NET.Test.Sdk.targets
+++ b/src/package/Microsoft.NET.Test.Sdk/Microsoft.NET.Test.Sdk.targets
@@ -1,0 +1,6 @@
+<Project InitialTargets="NonCompatibleTargetFrameworkError_Microsoft_NET_Test_Sdk_net8_0">
+  <Target Name="NonCompatibleTargetFrameworkError_Microsoft_NET_Test_Sdk_net8_0"
+          Condition="'$(SuppressTfmSupportBuildWarnings)' == ''">
+    <Warning Text="Microsoft.NET.Test.Sdk doesn't support $(TargetFramework) and has not been tested with it. Consider upgrading your TargetFramework to net8.0 or later. You may also set &lt;SuppressTfmSupportBuildWarnings&gt;true&lt;/SuppressTfmSupportBuildWarnings&gt; in the project file to ignore this warning and attempt to run in this unsupported configuration at your own risk." />
+  </Target>
+</Project>


### PR DESCRIPTION
## Description

Write warning when attempting to restore on an unsupported TFM (that is netcoreapp net5, net6, net7 and netstandard).

![image](https://github.com/user-attachments/assets/6e6f49de-7311-40df-9673-70ff4904c836)

Fix #15069 