### PR TITLE
Fix stack trace for Trace.Fail and Debug.Fail

### DIFF
--- a/src/testhost.x86/TestHostTraceListener.cs
+++ b/src/testhost.x86/TestHostTraceListener.cs
@@ -49,7 +49,8 @@ internal class TestHostTraceListener : DefaultTraceListener
         var debugMethodFound = false;
         var frameCount = 0;
         MethodBase? method = null;
-        foreach (var f in stack.GetFrames())
+        var frames = stack.GetFrames();
+        foreach (var f in frames)
         {
             var m = f?.GetMethod();
             var declaringType = m?.DeclaringType;
@@ -65,7 +66,7 @@ internal class TestHostTraceListener : DefaultTraceListener
             }
         }
 
-        var stackTrace = string.Join(Environment.NewLine, stack.ToString().Split(Environment.NewLine).TakeLast(frameCount));
+        var stackTrace = new StackTrace(frames.TakeLast(frameCount)).ToString();
         var methodName = method != null ? $"{method.DeclaringType?.Name}.{method.Name}" : "<method>";
         var wholeMessage = $"Method {methodName} failed with '{message}', and was translated to {typeof(DebugAssertException).FullName} to avoid terminating the process hosting the test.";
 


### PR DESCRIPTION
## Description
I see the stack trace included always, but the stack trace is incorrect, the way we count the frames to include was wrong, and we did not cut the stack trace to start with debug fail and the test method.

The first highlight is extra, the next highlight shows that the originating method is there:

![image](https://github.com/user-attachments/assets/5ebcedbd-59de-4641-b56f-b652c13ee0f0)


Replace #15092

Fix #5160
