### PR TITLE
Sourcebuild fix

### DIFF
--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.sourcebuild.nuspec
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.sourcebuild.nuspec
@@ -102,10 +102,25 @@
     <file src="$SourceBuildTfmCurrent$\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.dll" target="contentFiles\any\$SourceBuildTfmCurrent$\Extensions" />
 
     <!-- Resources -->
-    <file src="$SourceBuildTfmPrevious$\**\Microsoft.TestPlatform.*.resources.dll" target="contentFiles\any\$SourceBuildTfmPrevious$" />
-    <file src="$SourceBuildTfmCurrent$\**\Microsoft.TestPlatform.*.resources.dll" target="contentFiles\any\$SourceBuildTfmCurrent$" />
-    <file src="$SourceBuildTfmPrevious$\**\Microsoft.VisualStudio.TestPlatform.*.resources.dll" target="contentFiles\any\$SourceBuildTfmPrevious$" />
-    <file src="$SourceBuildTfmCurrent$\**\Microsoft.VisualStudio.TestPlatform.*.resources.dll" target="contentFiles\any\$SourceBuildTfmCurrent$" />
+    <!-- Copy all, except the excluded, because those belong to Extensions folder. -->
+    <file src="$SourceBuildTfmPrevious$\**\Microsoft.TestPlatform.*.resources.dll" target="contentFiles\any\$SourceBuildTfmPrevious$" exclude="**.TestHostRuntimeProvider**;**BlameDataCollector**" />
+    <file src="$SourceBuildTfmCurrent$\**\Microsoft.TestPlatform.*.resources.dll" target="contentFiles\any\$SourceBuildTfmCurrent$" exclude="**.TestHostRuntimeProvider**;**BlameDataCollector**" />
+
+    <file src="$SourceBuildTfmPrevious$\**\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfmPrevious$\Extensions" />
+    <file src="$SourceBuildTfmCurrent$\**\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfmCurrent$\Extensions" />
+    <file src="$SourceBuildTfmPrevious$\**\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfmPrevious$\Extensions" />
+    <file src="$SourceBuildTfmCurrent$\**\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfmCurrent$\Extensions" />
+    
+    <!-- Copy all, except the excluded, because those belong to Extensions folder. -->
+    <file src="$SourceBuildTfmPrevious$\**\Microsoft.VisualStudio.TestPlatform.*.resources.dll" target="contentFiles\any\$SourceBuildTfmPrevious$" exclude="**Html**;**Trx**" />
+    <file src="$SourceBuildTfmCurrent$\**\Microsoft.VisualStudio.TestPlatform.*.resources.dll" target="contentFiles\any\$SourceBuildTfmCurrent$" exclude="**Html**;**Trx**" />
+
+    <file src="$SourceBuildTfmPrevious$\**\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfmPrevious$\Extensions" />
+    <file src="$SourceBuildTfmCurrent$\**\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfmCurrent$\Extensions" />
+    <file src="$SourceBuildTfmPrevious$\**\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfmPrevious$\Extensions" />
+    <file src="$SourceBuildTfmCurrent$\**\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfmCurrent$\Extensions" />
+
+
     <file src="$SourceBuildTfmPrevious$\**\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfmPrevious$" />
     <file src="$SourceBuildTfmCurrent$\**\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfmCurrent$" />
   </files>

--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.sourcebuild.product.nuspec
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.sourcebuild.product.nuspec
@@ -56,13 +56,20 @@
 
     <!-- Extensions -->
     <file src="$SourceBuildTfmCurrent$\Microsoft.Diagnostics.NETCore.Client\Microsoft.Diagnostics.NETCore.Client.dll" target="contentFiles\any\$SourceBuildTfmCurrent$\Extensions" />
+    <file src="$SourceBuildTfmCurrent$\Microsoft.TestPlatform.Extensions.BlameDataCollector.dll" target="contentFiles\any\$SourceBuildTfmCurrent$\Extensions" />
     <file src="$SourceBuildTfmCurrent$\Microsoft.TestPlatform.TesthostRuntimeProvider.dll" target="contentFiles\any\$SourceBuildTfmCurrent$\Extensions" />
     <file src="$SourceBuildTfmCurrent$\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.dll" target="contentFiles\any\$SourceBuildTfmCurrent$\Extensions" />
     <file src="$SourceBuildTfmCurrent$\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.dll" target="contentFiles\any\$SourceBuildTfmCurrent$\Extensions" />
 
     <!-- Resources -->
-    <file src="$SourceBuildTfmCurrent$\**\Microsoft.TestPlatform.*.resources.dll" target="contentFiles\any\$SourceBuildTfmCurrent$" />
-    <file src="$SourceBuildTfmCurrent$\**\Microsoft.VisualStudio.TestPlatform.*.resources.dll" target="contentFiles\any\$SourceBuildTfmCurrent$" />
+    <file src="$SourceBuildTfmCurrent$\**\Microsoft.TestPlatform.*.resources.dll" target="contentFiles\any\$SourceBuildTfmCurrent$" exclude="**.TestHostRuntimeProvider**;**BlameDataCollector**" />
+    <file src="$SourceBuildTfmCurrent$\**\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfmCurrent$\Extensions" />
+    <file src="$SourceBuildTfmCurrent$\**\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfmCurrent$\Extensions" />
+    
+    <file src="$SourceBuildTfmCurrent$\**\Microsoft.VisualStudio.TestPlatform.*.resources.dll" target="contentFiles\any\$SourceBuildTfmCurrent$" exclude="**Html**;**Trx**" />
+    <file src="$SourceBuildTfmCurrent$\**\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfmCurrent$\Extensions" />
+    <file src="$SourceBuildTfmCurrent$\**\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfmCurrent$\Extensions" />
+    
     <file src="$SourceBuildTfmCurrent$\**\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfmCurrent$" />
   </files>
 </package>


### PR DESCRIPTION
## Description

Move resources to the right place, add blame collector dll.

Difference between the packages from the normal .CLI:

Microsoft.TestPlatform.Extensions.EventLogCollector.dll (and resources) - not included on purpose this is windows only collector
Microsoft.CodeCoverage.IO.dll (and resources) - not included, this is an old component
TesthostNetFramework - build of .net framework testhost and all dependent dlls, this is convenience for running .net framework tests
dumpminitool*.exe - this is windows only helper for blame data collector



## Related issue
Fix #15228 