### PR TITLE
Feature/add template replacements to trx logger

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Constants.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Constants.cs
@@ -81,6 +81,41 @@ internal static class Constants
     public static string WarnOnFileOverwrite = "WarnOnFileOverwrite";
 
     /// <summary>
+    /// Template placeholder for assembly name in log file name.
+    /// </summary>
+    public const string AssemblyTemplate = "{assembly}";
+
+    /// <summary>
+    /// Template placeholder for test framework in log file name.
+    /// </summary>
+    public const string FrameworkTemplate = "{framework}";
+
+    /// <summary>
+    /// Template placeholder for date in log file name (yyyyMMdd format).
+    /// </summary>
+    public const string DateTemplate = "{date}";
+
+    /// <summary>
+    /// Template placeholder for time in log file name (HHmmss format).
+    /// </summary>
+    public const string TimeTemplate = "{time}";
+
+    /// <summary>
+    /// Template placeholder for machine name in log file name.
+    /// </summary>
+    public const string MachineTemplate = "{machine}";
+
+    /// <summary>
+    /// Template placeholder for username in log file name.
+    /// </summary>
+    public const string UserTemplate = "{user}";
+
+    /// <summary>
+    /// Template placeholder for build configuration (Debug/Release) in log file name.
+    /// </summary>
+    public const string ConfigurationTemplate = "{configuration}";
+
+    /// <summary>
     /// Mstest adapter string
     /// </summary>
     public const string MstestAdapterString = "mstestadapter";


### PR DESCRIPTION
This pull request enhances the TRX logger's file naming capabilities by introducing support for template placeholders, allowing dynamic and customizable log file names based on test context and environment. It adds new properties to capture assembly name, target framework, and build configuration, and processes these placeholders during file name generation.

**Dynamic File Naming Enhancements:**

* Added support for template placeholders in log file names, enabling dynamic replacement for assembly name, framework, date, time, machine name, user, and build configuration (e.g., `{assembly}`, `{framework}`, `{date}`) in `TrxLogger.cs` and defined them in `Constants.cs`. [[1]](diffhunk://#diff-5adf100ca9ad75347148bc8003778aea8255804220615a87de0c7ebc80d3310eR495-R573) [[2]](diffhunk://#diff-db43220f3628c62c918a605e5511be173d49d3fce17c528633f5348414ec77d5R83-R117)
* Implemented the `ProcessTemplateReplacements` method to handle case-insensitive replacement of these placeholders within file name patterns, ensuring compatibility and efficient processing.

**Context Capture for Template Replacement:**

* Added private fields (`_assemblyName`, `_targetFramework`, `_configuration`) in `TrxLogger.cs` to store relevant values for template substitution.
* Captured assembly name from the first test result and populated target framework and configuration from logger parameters to support template replacement. [[1]](diffhunk://#diff-5adf100ca9ad75347148bc8003778aea8255804220615a87de0c7ebc80d3310eR271-R276) [[2]](diffhunk://#diff-5adf100ca9ad75347148bc8003778aea8255804220615a87de0c7ebc80d3310eR583-R617)

**Integration with File Name Generation:**

* Updated file name and prefix handling to process template replacements before generating the TRX file path, ensuring user-specified patterns are dynamically populated with context-specific values.
