### PR TITLE
Update global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,14 @@
 {
-  "sdk": {
-    "version": "10.0.100-preview.5.25269.23",
-    "rollForward": "minor",
-    "allowPrerelease": false,
-    "architecture": "x64"
+"sdk": {
+    "version": "10.0.100-preview.6.25315.102",
+    "paths": [
+      ".dotnet",
+      "$host$"
+    ],
+    "errorMessage": "The .NET SDK could not be found, please run ./build.cmd on Windows or ./build.sh on Linux and macOS.",
+    "allowPrerelease": true,
+    "rollForward": "latestFeature",
+    "architecture": x64
   },
   "tools": {
     "runtimes": {
@@ -30,7 +35,7 @@
       "version": "17.8.0"
     },
     "vswhere": "2.2.7",
-    "dotnet": "10.0.100-preview.5.25269.23"
+    "dotnet": "10.0.100-preview.6.25315.102"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.25325.4"

--- a/global.json
+++ b/global.json
@@ -8,7 +8,7 @@
     "errorMessage": "The .NET SDK could not be found, please run ./build.cmd on Windows or ./build.sh on Linux and macOS.",
     "allowPrerelease": true,
     "rollForward": "latestFeature",
-    "architecture": x64
+    "architecture": "x64"
   },
   "tools": {
     "runtimes": {


### PR DESCRIPTION
Sign validation fails with SDK being too new for the required msbuild, but testfx should be using the same setup and works, so I try upgrading first. 

https://dnceng.visualstudio.com/internal/_build/results?buildId=2745254&view=logs&j=b11b921d-8982-5bb3-754b-b114d42fd804&t=fb192a8b-e433-5fc8-e2b0-276ab015e7d5
