### PR TITLE
Fixing async apis and reducing the number of threads we block

### DIFF
--- a/playground/TestPlatform.Playground/Program.cs
+++ b/playground/TestPlatform.Playground/Program.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 
 using Microsoft.TestPlatform.VsTestConsole.TranslationLayer;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -20,7 +21,7 @@ namespace TestPlatform.Playground;
 
 internal class Program
 {
-    static void Main()
+    static async Task Main()
     {
         // This project references TranslationLayer, vstest.console, TestHostProvider, testhost and MSTest1 projects, to make sure
         // we build all the dependencies of that are used to run tests via VSTestConsoleWrapper. It then copies the components from
@@ -141,8 +142,9 @@ internal class Program
 #pragma warning restore CS0618 // Type or member is obsolete
         var discoveryHandler = new PlaygroundTestDiscoveryHandler(detailedOutput);
         var sw = Stopwatch.StartNew();
+
         // Discovery
-        r.DiscoverTests(sources, sourceSettings, options, sessionHandler.TestSessionInfo, discoveryHandler);
+        await r.DiscoverTestsAsync(sources, sourceSettings, options, sessionHandler.TestSessionInfo, discoveryHandler);
         var discoveryDuration = sw.ElapsedMilliseconds;
         Console.WriteLine($"Discovery done in {discoveryDuration} ms");
         sw.Restart();

--- a/playground/TestPlatform.Playground/Program.cs
+++ b/playground/TestPlatform.Playground/Program.cs
@@ -9,7 +9,9 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+#pragma warning disable IDE0005 // Using directive is unnecessary.
 using System.Threading.Tasks;
+#pragma warning restore IDE0005 // Using directive is unnecessary.
 
 using Microsoft.TestPlatform.VsTestConsole.TranslationLayer;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -145,13 +147,14 @@ internal class Program
 
         // Discovery
         await r.DiscoverTestsAsync(sources, sourceSettings, options, sessionHandler.TestSessionInfo, discoveryHandler);
+        // r.DiscoverTests(sources, sourceSettings, options, sessionHandler.TestSessionInfo, discoveryHandler);
         var discoveryDuration = sw.ElapsedMilliseconds;
         Console.WriteLine($"Discovery done in {discoveryDuration} ms");
         sw.Restart();
         // Run with test cases and custom testhost launcher
         //r.RunTestsWithCustomTestHost(discoveryHandler.TestCases, sourceSettings, options, sessionHandler.TestSessionInfo, new TestRunHandler(detailedOutput), new DebuggerTestHostLauncher());
         //// Run with test cases and without custom testhost launcher
-        r.RunTests(discoveryHandler.TestCases, sourceSettings, options, sessionHandler.TestSessionInfo, new TestRunHandler(detailedOutput));
+        await r.RunTestsAsync(discoveryHandler.TestCases, sourceSettings, options, sessionHandler.TestSessionInfo, new TestRunHandler(detailedOutput));
         //// Run with sources and custom testhost launcher and debugging
         //r.RunTestsWithCustomTestHost(sources, sourceSettings, options, sessionHandler.TestSessionInfo, new TestRunHandler(detailedOutput), new DebuggerTestHostLauncher());
         //// Run with sources

--- a/playground/TestPlatform.Playground/Properties/launchSettings.json
+++ b/playground/TestPlatform.Playground/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "TestPlatform.Playground": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ThreadPool_ForceMinWorkerThreads": "1",
+        "DOTNET_ThreadPool_ForceMaxWorkerThreads": "1"
+      }
+    }
+  }
+}

--- a/playground/TestPlatform.Playground/TestPlatform.Playground.csproj
+++ b/playground/TestPlatform.Playground/TestPlatform.Playground.csproj
@@ -33,7 +33,7 @@
     <ProjectReference Include="$(RepoRoot)src\DataCollectors\DumpMinitool.arm64\DumpMinitool.arm64.csproj" SetTargetFramework="TargetFramework=$(NetFrameworkMinimum)" />
 
     <!-- Event log collector only works on .NET Framework, and so we build it only for that. -->
