### PR TITLE
Add `DisableVSTestTestHostCopy` property

### DIFF
--- a/src/package/Microsoft.TestPlatform.TestHost/Microsoft.TestPlatform.TestHost.props
+++ b/src/package/Microsoft.TestPlatform.TestHost/Microsoft.TestPlatform.TestHost.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Condition=" ('$(Platform)' == 'x86' OR '$(PlatformTarget)' == 'x86') AND '$(OS)' == 'Windows_NT'">
+  <ItemGroup Condition=" ('$(Platform)' == 'x86' OR '$(PlatformTarget)' == 'x86') AND '$(OS)' == 'Windows_NT' AND '$(DisableVSTestTestHostCopy)'!='true'">
     <Content Include="$(MSBuildThisFileDirectory)x86\testhost.x86.exe">
       <Link>testhost.x86.exe</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -12,7 +12,7 @@
       <Visible>False</Visible>
     </Content>
   </ItemGroup>
-  <ItemGroup Condition=" ('$(Platform)'!= 'x86' AND '$(PlatformTarget)' != 'x86') AND '$(OS)' == 'Windows_NT'" >
+  <ItemGroup Condition=" ('$(Platform)'!= 'x86' AND '$(PlatformTarget)' != 'x86') AND '$(OS)' == 'Windows_NT'  AND '$(DisableVSTestTestHostCopy)'!='true'" >
     <Content Include="$(MSBuildThisFileDirectory)x64\testhost.exe">
       <Link>testhost.exe</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
When MTP is used along with Microsoft.NET.Test.Sdk (e.g, via `MSTest` metapackage), I would like to be able to tell VSTest to not copy testhost.

In addition, In MTP v2 or MSTest v4, I want to discuss the possibility of setting `DisableVSTestTestHostCopy` to true by default (either in MSTest.TestAdapter.props or in Microsoft.Testing.Platform.props)