### PR TITLE
Run tests against vsix runner

### DIFF
--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/AcceptanceTestBase.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/AcceptanceTestBase.cs
@@ -40,7 +40,7 @@ public class AcceptanceTestBase : IntegrationTestBase
 
     public const string NETFX462_48 = "net462;net472;net48";
     public const string NETFX462_NET11 = "net462;net472;net48;net8.0;net9.0;net10.0;net11.0";
-    public const string DEFAULT_RUNNER_NETFX = Net462TargetFramework;
+    public const string DEFAULT_RUNNER_NETFX = Net48TargetFramework;
     public const string DEFAULT_HOST_NETFX = Net462TargetFramework;
     public const string DEFAULT_RUNNER_NETCORE = Core80TargetFramework;
     public const string DEFAULT_HOST_NETCORE = Core80TargetFramework;
@@ -52,6 +52,8 @@ public class AcceptanceTestBase : IntegrationTestBase
     public const string LATEST_TO_LEGACY = "Latest;LatestPreview;LatestStable;RecentStable;MostDownloaded;PreviousStable;LegacyStable";
     public const string LATESTPREVIEW_TO_LEGACY = "LatestPreview;LatestStable;RecentStable;MostDownloaded;PreviousStable;LegacyStable";
     public const string LATEST = "Latest";
+    // "Special" version for runner, to take the latest from VSIX we don't ship any other component that way, so we need separate value to control it.
+    public const string LATESTVSIX = "LatestVsix";
     public const string LATESTSTABLE = "LatestStable";
     internal const string MSTEST = "MSTest";
 

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Build.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Build.cs
@@ -374,5 +374,14 @@ public class Build : IntegrationTestBase
 
             ZipFile.ExtractToDirectory(packagePath, unzipPath);
         }
+
+        var vsixPath = IntegrationTestEnvironment.LocalVsixInsertion;
+        var vsixUnzipPath = Path.Combine(IntegrationTestEnvironment.PublishDirectory, Path.GetFileName(vsixPath));
+        if (Directory.Exists(vsixUnzipPath))
+        {
+            Directory.Delete(vsixUnzipPath, recursive: true);
+        }
+
+        ZipFile.ExtractToDirectory(vsixPath, vsixUnzipPath);
     }
 }

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Build.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Build.cs
@@ -375,13 +375,17 @@ public class Build : IntegrationTestBase
             ZipFile.ExtractToDirectory(packagePath, unzipPath);
         }
 
-        var vsixPath = IntegrationTestEnvironment.LocalVsixInsertion;
-        var vsixUnzipPath = Path.Combine(IntegrationTestEnvironment.PublishDirectory, Path.GetFileName(vsixPath));
-        if (Directory.Exists(vsixUnzipPath))
+        // Unzip VSIX so we can test with it on Windows.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            Directory.Delete(vsixUnzipPath, recursive: true);
-        }
+            var vsixPath = IntegrationTestEnvironment.LocalVsixInsertion;
+            var vsixUnzipPath = Path.Combine(IntegrationTestEnvironment.PublishDirectory, Path.GetFileName(vsixPath));
+            if (Directory.Exists(vsixUnzipPath))
+            {
+                Directory.Delete(vsixUnzipPath, recursive: true);
+            }
 
-        ZipFile.ExtractToDirectory(vsixPath, vsixUnzipPath);
+            ZipFile.ExtractToDirectory(vsixPath, vsixUnzipPath);
+        }
     }
 }

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/MSTestCompatibilityDataSource.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/MSTestCompatibilityDataSource.cs
@@ -56,6 +56,7 @@ public class MSTestCompatibilityDataSource : TestDataSourceAttribute<RunnerInfo>
         _builder.WithEveryVersionOfHost = false;
         _builder.WithEveryVersionOfAdapter = true;
         _builder.WithOlderConfigurations = false;
+        _builder.WithVSIXRunner = false;
         _builder.WithInProcess = InProcess;
 
         _builder.BeforeRunnerFeature = BeforeRunnerFeature;

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/RunnerCompatibilityDataSource.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/RunnerCompatibilityDataSource.cs
@@ -59,6 +59,7 @@ public class RunnerCompatibilityDataSource : TestDataSourceAttribute<RunnerInfo>
     public override void CreateData(MethodInfo methodInfo)
     {
         _builder.WithEveryVersionOfRunner = true;
+        _builder.WithVSIXRunner = true;
         _builder.WithEveryVersionOfHost = false;
         _builder.WithEveryVersionOfAdapter = false;
         _builder.WithOlderConfigurations = false;

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/TestPlatformCompatibilityDataSource.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/TestPlatformCompatibilityDataSource.cs
@@ -58,6 +58,7 @@ public class TestPlatformCompatibilityDataSource : TestDataSourceAttribute<Runne
     public bool WithEveryVersionOfAdapter { get; set; } = true;
 
     public bool WithOlderConfigurations { get; set; } = true;
+    public bool WithVSIXRunner { get; set; } = true;
 
     public string? BeforeRunnerFeature { get; set; }
     public string? AfterRunnerFeature { get; set; }
@@ -74,6 +75,7 @@ public class TestPlatformCompatibilityDataSource : TestDataSourceAttribute<Runne
         _builder.WithEveryVersionOfHost = WithEveryVersionOfHost;
         _builder.WithEveryVersionOfAdapter = WithEveryVersionOfAdapter;
         _builder.WithOlderConfigurations = WithOlderConfigurations;
+        _builder.WithVSIXRunner = WithVSIXRunner;
         _builder.WithInProcess = WithInProcess;
 
         _builder.BeforeRunnerFeature = BeforeRunnerFeature;

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/TesthostCompatibilityDataSource.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/TesthostCompatibilityDataSource.cs
@@ -51,6 +51,7 @@ public class TestHostCompatibilityDataSource : TestDataSourceAttribute<RunnerInf
         _builder.WithEveryVersionOfAdapter = false;
         _builder.WithOlderConfigurations = false;
         _builder.WithInProcess = false;
+        _builder.WithVSIXRunner = false;
 
         _builder.BeforeTestHostFeature = BeforeFeature;
         _builder.AfterTestHostFeature = AfterFeature;

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestEnvironment.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestEnvironment.cs
@@ -29,6 +29,7 @@ public class IntegrationTestEnvironment
     public static string ArtifactsTempDirectory { get; } = Path.Combine(RepoRootDirectory, "artifacts", "tmp", BuildConfiguration);
 
     public static string LocalPackageSource { get; } = Path.Combine(RepoRootDirectory, "artifacts", "packages", BuildConfiguration, "Shipping").TrimEnd(Path.DirectorySeparatorChar);
+    public static string LocalVsixInsertion { get; } = Path.Combine(RepoRootDirectory, "artifacts", "VSSetup", BuildConfiguration, "Insertion", "Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI.vsix");
     public static string LatestLocallyBuiltNugetVersion { get; } = GetLatestLocallyBuiltPackageVersion();
 
     /// <summary>


### PR DESCRIPTION
## Description

Run tests locally against the insertion we put into VS, because it is produced differently than the microsoft.testplatform package, and we want to avoid configuration drift and breaking VS.
