### PR TITLE
Set dotnet_root_<arch> always

### DIFF
--- a/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
@@ -72,6 +72,9 @@ internal partial class FeatureFlag : IFeatureFlag
     // Disable not sharing .NET Framework testhosts. Which will return behavior to sharing testhosts when they are running .NET Framework dlls, and are not disabling appdomains or running in parallel.
     public const string VSTEST_DISABLE_SHARING_NETFRAMEWORK_TESTHOST = nameof(VSTEST_DISABLE_SHARING_NETFRAMEWORK_TESTHOST);
 
+    // Disable setting DOTNET_ROOT environment variable on non-Windows platforms. We used to set it only only on Windows when we found testhost.exe, now we set it always to allow xunit v3 to run tests in child process.
+    public const string VSTEST_DISABLE_DOTNET_ROOT_ON_NONWINDOWS = nameof(VSTEST_DISABLE_DOTNET_ROOT_ON_NONWINDOWS);
+
 
     [Obsolete("Only use this in tests.")]
     internal static void Reset()

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -581,7 +581,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
                     // to avoid setting DOTNET_ROOT that points to x64 but is picked up by x86 host.
                     //
                     // Also avoid setting it if we are already getting it from the surrounding environment.
-                    var architectureFromEnv = (Architecture)Enum.Parse(typeof(Architecture), dotnetRootArchitecture, ignoreCase: true);
+                    var architectureFromEnv = (Architecture)Enum.Parse(typeof(Architecture), dotnetRootArchitecture!, ignoreCase: true);
                     if (architectureFromEnv == _architecture)
                     {
                         if (_architecture == Architecture.X86)
@@ -838,7 +838,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
                 var dotnetEnvVars = testHostStartInfo.EnvironmentVariables?
                     .Where(kvp => kvp.Key.StartsWith("DOTNET_", StringComparison.OrdinalIgnoreCase))
                     .Select(kvp => $"{kvp.Key}={kvp.Value}")
-                    .ToList();
+                    .ToArray() ?? Array.Empty<string>();
 
                 EqtTrace.Verbose($"DotnetTestHostManager: Starting process '{0}' with command line '{1}' and DOTNET environment: {string.Join(", ", dotnetEnvVars)} ", testHostStartInfo.FileName, testHostStartInfo.Arguments);
             }

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -915,28 +915,23 @@ public class DotnetTestHostManagerTests
     }
 
     [TestMethod]
-    [DataRow("DOTNET_ROOT(x86)", "x86")]
-    [DataRow("DOTNET_ROOT", "x64")]
-    [DataRow("DOTNET_ROOT_WRONG", "")]
-    [TestCategory("Windows")]
-    public void GetTestHostProcessStartInfoShouldForwardDOTNET_ROOTEnvVarsForAppHost(string envVar, string expectedValue)
+    [DataRow("x64")]
+    [DataRow("x86")]
+    [DataRow("arm64")]
+    public void GetTestHostProcessStartInfoShouldForwardDOTNET_ROOTEnvVarsForAppHost(string architecture)
     {
+        var path = @"C:\dotnet";
         _mockFileHelper.Setup(ph => ph.Exists("testhost.exe")).Returns(true);
         _mockEnvironment.Setup(ev => ev.OperatingSystem).Returns(PlatformOperatingSystem.Windows);
         _mockEnvironmentVariable.Reset();
-        _mockEnvironmentVariable.Setup(x => x.GetEnvironmentVariable($"VSTEST_WINAPPHOST_{envVar}")).Returns(expectedValue);
+        _mockEnvironmentVariable.Setup(x => x.GetEnvironmentVariable($"VSTEST_DOTNET_ROOT_PATH")).Returns(path);
+        _mockEnvironmentVariable.Setup(x => x.GetEnvironmentVariable($"VSTEST_DOTNET_ROOT_ARCHITECTURE")).Returns(architecture);
 
         var startInfo = _dotnetHostManager.GetTestHostProcessStartInfo(_testSource, null, _defaultConnectionInfo);
-        if (!string.IsNullOrEmpty(expectedValue))
-        {
-            Assert.AreEqual(1, startInfo.EnvironmentVariables!.Count);
-            Assert.IsNotNull(startInfo.EnvironmentVariables[envVar]);
-            Assert.AreEqual(startInfo.EnvironmentVariables[envVar], expectedValue);
-        }
-        else
-        {
-            Assert.AreEqual(0, startInfo.EnvironmentVariables!.Count);
-        }
+
+        var envVar = $"DOTNET_ROOT_{architecture.ToUpperInvariant()}";
+        Assert.IsNotNull(startInfo.EnvironmentVariables![envVar]);
+        Assert.AreEqual(startInfo.EnvironmentVariables![envVar], path);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Description

Always set DOTNET_ROOT_<ARCH> (e.g. DOTNET_ROOT_X64) when running under dotnet test, to make sure that the location of dotnet".exe", propagates to the testhost and child processes when we are on windows, linux and macos. This allows local installations of dotnet to be used to run tests that run child executables. On Windows this is alread in place for a long time when testhost.exe is found, so it can resolve correctly dotnet that is not in program files.

On Linux and MacOS it will be used to run xunit v3 tests.

There is a feature flag to disable this new behavior: `VSTEST_DISABLE_DOTNET_ROOT_ON_NONWINDOWS=1`

## Related issue

Will fix https://github.com/dotnet/sdk/issues/50331 once merged and flown.

Working:

<img width="1281" height="330" alt="image" src="https://github.com/user-attachments/assets/a810c418-995d-4622-866a-55dff4b0bccd" />


Reverting to broken behavior with the feature flag:

<img width="1668" height="993" alt="image" src="https://github.com/user-attachments/assets/a5dc1a62-713a-481d-b2e6-0d72d8f946f2" />

