### PR TITLE
Don't hardcode old vswhere version in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -29,7 +29,6 @@
     "vs": {
       "version": "17.8.0"
     },
-    "vswhere": "2.2.7",
     "dotnet": "10.0.100-preview.7.25372.107"
   },
   "msbuild-sdks": {


### PR DESCRIPTION
arcade provides a newer one now.

