### PR TITLE
Make the warning error, and restore previous props so we attempt to run

### DIFF
--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -20,7 +20,7 @@ function Verify-Nuget-Packages {
         "Microsoft.CodeCoverage"                      = 59;
         "Microsoft.NET.Test.Sdk"                      = 20;
         "Microsoft.TestPlatform"                      = 619;
-        "Microsoft.TestPlatform.Build"                = 20;
+        "Microsoft.TestPlatform.Build"                = 25;
         "Microsoft.TestPlatform.CLI"                  = 481;
         "Microsoft.TestPlatform.Extensions.TrxLogger" = 34;
         "Microsoft.TestPlatform.ObjectModel"          = 92;

--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -18,9 +18,9 @@ function Verify-Nuget-Packages {
     Write-Host "Starting Verify-Nuget-Packages."
     $expectedNumOfFiles = @{
         "Microsoft.CodeCoverage"                      = 59;
-        "Microsoft.NET.Test.Sdk"                      = 20;
+        "Microsoft.NET.Test.Sdk"                      = 25;
         "Microsoft.TestPlatform"                      = 619;
-        "Microsoft.TestPlatform.Build"                = 25;
+        "Microsoft.TestPlatform.Build"                = 20;
         "Microsoft.TestPlatform.CLI"                  = 481;
         "Microsoft.TestPlatform.Extensions.TrxLogger" = 34;
         "Microsoft.TestPlatform.ObjectModel"          = 92;

--- a/src/package/Microsoft.NET.Test.Sdk/Microsoft.NET.Test.Sdk.nuspec
+++ b/src/package/Microsoft.NET.Test.Sdk/Microsoft.NET.Test.Sdk.nuspec
@@ -31,7 +31,7 @@
     <file src="netstandard2.0\Microsoft.NET.Test.Sdk.props" target="build\net8.0\" />
     <file src="netstandard2.0\Microsoft.NET.Test.Sdk.props" target="build\net462\" />
 
-    <!-- Add incompatibility warning, and add the props, in case user decides to ignore it. -->
+    <!-- Add incompatibility error, and add the props, in case user decides to ignore it. -->
     <file src="netstandard2.0\Microsoft.NET.Test.Sdk.props" target="buildMultiTargeting\netcoreapp2.0\" />
     <file src="netstandard2.0\Microsoft.NET.Test.Sdk.targets" target="buildMultiTargeting\netcoreapp2.0\" />
 

--- a/src/package/Microsoft.NET.Test.Sdk/Microsoft.NET.Test.Sdk.nuspec
+++ b/src/package/Microsoft.NET.Test.Sdk/Microsoft.NET.Test.Sdk.nuspec
@@ -8,10 +8,15 @@
         <dependency id="Microsoft.TestPlatform.TestHost" version="$Version$" />
         <dependency id="Microsoft.CodeCoverage" version="$Version$" />
       </group>
+
       <group targetFramework="net462">
         <!-- TestHost gets shipped with vstest.console -->
         <dependency id="Microsoft.CodeCoverage" version="$Version$" />
       </group>
+
+      <group targetFramework="native0.0">
+      </group>
+      
     </dependencies>
   </metadata>
 
@@ -26,13 +31,22 @@
     <file src="netstandard2.0\Microsoft.NET.Test.Sdk.props" target="build\net8.0\" />
     <file src="netstandard2.0\Microsoft.NET.Test.Sdk.props" target="build\net462\" />
 
-    <!-- Add incompatibility warning. -->
+    <!-- Add incompatibility warning, and add the props, in case user decides to ignore it. -->
+    <file src="netstandard2.0\Microsoft.NET.Test.Sdk.props" target="buildMultiTargeting\netcoreapp2.0\" />
     <file src="netstandard2.0\Microsoft.NET.Test.Sdk.targets" target="buildMultiTargeting\netcoreapp2.0\" />
+
+    <file src="netstandard2.0\Microsoft.NET.Test.Sdk.props" target="build\netcoreapp2.0\" />
     <file src="netstandard2.0\Microsoft.NET.Test.Sdk.targets" target="build\netcoreapp2.0\" />
+
+    <file src="netstandard2.0\Microsoft.NET.Test.Sdk.props" target="buildMultiTargeting\netstandard2.0\" />
     <file src="netstandard2.0\Microsoft.NET.Test.Sdk.targets" target="buildMultiTargeting\netstandard2.0\" />
+
+    <file src="netstandard2.0\Microsoft.NET.Test.Sdk.props" target="build\netstandard2.0\" />
     <file src="netstandard2.0\Microsoft.NET.Test.Sdk.targets" target="build\netstandard2.0\" />
 
     <file src="netstandard2.0\_._" target="lib/net8.0" />
     <file src="netstandard2.0\_._" target="lib/net462" />
+
+    <file src="netstandard2.0\_._" target="lib/native" />
   </files>
 </package>

--- a/src/package/Microsoft.NET.Test.Sdk/Microsoft.NET.Test.Sdk.targets
+++ b/src/package/Microsoft.NET.Test.Sdk/Microsoft.NET.Test.Sdk.targets
@@ -1,6 +1,6 @@
 <Project InitialTargets="NonCompatibleTargetFrameworkError_Microsoft_NET_Test_Sdk_net8_0">
   <Target Name="NonCompatibleTargetFrameworkError_Microsoft_NET_Test_Sdk_net8_0"
-          Condition="'$(SuppressTfmSupportBuildWarnings)' == ''">
-    <Warning Text="Microsoft.NET.Test.Sdk doesn't support $(TargetFramework) and has not been tested with it. Consider upgrading your TargetFramework to net8.0 or later. You may also set &lt;SuppressTfmSupportBuildWarnings&gt;true&lt;/SuppressTfmSupportBuildWarnings&gt; in the project file to ignore this warning and attempt to run in this unsupported configuration at your own risk." />
+          Condition="'$(SuppressTfmSupportBuildErrors)' == ''">
+    <Error Text="Microsoft.NET.Test.Sdk doesn't support $(TargetFramework) and has not been tested with it. Consider upgrading your TargetFramework to net8.0 or later. You may also set &lt;SuppressTfmSupportBuildErrors&gt;true&lt;/SuppressTfmSupportBuildErrors&gt; in the project file to ignore this warning and attempt to run in this unsupported configuration at your own risk." />
   </Target>
 </Project>


### PR DESCRIPTION
## Description

Add targets so we don't fallback on package restore on unsupported tfms, and don't end up restoring wrong tfm by accident. Add props back in so we attempt to run via dotnet test.

## Related issue

Related #15069 
