### PR TITLE
[rel/18.0] Disable DynamicNative instrumentation by default

### DIFF
--- a/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
@@ -75,6 +75,10 @@ internal partial class FeatureFlag : IFeatureFlag
     // Disable setting DOTNET_ROOT environment variable on non-Windows platforms. We used to set it only only on Windows when we found testhost.exe, now we set it always to allow xunit v3 to run tests in child process.
     public const string VSTEST_DISABLE_DOTNET_ROOT_ON_NONWINDOWS = nameof(VSTEST_DISABLE_DOTNET_ROOT_ON_NONWINDOWS);
 
+    // Disable turning dynamic code coverage for native code to OFF by default. Setting this to 1 will skip adding the setting.
+    public const string VSTEST_DISABLE_DYNAMICNATIVE_CODECOVERAGE_DEFAULT_SETTING = nameof(VSTEST_DISABLE_DYNAMICNATIVE_CODECOVERAGE_DEFAULT_SETTING);
+
+
 
     [Obsolete("Only use this in tests.")]
     internal static void Reset()

--- a/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
@@ -723,7 +723,6 @@ public class InferRunSettingsHelper
     {
         var root = xmlDocument.DocumentElement;
 
-        // TODO: is this good way to find the node, can users have different casing, can they have  uri="datacollector://Microsoft/CodeCoverage/2.0" or  assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
         var dataCollectorNodes = root?.SelectNodes("DataCollectionRunSettings/DataCollectors/DataCollector");
         if (dataCollectorNodes == null)
         {

--- a/src/Microsoft.TestPlatform.Utilities/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TestPlatform.Utilities/PublicAPI/PublicAPI.Shipped.txt
@@ -39,4 +39,6 @@ static Microsoft.VisualStudio.TestPlatform.Utilities.MSTestSettingsUtilities.IsL
 static Microsoft.VisualStudio.TestPlatform.Utilities.ParallelRunSettingsUtilities.UpdateRunSettingsWithParallelSettingIfNotConfigured(System.Xml.XPath.XPathNavigator! navigator) -> void
 static Microsoft.VisualStudio.TestPlatform.Utilities.StringExtensions.Tokenize(this string? input, char separator, char escape) -> System.Collections.Generic.IEnumerable<string!>!
 static Microsoft.VisualStudio.TestPlatform.Utilities.InferRunSettingsHelper.UpdateBatchSize(System.Xml.XmlDocument! runSettingsDocument, long batchSizeValue) -> void
+static Microsoft.VisualStudio.TestPlatform.Utilities.InferRunSettingsHelper.UpdateCollectCoverageSettings(System.Xml.XmlDocument! xmlDocument) -> bool
+
 

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -845,6 +845,11 @@ internal class TestRequestManager : ITestRequestManager
         settingsUpdated |= AddOrUpdateBuiltInLoggers(document, runConfiguration, loggerRunSettings);
         settingsUpdated |= AddOrUpdateBatchSize(document, runConfiguration, isDiscovery);
 
+        if (!FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_DISABLE_DYNAMICNATIVE_CODECOVERAGE_DEFAULT_SETTING))
+        {
+            settingsUpdated |= UpdateCollectCoverageSettings(document, runConfiguration);
+        }
+
         updatedRunSettingsXml = navigator.OuterXml;
 
         return settingsUpdated;
@@ -1244,6 +1249,11 @@ internal class TestRequestManager : ITestRequestManager
         }
 
         return false;
+    }
+
+    internal static bool UpdateCollectCoverageSettings(XmlDocument xmlDocument, RunConfiguration _)
+    {
+        return InferRunSettingsHelper.UpdateCollectCoverageSettings(xmlDocument);
     }
 
     private void RunTests(


### PR DESCRIPTION
## Description

Partially fix https://github.com/dotnet/sdk/issues/50950 by disabling the DynamicNative instrumentation by default for all code coverage versions.

This change applies the workaround 1 to all runs under vstest 18: https://github.com/dotnet/sdk/issues/50950#issuecomment-3410388878

```xml
 <CodeCoverage>
    <EnableDynamicNativeInstrumentation>false</EnableDynamicNativeInstrumentation>
</CodeCoverage>
```

This reduces the blast radius of the linked issue. DynamicNative code coverage is not needed for projects that only deal with .NET (managed) components.

If user explicitly enables DynamicNative they will still see the error until a fixed version of Code Coverage is published that loads covrun64 in a way that is compatible with .NET 10.

This change will be effective in VSTest 18, including VisualStudio 18, and dotnet test in .NET 10 SDK 10.0.1xx.

User can globally opt out from this fix by setting `VSTEST_DISABLE_DYNAMICNATIVE_CODECOVERAGE_DEFAULT_SETTING=1`. Or they can opt out per run by using runsettings and setting the value themselves to the desired value.
