### PR TITLE
Fix .NET 10 regression for traits

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/TestProperty/TestProperty.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TestProperty/TestProperty.cs
@@ -135,7 +135,7 @@ public class TestProperty : IEquatable<TestProperty>
     /// <inheritdoc/>
     public override bool Equals(object? obj)
     {
-        return base.Equals(obj as TestProperty);
+        return Equals(obj as TestProperty);
     }
 
     /// <inheritdoc/>

--- a/src/Microsoft.TestPlatform.ObjectModel/TraitCollection.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TraitCollection.cs
@@ -65,7 +65,7 @@ public class TraitCollection : IEnumerable<Trait>
 
     private IEnumerable<Trait> GetTraits()
     {
-        if (!_testObject.Properties.Contains(TraitsProperty))
+        if (!_testObject.Properties.Contains(TraitsProperty, EqualityComparer<TestProperty>.Default))
         {
             return Array.Empty<Trait>();
         }

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/Microsoft.TestPlatform.CommunicationUtilities.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/Microsoft.TestPlatform.CommunicationUtilities.UnitTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>Microsoft.TestPlatform.CommunicationUtilities.UnitTests</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #15369

This is a regression from .NET runtime. It impacts users updating to .NET 10 SDK as vstest.console.exe is run under .NET 10. It still impacts users even if their test projects don't target net10.0.

This is already covered by some tests, just that we need to run those tests on net10.0.

Without the change, the following tests fail:

```
failed CloneShouldCloneTestCaseObject (179ms)
  Assert.AreEqual failed. Expected:<1>. Actual:<0>.
    at Microsoft.TestPlatform.CommunicationUtilities.UnitTests.JsonDataSerializerTests.VerifyTestCaseClone(TestCase clonedTestCase, TestCase testCase, Trait expectedTrait) in \test\Microsoft.TestPlatform.CommunicationUtilities.UnitTests\JsonDataSerializerTests.cs:244
    at Microsoft.TestPlatform.CommunicationUtilities.UnitTests.JsonDataSerializerTests.CloneShouldCloneTestCaseObject() in \test\Microsoft.TestPlatform.CommunicationUtilities.UnitTests\JsonDataSerializerTests.cs:199
    at InvokeStub_JsonDataSerializerTests.CloneShouldCloneTestCaseObject(Object, Object, IntPtr*)
    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)

failed TestCaseObjectShouldContainAllPropertiesOnDeserializationV2 (4ms)
  Test method Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization.TestCaseSerializationTests.TestCaseObjectShouldContainAllPropertiesOnDeserializationV2 threw exception:
  System.InvalidOperationException: Sequence contains no elements
    at System.Linq.ThrowHelper.ThrowNoElementsException()
    at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
    at Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization.TestCaseSerializationTests.TestCaseObjectShouldContainAllPropertiesOnDeserializationV2() in \test\Microsoft.TestPlatform.CommunicationUtilities.UnitTests\Serialization\TestCaseSerializationTests.cs:180
    at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)

failed TestCaseObjectShouldDeserializeTraitsWithSpecialCharacters (2) (0ms)
  Assert.AreEqual failed. Expected:<1>. Actual:<0>.
    at Microsoft.TestPlatform.CommunicationUtilities.UnitTests.Serialization.TestCaseSerializationTests.TestCaseObjectShouldDeserializeTraitsWithSpecialCharacters(Int32 version) in \test\Microsoft.TestPlatform.CommunicationUtilities.UnitTests\Serialization\TestCaseSerializationTests.cs:250
    at InvokeStub_TestCaseSerializationTests.TestCaseObjectShouldDeserializeTraitsWithSpecialCharacters(Object, Span`1)
    at System.Reflection.MethodBaseInvoker.InvokeWithOneArg(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
```