### PR TITLE
Add net8.0 target for TranslationLayer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -108,7 +108,7 @@
       Library that is loaded by others and by us. We don't know where it will run (e.b. TranslationLayer),
       we need to support all frameworks from minimum, and also netstandard2.0.
     -->
-    <LibraryTargetFrameworks>$(NetFrameworkMinimum);netstandard2.0</LibraryTargetFrameworks>
+    <LibraryTargetFrameworks>$(NetFrameworkMinimum);$(NetCoreAppMinimum);netstandard2.0</LibraryTargetFrameworks>
   </PropertyGroup>
 
   <!-- Build & pack config -->

--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -28,7 +28,7 @@ function Verify-Nuget-Packages {
         "Microsoft.TestPlatform.AdapterUtilities"     = 61
         "Microsoft.TestPlatform.Portable"             = 608
         "Microsoft.TestPlatform.TestHost"             = 63
-        "Microsoft.TestPlatform.TranslationLayer"     = 122
+        "Microsoft.TestPlatform.TranslationLayer"     = 174
         "Microsoft.TestPlatform.Internal.Uwp"         = 38
     }
 

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.nuspec
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.nuspec
@@ -10,6 +10,12 @@
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="NETStandard.Library" version="[2.0.0, )" />
+        <dependency id="Newtonsoft.Json" version="$NewtonsoftJsonVersion$"/>
+        <dependency id="Microsoft.TestPlatform.ObjectModel" version="$Version$"/>
+      </group>
+      <group targetFramework="net8.0">
+        <dependency id="Newtonsoft.Json" version="$NewtonsoftJsonVersion$"/>
+        <dependency id="Microsoft.TestPlatform.ObjectModel" version="$Version$"/>
       </group>
     </dependencies>
 
@@ -30,17 +36,17 @@
     <file src="net462\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.dll" target="lib\net462\" />
     <file src="net462\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.XML" target="lib\net462\" />
     <file src="net462\Microsoft.TestPlatform.CommunicationUtilities.dll" target="lib\net462\" />
-    <file src="net462\Microsoft.TestPlatform.CoreUtilities.dll" target="lib\net462\" />
-    <file src="net462\Microsoft.TestPlatform.PlatformAbstractions.dll" target="lib\net462\" />
     <file src="net462\Microsoft.VisualStudio.TestPlatform.Common.dll" target="lib\net462\" />
 
     <file src="netstandard2.0\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.dll" target="lib\netstandard2.0\" />
     <file src="netstandard2.0\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.XML" target="lib\netstandard2.0\" />
     <file src="netstandard2.0\Microsoft.TestPlatform.CommunicationUtilities.dll" target="lib\netstandard2.0\" />
-    <file src="netstandard2.0\Microsoft.TestPlatform.CoreUtilities.dll" target="lib\netstandard2.0\" />
-    <file src="netstandard2.0\Microsoft.TestPlatform.PlatformAbstractions.dll" target="lib\netstandard2.0\" />
     <file src="netstandard2.0\Microsoft.VisualStudio.TestPlatform.Common.dll" target="lib\netstandard2.0\" />
 
+    <file src="net8.0\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.dll" target="lib\net8.0\" />
+    <file src="net8.0\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.XML" target="lib\net8.0\" />
+    <file src="net8.0\Microsoft.TestPlatform.CommunicationUtilities.dll" target="lib\net8.0\" />
+    <file src="net8.0\Microsoft.VisualStudio.TestPlatform.Common.dll" target="lib\net8.0\" />
 
     <!-- Add localized resources -->
     <file src="net462\cs\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="lib\net462\cs" />
@@ -154,5 +160,61 @@
     <file src="netstandard2.0\tr\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="lib\netstandard2.0\tr" />
     <file src="netstandard2.0\zh-Hans\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="lib\netstandard2.0\zh-Hans" />
     <file src="netstandard2.0\zh-Hant\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="lib\netstandard2.0\zh-Hant" />
