### PR TITLE
Find attach vs only from env var or path

### DIFF
--- a/playground/TestPlatform.Playground/Program.cs
+++ b/playground/TestPlatform.Playground/Program.cs
@@ -59,7 +59,7 @@ internal class Program
 
                     <!-- The settings below are what VS sends by default. -->
                     <CollectSourceInformation>true</CollectSourceInformation>
-
+                    <DesignMode>True</DesignMode>
                 </RunConfiguration>
                 <BoostTestInternalSettings xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                     <VSProcessId>999999</VSProcessId>
@@ -91,7 +91,7 @@ internal class Program
 
         var sources = new[] {
             Path.Combine(playground, "bin", "MSTest1", "Debug", "net48", "MSTest1.dll"),
-            // Path.Combine(playground, "bin", "MSTest2", "Debug", "net48", "MSTest2.dll"),
+            Path.Combine(playground, "bin", "MSTest2", "Debug", "net48", "MSTest2.dll"),
             // The built in .NET projects don't now work right now in Playground, there is some conflict with Arcade.
             // But if you create one outside of Playground it will work. 
             //Path.Combine(playground, "bin", "MSTest1", "Debug", "net7.0", "MSTest1.dll"),
@@ -100,24 +100,28 @@ internal class Program
         //// Console mode
         //// Uncomment if providing command line parameters is easier for you
         //// than converting them to settings, or when you debug command line scenario specifically.
-        var settingsFile = Path.GetTempFileName();
-        try
-        {
-            File.WriteAllText(settingsFile, sourceSettings);
-            var processStartInfo = new ProcessStartInfo
-            {
-                FileName = console,
-                Arguments = $"{string.Join(" ", sources)} --settings:{settingsFile} --logger:trx;LogFileName=my.trx;WarnOnFileOverwrite=false",
-                UseShellExecute = false,
-            };
-            EnvironmentVariables.Variables.ToList().ForEach(processStartInfo.Environment.Add);
-            var process = Process.Start(processStartInfo);
-            process!.WaitForExit();
-        }
-        finally
-        {
-            try { File.Delete(settingsFile); } catch { }
-        }
+        //var settingsFile = Path.GetTempFileName();
+        //try
+        //{
+        //    File.WriteAllText(settingsFile, sourceSettings);
+        //    var processStartInfo = new ProcessStartInfo
+        //    {
+        //        FileName = console,
+        //        Arguments = $"{string.Join(" ", sources)} --settings:{settingsFile} --logger:trx;LogFileName=my.trx;WarnOnFileOverwrite=false",
+        //        UseShellExecute = false,
+        //    };
+        //    EnvironmentVariables.Variables.ToList().ForEach(processStartInfo.Environment.Add);
+        //    var process = Process.Start(processStartInfo);
+        //    process.WaitForExit();
+        //    if (process.ExitCode != 0)
+        //    {
+        //        throw new Exception($"Process failed with {process.ExitCode}");
+        //    }
+        //}
+        //finally
+        //{
+        //    try { File.Delete(settingsFile); } catch { }
+        //}
 
         // design mode
         var detailedOutput = true;

--- a/playground/TestPlatform.Playground/Program.cs
+++ b/playground/TestPlatform.Playground/Program.cs
@@ -37,6 +37,8 @@ internal class Program
         var here = Path.GetDirectoryName(thisAssemblyPath)!;
         var playground = Path.GetFullPath(Path.Combine(here, "..", "..", "..", ".."));
 
+        Environment.SetEnvironmentVariable("VSTEST_DEBUG_ATTACHVS_PATH", Path.Combine(here, "AttachVS.exe"));
+
         var console = Path.Combine(here, "vstest.console", "netfx", "vstest.console.exe");
 
         var sourceSettings = $$$"""
@@ -57,7 +59,7 @@ internal class Program
 
                     <!-- The settings below are what VS sends by default. -->
                     <CollectSourceInformation>true</CollectSourceInformation>
-                    <DesignMode>True</DesignMode>
+
                 </RunConfiguration>
                 <BoostTestInternalSettings xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                     <VSProcessId>999999</VSProcessId>
@@ -89,7 +91,7 @@ internal class Program
 
         var sources = new[] {
             Path.Combine(playground, "bin", "MSTest1", "Debug", "net48", "MSTest1.dll"),
-            Path.Combine(playground, "bin", "MSTest2", "Debug", "net48", "MSTest2.dll"),
+            // Path.Combine(playground, "bin", "MSTest2", "Debug", "net48", "MSTest2.dll"),
             // The built in .NET projects don't now work right now in Playground, there is some conflict with Arcade.
             // But if you create one outside of Playground it will work. 
             //Path.Combine(playground, "bin", "MSTest1", "Debug", "net7.0", "MSTest1.dll"),
@@ -98,28 +100,24 @@ internal class Program
         //// Console mode
         //// Uncomment if providing command line parameters is easier for you
         //// than converting them to settings, or when you debug command line scenario specifically.
-        //var settingsFile = Path.GetTempFileName();
-        //try
-        //{
-        //    File.WriteAllText(settingsFile, sourceSettings);
-        //    var processStartInfo = new ProcessStartInfo
-        //    {
-        //        FileName = console,
-        //        Arguments = $"{string.Join(" ", sources)} --settings:{settingsFile} --logger:trx;LogFileName=my.trx;WarnOnFileOverwrite=false",
-        //        UseShellExecute = false,
-        //    };
-        //    EnvironmentVariables.Variables.ToList().ForEach(processStartInfo.Environment.Add);
-        //    var process = Process.Start(processStartInfo);
-        //    process.WaitForExit();
-        //    if (process.ExitCode != 0)
-        //    {
-        //        throw new Exception($"Process failed with {process.ExitCode}");
-        //    }
-        //}
-        //finally
-        //{
-        //    try { File.Delete(settingsFile); } catch { }
-        //}
+        var settingsFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(settingsFile, sourceSettings);
+            var processStartInfo = new ProcessStartInfo
+            {
+                FileName = console,
+                Arguments = $"{string.Join(" ", sources)} --settings:{settingsFile} --logger:trx;LogFileName=my.trx;WarnOnFileOverwrite=false",
+                UseShellExecute = false,
+            };
+            EnvironmentVariables.Variables.ToList().ForEach(processStartInfo.Environment.Add);
+            var process = Process.Start(processStartInfo);
+            process!.WaitForExit();
+        }
+        finally
+        {
+            try { File.Delete(settingsFile); } catch { }
+        }
 
         // design mode
         var detailedOutput = true;

--- a/src/Microsoft.TestPlatform.Execution.Shared/DebuggerBreakpoint.cs
+++ b/src/Microsoft.TestPlatform.Execution.Shared/DebuggerBreakpoint.cs
@@ -8,7 +8,6 @@ extern alias Abstraction;
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
@@ -96,29 +95,7 @@ internal static class DebuggerBreakpoint
 
     private static string? FindAttachVs()
     {
-        var fromPath = FindOnPath("AttachVS.exe");
-        if (fromPath != null)
-        {
-            return fromPath;
-        }
-
-
-        // Don't use current process MainModule here, it resolves to dotnet if you invoke
-        // dotnet vstest.console.dll, or dotnet testhost.dll. Use the entry assembly instead.
-        var parent = Path.GetDirectoryName(Assembly.GetEntryAssembly()!.Location);
-        while (parent != null)
-        {
-            var path = Path.Combine(parent, @"artifacts\bin\AttachVS\Debug\net472\AttachVS.exe");
-            Debug.WriteLine($"Looking for AttachVS in: {path}.");
-            if (File.Exists(path))
-            {
-                return path;
-            }
-
-            parent = Path.GetDirectoryName(parent);
-        }
-
-        return parent;
+        return FindOnPath("AttachVS.exe");
     }
 
     private static string? FindOnPath(string exeName)


### PR DESCRIPTION
## Description

Don't assume attachVS is in specific path relative to the exe.

## Related issue

Kindly link any related issues. E.g. Fixes #xyz.

- [ ] I have ensured that there is a previously discussed and approved issue.