-    <ProjectReference Include="$(RepoRoot)src\DataCollectors\Microsoft.TestPlatform.Extensions.EventLogCollector\Microsoft.TestPlatform.Extensions.EventLogCollector.csproj"  SetTargetFramework="TargetFramework=$(NetFrameworkRunnerTargetFramework)"  />
+    <ProjectReference Include="$(RepoRoot)src\DataCollectors\Microsoft.TestPlatform.Extensions.EventLogCollector\Microsoft.TestPlatform.Extensions.EventLogCollector.csproj" SetTargetFramework="TargetFramework=$(NetFrameworkRunnerTargetFramework)" />
 
     <ProjectReference Include="$(RepoRoot)src\datacollector\datacollector.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Microsoft.TestPlatform.Extensions.BlameDataCollector\Microsoft.TestPlatform.Extensions.BlameDataCollector.csproj" />

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/ITranslationLayerRequestSenderAsync.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/ITranslationLayerRequestSenderAsync.cs
@@ -17,6 +17,9 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces;
 /// </summary>
 internal interface ITranslationLayerRequestSenderAsync : IDisposable
 {
+
+    int StartServer();
+
     /// <summary>
     /// Asynchronous equivalent of <see cref="
     ///     ITranslationLayerRequestSender.InitializeCommunication"/>
@@ -24,7 +27,7 @@ internal interface ITranslationLayerRequestSenderAsync : IDisposable
     ///     ITranslationLayerRequestSender.WaitForRequestHandlerConnection(
     ///     int)"/>.
     /// </summary>
-    Task<int> InitializeCommunicationAsync(int clientConnectionTimeout);
+    Task InitializeCommunicationAsync(int clientConnectionTimeout);
 
     /// <summary>
     /// Asynchronous equivalent of ITranslationLayerRequestSender.DiscoverTests/>.

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
@@ -160,10 +160,10 @@ internal sealed class VsTestConsoleProcessManager : IProcessManager, IDisposable
         _process!.EnableRaisingEvents = true;
         _process.Exited += Process_Exited;
 
-        _process.OutputDataReceived += Process_OutputDataReceived;
-        _process.ErrorDataReceived += Process_ErrorDataReceived;
-        _process.BeginOutputReadLine();
-        _process.BeginErrorReadLine();
+        // _process.OutputDataReceived += Process_OutputDataReceived;
+        // _process.ErrorDataReceived += Process_ErrorDataReceived;
+        // _process.BeginOutputReadLine();
+        // _process.BeginErrorReadLine();
         _processExitedEvent.Reset();
     }
 

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleRequestSender.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleRequestSender.cs
@@ -132,10 +132,22 @@ internal class VsTestConsoleRequestSender : ITranslationLayerRequestSender
 
         _processExitCancellationTokenSource = new CancellationTokenSource();
 
-        // todo: report standard error on timeout
-        await Task.WhenAny(_communicationManager.AcceptClientAsync(), Task.Delay(clientConnectionTimeout)).ConfigureAwait(false);
+        _handShakeSuccessful = false;
+        _handShakeComplete.Reset();
 
-        await HandShakeWithVsTestConsoleAsync().ConfigureAwait(false);
+        try
+        {
+            // todo: report standard error on timeout
+            await Task.WhenAny(_communicationManager.AcceptClientAsync(), Task.Delay(clientConnectionTimeout)).ConfigureAwait(false);
+
+            await HandShakeWithVsTestConsoleAsync().ConfigureAwait(false);
+
+            _handShakeSuccessful = true;
+        }
+        finally
+        {
+            _handShakeComplete.Set();
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleRequestSender.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleRequestSender.cs
@@ -120,36 +120,22 @@ internal class VsTestConsoleRequestSender : ITranslationLayerRequestSender
         return waitSuccess && _handShakeSuccessful;
     }
 
+    public int StartServer()
+    {
+        return _communicationManager.HostServer(new IPEndPoint(IPAddress.Loopback, 0)).Port;
+    }
+
     /// <inheritdoc/>
-    public async Task<int> InitializeCommunicationAsync(int clientConnectionTimeout)
+    public async Task InitializeCommunicationAsync(int clientConnectionTimeout)
     {
         EqtTrace.Info($"VsTestConsoleRequestSender.InitializeCommunicationAsync: Started with client connection timeout {clientConnectionTimeout} milliseconds.");
 
         _processExitCancellationTokenSource = new CancellationTokenSource();
-        _handShakeSuccessful = false;
-        _handShakeComplete.Reset();
-        int port = -1;
-        try
-        {
-            port = _communicationManager.HostServer(new IPEndPoint(IPAddress.Loopback, 0)).Port;
-            var timeoutSource = new CancellationTokenSource(clientConnectionTimeout);
-            await Task.Run(() =>
-                _communicationManager.AcceptClientAsync(), timeoutSource.Token).ConfigureAwait(false);
 
-            _handShakeSuccessful = await HandShakeWithVsTestConsoleAsync().ConfigureAwait(false);
-            _handShakeComplete.Set();
-        }
-        catch (Exception ex)
-        {
-            EqtTrace.Error(
-                "VsTestConsoleRequestSender.InitializeCommunicationAsync: Error initializing communication with VstestConsole: {0}",
-                ex);
-            _handShakeComplete.Set();
-        }
+        // todo: report standard error on timeout
+        await Task.WhenAny(_communicationManager.AcceptClientAsync(), Task.Delay(clientConnectionTimeout)).ConfigureAwait(false);
 
-        EqtTrace.Info("VsTestConsoleRequestSender.InitializeCommunicationAsync: Ended.");
-
-        return _handShakeSuccessful ? port : -1;
+        await HandShakeWithVsTestConsoleAsync().ConfigureAwait(false);
     }
 
     /// <inheritdoc/>

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
@@ -659,7 +659,7 @@ public class VsTestConsoleWrapper : IVsTestConsoleWrapper
 
         var timeout = EnvironmentHelper.GetConnectionTimeout();
         // Start communication
-        var port = await _requestSender.InitializeCommunicationAsync(timeout * 1000).ConfigureAwait(false);
+        var port = _requestSender.StartServer();
 
         if (port > 0)
         {
@@ -681,6 +681,8 @@ public class VsTestConsoleWrapper : IVsTestConsoleWrapper
             _requestSender.Close();
             throw new TransationLayerException("Error hosting communication channel and connecting to console");
         }
+
+        await _requestSender.InitializeCommunicationAsync(timeout * 1000).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
- [ ] combining sync and async apis to talk with the server does not work. probably some flag for the connection is not set.
e.g. if we do discoveryAsync, and then do RunTests (sync), we get stuck.
- [ ] capture the output but use task factory to get the output and await closing the process with async to ensure the streams are dumped.