### PR TITLE
Use the standard sdk for architecture switch test

### DIFF
--- a/test/TestAssets/ArchitectureSwitch/global.json
+++ b/test/TestAssets/ArchitectureSwitch/global.json
@@ -1,5 +1,0 @@
-{
-  "sdk": {
-    "version": "6.0.200-preview"
-  }
-}


### PR DESCRIPTION
## Description

This test used upgraded sdk to get the --arch switch early, but now is using an outdated SDK, so we will stop pinning it to keep up.

https://dev.azure.com/dnceng/internal/_git/microsoft-vstest/pullrequest/51338?discussionId=214111&_a=files