+
+    <file src="net8.0\cs\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="lib\net8.0\cs" />
+    <file src="net8.0\de\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="lib\net8.0\de" />
+    <file src="net8.0\es\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="lib\net8.0\es" />
+    <file src="net8.0\fr\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="lib\net8.0\fr" />
+    <file src="net8.0\it\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="lib\net8.0\it" />
+    <file src="net8.0\ja\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="lib\net8.0\ja" />
+    <file src="net8.0\ko\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="lib\net8.0\ko" />
+    <file src="net8.0\pl\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="lib\net8.0\pl" />
+    <file src="net8.0\pt-BR\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="lib\net8.0\pt-BR" />
+    <file src="net8.0\ru\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="lib\net8.0\ru" />
+    <file src="net8.0\tr\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="lib\net8.0\tr" />
+    <file src="net8.0\zh-Hans\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="lib\net8.0\zh-Hans" />
+    <file src="net8.0\zh-Hant\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="lib\net8.0\zh-Hant" />
+
+    <file src="net8.0\cs\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="lib\net8.0\cs" />
+    <file src="net8.0\de\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="lib\net8.0\de" />
+    <file src="net8.0\es\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="lib\net8.0\es" />
+    <file src="net8.0\fr\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="lib\net8.0\fr" />
+    <file src="net8.0\it\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="lib\net8.0\it" />
+    <file src="net8.0\ja\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="lib\net8.0\ja" />
+    <file src="net8.0\ko\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="lib\net8.0\ko" />
+    <file src="net8.0\pl\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="lib\net8.0\pl" />
+    <file src="net8.0\pt-BR\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="lib\net8.0\pt-BR" />
+    <file src="net8.0\ru\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="lib\net8.0\ru" />
+    <file src="net8.0\tr\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="lib\net8.0\tr" />
+    <file src="net8.0\zh-Hans\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="lib\net8.0\zh-Hans" />
+    <file src="net8.0\zh-Hant\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="lib\net8.0\zh-Hant" />
+
+    <file src="net8.0\cs\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\net8.0\cs" />
+    <file src="net8.0\de\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\net8.0\de" />
+    <file src="net8.0\es\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\net8.0\es" />
+    <file src="net8.0\fr\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\net8.0\fr" />
+    <file src="net8.0\it\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\net8.0\it" />
+    <file src="net8.0\ja\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\net8.0\ja" />
+    <file src="net8.0\ko\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\net8.0\ko" />
+    <file src="net8.0\pl\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\net8.0\pl" />
+    <file src="net8.0\pt-BR\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\net8.0\pt-BR" />
+    <file src="net8.0\ru\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\net8.0\ru" />
+    <file src="net8.0\tr\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\net8.0\tr" />
+    <file src="net8.0\zh-Hans\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\net8.0\zh-Hans" />
+    <file src="net8.0\zh-Hant\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="lib\net8.0\zh-Hant" />
+
+    <file src="net8.0\cs\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="lib\net8.0\cs" />
+    <file src="net8.0\de\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="lib\net8.0\de" />
+    <file src="net8.0\es\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="lib\net8.0\es" />
+    <file src="net8.0\fr\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="lib\net8.0\fr" />
+    <file src="net8.0\it\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="lib\net8.0\it" />
+    <file src="net8.0\ja\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="lib\net8.0\ja" />
+    <file src="net8.0\ko\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="lib\net8.0\ko" />
+    <file src="net8.0\pl\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="lib\net8.0\pl" />
+    <file src="net8.0\pt-BR\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="lib\net8.0\pt-BR" />
+    <file src="net8.0\ru\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="lib\net8.0\ru" />
+    <file src="net8.0\tr\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="lib\net8.0\tr" />
+    <file src="net8.0\zh-Hans\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="lib\net8.0\zh-Hans" />
+    <file src="net8.0\zh-Hant\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="lib\net8.0\zh-Hant" />
   </files>
 </package>

--- a/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.csproj
+++ b/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.csproj
@@ -92,7 +92,7 @@
     <PackageReference Include="Microsoft.Internal.TestPlatform.Extensions" Version="$(MicrosoftInternalTestPlatformExtensions)" PrivateAssets="All" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.VisualStudio.TraceDataCollector" Version="$(MicrosoftInternalCodeCoverageVersion)" PrivateAssets="All" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Internal.CodeCoverage" Version="$(MicrosoftInternalCodeCoverageVersion)" PrivateAssets="All" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsVersion)" PrivateAssets="All" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsVersion)" PrivateAssets="All" GeneratePathProperty="true" NoWarn="NU1603" />
     <PackageReference Include="Microsoft.QualityTools.Testing.Fakes.TestRunnerHarness" Version="$(MicrosoftFakesVersion)" PrivateAssets="All" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="$(MicrosoftVSTelemetryVersion)" PrivateAssets="All" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities.Internal" Version="$(MicrosoftVSUtilitiesInternalVersion)" PrivateAssets="All" GeneratePathProperty="true" />


### PR DESCRIPTION
Translation layer targets netstandard2.0 but depends on object model that has net8.0 target, which will restore net8.0 object model in consuming project if the project supports net8.0 or newer.

To avoid this mixup of dependencies, add target for the translation layer. Especially since we already support .NET Framework explicitly.

Remove dependency dlls that we already ship in object model package, and fix dependencies on newtonsoft and object model for netstandard2.0.
