### PR TITLE
Add LoongArch64 support

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/Architecture.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Architecture.cs
@@ -14,4 +14,5 @@ public enum Architecture
     S390x,
     Ppc64le,
     RiscV64,
+    LoongArch64,
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Shipped.txt
@@ -975,3 +975,4 @@ Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.CaptureStandard
 Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.ForwardStandardOutput.get -> bool
 Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.DisableSharedTestHost.get -> bool
 Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.SkipDefaultAdapters.get -> bool
+Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture.LoongArch64 = 9 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.Architecture

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/PlatformArchitecture.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/System/PlatformArchitecture.cs
@@ -15,4 +15,5 @@ public enum PlatformArchitecture
     S390x,
     Ppc64le,
     RiscV64,
+    LoongArch64,
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/PublicAPI/PublicAPI.Shipped.txt
@@ -121,3 +121,4 @@ static Microsoft.VisualStudio.TestPlatform.ObjectModel.PlatformEqtTrace.ErrorOnI
 static Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformAssemblyExtensions.GetAssemblyLocation(this System.Reflection.Assembly! assembly) -> string!
 virtual Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformAssemblyResolver.Dispose(bool disposing) -> void
 Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture.RiscV64 = 6 -> Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture
+Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture.LoongArch64 = 7 -> Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformArchitecture

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformEnvironment.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformEnvironment.cs
@@ -28,6 +28,7 @@ public class PlatformEnvironment : IEnvironment
                 // preview 6 or later, so use the numerical value for now.
                 // case System.Runtime.InteropServices.Architecture.S390x:
                 (Architecture)5 => PlatformArchitecture.S390x,
+                (Architecture)6 => PlatformArchitecture.LoongArch64,
                 (Architecture)8 => PlatformArchitecture.Ppc64le,
                 (Architecture)9 => PlatformArchitecture.RiscV64,
                 _ => throw new NotSupportedException(),

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
@@ -41,6 +41,7 @@ public partial class ProcessHelper : IProcessHelper
             // preview 6 or later, so use the numerical value for now.
             // case System.Runtime.InteropServices.Architecture.S390x:
             (Architecture)5 => PlatformArchitecture.S390x,
+            (Architecture)6 => PlatformArchitecture.LoongArch64,
             (Architecture)8 => PlatformArchitecture.Ppc64le,
             (Architecture)9 => PlatformArchitecture.RiscV64,
             _ => throw new NotSupportedException(),

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -293,6 +293,7 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
             PlatformArchitecture.S390x => Architecture.S390x,
             PlatformArchitecture.Ppc64le => Architecture.Ppc64le,
             PlatformArchitecture.RiscV64 => Architecture.RiscV64,
+            PlatformArchitecture.LoongArch64 => Architecture.LoongArch64,
             _ => throw new NotSupportedException(),
         };
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -648,6 +648,8 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
                     return PlatformArchitecture.Ppc64le;
                 case Architecture.RiscV64:
                     return PlatformArchitecture.RiscV64;
+                case Architecture.LoongArch64:
+                    return PlatformArchitecture.LoongArch64;
                 case Architecture.AnyCPU:
                 case Architecture.Default:
                 default:
@@ -667,6 +669,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
                 Architecture.S390x => platformAchitecture == PlatformArchitecture.S390x,
                 Architecture.Ppc64le => platformAchitecture == PlatformArchitecture.Ppc64le,
                 Architecture.RiscV64 => platformAchitecture == PlatformArchitecture.RiscV64,
+                Architecture.LoongArch64 => platformAchitecture == PlatformArchitecture.LoongArch64,
                 _ => throw new TestPlatformException($"Invalid target architecture '{targetArchitecture}'"),
             };
 

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -888,6 +888,8 @@ internal class TestRequestManager : ITestRequestManager
                     return Architecture.Ppc64le;
                 case PlatformArchitecture.RiscV64:
                     return Architecture.RiscV64;
+                case PlatformArchitecture.LoongArch64:
+                    return Architecture.LoongArch64;
                 default:
                     EqtTrace.Error($"TestRequestManager.TranslateToArchitecture: Unhandled architecture '{targetArchitecture}'.");
                     break;

--- a/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
@@ -85,7 +85,7 @@ public class PlatformArgumentProcessorTests
     {
         ExceptionUtilities.ThrowsException<CommandLineException>(
             () => _executor.Initialize("foo"),
-            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x, Ppc64le, RiscV64.",
+            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x, Ppc64le, RiscV64, LoongArch64.",
             "foo");
     }
 
@@ -94,7 +94,7 @@ public class PlatformArgumentProcessorTests
     {
         ExceptionUtilities.ThrowsException<CommandLineException>(
             () => _executor.Initialize("AnyCPU"),
-            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x, Ppc64le, RiscV64.",
+            "Invalid platform type: {0}. Valid platform types are X86, X64, ARM, ARM64, S390x, Ppc64le, RiscV64, LoongArch64.",
             "AnyCPU");
     }
 


### PR DESCRIPTION
## Description

add loongarch64 to architecture enums, which is supported by .NET >=9

## Related issue

- [ ] I have ensured that there is a previously discussed and approved issue.
