### PR TITLE
Revert adding dotnet_host_path workaround

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -34,12 +34,8 @@ Param(
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
-# Workaround for DOTNET_HOST_PATH not being set by older MSBuild
-if (-not $env:DOTNET_HOST_PATH) {
-    $env:DOTNET_HOST_PATH = [System.IO.Path]::GetFullPath((Join-Path (Join-Path (Join-Path $PSScriptRoot '..') '.dotnet') 'dotnet'))
-    if (-not (Test-Path $env:DOTNET_HOST_PATH)) {
-      $env:DOTNET_HOST_PATH = "$($env:DOTNET_HOST_PATH).exe"
-    }
-}
+# Add steps that need to happen before build here
 
+
+# Call the build script provided by Arcade
 & $PSScriptRoot/common/build.ps1 @PSBoundParameters


### PR DESCRIPTION
## Description
https://github.com/microsoft/vstest/pull/15264 added workaround for dotnet_host_path, but this workaround is not needed after update to newest VS on images. This should have not been merged. Removing it.
