### PR TITLE
Avoid iterator in TraitCollection.GetTraits

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/TraitCollection.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TraitCollection.cs
@@ -63,19 +63,21 @@ public class TraitCollection : IEnumerable<Trait>
         return GetEnumerator();
     }
 
-    private IEnumerable<Trait> GetTraits()
+    private Trait[] GetTraits()
     {
         if (!_testObject.Properties.Contains(TraitsProperty))
         {
-            yield break;
+            return Array.Empty<Trait>();
         }
 
-        var traits = _testObject.GetPropertyValue(TraitsProperty, Enumerable.Empty<KeyValuePair<string, string>>().ToArray());
-
-        foreach (var trait in traits)
+        var traitsKvp = _testObject.GetPropertyValue(TraitsProperty, Enumerable.Empty<KeyValuePair<string, string>>().ToArray());
+        var traits = new Trait[traitsKvp.Length];
+        for (int i = 0; i < traits.Length; i++)
         {
-            yield return new Trait(trait);
+            traits[i] = new Trait(traitsKvp[i]);
         }
+
+        return traits;
     }
 
     private void Add(IEnumerable<Trait> traits, IEnumerable<Trait> newTraits)

--- a/src/Microsoft.TestPlatform.ObjectModel/TraitCollection.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TraitCollection.cs
@@ -63,7 +63,7 @@ public class TraitCollection : IEnumerable<Trait>
         return GetEnumerator();
     }
 
-    private Trait[] GetTraits()
+    private IEnumerable<Trait> GetTraits()
     {
         if (!_testObject.Properties.Contains(TraitsProperty))
         {


### PR DESCRIPTION
Hopefully eliminates the iterator state machine allocations:

<img width="1741" height="35" alt="image" src="https://github.com/user-attachments/assets/8d00870d-b128-45b1-9fd8-083beb358777" />

I need to benchmark it to see before/after and ensure it's an improvement.