### PR TITLE
Update branding to 18.3.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
       from appending +<commitId>, which breaks DTAAgent.
     -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
-    <VersionPrefix>18.1.0</VersionPrefix>
+    <VersionPrefix>18.3.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
   </PropertyGroup>
   <PropertyGroup Label="Arcade settings">


### PR DESCRIPTION
## Description

Next insertion will be to VS version 18.3 (18.2 and 18.1 were stabilizing for the new release cadence).
