### PR TITLE
Fix names in pipeline matrix so we don't have to align them

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,10 +156,10 @@ stages:
             value: Release
         strategy:
           matrix:
-            Ubuntu_22_04:
+            ubuntu:
               vmImage: ubuntu-22.04
               pwsh: true
-            macOS_12:
+            macOS:
               vmImage: macos-14
               pwsh: true
         pool:


### PR DESCRIPTION
When images are updated we forget to update the name of the leg, this makes it easier since we only build on 1 leg for ubu or macos anyway.