### PR TITLE
Determine architecture of remote process on windows

### DIFF
--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
@@ -47,12 +47,6 @@ public partial class ProcessHelper : IProcessHelper
             _ => throw new NotSupportedException(),
         };
     }
-
-    public PlatformArchitecture GetProcessArchitecture(int processId)
-    {
-        // Return the same as the current process.
-        return GetCurrentProcessArchitecture();
-    }
 }
 
 #endif


### PR DESCRIPTION
## Description
Figuring out the process architecture of remote process was not implemented for netcore, which makes it not work in dotnet test.
This fixes it for windows, because that is the only place where we use windows api to dump the processes, on macos and linux we use the netcore client.

## Related issue

Kindly link any related issues. E.g. Fixes #xyz.

- [ ] I have ensured that there is a previously discussed and approved issue.
