### PR TITLE
Move to mstest 4

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -78,14 +78,14 @@
   <PropertyGroup Label="VSTest test settings">
     <!-- Name of the elements must be in sync with test\Microsoft.TestPlatform.TestUtilities\IntegrationTestBase.cs -->
     <AwesomeAssertionsVersion>8.1.0</AwesomeAssertionsVersion>
-    <MicrosoftTestingPlatformVersion>1.7.2</MicrosoftTestingPlatformVersion>
+    <MicrosoftTestingPlatformVersion>2.1.0</MicrosoftTestingPlatformVersion>
     <MoqVersion>4.16.1</MoqVersion>
     <!-- For coverage use our own package on latest stable -->
-    <MicrosoftCodeCoverageVersion>17.9.0</MicrosoftCodeCoverageVersion>
+    <MicrosoftCodeCoverageVersion>18.3.0</MicrosoftCodeCoverageVersion>
     <!-- These versions are used for running unit tests, and running acceptance tests. They are also used as the default version for projects
     in TestAssets.sln to allow running and debugging tests in that solution directly in VS without having to run them via AcceptanceTests. -->
-    <MSTestTestFrameworkVersion>3.9.3</MSTestTestFrameworkVersion>
-    <MSTestTestAdapterVersion>3.9.3</MSTestTestAdapterVersion>
+    <MSTestTestFrameworkVersion>4.1.0</MSTestTestFrameworkVersion>
+    <MSTestTestAdapterVersion>4.1.0</MSTestTestAdapterVersion>
     <XUnitFrameworkVersion>2.4.2</XUnitFrameworkVersion>
     <XUnitAdapterVersion>2.4.5</XUnitAdapterVersion>
     <XUnitConsoleRunnerVersion>2.4.2</XUnitConsoleRunnerVersion>

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IProcessManager.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IProcessManager.cs
@@ -32,7 +32,7 @@ internal interface IProcessManager
     event EventHandler ProcessExited;
 
     /// <summary>
-    /// Process that we manage, or managed, useful for reporting to corellate log messages when the process no longer lives.
+    /// Process that we manage, or managed, useful for reporting to correlate log messages when the process no longer lives.
     /// </summary>
-    int ProcessId { get; set; }
+    int ProcessId { get; }
 }

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IProcessManager.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IProcessManager.cs
@@ -30,4 +30,9 @@ internal interface IProcessManager
     /// Raise event on process exit
     /// </summary>
     event EventHandler ProcessExited;
+
+    /// <summary>
+    /// Process that we manage, or managed, useful for reporting to corellate log messages when the process no longer lives.
+    /// </summary>
+    int ProcessId { get; set; }
 }

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
@@ -54,11 +54,15 @@ internal sealed class VsTestConsoleProcessManager : IProcessManager, IDisposable
     private readonly string? _dotnetExePath;
     private readonly ManualResetEvent _processExitedEvent = new(false);
     private Process? _process;
+
     private bool _vstestConsoleStarted;
     private bool _vstestConsoleExited;
     private bool _isDisposed;
 
     internal IFileHelper FileHelper { get; set; }
+
+    /// <inheritdoc/>
+    public int ProcessId { get; set; }
 
     /// <inheritdoc/>
     public event EventHandler? ProcessExited;
@@ -136,7 +140,7 @@ internal sealed class VsTestConsoleProcessManager : IProcessManager, IDisposable
                 {
                     // Not printing the value on purpose, env variables can contain secrets and we don't need to know the values
                     // most of the time.
-                    EqtTrace.Verbose("VsTestCommandLineWrapper.StartProcess: Setting environment variable: {0}", envVariable.Key);
+                    // EqtTrace.Verbose("VsTestCommandLineWrapper.StartProcess: Setting environment variable: {0}", envVariable.Key);
                     info.EnvironmentVariables[envVariable.Key] = envVariable.Value?.ToString();
                 }
             }
@@ -145,6 +149,8 @@ internal sealed class VsTestConsoleProcessManager : IProcessManager, IDisposable
         try
         {
             _process = Process.Start(info);
+            ProcessId = _process!.Id;
+            EqtTrace.Info($"VsTestConsoleProcessManager.StartProcess: Started process id:{_process.Id}"); // Not normally needed, but if you run multiple instances of wrapper it helps to also add {Environment.StackTrace}
         }
         catch (Win32Exception ex)
         {
@@ -173,9 +179,10 @@ internal sealed class VsTestConsoleProcessManager : IProcessManager, IDisposable
     public void ShutdownProcess()
     {
         // Ideally process should die by itself
+        EqtTrace.Info($"VsTestConsoleProcessManager.ShutDownProcess : Will terminate vstest.console process id:{ProcessId}, waiting {Endsessiontimeout} milliseconds for it to exit.");
         if (!_processExitedEvent.WaitOne(Endsessiontimeout) && IsProcessInitialized())
         {
-            EqtTrace.Info($"VsTestConsoleProcessManager.ShutDownProcess : Terminating vstest.console process after waiting for {Endsessiontimeout} milliseconds.");
+            EqtTrace.Info($"VsTestConsoleProcessManager.ShutDownProcess : Terminating vstest.console process id:{ProcessId} after waiting for {Endsessiontimeout} milliseconds.");
             _vstestConsoleExited = true;
             if (_process is not null)
             {
@@ -185,6 +192,11 @@ internal sealed class VsTestConsoleProcessManager : IProcessManager, IDisposable
                 _process.Dispose();
                 _process = null;
             }
+            EqtTrace.Info($"VsTestConsoleProcessManager.ShutDownProcess : Terminated vstest.console process id:{ProcessId}.");
+        }
+        else
+        {
+            EqtTrace.Verbose($"VsTestConsoleProcessManager.ShutDownProcess : Process id:{ProcessId} already exited, doing nothing.");
         }
     }
 

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
@@ -3,6 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+#if !NET5_0_OR_GREATER
+using System.Diagnostics;
+#endif
 using System.Globalization;
 using System.Linq;
 using System.Threading;

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
@@ -3,10 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-#if !NET5_0_OR_GREATER
 using System.Diagnostics;
-#endif
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -135,6 +134,22 @@ public class VsTestConsoleWrapper : IVsTestConsoleWrapper
 
         _vstestConsoleProcessManager.ProcessExited += (sender, args) => _requestSender.OnProcessExited();
         _sessionStarted = false;
+
+        // TODO: this is writing into the same file in integration tests (there is just 1 eqTrace for whole process)
+        // figure out how to make it useful. The logs helped a bit in debugging, but not by much.
+        //if (_consoleParameters.TraceLevel == TraceLevel.Verbose && !string.IsNullOrWhiteSpace(_consoleParameters.LogFilePath))
+        //{
+        //    var logFilePath = Path.ChangeExtension(
+        //        _consoleParameters.LogFilePath,
+        //        string.Format(
+        //            CultureInfo.InvariantCulture,
+        //            "translationLayer.{0}_{1}{2}",
+        //            DateTime.Now.ToString("yy-MM-dd_HH-mm-ss_fffff", CultureInfo.CurrentCulture),
+        //            new PlatformEnvironment().GetCurrentManagedThreadId(),
+        //            Path.GetExtension(_consoleParameters.LogFilePath))
+        //        );
+        //    EqtTrace.InitializeTrace(logFilePath, PlatformTraceLevel.Verbose);
+        //}
     }
 
 
@@ -635,10 +650,12 @@ public class VsTestConsoleWrapper : IVsTestConsoleWrapper
     /// <inheritdoc/>
     public void EndSession()
     {
-        EqtTrace.Info("VsTestConsoleWrapper.EndSession: Ending VsTestConsoleWrapper session");
+        EqtTrace.Info($"VsTestConsoleWrapper.EndSession: Ending VsTestConsoleWrapper session - process id:{_vstestConsoleProcessManager.ProcessId}");
 
         _requestSender.EndSession();
         _requestSender.Close();
+
+        EqtTrace.Info("VsTestConsoleWrapper.EndSession: Ended VsTestConsoleWrapper session");
 
         // If vstest.console is still hanging around, it should be explicitly killed.
         _vstestConsoleProcessManager.ShutdownProcess();

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -1638,6 +1638,12 @@ internal static class KnownPlatformSourceFilter
         "Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll",
         "Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.dll",
         "Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.resources.dll",
+
+        // For MSTest v4
+        "MSTest.TestAdapter.dll",
+        "MSTest.TestFramework.dll",
+        "MSTest.TestFramework.Extensions.dll",
+        "MSTestAdapter.PlatformServices.dll",
     }, StringComparer.OrdinalIgnoreCase);
 
 

--- a/test/DataCollectors/Microsoft.TestPlatform.Extensions.EventLogCollector.UnitTests/EventLogDataCollectorTests.cs
+++ b/test/DataCollectors/Microsoft.TestPlatform.Extensions.EventLogCollector.UnitTests/EventLogDataCollectorTests.cs
@@ -59,7 +59,7 @@ public class EventLogDataCollectorTests
     [TestMethod]
     public void InitializeShouldThrowExceptionIfEventsIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () => _eventLogDataCollector.Initialize(
                 null,
                 null!,
@@ -71,7 +71,7 @@ public class EventLogDataCollectorTests
     [TestMethod]
     public void InitializeShouldThrowExceptionIfCollectionSinkIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () => _eventLogDataCollector.Initialize(
                 null,
                 _mockDataCollectionEvents.Object,
@@ -83,7 +83,7 @@ public class EventLogDataCollectorTests
     [TestMethod]
     public void InitializeShouldThrowExceptionIfLoggerIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () => _eventLogDataCollector.Initialize(
                 null,
                 _mockDataCollectionEvents.Object,
@@ -269,7 +269,7 @@ public class EventLogDataCollectorTests
         var tc = new TestCase();
         var context = new DataCollectionContext(new SessionId(Guid.NewGuid()), new TestExecId(Guid.NewGuid()));
 
-        Assert.ThrowsException<EventLogCollectorException>(() => _mockDataCollectionEvents.Raise(x => x.TestCaseEnd += null, new TestCaseEndEventArgs(context, tc, TestOutcome.Passed)));
+        Assert.ThrowsExactly<EventLogCollectorException>(() => _mockDataCollectionEvents.Raise(x => x.TestCaseEnd += null, new TestCaseEndEventArgs(context, tc, TestOutcome.Passed)));
     }
 
     public void SessionEndEventShouldThrowIfSessionStartEventtIsNotInvoked()
@@ -278,7 +278,7 @@ public class EventLogDataCollectorTests
         eventLogDataCollector.Initialize(null, _mockDataCollectionEvents.Object, _mockDataCollectionSink, _mockDataCollectionLogger.Object, _dataCollectionEnvironmentContext);
         var tc = new TestCase();
 
-        Assert.ThrowsException<EventLogCollectorException>(() => _mockDataCollectionEvents.Raise(x => x.SessionEnd += null, new SessionEndEventArgs(_dataCollectionEnvironmentContext.SessionDataCollectionContext)));
+        Assert.ThrowsExactly<EventLogCollectorException>(() => _mockDataCollectionEvents.Raise(x => x.SessionEnd += null, new SessionEndEventArgs(_dataCollectionEnvironmentContext.SessionDataCollectionContext)));
     }
 
     [TestMethod]
@@ -322,7 +322,7 @@ public class EventLogDataCollectorTests
         XmlDocument expectedXmlDoc = new();
         expectedXmlDoc.LoadXml(configurationString);
         _mockFileHelper.Setup(x => x.Exists(It.IsAny<string>())).Throws<Exception>();
-        Assert.ThrowsException<Exception>(
+        Assert.ThrowsExactly<Exception>(
             () => _eventLogDataCollector.WriteEventLogs(
                 new List<EventLogEntry>(),
                 20,

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/AppDomainTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/AppDomainTests.cs
@@ -53,9 +53,7 @@ public class AppDomainTests : AcceptanceTestBase
 
         Assert.IsTrue(
             IsFilesContentEqual(testAppDomainDetailFileName, dataCollectorAppDomainDetailFileName),
-            "Different AppDomains, test: {0} datacollector: {1}",
-            File.ReadAllText(testAppDomainDetailFileName),
-            File.ReadAllText(dataCollectorAppDomainDetailFileName));
+            $"Different AppDomains, test: {File.ReadAllText(testAppDomainDetailFileName)} datacollector: {File.ReadAllText(dataCollectorAppDomainDetailFileName)}");
         ValidateSummaryStatus(1, 1, 1);
         File.Delete(runsettingsFilePath);
     }
@@ -66,7 +64,8 @@ public class AppDomainTests : AcceptanceTestBase
         Assert.IsTrue(File.Exists(filePath2), "File doesn't exist: {0}.", filePath2);
         var content1 = File.ReadAllText(filePath1);
         var content2 = File.ReadAllText(filePath2);
-        Assert.IsTrue(string.Equals(content1, content2, StringComparison.Ordinal), "Content mismatch{2}- file1 content:{2}{0}{2}- file2 content:{2}{1}{2}", content1, content2, Environment.NewLine);
+        var errorSummary = string.Format(CultureInfo.InvariantCulture, "Content mismatch{2}- file1 content:{2}{0}{2}- file2 content:{2}{1}{2}", content1, content2, Environment.NewLine);
+        Assert.IsTrue(string.Equals(content1, content2, StringComparison.Ordinal), errorSummary);
         return string.Equals(content1, content2, StringComparison.Ordinal);
     }
 

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectorAttachmentsProcessorsFactoryTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectorAttachmentsProcessorsFactoryTests.cs
@@ -63,7 +63,7 @@ public class DataCollectorAttachmentsProcessorsFactoryTests : AcceptanceTestBase
         Assert.AreEqual(typeof(CodeCoverageDataAttachmentsHandler).AssemblyQualifiedName, dataCollectorAttachmentsProcessors[2].DataCollectorAttachmentProcessorInstance.GetType().AssemblyQualifiedName);
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(true)]
     [DataRow(false)]
     public void Create_EmptyOrNullInvokedDataCollector_ShouldReturnCodeCoverageDataAttachmentsHandler(bool empty)

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestMSBuildOutputTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestMSBuildOutputTests.cs
@@ -37,7 +37,7 @@ public class DotnetTestMSBuildOutputTests : AcceptanceTestBase
 
         StdOutputContains("TESTERROR");
         StdOutputContains("FailingTest (");
-        StdOutputContains("): Error Message: Assert.AreEqual failed. Expected:<ğğğ𦮙我們剛才從𓋴𓅓𓏏𓇏𓇌𓀀>. Actual:<not the same>.");
+        StdOutputContains("Expected: \"ğğğ𦮙我們剛才從𓋴𓅓𓏏𓇏𓇌𓀀\"");
         StdOutputContains("at TerminalLoggerUnitTests.UnitTest1.FailingTest() in");
         // We are sending those as low prio messages, they won't show up on screen but will be in binlog.
         //StdOutputContains("passed PassingTest");

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
@@ -445,6 +445,8 @@ public class ExecutionTests : AcceptanceTestBase
         // Because of this in typical run we get a lot of dlls that we are sure don't have tests, like Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll
         // or testhost.dll. Those dlls are built for net8.0 tfm, so theoretically they should be tests, but attempting to run them fails to find runtimeconfig.json
         // or deps.json, and fails the run.
+        //
+        // IF THIS TEST FAILS ADD THE DLL TO KnownPlatformSources.
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
         var testAssemblyPath = _testEnvironment.GetTestAsset("SimpleTestProject.dll");
@@ -469,6 +471,8 @@ public class ExecutionTests : AcceptanceTestBase
         // Because of this in typical run we get a lot of dlls that we are sure don't have tests, like Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll
         // or testhost.dll. Those dlls are built for net8.0 tfm, so theoretically they should be tests, but attempting to run them fails to find runtimeconfig.json
         // or deps.json, and fails the run.
+        //
+        // IF THIS TEST FAILS ADD THE DLL TO KnownPlatformSources.
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
         var testAssemblyPath = _testEnvironment.GetTestAsset("NUTestProject.dll");
@@ -492,6 +496,8 @@ public class ExecutionTests : AcceptanceTestBase
         // Because of this in typical run we get a lot of dlls that we are sure don't have tests, like Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll
         // or testhost.dll. Those dlls are built for net8.0 tfm, so theoretically they should be tests, but attempting to run them fails to find runtimeconfig.json
         // or deps.json, and fails the run.
+        //
+        // IF THIS TEST FAILS ADD THE DLL TO KnownPlatformSources.
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
         var testAssemblyPath = _testEnvironment.GetTestAsset("SimpleTestProject.dll");

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Performance/TranslationLayer/DiscoveryPerfTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Performance/TranslationLayer/DiscoveryPerfTests.cs
@@ -45,8 +45,14 @@ public class DiscoveryPerfTests : TelemetryPerfTestBase
             var perfyTestAdapterEnv = new Dictionary<string, string?> { ["TEST_COUNT"] = expectedNumberOfTests.ToString(CultureInfo.InvariantCulture) };
             var vstestConsoleWrapper = GetVsTestConsoleWrapper(perfyTestAdapterEnv, traceLevel: System.Diagnostics.TraceLevel.Off);
             var assetPath = GetPerfAssetFullPath(projectName);
-            vstestConsoleWrapper.DiscoverTests(assetPath, GetDefaultRunSettings(), options, discoveryEventHandler2);
-            vstestConsoleWrapper.EndSession();
+            try
+            {
+                vstestConsoleWrapper.DiscoverTests(assetPath, GetDefaultRunSettings(), options, discoveryEventHandler2);
+            }
+            finally
+            {
+                vstestConsoleWrapper.EndSession();
+            }
         }
         Assert.AreEqual(expectedNumberOfTests, discoveryEventHandler2.Metrics![TelemetryDataConstants.TotalTestsDiscovered]);
         PostTelemetry(discoveryEventHandler2.Metrics, perfAnalyzer, projectName);
@@ -87,8 +93,14 @@ public class DiscoveryPerfTests : TelemetryPerfTestBase
             // This tells to PerfyTestAdapter how many tests it should return, this is our overhead baseline.
             var perfyTestAdapterEnv = new Dictionary<string, string?> { ["TEST_COUNT"] = expectedNumberOfTests.ToString(CultureInfo.InvariantCulture) };
             var vstestConsoleWrapper = GetVsTestConsoleWrapper(perfyTestAdapterEnv, traceLevel: System.Diagnostics.TraceLevel.Off);
-            vstestConsoleWrapper.DiscoverTests(GetPerfAssetFullPath(projectName), GetDefaultRunSettings(), options, discoveryEventHandler2);
-            vstestConsoleWrapper.EndSession();
+            try
+            {
+                vstestConsoleWrapper.DiscoverTests(GetPerfAssetFullPath(projectName), GetDefaultRunSettings(), options, discoveryEventHandler2);
+            }
+            finally
+            {
+                vstestConsoleWrapper.EndSession();
+            }
         }
 
         Assert.AreEqual(expectedNumberOfTests, discoveryEventHandler2.Metrics![TelemetryDataConstants.TotalTestsDiscovered]);

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Performance/TranslationLayer/ExecutionPerfTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Performance/TranslationLayer/ExecutionPerfTests.cs
@@ -45,8 +45,14 @@ public class ExecutionPerfTests : TelemetryPerfTestBase
             // This tells to PerfyTestAdapter how many tests it should return, this is our overhead baseline.
             var perfyTestAdapterEnv = new Dictionary<string, string?> { ["TEST_COUNT"] = expectedNumberOfTests.ToString(CultureInfo.InvariantCulture) };
             var vstestConsoleWrapper = GetVsTestConsoleWrapper(perfyTestAdapterEnv, traceLevel: System.Diagnostics.TraceLevel.Off);
-            vstestConsoleWrapper.RunTests(GetPerfAssetFullPath(projectName), GetDefaultRunSettings(), options, runEventHandler);
-            vstestConsoleWrapper.EndSession();
+            try
+            {
+                vstestConsoleWrapper.RunTests(GetPerfAssetFullPath(projectName), GetDefaultRunSettings(), options, runEventHandler);
+            }
+            finally
+            {
+                vstestConsoleWrapper.EndSession();
+            }
         }
 
         Assert.AreEqual(expectedNumberOfTests, runEventHandler.Metrics![TelemetryDataConstants.TotalTestsRun]);
@@ -86,8 +92,14 @@ public class ExecutionPerfTests : TelemetryPerfTestBase
             // This tells to PerfyTestAdapter how many tests it should return, this is our overhead baseline.
             var perfyTestAdapterEnv = new Dictionary<string, string?> { ["TEST_COUNT"] = expectedNumberOfTests.ToString(CultureInfo.InvariantCulture) };
             var vstestConsoleWrapper = GetVsTestConsoleWrapper(perfyTestAdapterEnv, traceLevel: System.Diagnostics.TraceLevel.Off);
-            vstestConsoleWrapper.RunTests(GetPerfAssetFullPath(projectName), GetDefaultRunSettings(), options, runEventHandler);
-            vstestConsoleWrapper.EndSession();
+            try
+            {
+                vstestConsoleWrapper.RunTests(GetPerfAssetFullPath(projectName), GetDefaultRunSettings(), options, runEventHandler);
+            }
+            finally
+            {
+                vstestConsoleWrapper.EndSession();
+            }
         }
 
         Assert.AreEqual(expectedNumberOfTests, runEventHandler.Metrics![TelemetryDataConstants.TotalTestsRun]);

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/PostProcessingTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/PostProcessingTests.cs
@@ -44,19 +44,19 @@ public class PostProcessingTests : AcceptanceTestBase
         {
             string projectFolder = Path.Combine(TempDirectory.Path, i.ToString(CultureInfo.InvariantCulture));
             ExecuteApplication(GetConsoleRunnerPath(), $"new mstest -o {projectFolder}", out string stdOut, out string stdError, out int exitCode);
-            Assert.AreEqual(exitCode, 0);
+            Assert.AreEqual(0, exitCode);
             ExecuteApplication(GetConsoleRunnerPath(), $"build {projectFolder} -c release", out stdOut, out stdError, out exitCode);
-            Assert.AreEqual(exitCode, 0);
+            Assert.AreEqual(0, exitCode);
 
             string testContainer = Directory.GetFiles(Path.Combine(projectFolder, "bin"), $"{i}.dll", SearchOption.AllDirectories).Single();
 
             ExecuteVsTestConsole($"{testContainer} --Collect:\"SampleDataCollector\" --TestAdapterPath:\"{extensionsPath}\" --ResultsDirectory:\"{Path.GetDirectoryName(testContainer)}\" --Settings:\"{runSettings}\" --ArtifactsProcessingMode-Collect --TestSessionCorrelationId:\"{correlationSessionId}\" --Diag:\"{TempDirectory.Path + '/'}\"", out stdOut, out stdError, out exitCode);
-            Assert.AreEqual(exitCode, 0);
+            Assert.AreEqual(0, exitCode);
         });
 
         // Post process artifacts
         ExecuteVsTestConsole($"--ArtifactsProcessingMode-PostProcess --TestSessionCorrelationId:\"{correlationSessionId}\" --Diag:\"{TempDirectory.Path + "/mergeLog/"}\"", out string stdOut, out string stdError, out int exitCode);
-        Assert.AreEqual(exitCode, 0);
+        Assert.AreEqual(0, exitCode);
 
         using StringReader reader = new(stdOut);
         Assert.AreEqual(string.Empty, reader.ReadLine().Trim());

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TelemetryTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TelemetryTests.cs
@@ -85,7 +85,7 @@ public class TelemetryTests : AcceptanceTestBase
     {
         if (!Directory.Exists(tempDirectory.Path))
         {
-            Assert.Fail("Could not find the telemetry logs folder at {0}", tempDirectory.Path);
+            Assert.Fail($"Could not find the telemetry logs folder at {tempDirectory.Path}");
         }
 
         bool isValid = false;

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/CustomTestHostTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/CustomTestHostTests.cs
@@ -150,7 +150,7 @@ public class CustomTestHostTests : AcceptanceTestBase
         // Arrange
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        var vstestConsoleWrapper = GetVsTestConsoleWrapper();
+        _vstestConsoleWrapper = GetVsTestConsoleWrapper();
         var runEventHandler = new RunEventHandler();
         var netFrameworkDll = GetTestDllForFramework("MSTestProject1.dll", DEFAULT_HOST_NETFX);
         var netDll = GetTestDllForFramework("MSTestProject1.dll", DEFAULT_HOST_NETCORE);
@@ -159,7 +159,7 @@ public class CustomTestHostTests : AcceptanceTestBase
         // Act
         // We have no preference around what TFM is used. It will be autodetected.
         var runsettingsXml = "<RunSettings><RunConfiguration></RunConfiguration></RunSettings>";
-        vstestConsoleWrapper.RunTestsWithCustomTestHost(new[] { netFrameworkDll, netDll }, runsettingsXml, runEventHandler, testHostLauncher);
+        _vstestConsoleWrapper.RunTestsWithCustomTestHost(new[] { netFrameworkDll, netDll }, runsettingsXml, runEventHandler, testHostLauncher);
 
         // Assert
         if (runEventHandler.Errors.Any())
@@ -202,7 +202,7 @@ public class CustomTestHostTests : AcceptanceTestBase
         // Arrange
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        var vstestConsoleWrapper = GetVsTestConsoleWrapper();
+        _vstestConsoleWrapper = GetVsTestConsoleWrapper();
         var runEventHandler = new RunEventHandler();
         var netFrameworkDll = GetTestDllForFramework("MSTestProject1.dll", DEFAULT_HOST_NETFX);
         var netDll = GetTestDllForFramework("MSTestProject1.dll", DEFAULT_HOST_NETCORE);
@@ -211,7 +211,7 @@ public class CustomTestHostTests : AcceptanceTestBase
         // Act
         // We have no preference around what TFM is used. It will be autodetected.
         var runsettingsXml = "<RunSettings><RunConfiguration></RunConfiguration></RunSettings>";
-        vstestConsoleWrapper.RunTestsWithCustomTestHost(new[] { netFrameworkDll, netDll }, runsettingsXml, runEventHandler, testHostLauncher);
+        _vstestConsoleWrapper.RunTestsWithCustomTestHost(new[] { netFrameworkDll, netDll }, runsettingsXml, runEventHandler, testHostLauncher);
 
         // Assert
         runEventHandler.Errors.Should().BeEmpty();

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/DiscoverTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/DiscoverTests.cs
@@ -53,8 +53,8 @@ public class DiscoverTests : AcceptanceTestBase
         _discoveryEventHandler = new DiscoveryEventHandler();
         _discoveryEventHandler2 = new DiscoveryEventHandler2();
 
-        var vstestConsoleWrapper = GetVsTestConsoleWrapper();
-        vstestConsoleWrapper.DiscoverTests(GetTestDlls("MSTestProject1.dll", "MSTestProject2.dll"), GetDefaultRunSettings(), _discoveryEventHandler);
+        _vstestConsoleWrapper = GetVsTestConsoleWrapper();
+        _vstestConsoleWrapper.DiscoverTests(GetTestDlls("MSTestProject1.dll", "MSTestProject2.dll"), GetDefaultRunSettings(), _discoveryEventHandler);
 
         // Assert.
         Assert.AreEqual(6, _discoveryEventHandler.DiscoveredTestCases.Count);
@@ -71,8 +71,8 @@ public class DiscoverTests : AcceptanceTestBase
         _discoveryEventHandler = new DiscoveryEventHandler();
         _discoveryEventHandler2 = new DiscoveryEventHandler2();
 
-        var vstestConsoleWrapper = GetVsTestConsoleWrapper();
-        vstestConsoleWrapper.DiscoverTests(
+        _vstestConsoleWrapper = GetVsTestConsoleWrapper();
+        _vstestConsoleWrapper.DiscoverTests(
             GetTestDlls("MSTestProject1.dll", "MSTestProject2.dll"),
             GetDefaultRunSettings(),
             new TestPlatformOptions() { CollectMetrics = false },

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/DiscoverTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/DiscoverTests.cs
@@ -201,11 +201,11 @@ public class DiscoverTests : AcceptanceTestBase
         // Release builds optimize code, hence line numbers are different.
         if (IntegrationTestEnvironment.BuildConfiguration.StartsWith("release", StringComparison.OrdinalIgnoreCase))
         {
-            Assert.AreEqual(25, testCase.First().LineNumber);
+            Assert.AreEqual(22, testCase.First().LineNumber);
         }
         else
         {
-            Assert.AreEqual(24, testCase.First().LineNumber);
+            Assert.AreEqual(21, testCase.First().LineNumber);
         }
     }
 

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/RunTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/RunTests.cs
@@ -50,9 +50,9 @@ public class RunTests : AcceptanceTestBase
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        var vstestConsoleWrapper = GetVsTestConsoleWrapper();
+        _vstestConsoleWrapper = GetVsTestConsoleWrapper();
         var runEventHandler = new RunEventHandler();
-        vstestConsoleWrapper.RunTests(GetTestDlls("MSTestProject1.dll", "MSTestProject2.dll"), GetDefaultRunSettings(), runEventHandler);
+        _vstestConsoleWrapper.RunTests(GetTestDlls("MSTestProject1.dll", "MSTestProject2.dll"), GetDefaultRunSettings(), runEventHandler);
 
         // Assert
         Assert.AreEqual(6, runEventHandler.TestResults.Count);
@@ -69,7 +69,7 @@ public class RunTests : AcceptanceTestBase
         // Arrange
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        var vstestConsoleWrapper = GetVsTestConsoleWrapper();
+        _vstestConsoleWrapper = GetVsTestConsoleWrapper();
         var runEventHandler = new RunEventHandler();
         var compatibleDll = GetTestDllForFramework("MSTestProject1.dll", DEFAULT_HOST_NETFX);
         var incompatibleDll = GetTestDllForFramework("MSTestProject1.dll", DEFAULT_HOST_NETCORE);
@@ -77,7 +77,7 @@ public class RunTests : AcceptanceTestBase
         // Act
         // We have no preference around what TFM is used. It will be autodetected.
         var runsettingsXml = "<RunSettings><RunConfiguration></RunConfiguration></RunSettings>";
-        vstestConsoleWrapper.RunTests(new[] { compatibleDll, incompatibleDll }, runsettingsXml, runEventHandler);
+        _vstestConsoleWrapper.RunTests(new[] { compatibleDll, incompatibleDll }, runsettingsXml, runEventHandler);
 
         // Assert
         runEventHandler.TestResults.Should().HaveCount(3, "we failed to run those tests because they are not compatible.");
@@ -92,7 +92,7 @@ public class RunTests : AcceptanceTestBase
         // Arrange
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        var vstestConsoleWrapper = GetVsTestConsoleWrapper();
+        _vstestConsoleWrapper = GetVsTestConsoleWrapper();
         var runEventHandler = new RunEventHandler();
         var netFrameworkDll = GetTestDllForFramework("MSTestProject1.dll", DEFAULT_HOST_NETFX);
         var netDll = GetTestDllForFramework("MSTestProject1.dll", DEFAULT_HOST_NETCORE);
@@ -100,7 +100,7 @@ public class RunTests : AcceptanceTestBase
         // Act
         // We have no preference around what TFM is used. It will be autodetected.
         var runsettingsXml = "<RunSettings><RunConfiguration></RunConfiguration></RunSettings>";
-        vstestConsoleWrapper.RunTests(new[] { netFrameworkDll, netDll }, runsettingsXml, runEventHandler);
+        _vstestConsoleWrapper.RunTests(new[] { netFrameworkDll, netDll }, runsettingsXml, runEventHandler);
 
         // Assert
         runEventHandler.Errors.Should().BeEmpty();

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/RunTestsWithFilterTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/RunTestsWithFilterTests.cs
@@ -43,10 +43,10 @@ public class RunTestsWithFilterTests : AcceptanceTestBase
 
         _runEventHandler = new RunEventHandler();
 
-        var vstestConsoleWrapper = GetVsTestConsoleWrapper();
+        _vstestConsoleWrapper = GetVsTestConsoleWrapper();
         var sources = new List<string> { GetAssetFullPath("MSTestProject1.dll") };
 
-        vstestConsoleWrapper.RunTests(
+        _vstestConsoleWrapper.RunTests(
             sources,
             GetDefaultRunSettings(),
             new TestPlatformOptions() { TestCaseFilter = "FullyQualifiedName=MSTestProject1.UnitTest1.PassingTest" },

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/SerializeTestRunTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/SerializeTestRunTests.cs
@@ -100,7 +100,7 @@ public class SerialTestRunDecoratorTests : AcceptanceTestBase
         // Act
         var testDll = GetAssetFullPath("SerializeTestRunTestProject.dll");
         _vstestConsoleWrapper.RunTests(new string[] { testDll }, _runsettings, _runEventHandler);
-        _ = Assert.ThrowsException<InvalidOperationException>(_runEventHandler.EnsureSuccess);
+        _ = Assert.ThrowsExactly<InvalidOperationException>(_runEventHandler.EnsureSuccess);
 
         StringBuilder builder = new();
         foreach (string? error in _runEventHandler.Errors)

--- a/test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/ManagedNameUtilities/ManagedNameParserTests.cs
+++ b/test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/ManagedNameUtilities/ManagedNameParserTests.cs
@@ -70,12 +70,12 @@ public class ManagedNameParserTests
             return (method, arity, parameterTypes);
         }
 
-        Assert.ThrowsException<InvalidManagedNameException>(() => Parse(" Method"), "Whitespace is not valid in a ManagedName (pos: 0)");
-        Assert.ThrowsException<InvalidManagedNameException>(() => Parse("Method( List)"), "Whitespace is not valid in a ManagedName (pos: 7)");
+        Assert.ThrowsExactly<InvalidManagedNameException>(() => Parse(" Method"), "Whitespace is not valid in a ManagedName (pos: 0)");
+        Assert.ThrowsExactly<InvalidManagedNameException>(() => Parse("Method( List)"), "Whitespace is not valid in a ManagedName (pos: 7)");
 
-        Assert.ThrowsException<InvalidManagedNameException>(() => Parse("Method(List)xa"), "Unexpected characters after the end of the ManagedName (pos: 7)");
+        Assert.ThrowsExactly<InvalidManagedNameException>(() => Parse("Method(List)xa"), "Unexpected characters after the end of the ManagedName (pos: 7)");
 
-        Assert.ThrowsException<InvalidManagedNameException>(() => Parse("Method("), "ManagedName is incomplete");
-        Assert.ThrowsException<InvalidManagedNameException>(() => Parse("Method`4a"), "Method arity must be numeric");
+        Assert.ThrowsExactly<InvalidManagedNameException>(() => Parse("Method("), "ManagedName is incomplete");
+        Assert.ThrowsExactly<InvalidManagedNameException>(() => Parse("Method`4a"), "Method arity must be numeric");
     }
 }

--- a/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeClientTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/DesignMode/DesignModeClientTests.cs
@@ -108,7 +108,7 @@ public class DesignModeClientTests
         _mockCommunicationManager.Setup(cm => cm.WaitForServerConnection(It.IsAny<int>())).Returns(false);
         _mockCommunicationManager.SetupSequence(cm => cm.ReceiveMessage()).Returns(verCheck).Returns(sessionEnd);
 
-        Assert.ThrowsException<TimeoutException>(() => _designModeClient.ConnectToClientAndProcessRequests(PortNumber, _mockTestRequestManager.Object));
+        Assert.ThrowsExactly<TimeoutException>(() => _designModeClient.ConnectToClientAndProcessRequests(PortNumber, _mockTestRequestManager.Object));
 
         _mockCommunicationManager.Verify(cm => cm.SetupClientAsync(new IPEndPoint(IPAddress.Loopback, PortNumber)), Times.Once);
         _mockCommunicationManager.Verify(cm => cm.WaitForServerConnection(It.IsAny<int>()), Times.Once);
@@ -272,7 +272,7 @@ public class DesignModeClientTests
     {
         _mockCommunicationManager.Setup(cm => cm.WaitForServerConnection(It.IsAny<int>())).Returns(false);
 
-        var ex = Assert.ThrowsException<TimeoutException>(() => _designModeClient.ConnectToClientAndProcessRequests(PortNumber, _mockTestRequestManager.Object));
+        var ex = Assert.ThrowsExactly<TimeoutException>(() => _designModeClient.ConnectToClientAndProcessRequests(PortNumber, _mockTestRequestManager.Object));
         Assert.AreEqual("vstest.console process failed to connect to translation layer process after 90 seconds. This may occur due to machine slowness, please set environment variable VSTEST_CONNECTION_TIMEOUT to increase timeout.", ex.Message);
 
         _mockCommunicationManager.Verify(cm => cm.SetupClientAsync(new IPEndPoint(IPAddress.Loopback, PortNumber)), Times.Once);
@@ -309,7 +309,6 @@ public class DesignModeClientTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(TestPlatformException))]
     public void DesignModeClientLaunchCustomHostMustThrowIfInvalidAckComes()
     {
         var testableDesignModeClient = new TestableDesignModeClient(_mockCommunicationManager.Object, JsonDataSerializer.Instance, _mockPlatformEnvironment.Object);
@@ -324,11 +323,10 @@ public class DesignModeClientTests
             .Callback(() => Task.Run(sendMessageAction));
 
         var info = new TestProcessStartInfo();
-        testableDesignModeClient.LaunchCustomHost(info, CancellationToken.None);
+        Assert.ThrowsExactly<TestPlatformException>(() => testableDesignModeClient.LaunchCustomHost(info, CancellationToken.None));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(TestPlatformException))]
     public void DesignModeClientLaunchCustomHostMustThrowIfCancellationOccursBeforeHostLaunch()
     {
         var testableDesignModeClient = new TestableDesignModeClient(_mockCommunicationManager.Object, JsonDataSerializer.Instance, _mockPlatformEnvironment.Object);
@@ -337,7 +335,7 @@ public class DesignModeClientTests
         var cancellationTokenSource = new CancellationTokenSource();
         cancellationTokenSource.Cancel();
 
-        testableDesignModeClient.LaunchCustomHost(info, cancellationTokenSource.Token);
+        Assert.ThrowsExactly<TestPlatformException>(() => testableDesignModeClient.LaunchCustomHost(info, cancellationTokenSource.Token));
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Client.UnitTests/Discovery/DiscoveryRequestTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/Discovery/DiscoveryRequestTests.cs
@@ -58,7 +58,7 @@ public class DiscoveryRequestTests
     {
         _discoveryRequest.Dispose();
 
-        Assert.ThrowsException<ObjectDisposedException>(() => _discoveryRequest.DiscoverAsync());
+        Assert.ThrowsExactly<ObjectDisposedException>(() => _discoveryRequest.DiscoverAsync());
     }
 
     [TestMethod]
@@ -90,10 +90,10 @@ public class DiscoveryRequestTests
     public void AbortIfDiscoveryRequestDisposedShouldThrowObjectDisposedException()
     {
         _discoveryRequest.Dispose();
-        Assert.ThrowsException<ObjectDisposedException>(() => _discoveryRequest.Abort());
+        Assert.ThrowsExactly<ObjectDisposedException>(() => _discoveryRequest.Abort());
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DynamicData(nameof(ProtocolConfigVersionProvider))]
     public void AbortIfDiscoveryIsinProgressShouldCallDiscoveryManagerAbort(int version)
     {
@@ -128,7 +128,7 @@ public class DiscoveryRequestTests
     public void WaitForCompletionIfDiscoveryRequestDisposedShouldThrowObjectDisposedException()
     {
         _discoveryRequest.Dispose();
-        Assert.ThrowsException<ObjectDisposedException>(() => _discoveryRequest.WaitForCompletion());
+        Assert.ThrowsExactly<ObjectDisposedException>(() => _discoveryRequest.WaitForCompletion());
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Client.UnitTests/Execution/TestRunRequestTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/Execution/TestRunRequestTests.cs
@@ -58,14 +58,14 @@ public class TestRunRequestTests
     {
         _testRunRequest.Dispose();
 
-        Assert.ThrowsException<ObjectDisposedException>(() => _testRunRequest.ExecuteAsync());
+        Assert.ThrowsExactly<ObjectDisposedException>(() => _testRunRequest.ExecuteAsync());
     }
 
     [TestMethod]
     public void ExecuteAsycIfStateIsNotPendingThrowsInvalidOperationException()
     {
         _testRunRequest.ExecuteAsync();
-        Assert.ThrowsException<InvalidOperationException>(() => _testRunRequest.ExecuteAsync());
+        Assert.ThrowsExactly<InvalidOperationException>(() => _testRunRequest.ExecuteAsync());
     }
 
     [TestMethod]
@@ -122,13 +122,13 @@ public class TestRunRequestTests
     public void WaitForCompletionIfTestRunRequestDisposedShouldThrowObjectDisposedException()
     {
         _testRunRequest.Dispose();
-        Assert.ThrowsException<ObjectDisposedException>(() => _testRunRequest.WaitForCompletion());
+        Assert.ThrowsExactly<ObjectDisposedException>(() => _testRunRequest.WaitForCompletion());
     }
 
     [TestMethod]
     public void WaitForCompletionIfTestRunStatePendingShouldThrowInvalidOperationException()
     {
-        Assert.ThrowsException<InvalidOperationException>(() => _testRunRequest.WaitForCompletion());
+        Assert.ThrowsExactly<InvalidOperationException>(() => _testRunRequest.WaitForCompletion());
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Client.UnitTests/TestPlatformTests.cs
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/TestPlatformTests.cs
@@ -105,7 +105,7 @@ public class TestPlatformTests
     {
         TestPlatform tp = new();
 
-        Assert.ThrowsException<ArgumentNullException>(() => tp.CreateDiscoveryRequest(_mockRequestData.Object, null!, new TestPlatformOptions(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>()));
+        Assert.ThrowsExactly<ArgumentNullException>(() => tp.CreateDiscoveryRequest(_mockRequestData.Object, null!, new TestPlatformOptions(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>()));
     }
 
     [TestMethod]
@@ -283,7 +283,7 @@ public class TestPlatformTests
     {
         var tp = new TestPlatform();
 
-        Assert.ThrowsException<ArgumentNullException>(() => tp.CreateTestRunRequest(_mockRequestData.Object, null!, new TestPlatformOptions(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>()));
+        Assert.ThrowsExactly<ArgumentNullException>(() => tp.CreateTestRunRequest(_mockRequestData.Object, null!, new TestPlatformOptions(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>()));
     }
 
     /// <summary>
@@ -424,7 +424,7 @@ public class TestPlatformTests
     {
         var tp = new TestableTestPlatform(_testEngine.Object, _hostManager.Object);
 
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             tp.StartTestSession(
                 new Mock<IRequestData>().Object,
                 null!,

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/DataCollectorExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/DataCollectorExtensionManagerTests.cs
@@ -22,7 +22,7 @@ public class DataCollectorExtensionManagerTests
     [TestMethod]
     public void CreateShouldThrowExceptionIfMessageLoggerIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             var dataCollectionExtensionManager = DataCollectorExtensionManager.Create(null!);
         });

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestExtensionManagerTests.cs
@@ -42,7 +42,7 @@ public class TestExtensionManagerTests
     [TestMethod]
     public void TestExtensionManagerConstructorShouldThrowExceptionIfMessageLoggerIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _testExtensionManager = new DummyTestExtensionManager(_unfilteredTestExtensions, _filteredTestExtensions, null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _testExtensionManager = new DummyTestExtensionManager(_unfilteredTestExtensions, _filteredTestExtensions, null!));
     }
 
     [TestMethod]
@@ -60,7 +60,7 @@ public class TestExtensionManagerTests
     {
         _testExtensionManager = new DummyTestExtensionManager(_unfilteredTestExtensions, _filteredTestExtensions, _messageLogger);
         TestPluginCacheHelper.SetupMockAdditionalPathExtensions(typeof(TestExtensionManagerTests));
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             {
                 var result = _testExtensionManager.TryGetTestExtension(default(Uri)!);
             }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestLoggerExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestLoggerExtensionManagerTests.cs
@@ -22,7 +22,7 @@ public class TestLoggerExtensionManagerTests
     [TestMethod]
     public void CreateShouldThrowExceptionIfMessageLoggerIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             var testLoggerExtensionManager = TestLoggerExtensionManager.Create(null!);
         });

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginCacheTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginCacheTests.cs
@@ -259,7 +259,7 @@ public class TestPluginCacheTests
     [TestMethod]
     public void GetResolutionPathsShouldThrowIfExtensionAssemblyIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => TestPluginCache.GetResolutionPaths(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => TestPluginCache.GetResolutionPaths(null!));
     }
 
     [TestMethod]
@@ -335,7 +335,7 @@ public class TestPluginCacheTests
         //TODO : make ITestDiscoverer interface and then mock it in order to make this test case pass.
 
         var extensionAssembly = typeof(TestPluginCacheTests).Assembly.Location;
-        Assert.ThrowsException<Exception>(() => _testablePluginCache.GetTestExtensions<TestDiscovererPluginInformation, ITestDiscoverer>(extensionAssembly));
+        Assert.ThrowsExactly<Exception>(() => _testablePluginCache.GetTestExtensions<TestDiscovererPluginInformation, ITestDiscoverer>(extensionAssembly));
     }
 
     #endregion

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginManagerTests.cs
@@ -32,7 +32,7 @@ public class TestPluginManagerTests
     [TestMethod]
     public void GetTestExtensionTypeShouldThrowIfTypeNotFound()
     {
-        Assert.ThrowsException<TypeLoadException>(() => TestPluginManager.GetTestExtensionType("randomassemblyname.random"));
+        Assert.ThrowsExactly<TypeLoadException>(() => TestPluginManager.GetTestExtensionType("randomassemblyname.random"));
     }
 
     [TestMethod]
@@ -46,7 +46,7 @@ public class TestPluginManagerTests
     [TestMethod]
     public void CreateTestExtensionShouldThrowIfInstanceCannotBeCreated()
     {
-        Assert.ThrowsException<MissingMethodException>(() => TestPluginManager.CreateTestExtension<ITestLogger>(typeof(AbstractDummyLogger)));
+        Assert.ThrowsExactly<MissingMethodException>(() => TestPluginManager.CreateTestExtension<ITestLogger>(typeof(AbstractDummyLogger)));
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/RunSettingsProviderExtensionsTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/Utilities/RunSettingsProviderExtensionsTests.cs
@@ -40,21 +40,21 @@ public class RunSettingsProviderExtensionsTests
     [TestMethod]
     public void UpdateRunSettingsShouldThrownExceptionIfRunSettingsProviderIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () => RunSettingsProviderExtensions.UpdateRunSettings(null!, "<RunSettings></RunSettings>"));
     }
 
     [TestMethod]
     public void UpdateRunSettingsShouldThrownExceptionIfSettingsXmlIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () => _runSettingsProvider.UpdateRunSettings(null!));
     }
 
     [TestMethod]
     public void UpdateRunSettingsShouldThrownExceptionIfSettingsXmlIsEmptyOrWhiteSpace()
     {
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () => _runSettingsProvider.UpdateRunSettings("  "));
     }
 
@@ -101,41 +101,41 @@ public class RunSettingsProviderExtensionsTests
 
         var runConfiguration =
             XmlRunSettingsUtilities.GetRunConfigurationNode(_runSettingsProvider.ActiveRunSettings!.SettingsXml);
-        Assert.AreEqual(runConfiguration.TargetPlatform, Architecture.X64);
+        Assert.AreEqual(Architecture.X64, runConfiguration.TargetPlatform);
     }
 
     [TestMethod]
     public void AddDefaultRunSettingsShouldThrowExceptionIfArgumentIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             RunSettingsProviderExtensions.AddDefaultRunSettings(null!));
     }
 
     [TestMethod]
     public void UpdateRunSettingsNodeShouldThrowExceptionIfKeyIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             _runSettingsProvider.UpdateRunSettingsNode(null!, "data"));
     }
 
     [TestMethod]
     public void UpdateRunSettingsNodeShouldThrowExceptionIfKeyIsEmptyOrWhiteSpace()
     {
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             _runSettingsProvider.UpdateRunSettingsNode("  ", "data"));
     }
 
     [TestMethod]
     public void UpdateRunSettingsNodeShouldThrowExceptionIfDataIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             _runSettingsProvider.UpdateRunSettingsNode("Key", null!));
     }
 
     [TestMethod]
     public void UpdateRunSettingsNodeShouldThrowExceptionIfRunSettingsProviderIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             RunSettingsProviderExtensions.UpdateRunSettingsNode(null!, "Key", "data"));
     }
 
@@ -212,28 +212,28 @@ public class RunSettingsProviderExtensionsTests
     [TestMethod]
     public void UpdateRunSettingsNodeInnerXmlShouldThrowExceptionIfKeyIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             _runSettingsProvider.UpdateRunSettingsNodeInnerXml(null!, "<myxml/>"));
     }
 
     [TestMethod]
     public void UpdateRunSettingsNodeInnerXmlShouldThrowExceptionIfKeyIsEmptyOrWhiteSpace()
     {
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             _runSettingsProvider.UpdateRunSettingsNodeInnerXml("  ", "<myxml/>"));
     }
 
     [TestMethod]
     public void UpdateRunSettingsNodeInnerXmlShouldThrowExceptionIfXmlIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             _runSettingsProvider.UpdateRunSettingsNodeInnerXml("Key", null!));
     }
 
     [TestMethod]
     public void UpdateRunSettingsNodeInnerXmlShouldThrowExceptionIfRunSettingsProviderIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             RunSettingsProviderExtensions.UpdateRunSettingsNodeInnerXml(null!, "Key", "<myxml/>"));
     }
 
@@ -259,13 +259,13 @@ public class RunSettingsProviderExtensionsTests
     [TestMethod]
     public void QueryRunSettingsNodeShouldThrowIfKeyIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _runSettingsProvider.QueryRunSettingsNode(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _runSettingsProvider.QueryRunSettingsNode(null!));
     }
 
     [TestMethod]
     public void QueryRunSettingsNodeShouldThrowIfKeyIsEmptyOrWhiteSpace()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _runSettingsProvider.QueryRunSettingsNode("  "));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _runSettingsProvider.QueryRunSettingsNode("  "));
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/ConditionTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/ConditionTests.cs
@@ -17,21 +17,21 @@ public class ConditionTests
     public void ParseShouldThrownFormatExceptionOnNullConditionString()
     {
         string? conditionString = null;
-        Assert.ThrowsException<FormatException>(() => Condition.Parse(conditionString));
+        Assert.ThrowsExactly<FormatException>(() => Condition.Parse(conditionString));
     }
 
     [TestMethod]
     public void ParseShouldThrownFormatExceptionOnEmptyConditionString()
     {
         var conditionString = "";
-        Assert.ThrowsException<FormatException>(() => Condition.Parse(conditionString));
+        Assert.ThrowsExactly<FormatException>(() => Condition.Parse(conditionString));
     }
 
     [TestMethod]
     public void ParseShouldThrownFormatExceptionOnIncompleteConditionString()
     {
         var conditionString = "PropertyName=";
-        Assert.ThrowsException<FormatException>(() => Condition.Parse(conditionString));
+        Assert.ThrowsExactly<FormatException>(() => Condition.Parse(conditionString));
     }
 
     [TestMethod]
@@ -114,7 +114,7 @@ public class ConditionTests
     {
         var conditionString = @"FullyQualifiedName=Test1(""!"")";
 
-        Assert.ThrowsException<FormatException>(() => Condition.Parse(conditionString));
+        Assert.ThrowsExactly<FormatException>(() => Condition.Parse(conditionString));
     }
 
     [TestMethod]
@@ -122,13 +122,13 @@ public class ConditionTests
     {
         var conditionString = @"FullyQualifiedName!Test1()";
 
-        Assert.ThrowsException<FormatException>(() => Condition.Parse(conditionString));
+        Assert.ThrowsExactly<FormatException>(() => Condition.Parse(conditionString));
     }
 
     [TestMethod]
     public void TokenizeNullThrowsArgumentNullException()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => Condition.TokenizeFilterConditionString(null!), "str");
+        Assert.ThrowsExactly<ArgumentNullException>(() => Condition.TokenizeFilterConditionString(null!), "str");
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FastFilterTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FastFilterTests.cs
@@ -105,8 +105,8 @@ public class FastFilterTests
         string[]? invalidProperties = filterExpressionWrapper.ValidForProperties(new List<string>() { "FullyQualifiedName" }, null);
 
         Assert.IsNotNull(invalidProperties);
-        Assert.AreEqual(invalidProperties.Length, 1);
-        Assert.AreEqual(invalidProperties[0], "Category");
+        Assert.AreEqual(1, invalidProperties.Length);
+        Assert.AreEqual("Category", invalidProperties[0]);
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FilterExpressionTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FilterExpressionTests.cs
@@ -16,7 +16,7 @@ public class FilterExpressionTests
     [TestMethod]
     public void TokenizeNullThrowsArgumentNullException()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => FilterExpression.TokenizeFilterExpressionString(null!), "str");
+        Assert.ThrowsExactly<ArgumentNullException>(() => FilterExpression.TokenizeFilterExpressionString(null!), "str");
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Hosting/TestHostExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Hosting/TestHostExtensionManagerTests.cs
@@ -22,7 +22,7 @@ public class TestHostExtensionManagerTests
     [TestMethod]
     public void CreateShouldThrowExceptionIfMessageLoggerIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             var testLoggerExtensionManager = TestRuntimeExtensionManager.Create(null!);
         });

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Logging/InternalTestLoggerEventsTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Logging/InternalTestLoggerEventsTests.cs
@@ -102,13 +102,13 @@ public class InternalTestLoggerEventsBehaviors
     [TestMethod]
     public void RaiseTestResultShouldThrowExceptionIfNullTestResultEventArgsIsPassed()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _loggerEvents.RaiseTestResult(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _loggerEvents.RaiseTestResult(null!));
     }
 
     [TestMethod]
     public void RaiseTestRunMessageShouldThrowExceptioIfNullTestRunMessageEventArgsIsPassed()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _loggerEvents.RaiseTestRunMessage(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _loggerEvents.RaiseTestRunMessage(null!));
     }
 
     [TestMethod]
@@ -171,7 +171,7 @@ public class InternalTestLoggerEventsBehaviors
     {
         var loggerEvents = GetDisposedLoggerEvents();
 
-        Assert.ThrowsException<ObjectDisposedException>(() => loggerEvents.RaiseTestResult(new TestResultEventArgs(new TestResult(new TestCase("This is a string.", new Uri("some://uri"), "DummySourceFileName")))));
+        Assert.ThrowsExactly<ObjectDisposedException>(() => loggerEvents.RaiseTestResult(new TestResultEventArgs(new TestResult(new TestCase("This is a string.", new Uri("some://uri"), "DummySourceFileName")))));
     }
 
     [TestMethod]
@@ -179,7 +179,7 @@ public class InternalTestLoggerEventsBehaviors
     {
         var loggerEvents = GetDisposedLoggerEvents();
 
-        Assert.ThrowsException<ObjectDisposedException>(() => loggerEvents.RaiseTestRunMessage(new TestRunMessageEventArgs(TestMessageLevel.Error, "This is a string.")));
+        Assert.ThrowsExactly<ObjectDisposedException>(() => loggerEvents.RaiseTestRunMessage(new TestRunMessageEventArgs(TestMessageLevel.Error, "This is a string.")));
     }
 
     [TestMethod]
@@ -187,7 +187,7 @@ public class InternalTestLoggerEventsBehaviors
     {
         var loggerEvents = GetDisposedLoggerEvents();
 
-        Assert.ThrowsException<ObjectDisposedException>(() => loggerEvents.CompleteTestRun(null, true, false, null, null, null, new TimeSpan()));
+        Assert.ThrowsExactly<ObjectDisposedException>(() => loggerEvents.CompleteTestRun(null, true, false, null, null, null, new TimeSpan()));
     }
 
     [TestMethod]
@@ -195,7 +195,7 @@ public class InternalTestLoggerEventsBehaviors
     {
         var loggerEvents = GetDisposedLoggerEvents();
 
-        Assert.ThrowsException<ObjectDisposedException>(() => loggerEvents.EnableEvents());
+        Assert.ThrowsExactly<ObjectDisposedException>(() => loggerEvents.EnableEvents());
     }
 
     [TestMethod]
@@ -231,7 +231,7 @@ public class InternalTestLoggerEventsBehaviors
     [TestMethod]
     public void RaiseDiscoveryStartShouldThrowExceptionIfNullDiscoveryStartEventArgsIsPassed()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _loggerEvents.RaiseDiscoveryStart(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _loggerEvents.RaiseDiscoveryStart(null!));
     }
 
     /// <summary>
@@ -240,7 +240,7 @@ public class InternalTestLoggerEventsBehaviors
     [TestMethod]
     public void RaiseDiscoveredTestsShouldThrowExceptionIfNullDiscoveredTestsEventArgsIsPassed()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _loggerEvents.RaiseDiscoveredTests(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _loggerEvents.RaiseDiscoveredTests(null!));
     }
 
     /// <summary>
@@ -253,7 +253,7 @@ public class InternalTestLoggerEventsBehaviors
         List<TestCase> testCases = [new TestCase("This is a string.", new Uri("some://uri"), "DummySourceFileName")];
         DiscoveredTestsEventArgs discoveredTestsEventArgs = new(testCases);
 
-        Assert.ThrowsException<ObjectDisposedException>(() => loggerEvents.RaiseDiscoveredTests(discoveredTestsEventArgs));
+        Assert.ThrowsExactly<ObjectDisposedException>(() => loggerEvents.RaiseDiscoveredTests(discoveredTestsEventArgs));
     }
 
     /// <summary>
@@ -294,7 +294,7 @@ public class InternalTestLoggerEventsBehaviors
     [TestMethod]
     public void RaiseDiscoveryCompleteShouldThrowExceptionIfNullDiscoveryCompleteEventArgsIsPassed()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _loggerEvents.RaiseDiscoveryComplete(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _loggerEvents.RaiseDiscoveryComplete(null!));
     }
 
     /// <summary>
@@ -307,7 +307,7 @@ public class InternalTestLoggerEventsBehaviors
         DiscoveryCriteria discoveryCriteria = new() { TestCaseFilter = "Name=Test1" };
         DiscoveryStartEventArgs discoveryStartEventArgs = new(discoveryCriteria);
 
-        Assert.ThrowsException<ObjectDisposedException>(() => loggerEvents.RaiseDiscoveryStart(discoveryStartEventArgs));
+        Assert.ThrowsExactly<ObjectDisposedException>(() => loggerEvents.RaiseDiscoveryStart(discoveryStartEventArgs));
     }
 
     /// <summary>
@@ -319,7 +319,7 @@ public class InternalTestLoggerEventsBehaviors
         var loggerEvents = GetDisposedLoggerEvents();
         DiscoveryCompleteEventArgs discoveryCompleteEventArgs = new(2, false);
 
-        Assert.ThrowsException<ObjectDisposedException>(() => loggerEvents.RaiseDiscoveryComplete(discoveryCompleteEventArgs));
+        Assert.ThrowsExactly<ObjectDisposedException>(() => loggerEvents.RaiseDiscoveryComplete(discoveryCompleteEventArgs));
     }
 
     /// <summary>
@@ -392,7 +392,7 @@ public class InternalTestLoggerEventsBehaviors
     [TestMethod]
     public void RaiseTestRunStartShouldThrowExceptionIfNullTestRunStartEventArgsIsPassed()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _loggerEvents.RaiseTestRunStart(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _loggerEvents.RaiseTestRunStart(null!));
     }
 
     /// <summary>
@@ -401,7 +401,7 @@ public class InternalTestLoggerEventsBehaviors
     [TestMethod]
     public void RaiseDiscoveryMessageShouldThrowExceptionIfNullTestRunMessageEventArgsIsPassed()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _loggerEvents.RaiseDiscoveryMessage(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _loggerEvents.RaiseDiscoveryMessage(null!));
     }
 
     /// <summary>
@@ -414,7 +414,7 @@ public class InternalTestLoggerEventsBehaviors
         TestRunCriteria testRunCriteria = new(new List<string> { @"x:dummy\foo.dll" }, 10, false, string.Empty, TimeSpan.MaxValue, null, "Name=Test1", null);
         TestRunStartEventArgs testRunStartEventArgs = new(testRunCriteria);
 
-        Assert.ThrowsException<ObjectDisposedException>(() => loggerEvents.RaiseTestRunStart(testRunStartEventArgs));
+        Assert.ThrowsExactly<ObjectDisposedException>(() => loggerEvents.RaiseTestRunStart(testRunStartEventArgs));
     }
 
     /// <summary>
@@ -427,7 +427,7 @@ public class InternalTestLoggerEventsBehaviors
         string message = "This is the test message";
         TestRunMessageEventArgs testRunMessageEventArgs = new(TestMessageLevel.Informational, message);
 
-        Assert.ThrowsException<ObjectDisposedException>(() => loggerEvents.RaiseDiscoveryMessage(testRunMessageEventArgs));
+        Assert.ThrowsExactly<ObjectDisposedException>(() => loggerEvents.RaiseDiscoveryMessage(testRunMessageEventArgs));
     }
 
     /// <summary>

--- a/test/Microsoft.TestPlatform.Common.UnitTests/RequestDataTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/RequestDataTests.cs
@@ -34,19 +34,17 @@ public class RequestDataTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void RequestDataShouldThrowArgumentNullExpectionOnNullMetricsCollection()
     {
         var requestData = new RequestData();
-        requestData.MetricsCollection = null!;
+        Assert.ThrowsExactly<ArgumentNullException>(() => requestData.MetricsCollection = null!);
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void RequestDataShouldThrowArgumentNullExpectionOnNullProtocolConfig()
     {
         var requestData = new RequestData();
-        requestData.ProtocolConfig = null;
+        Assert.ThrowsExactly<ArgumentNullException>(() => requestData.ProtocolConfig = null);
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Common.UnitTests/RunSettingsManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/RunSettingsManagerTests.cs
@@ -48,7 +48,7 @@ public class RunSettingsManagerTests
     {
         var instance = RunSettingsManager.Instance;
 
-        Assert.ThrowsException<ArgumentNullException>(() => instance.SetActiveRunSettings(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => instance.SetActiveRunSettings(null!));
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Common.UnitTests/RunSettingsTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/RunSettingsTests.cs
@@ -30,14 +30,14 @@ public class RunSettingsTests
     public void LoadSettingsXmlShouldThrowOnNullSettings()
     {
         var runSettings = new RunSettings();
-        Assert.ThrowsException<ArgumentException>(() => runSettings.LoadSettingsXml(null!));
+        Assert.ThrowsExactly<ArgumentException>(() => runSettings.LoadSettingsXml(null!));
     }
 
     [TestMethod]
     public void LoadSettingsXmlShouldThrowOnEmptySettings()
     {
         var runSettings = new RunSettings();
-        Assert.ThrowsException<ArgumentException>(() => runSettings.LoadSettingsXml("  "));
+        Assert.ThrowsExactly<ArgumentException>(() => runSettings.LoadSettingsXml("  "));
     }
 
     [TestMethod]
@@ -63,7 +63,7 @@ public class RunSettingsTests
         var runSettings = new RunSettings();
         var invalidSettings = GetInvalidRunSettings();
 
-        Assert.ThrowsException<SettingsException>(
+        Assert.ThrowsExactly<SettingsException>(
             () => runSettings.LoadSettingsXml(invalidSettings),
             "An error occurred while loading the run settings.");
     }
@@ -76,7 +76,7 @@ public class RunSettingsTests
     public void InitializeSettingsProvidersShouldThrowOnNullSettings()
     {
         var runSettings = new RunSettings();
-        Assert.ThrowsException<ArgumentNullException>(() => runSettings.InitializeSettingsProviders(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => runSettings.InitializeSettingsProviders(null!));
     }
 
     [TestMethod]
@@ -100,7 +100,7 @@ public class RunSettingsTests
         Action action =
             () => runSettings.GetSettings("OrphanNode");
 
-        Assert.ThrowsException<SettingsException>(
+        Assert.ThrowsExactly<SettingsException>(
             action,
             "Settings Provider named '{0}' was not found.  The settings can not be loaded.",
             "OrphanNode");
@@ -117,7 +117,7 @@ public class RunSettingsTests
         Action action =
             () => runSettings.GetSettings("BadSettings");
 
-        Assert.ThrowsException<SettingsException>(
+        Assert.ThrowsExactly<SettingsException>(
             action,
             "An error occurred while initializing the settings provider named '{0}'",
             "BadSettings");
@@ -127,7 +127,7 @@ public class RunSettingsTests
     public void InitializeSettingsProvidersShouldThrowIfInvalidRunSettingsIsPassed()
     {
         var runSettings = new RunSettings();
-        Assert.ThrowsException<SettingsException>(
+        Assert.ThrowsExactly<SettingsException>(
             () => runSettings.InitializeSettingsProviders(GetInvalidRunSettings()),
             "An error occurred while loading the run settings.");
     }
@@ -137,7 +137,7 @@ public class RunSettingsTests
     {
         var runSettings = new RunSettings();
         runSettings.InitializeSettingsProviders(GetEmptyRunSettings());
-        Assert.ThrowsException<InvalidOperationException>(
+        Assert.ThrowsExactly<InvalidOperationException>(
             () => runSettings.InitializeSettingsProviders(GetEmptyRunSettings()),
             "The Run Settings have already been loaded.");
     }
@@ -211,7 +211,7 @@ public class RunSettingsTests
     {
         var runSettings = new RunSettings();
 
-        Assert.ThrowsException<ArgumentException>(() => runSettings.GetSettings(null!));
+        Assert.ThrowsExactly<ArgumentException>(() => runSettings.GetSettings(null!));
     }
 
     [TestMethod]
@@ -219,7 +219,7 @@ public class RunSettingsTests
     {
         var runSettings = new RunSettings();
 
-        Assert.ThrowsException<ArgumentException>(() => runSettings.GetSettings("  "));
+        Assert.ThrowsExactly<ArgumentException>(() => runSettings.GetSettings("  "));
     }
 
     // The remaining GetSettings tests are covered in the InitializeSettingsProviders tests above.

--- a/test/Microsoft.TestPlatform.Common.UnitTests/SettingsProvider/SettingsProviderExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/SettingsProvider/SettingsProviderExtensionManagerTests.cs
@@ -132,8 +132,8 @@ public class SettingsProviderExtensionManagerTests
         };
         var spm = new TestableSettingsProviderManager(extensions, unfilteredExtensions, new Mock<IMessageLogger>().Object);
 
-        Assert.ThrowsException<ArgumentException>(() => spm.GetSettingsProvider(null!));
-        Assert.ThrowsException<ArgumentException>(() => spm.GetSettingsProvider(string.Empty));
+        Assert.ThrowsExactly<ArgumentException>(() => spm.GetSettingsProvider(null!));
+        Assert.ThrowsExactly<ArgumentException>(() => spm.GetSettingsProvider(string.Empty));
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Utilities/FakesUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Utilities/FakesUtilitiesTests.cs
@@ -19,13 +19,13 @@ public class FakesUtilitiesTests
     public void FakesSettingsShouldThrowExceptionIfSourcesArePassedAsNull()
     {
         string runSettingsXml = @"<RunSettings><RunConfiguration><TargetFrameworkVersion>.netstandard,Version=5.0</TargetFrameworkVersion></RunConfiguration ></RunSettings>";
-        Assert.ThrowsException<ArgumentNullException>(() => FakesUtilities.GenerateFakesSettingsForRunConfiguration(null!, runSettingsXml));
+        Assert.ThrowsExactly<ArgumentNullException>(() => FakesUtilities.GenerateFakesSettingsForRunConfiguration(null!, runSettingsXml));
     }
 
     [TestMethod]
     public void FakesSettingsShouldThrowExceptionIfRunSettingsIsPassedAsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => FakesUtilities.GenerateFakesSettingsForRunConfiguration([], null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => FakesUtilities.GenerateFakesSettingsForRunConfiguration([], null!));
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Utilities/RunSettingsUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Utilities/RunSettingsUtilitiesTests.cs
@@ -23,7 +23,7 @@ public class RunSettingsUtilitiesTests
     [TestMethod]
     public void CreateRunSettingsShouldThrowExceptionWhenInvalidXmlStringIsPassed()
     {
-        Assert.ThrowsException<SettingsException>(() => RunSettingsUtilities.CreateAndInitializeRunSettings("abc"));
+        Assert.ThrowsExactly<SettingsException>(() => RunSettingsUtilities.CreateAndInitializeRunSettings("abc"));
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/SocketClientTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/SocketClientTests.cs
@@ -113,7 +113,7 @@ public class SocketClientTests : SocketTestsBase, IDisposable
 
         // Validate that write on server side fails
         waitEvent.WaitOne(Timeout);
-        Assert.ThrowsException<IOException>(() => WriteData(Client!));
+        Assert.ThrowsExactly<IOException>(() => WriteData(Client!));
     }
 
     [TestMethod]
@@ -124,7 +124,7 @@ public class SocketClientTests : SocketTestsBase, IDisposable
         _socketClient.Stop();
 
         waitEvent.WaitOne(Timeout);
-        Assert.ThrowsException<CommunicationException>(() => channel!.Send(Dummydata));
+        Assert.ThrowsExactly<CommunicationException>(() => channel!.Send(Dummydata));
     }
 
     protected override ICommunicationChannel? SetupChannel(out ConnectedEventArgs? connectedEvent)

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/SocketCommunicationManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/SocketCommunicationManagerTests.cs
@@ -115,7 +115,7 @@ public class SocketCommunicationManagerTests : IDisposable
 
         _communicationManager.StopServer();
 
-        Assert.ThrowsException<AggregateException>(() => _tcpClient.ConnectAsync(IPAddress.Loopback, port).Wait());
+        Assert.ThrowsExactly<AggregateException>(() => _tcpClient.ConnectAsync(IPAddress.Loopback, port).Wait());
     }
 
     #endregion
@@ -169,7 +169,7 @@ public class SocketCommunicationManagerTests : IDisposable
         _communicationManager.StopClient();
 
         // Attempt to write on client socket should throw since it should have disconnected.
-        Assert.ThrowsException<SocketException>(() => WriteOnSocket(client.Client));
+        Assert.ThrowsExactly<SocketException>(() => WriteOnSocket(client.Client));
     }
 
     #endregion
@@ -300,8 +300,6 @@ public class SocketCommunicationManagerTests : IDisposable
         }
 
         clientThread.Join();
-
-        Assert.IsTrue(true);
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/SocketServerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/SocketServerTests.cs
@@ -78,7 +78,7 @@ public class SocketServerTests : SocketTestsBase, IDisposable
         _socketServer.Stop();
 
         waitEvent.WaitOne();
-        Assert.ThrowsException<IOException>(() => WriteData(_tcpClient));
+        Assert.ThrowsExactly<IOException>(() => WriteData(_tcpClient));
     }
 
     [TestMethod]
@@ -110,7 +110,7 @@ public class SocketServerTests : SocketTestsBase, IDisposable
         _socketServer.Stop();
 
         waitEvent.Wait();
-        Assert.ThrowsException<CommunicationException>(() => channel!.Send(Dummydata));
+        Assert.ThrowsExactly<CommunicationException>(() => channel!.Send(Dummydata));
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/AssemblyInitializer.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/AssemblyInitializer.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests;
+
+[TestClass]
+public static class AssemblyInitializer
+{
+    [AssemblyInitialize]
+    public static void SetTimeout(TestContext testContext)
+    {
+        // Set the value to 1 to avoid big timeouts for these unit tests. If you change the value you
+        // must do it at the start of a doNotParallelize test, to ensure you don't clean the default,
+        // because after it resets to 90 seconds.
+        Environment.SetEnvironmentVariable(EnvironmentHelper.VstestConnectionTimeout, "1");
+    }
+}

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/DataCollectionRequestHandlerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/DataCollectionRequestHandlerTests.cs
@@ -68,22 +68,16 @@ public class DataCollectionRequestHandlerTests
         _mockDataCollectionManager.Setup(x => x.SessionStarted(It.IsAny<SessionStartEventArgs>())).Returns(true);
     }
 
-    [TestCleanup]
-    public void Cleanup()
-    {
-        Environment.SetEnvironmentVariable(EnvironmentHelper.VstestConnectionTimeout, string.Empty);
-    }
-
     [TestMethod]
     public void CreateInstanceShouldThrowExceptionIfInstanceCommunicationManagerIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => DataCollectionRequestHandler.Create(null!, _mockMessageSink.Object));
+        Assert.ThrowsExactly<ArgumentNullException>(() => DataCollectionRequestHandler.Create(null!, _mockMessageSink.Object));
     }
 
     [TestMethod]
     public void CreateInstanceShouldThrowExceptinIfInstanceMessageSinkIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => DataCollectionRequestHandler.Create(_mockCommunicationManager.Object, null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => DataCollectionRequestHandler.Create(_mockCommunicationManager.Object, null!));
     }
 
     [TestMethod]
@@ -107,7 +101,7 @@ public class DataCollectionRequestHandlerTests
     {
         _mockCommunicationManager.Setup(x => x.SetupClientAsync(It.IsAny<IPEndPoint>())).Throws<Exception>();
 
-        Assert.ThrowsException<Exception>(() => _requestHandler.InitializeCommunication(123));
+        Assert.ThrowsExactly<Exception>(() => _requestHandler.InitializeCommunication(123));
     }
 
     [TestMethod]
@@ -123,7 +117,7 @@ public class DataCollectionRequestHandlerTests
     {
         _mockCommunicationManager.Setup(x => x.WaitForServerConnection(It.IsAny<int>())).Throws<Exception>();
 
-        Assert.ThrowsException<Exception>(() => _requestHandler.WaitForRequestSenderConnection(0));
+        Assert.ThrowsExactly<Exception>(() => _requestHandler.WaitForRequestSenderConnection(0));
     }
 
     [TestMethod]
@@ -142,7 +136,7 @@ public class DataCollectionRequestHandlerTests
         _mockCommunicationManager.Setup(x => x.SendMessage(MessageType.DataCollectionMessage, It.IsAny<DataCollectionMessageEventArgs>())).Throws<Exception>();
         var message = new DataCollectionMessageEventArgs(TestMessageLevel.Error, "message");
 
-        Assert.ThrowsException<Exception>(() => _requestHandler.SendDataCollectionMessage(message));
+        Assert.ThrowsExactly<Exception>(() => _requestHandler.SendDataCollectionMessage(message));
     }
 
     [TestMethod]
@@ -158,7 +152,7 @@ public class DataCollectionRequestHandlerTests
     {
         _mockCommunicationManager.Setup(x => x.StopClient()).Throws<Exception>();
 
-        Assert.ThrowsException<Exception>(() => _requestHandler.Close());
+        Assert.ThrowsExactly<Exception>(() => _requestHandler.Close());
     }
 
     [TestMethod]
@@ -258,7 +252,7 @@ public class DataCollectionRequestHandlerTests
     {
         _mockCommunicationManager.Setup(x => x.ReceiveMessage()).Throws<Exception>();
 
-        Assert.ThrowsException<Exception>(() => _requestHandler.ProcessRequests());
+        Assert.ThrowsExactly<Exception>(() => _requestHandler.ProcessRequests());
     }
 
     [TestMethod]
@@ -276,8 +270,12 @@ public class DataCollectionRequestHandlerTests
     }
 
     [TestMethod]
+    [DoNotParallelize]
     public void ProcessRequestsShouldSetDefaultTimeoutIfNoEnvVarialbeSet()
     {
+        // Make sure to use do-not parallelize because you set non-default value to the env variable.
+        using var _ = ResetableEnvironment.SetEnvironmentVariable(EnvironmentHelper.VstestConnectionTimeout, null);
+
         var beforeTestRunSTartPayload = new BeforeTestRunStartPayload { SettingsXml = "settingsxml", Sources = new List<string> { "test1.dll" } };
         _mockDataSerializer.Setup(x => x.DeserializePayload<BeforeTestRunStartPayload>(It.Is<Message>(y => y.MessageType == MessageType.BeforeTestRunStart)))
             .Returns(beforeTestRunSTartPayload);
@@ -288,10 +286,12 @@ public class DataCollectionRequestHandlerTests
     }
 
     [TestMethod]
+    [DoNotParallelize]
     public void ProcessRequestsShouldSetTimeoutBasedOnEnvVariable()
     {
         var timeout = 10;
-        Environment.SetEnvironmentVariable(EnvironmentHelper.VstestConnectionTimeout, timeout.ToString(CultureInfo.InvariantCulture));
+        // Make sure to use do-not parallelize because you set non-default value to the env variable.
+        using var _ = ResetableEnvironment.SetEnvironmentVariable(EnvironmentHelper.VstestConnectionTimeout, timeout.ToString(CultureInfo.InvariantCulture));
         var beforeTestRunSTartPayload = new BeforeTestRunStartPayload { SettingsXml = "settingsxml", Sources = new List<string> { "test1.dll" } };
         _mockDataSerializer.Setup(x => x.DeserializePayload<BeforeTestRunStartPayload>(It.Is<Message>(y => y.MessageType == MessageType.BeforeTestRunStart)))
             .Returns(beforeTestRunSTartPayload);

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/DataCollectionTestCaseEventHandlerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/DataCollectionTestCaseEventHandlerTests.cs
@@ -52,7 +52,7 @@ public class DataCollectionTestCaseEventHandlerTests
     public void InitializeShouldThrowExceptionIfExceptionIsThrownByCommunicationManager()
     {
         _mockCommunicationManager.Setup(x => x.HostServer(new IPEndPoint(IPAddress.Loopback, 0))).Throws<Exception>();
-        Assert.ThrowsException<Exception>(() => _requestHandler.InitializeCommunication());
+        Assert.ThrowsExactly<Exception>(() => _requestHandler.InitializeCommunication());
     }
 
     [TestMethod]
@@ -70,7 +70,7 @@ public class DataCollectionTestCaseEventHandlerTests
     {
         _mockCommunicationManager.Setup(x => x.WaitForClientConnection(It.IsAny<int>())).Throws<Exception>();
 
-        Assert.ThrowsException<Exception>(() => _requestHandler.WaitForRequestHandlerConnection(10));
+        Assert.ThrowsExactly<Exception>(() => _requestHandler.WaitForRequestHandlerConnection(10));
     }
 
     [TestMethod]
@@ -86,7 +86,7 @@ public class DataCollectionTestCaseEventHandlerTests
     {
         _mockCommunicationManager.Setup(x => x.StopServer()).Throws<Exception>();
 
-        Assert.ThrowsException<Exception>(
+        Assert.ThrowsExactly<Exception>(
             () => _requestHandler.Close());
     }
 
@@ -141,6 +141,6 @@ public class DataCollectionTestCaseEventHandlerTests
     {
         _mockCommunicationManager.Setup(x => x.ReceiveMessage()).Throws<Exception>();
 
-        Assert.ThrowsException<Exception>(() => _requestHandler.ProcessRequests());
+        Assert.ThrowsExactly<Exception>(() => _requestHandler.ProcessRequests());
     }
 }

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/DataCollectionTestCaseEventSenderTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/DataCollectionTestCaseEventSenderTests.cs
@@ -45,7 +45,7 @@ public class DataCollectionTestCaseEventSenderTests
     {
         _mockCommunicationManager.Setup(x => x.SetupClientAsync(It.IsAny<IPEndPoint>())).Throws<Exception>();
 
-        Assert.ThrowsException<Exception>(() => _dataCollectionTestCaseEventSender.InitializeCommunication(123));
+        Assert.ThrowsExactly<Exception>(() => _dataCollectionTestCaseEventSender.InitializeCommunication(123));
     }
 
     [TestMethod]
@@ -61,7 +61,7 @@ public class DataCollectionTestCaseEventSenderTests
     {
         _mockCommunicationManager.Setup(x => x.WaitForServerConnection(It.IsAny<int>())).Throws<Exception>();
 
-        Assert.ThrowsException<Exception>(() => _dataCollectionTestCaseEventSender.WaitForRequestSenderConnection(123));
+        Assert.ThrowsExactly<Exception>(() => _dataCollectionTestCaseEventSender.WaitForRequestSenderConnection(123));
     }
 
     [TestMethod]
@@ -77,7 +77,7 @@ public class DataCollectionTestCaseEventSenderTests
     {
         _mockCommunicationManager.Setup(x => x.StopClient()).Throws<Exception>();
 
-        Assert.ThrowsException<Exception>(() => _dataCollectionTestCaseEventSender.Close());
+        Assert.ThrowsExactly<Exception>(() => _dataCollectionTestCaseEventSender.Close());
     }
 
     [TestMethod]
@@ -97,7 +97,7 @@ public class DataCollectionTestCaseEventSenderTests
         var testcaseStartEventArgs = new TestCaseStartEventArgs(_testCase);
         _mockCommunicationManager.Setup(x => x.SendMessage(MessageType.DataCollectionTestStart, testcaseStartEventArgs)).Throws<Exception>();
 
-        Assert.ThrowsException<Exception>(() => _dataCollectionTestCaseEventSender.SendTestCaseStart(testcaseStartEventArgs));
+        Assert.ThrowsExactly<Exception>(() => _dataCollectionTestCaseEventSender.SendTestCaseStart(testcaseStartEventArgs));
     }
 
     [TestMethod]
@@ -120,6 +120,6 @@ public class DataCollectionTestCaseEventSenderTests
 
         _mockCommunicationManager.Setup(x => x.SendMessage(MessageType.DataCollectionTestEnd, It.IsAny<TestCaseEndEventArgs>())).Throws<Exception>();
 
-        Assert.ThrowsException<Exception>(() => _dataCollectionTestCaseEventSender.SendTestCaseEnd(testCaseEndEventArgs));
+        Assert.ThrowsExactly<Exception>(() => _dataCollectionTestCaseEventSender.SendTestCaseEnd(testCaseEndEventArgs));
     }
 }

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/ResetableEnvironment.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/ResetableEnvironment.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.TestPlatform.CommunicationUtilities.UnitTests;
+
+internal class ResetableEnvironment
+{
+    /// <summary>
+    /// Sets environment variable and resets it when returned object is disposed. Use with `using`.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static DisposableVariable SetEnvironmentVariable(string name, string? value)
+    {
+        string? originalValue = Environment.GetEnvironmentVariable(name);
+
+        Environment.SetEnvironmentVariable(name, value);
+
+        return new DisposableVariable(name, originalValue);
+    }
+}
+
+internal class DisposableVariable : IDisposable
+{
+    private readonly string _name;
+    private readonly string? _originalValue;
+
+    public DisposableVariable(string name, string? originalValue)
+    {
+        _name = name;
+        _originalValue = originalValue;
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(_name, _originalValue);
+    }
+}

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/Serialization/TestResultSerializationTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/Serialization/TestResultSerializationTests.cs
@@ -284,7 +284,7 @@ public class TestResultSerializationTests
         // only checked for version 2
         var version = int.MaxValue;
 
-        Assert.ThrowsException<NotSupportedException>(() => Serialize(TestResult, version));
+        Assert.ThrowsExactly<NotSupportedException>(() => Serialize(TestResult, version));
     }
 
     #endregion

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
@@ -63,12 +63,6 @@ public class TestRequestSenderTests
         _testRunCriteriaWithSources = new TestRunCriteriaWithSources(new Dictionary<string, IEnumerable<string>>(), "runsettings", null, null!);
     }
 
-    [TestCleanup]
-    public void Cleanup()
-    {
-        Environment.SetEnvironmentVariable(EnvironmentHelper.VstestConnectionTimeout, string.Empty);
-    }
-
     [TestMethod]
     public void InitializeCommunicationShouldHostServerAndAcceptClient()
     {
@@ -203,7 +197,7 @@ public class TestRequestSenderTests
         _mockChannel.Verify(mockChannel => mockChannel.Send(MessageType.CancelTestRun), Times.Never);
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow("")]
     [DataRow(" ")]
     [DataRow(null)]
@@ -263,7 +257,7 @@ public class TestRequestSenderTests
         SetupRaiseMessageReceivedOnCheckVersion();
         SetupFakeCommunicationChannel();
 
-        Assert.ThrowsException<TestPlatformException>(() => _testRequestSender.CheckVersionWithTestHost());
+        Assert.ThrowsExactly<TestPlatformException>(() => _testRequestSender.CheckVersionWithTestHost());
     }
 
     [TestMethod]
@@ -273,17 +267,19 @@ public class TestRequestSenderTests
         SetupRaiseMessageReceivedOnCheckVersion();
         SetupFakeCommunicationChannel();
 
-        Assert.ThrowsException<TestPlatformException>(() => _testRequestSender.CheckVersionWithTestHost());
+        Assert.ThrowsExactly<TestPlatformException>(() => _testRequestSender.CheckVersionWithTestHost());
     }
 
     [TestMethod]
+    [DoNotParallelize]
     public void CheckVersionWithTestHostShouldThrowIfProtocolNegotiationTimeouts()
     {
+        // Make sure to use do-not parallelize because you set non-default value to the env variable.
         Environment.SetEnvironmentVariable(EnvironmentHelper.VstestConnectionTimeout, "0");
 
         SetupFakeCommunicationChannel();
 
-        var message = Assert.ThrowsException<TestPlatformException>(() => _testRequestSender.CheckVersionWithTestHost()).Message;
+        var message = Assert.ThrowsExactly<TestPlatformException>(() => _testRequestSender.CheckVersionWithTestHost()).Message;
 
         Assert.AreEqual(message, TimoutErrorMessage);
     }

--- a/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Helpers/DotnetHostHelperTest.cs
+++ b/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Helpers/DotnetHostHelperTest.cs
@@ -44,7 +44,7 @@ public sealed class DotnetHostHelperTest : IDisposable
         Assert.AreEqual(finalMuxerPath, muxerPath);
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(PlatformArchitecture.X86, PlatformArchitecture.X64, PlatformOperatingSystem.Windows, "DOTNET_ROOT(x86)")]
     [DataRow(PlatformArchitecture.X86, PlatformArchitecture.X64, PlatformOperatingSystem.Windows, "DOTNET_ROOT")]
     [DataRow(PlatformArchitecture.X86, PlatformArchitecture.X64, PlatformOperatingSystem.Windows, "DOTNET_ROOT(x86)", true, DotnetMuxerResolutionStrategy.DotnetRootArchitectureLess)]
@@ -112,7 +112,7 @@ public sealed class DotnetHostHelperTest : IDisposable
         Assert.AreEqual(found ? envVars[envVar] : null, muxerPath);
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow("DOTNET_ROOT_ARM64", "DOTNET_ROOT", PlatformArchitecture.ARM64, PlatformArchitecture.X64)]
     [DataRow("DOTNET_ROOT(x86)", "DOTNET_ROOT", PlatformArchitecture.X86, PlatformArchitecture.X64)]
     [DataRow("DOTNET_ROOT_ARM64", "DOTNET_ROOT", PlatformArchitecture.ARM64, PlatformArchitecture.X64, DotnetMuxerResolutionStrategy.DotnetRootArchitecture | DotnetMuxerResolutionStrategy.DotnetRootArchitectureLess)]
@@ -151,7 +151,7 @@ public sealed class DotnetHostHelperTest : IDisposable
         Assert.AreEqual(envVars[nextEnv], muxerPath);
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(PlatformArchitecture.X64, PlatformArchitecture.X64, true)]
     [DataRow(PlatformArchitecture.X64, PlatformArchitecture.X86, false)]
     [DataRow(PlatformArchitecture.X64, PlatformArchitecture.X64, true, DotnetMuxerResolutionStrategy.GlobalInstallationLocation)]
@@ -180,7 +180,7 @@ public sealed class DotnetHostHelperTest : IDisposable
         Assert.AreEqual(found ? dotnetMuxer : null, muxerPath);
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(true, false, false, false)]
     [DataRow(false, true, false, false)]
     [DataRow(false, false, true, false)]
@@ -215,7 +215,7 @@ public sealed class DotnetHostHelperTest : IDisposable
         Assert.IsFalse(dotnetHostHelper.TryGetDotnetPathByArchitecture(PlatformArchitecture.X64, strategy, out string? muxerPath));
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(PlatformArchitecture.ARM64, "/etc/dotnet/install_location_arm64", true, PlatformOperatingSystem.OSX)]
     [DataRow(PlatformArchitecture.X64, "/etc/dotnet/install_location_x64", true, PlatformOperatingSystem.OSX)]
     [DataRow(PlatformArchitecture.ARM64, "/etc/dotnet/install_location", true, PlatformOperatingSystem.OSX)]
@@ -261,7 +261,7 @@ public sealed class DotnetHostHelperTest : IDisposable
         Assert.AreEqual(found ? dotnetMuxer : null, muxerPath);
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(PlatformArchitecture.X86, PlatformArchitecture.X64, "ProgramFiles(x86)", "dotnet", true)]
     [DataRow(PlatformArchitecture.X64, PlatformArchitecture.ARM64, "ProgramFiles", @"dotnet\x64", true)]
     [DataRow(PlatformArchitecture.X64, PlatformArchitecture.X64, "ProgramFiles", "dotnet", true)]
@@ -299,7 +299,7 @@ public sealed class DotnetHostHelperTest : IDisposable
     }
 
 #pragma warning disable MSTEST0042 // duplicate data row - TODO: Look more into it
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(PlatformArchitecture.X64, PlatformArchitecture.X64, "/usr/local/share/dotnet", "", true, PlatformOperatingSystem.OSX)]
     [DataRow(PlatformArchitecture.X64, PlatformArchitecture.ARM64, "/usr/local/share/dotnet/x64", "", true, PlatformOperatingSystem.OSX)]
     [DataRow(PlatformArchitecture.ARM64, PlatformArchitecture.X64, "/usr/local/share/dotnet", "", true, PlatformOperatingSystem.OSX)]

--- a/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Tracing/EqtTraceTests.cs
+++ b/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Tracing/EqtTraceTests.cs
@@ -41,7 +41,7 @@ public class EqtTraceTests
     [TestMethod]
     public void CheckInitializeLogFileTest()
     {
-        Assert.AreEqual(s_logFile, EqtTrace.LogFile, "Expected log file to be {0}", s_logFile);
+        Assert.AreEqual(s_logFile, EqtTrace.LogFile, $"Expected log file to be {s_logFile}");
     }
 
     [TestMethod]
@@ -52,7 +52,7 @@ public class EqtTraceTests
 #else
         EqtTrace.TraceLevel = PlatformTraceLevel.Verbose;
 #endif
-        Assert.IsTrue(EqtTrace.IsVerboseEnabled, "Expected trace state to be verbose actual state {0}", EqtTrace.IsVerboseEnabled);
+        Assert.IsTrue(EqtTrace.IsVerboseEnabled, $"Expected trace state to be verbose actual state {EqtTrace.IsVerboseEnabled}");
     }
 
     [TestMethod]
@@ -63,7 +63,7 @@ public class EqtTraceTests
 #else
         EqtTrace.TraceLevel = PlatformTraceLevel.Error;
 #endif
-        Assert.IsTrue(EqtTrace.IsErrorEnabled, "Expected trace state to be error actual state {0}", EqtTrace.IsErrorEnabled);
+        Assert.IsTrue(EqtTrace.IsErrorEnabled, $"Expected trace state to be error actual state {EqtTrace.IsErrorEnabled}");
     }
 
     [TestMethod]
@@ -74,7 +74,7 @@ public class EqtTraceTests
 #else
         EqtTrace.TraceLevel = PlatformTraceLevel.Info;
 #endif
-        Assert.IsTrue(EqtTrace.IsInfoEnabled, "Expected trace state to be info actual state {0}", EqtTrace.IsInfoEnabled);
+        Assert.IsTrue(EqtTrace.IsInfoEnabled, $"Expected trace state to be info actual state {EqtTrace.IsInfoEnabled}");
     }
 
     [TestMethod]
@@ -85,7 +85,7 @@ public class EqtTraceTests
 #else
         EqtTrace.TraceLevel = PlatformTraceLevel.Warning;
 #endif
-        Assert.IsTrue(EqtTrace.IsWarningEnabled, "Expected trace state to be warning actual state {0}", EqtTrace.IsWarningEnabled);
+        Assert.IsTrue(EqtTrace.IsWarningEnabled, $"Expected trace state to be warning actual state {EqtTrace.IsWarningEnabled}");
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Utilities/JobQueueTests.cs
+++ b/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Utilities/JobQueueTests.cs
@@ -17,7 +17,7 @@ public class JobQueueTests
     public void ConstructorThrowsWhenNullProcessHandlerIsProvided()
     {
         JobQueue<string>? jobQueue = null;
-        Assert.ThrowsException<ArgumentNullException>(() => jobQueue = new JobQueue<string>(null!, "dp", int.MaxValue, int.MaxValue, false, (message) => { }));
+        Assert.ThrowsExactly<ArgumentNullException>(() => jobQueue = new JobQueue<string>(null!, "dp", int.MaxValue, int.MaxValue, false, (message) => { }));
 
         if (jobQueue != null)
         {
@@ -29,9 +29,9 @@ public class JobQueueTests
     public void ThrowsWhenNullEmptyOrWhiteSpaceDisplayNameIsProvided()
     {
         JobQueue<string>? jobQueue = null;
-        Assert.ThrowsException<ArgumentException>(() => jobQueue = new JobQueue<string>(GetEmptyProcessHandler<string>(), null!, int.MaxValue, int.MaxValue, false, (message) => { }));
-        Assert.ThrowsException<ArgumentException>(() => jobQueue = new JobQueue<string>(GetEmptyProcessHandler<string>(), "", int.MaxValue, int.MaxValue, false, (message) => { }));
-        Assert.ThrowsException<ArgumentException>(() => jobQueue = new JobQueue<string>(GetEmptyProcessHandler<string>(), "    ", int.MaxValue, int.MaxValue, false, (message) => { }));
+        Assert.ThrowsExactly<ArgumentException>(() => jobQueue = new JobQueue<string>(GetEmptyProcessHandler<string>(), null!, int.MaxValue, int.MaxValue, false, (message) => { }));
+        Assert.ThrowsExactly<ArgumentException>(() => jobQueue = new JobQueue<string>(GetEmptyProcessHandler<string>(), "", int.MaxValue, int.MaxValue, false, (message) => { }));
+        Assert.ThrowsExactly<ArgumentException>(() => jobQueue = new JobQueue<string>(GetEmptyProcessHandler<string>(), "    ", int.MaxValue, int.MaxValue, false, (message) => { }));
 
         if (jobQueue != null)
         {
@@ -86,7 +86,7 @@ public class JobQueueTests
         var queue = new JobQueue<string>(GetEmptyProcessHandler<string>(), "dp", int.MaxValue, int.MaxValue, false, (message) => { });
         queue.Dispose();
 
-        Assert.ThrowsException<ObjectDisposedException>(() => queue.QueueJob("dp", 0));
+        Assert.ThrowsExactly<ObjectDisposedException>(() => queue.QueueJob("dp", 0));
     }
 
     [TestMethod]
@@ -95,7 +95,7 @@ public class JobQueueTests
         var queue = new JobQueue<string>(GetEmptyProcessHandler<string>(), "dp", int.MaxValue, int.MaxValue, false, (message) => { });
         queue.Dispose();
 
-        Assert.ThrowsException<ObjectDisposedException>(() => queue.Resume());
+        Assert.ThrowsExactly<ObjectDisposedException>(() => queue.Resume());
     }
 
     [TestMethod]
@@ -104,7 +104,7 @@ public class JobQueueTests
         var queue = new JobQueue<string>(GetEmptyProcessHandler<string>(), "dp", int.MaxValue, int.MaxValue, false, (message) => { });
         queue.Dispose();
 
-        Assert.ThrowsException<ObjectDisposedException>(() => queue.Pause());
+        Assert.ThrowsExactly<ObjectDisposedException>(() => queue.Pause());
     }
 
     [TestMethod]
@@ -113,7 +113,7 @@ public class JobQueueTests
         var queue = new JobQueue<string>(GetEmptyProcessHandler<string>(), "dp", int.MaxValue, int.MaxValue, false, (message) => { });
         queue.Dispose();
 
-        Assert.ThrowsException<ObjectDisposedException>(() => queue.Flush());
+        Assert.ThrowsExactly<ObjectDisposedException>(() => queue.Flush());
     }
 
     [TestMethod]
@@ -155,7 +155,7 @@ public class JobQueueTests
         using var queue = new JobQueue<string>(GetEmptyProcessHandler<string>(), "dp", int.MaxValue, int.MaxValue, false, (message) => { });
         queue.Pause();
 
-        Assert.ThrowsException<InvalidOperationException>(() => queue.Dispose());
+        Assert.ThrowsExactly<InvalidOperationException>(() => queue.Dispose());
 
         queue.Resume();
     }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Adapter/FrameworkHandleTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Adapter/FrameworkHandleTests.cs
@@ -44,7 +44,7 @@ public class FrameworkHandleTests
         var frameworkHandle = new FrameworkHandle(null, new TestRunCache(100, TimeSpan.MaxValue, (s, r, ip) => { }), tec, null!);
         frameworkHandle.Dispose();
 
-        Assert.ThrowsException<ObjectDisposedException>(() => frameworkHandle.LaunchProcessWithDebuggerAttached(null!, null!, null!, null!));
+        Assert.ThrowsExactly<ObjectDisposedException>(() => frameworkHandle.LaunchProcessWithDebuggerAttached(null!, null!, null!, null!));
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/AttachmentsProcessing/DataCollectorAttachmentProcessorAppDomainTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/AttachmentsProcessing/DataCollectorAttachmentProcessorAppDomainTests.cs
@@ -68,7 +68,7 @@ public class DataCollectorAttachmentProcessorAppDomainTests
         Task runProcessing = dcap.ProcessAttachmentSetsAsync(doc.DocumentElement, attachments, new Progress<int>((int report) => cts.Cancel()), _loggerMock.Object, cts.Token);
 
         //assert
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () => await runProcessing);
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(async () => await runProcessing);
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/AttachmentsProcessing/TestRunAttachmentsProcessingManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/AttachmentsProcessing/TestRunAttachmentsProcessingManagerTests.cs
@@ -603,7 +603,7 @@ public class TestRunAttachmentsProcessingManagerTests
         _mockAttachmentHandler2.Verify(h => h.ProcessAttachmentSetsAsync(It.IsAny<XmlElement>(), It.IsAny<ICollection<AttachmentSet>>(), It.IsAny<IProgress<int>>(), It.IsAny<IMessageLogger>(), It.IsAny<CancellationToken>()));
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(true)]
     [DataRow(false)]
     public async Task ProcessTestRunAttachmentsAsync_ShouldFlowCorrectDataCollectorConfiguration(bool withConfig)

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/DiscoveryDataAggregatorTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/DiscoveryDataAggregatorTests.cs
@@ -235,7 +235,7 @@ public class DiscoveryDataAggregatorTests
         Assert.IsFalse(runMetrics.TryGetValue(TelemetryDataConstants.NumberOfAdapterDiscoveredDuringDiscovery, out _));
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(DiscoveryStatus.FullyDiscovered)]
     [DataRow(DiscoveryStatus.PartiallyDiscovered)]
     [DataRow(DiscoveryStatus.NotDiscovered)]
@@ -253,7 +253,7 @@ public class DiscoveryDataAggregatorTests
         Assert.AreEqual(0, dataAggregator.GetSourcesWithStatus(DiscoveryStatus.NotDiscovered).Count);
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(DiscoveryStatus.FullyDiscovered)]
     [DataRow(DiscoveryStatus.PartiallyDiscovered)]
     [DataRow(DiscoveryStatus.NotDiscovered)]
@@ -273,7 +273,7 @@ public class DiscoveryDataAggregatorTests
         CollectionAssert.AreEquivalent(new[] { "a", "b" }, dataAggregator.GetSourcesWithStatus(discoveryStatus));
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(DiscoveryStatus.FullyDiscovered)]
     [DataRow(DiscoveryStatus.PartiallyDiscovered)]
     public void MarkSourcesWithStatusWhenSourceAddedAndStatusDifferentFromNotDiscoveredLogsWarning(DiscoveryStatus discoveryStatus)
@@ -288,7 +288,7 @@ public class DiscoveryDataAggregatorTests
         CollectionAssert.AreEquivalent(new[] { "a" }, dataAggregator.GetSourcesWithStatus(discoveryStatus));
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(DiscoveryStatus.NotDiscovered)]
     [DataRow(DiscoveryStatus.PartiallyDiscovered)]
     public void MarkSourcesWithStatusWhenSourceStatusWasFullyDiscoveredAndIsDowngradedLogsWarning(DiscoveryStatus discoveryStatus)
@@ -356,7 +356,7 @@ public class DiscoveryDataAggregatorTests
         CollectionAssert.AreEquivalent(new[] { "b" }, dataAggregator.GetSourcesWithStatus(DiscoveryStatus.PartiallyDiscovered));
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(DiscoveryStatus.FullyDiscovered)]
     [DataRow(DiscoveryStatus.PartiallyDiscovered)]
     [DataRow(DiscoveryStatus.NotDiscovered)]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelProxyDiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelProxyDiscoveryManagerTests.cs
@@ -382,14 +382,14 @@ public class ParallelProxyDiscoveryManagerTests
                 {
                     if (matchFound)
                     {
-                        Assert.Fail("Concurrency issue detected: Source['{0}'] got processed twice", processedSrc);
+                        Assert.Fail($"Concurrency issue detected: Source['{processedSrc}'] got processed twice");
                     }
 
                     matchFound = true;
                 }
             }
 
-            Assert.IsTrue(matchFound, "Concurrency issue detected: Source['{0}'] did NOT get processed at all", source);
+            Assert.IsTrue(matchFound, $"Concurrency issue detected: Source['{source}'] did NOT get processed at all");
         }
     }
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/Parallel/ParallelProxyExecutionManagerTests.cs
@@ -471,7 +471,7 @@ public class ParallelProxyExecutionManagerTests
                 {
                     if (matchFound)
                     {
-                        Assert.Fail("Concurrreny issue detected: Source['{0}'] got processed twice", processedSrc);
+                        Assert.Fail($"Concurrreny issue detected: Source['{processedSrc}'] got processed twice");
                     }
 
                     matchFound = true;
@@ -505,13 +505,12 @@ public class ParallelProxyExecutionManagerTests
                 if (processedTest.FullyQualifiedName.Equals(test.FullyQualifiedName))
                 {
                     if (matchFound)
-                        Assert.Fail("Concurrency issue detected: Test['{0}'] got processed twice", test.FullyQualifiedName);
+                        Assert.Fail($"Concurrency issue detected: Test['{test.FullyQualifiedName}'] got processed twice");
                     matchFound = true;
                 }
             }
 
-            Assert.IsTrue(matchFound, "Concurrency issue detected: Test['{0}'] did NOT get processed at all",
-                test.FullyQualifiedName);
+            Assert.IsTrue(matchFound, $"Concurrency issue detected: Test['{test.FullyQualifiedName}'] did NOT get processed at all");
         }
     }
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
@@ -610,7 +610,7 @@ public class ProxyDiscoveryManagerTests : ProxyBaseManagerTests
             _discoveryDataAggregator.GetSourcesWithStatus(DiscoveryStatus.FullyDiscovered));
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(true)]
     [DataRow(false)]
     public void HandleDiscoveryCompleteWhenAbortedNoPastDiscoveryAndNoLastCunkNotifiesWithCorrectDiscovery(bool trueIsEmptyFalseIsNull)
@@ -635,7 +635,7 @@ public class ProxyDiscoveryManagerTests : ProxyBaseManagerTests
         Assert.AreEqual(0, _discoveryDataAggregator.GetSourcesWithStatus(DiscoveryStatus.FullyDiscovered).Count);
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(true)]
     [DataRow(false)]
     public void HandleDiscoveryCompleteWhenAbortedPastDiscoveryAndNoLastCunkNotifiesWithCorrectDiscovery(bool trueIsEmptyFalseIsNull)

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
@@ -298,7 +298,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
         _mockTestHostManager.Setup(tmh => tmh.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(false));
 
-        Assert.ThrowsException<TestPlatformException>(() => _testExecutionManager.SetupChannel(new List<string> { "source.dll" }, runsettings));
+        Assert.ThrowsExactly<TestPlatformException>(() => _testExecutionManager.SetupChannel(new List<string> { "source.dll" }, runsettings));
     }
 
     [TestMethod]
@@ -309,7 +309,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
         _mockTestHostManager.Setup(tmh => tmh.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(true)).Callback(() => _mockTestHostManager.Raise(t => t.HostExited += null, new HostProviderEventArgs("I crashed!")));
 
-        Assert.AreEqual(string.Format(CultureInfo.CurrentCulture, CrossPlatEngineResources.Resources.TestHostExitedWithError, "source.dll", "I crashed!"), Assert.ThrowsException<TestPlatformException>(() => _testExecutionManager.SetupChannel(new List<string> { "source.dll" }, runsettings)).Message);
+        Assert.AreEqual(string.Format(CultureInfo.CurrentCulture, CrossPlatEngineResources.Resources.TestHostExitedWithError, "source.dll", "I crashed!"), Assert.ThrowsExactly<TestPlatformException>(() => _testExecutionManager.SetupChannel(new List<string> { "source.dll" }, runsettings)).Message);
     }
 
     [TestMethod]
@@ -320,7 +320,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
         _mockTestHostManager.Setup(tmh => tmh.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(true)).Callback(() => _mockTestHostManager.Raise(t => t.HostExited += null, new HostProviderEventArgs("I crashed!")));
 
-        Assert.AreEqual(string.Format(CultureInfo.CurrentCulture, CrossPlatEngineResources.Resources.TestHostExitedWithError, string.Join("', '", ["source1.dll", "source2.dll"]), "I crashed!"), Assert.ThrowsException<TestPlatformException>(() => _testExecutionManager.SetupChannel(new List<string> { "source1.dll", "source2.dll" }, runsettings)).Message);
+        Assert.AreEqual(string.Format(CultureInfo.CurrentCulture, CrossPlatEngineResources.Resources.TestHostExitedWithError, string.Join("', '", ["source1.dll", "source2.dll"]), "I crashed!"), Assert.ThrowsExactly<TestPlatformException>(() => _testExecutionManager.SetupChannel(new List<string> { "source1.dll", "source2.dll" }, runsettings)).Message);
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerWithDataCollectionTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerWithDataCollectionTests.cs
@@ -67,7 +67,7 @@ public class ProxyExecutionManagerWithDataCollectionTests
     {
         _mockDataCollectionManager.Setup(x => x.Initialize()).Throws<Exception>();
 
-        Assert.ThrowsException<Exception>(() => _proxyExecutionManager.Initialize(false));
+        Assert.ThrowsExactly<Exception>(() => _proxyExecutionManager.Initialize(false));
     }
 
     [TestMethod]
@@ -75,7 +75,7 @@ public class ProxyExecutionManagerWithDataCollectionTests
     {
         _mockDataCollectionManager.Setup(dc => dc.BeforeTestRunStart(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<ITestMessageEventHandler>())).Throws(new Exception("MyException"));
 
-        Assert.ThrowsException<Exception>(() => _proxyExecutionManager.Initialize(false));
+        Assert.ThrowsExactly<Exception>(() => _proxyExecutionManager.Initialize(false));
 
         _mockDataCollectionManager.Verify(dc => dc.BeforeTestRunStart(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<ITestMessageEventHandler>()), Times.Once);
         _mockDataCollectionManager.Verify(dc => dc.AfterTestRunEnd(It.IsAny<bool>(), It.IsAny<ITestMessageEventHandler>()), Times.Once);

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
@@ -278,7 +278,7 @@ public class ProxyOperationManagerTests : ProxyBaseManagerTests
 
         var operationManager = new TestableProxyOperationManager(_mockRequestData.Object, _mockRequestSender.Object, _mockTestHostManager.Object);
 
-        var message = Assert.ThrowsException<TestPlatformException>(() => operationManager.SetupChannel([], DefaultRunSettings)).Message;
+        var message = Assert.ThrowsExactly<TestPlatformException>(() => operationManager.SetupChannel([], DefaultRunSettings)).Message;
         Assert.AreEqual(message, TimoutErrorMessage);
     }
 
@@ -292,7 +292,7 @@ public class ProxyOperationManagerTests : ProxyBaseManagerTests
         var operationManager = new TestableProxyOperationManager(_mockRequestData.Object, _mockRequestSender.Object, _mockTestHostManager.Object, cancellationTokenSource);
 
         cancellationTokenSource.Cancel();
-        var message = Assert.ThrowsException<TestPlatformException>(() => operationManager.SetupChannel([], DefaultRunSettings)).Message;
+        var message = Assert.ThrowsExactly<TestPlatformException>(() => operationManager.SetupChannel([], DefaultRunSettings)).Message;
         Equals("Canceling the operation as requested.", message);
     }
 
@@ -307,7 +307,7 @@ public class ProxyOperationManagerTests : ProxyBaseManagerTests
         var cancellationTokenSource = new CancellationTokenSource();
         var operationManager = new TestableProxyOperationManager(_mockRequestData.Object, _mockRequestSender.Object, _mockTestHostManager.Object, cancellationTokenSource);
 
-        var message = Assert.ThrowsException<TestPlatformException>(() => operationManager.SetupChannel([], DefaultRunSettings)).Message;
+        var message = Assert.ThrowsExactly<TestPlatformException>(() => operationManager.SetupChannel([], DefaultRunSettings)).Message;
         Equals("Canceling the operation as requested.", message);
     }
 
@@ -321,7 +321,7 @@ public class ProxyOperationManagerTests : ProxyBaseManagerTests
         _mockTestHostManager.Setup(rs => rs.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>())).Callback(() => cancellationTokenSource.Cancel());
         var operationManager = new TestableProxyOperationManager(_mockRequestData.Object, _mockRequestSender.Object, _mockTestHostManager.Object, cancellationTokenSource);
 
-        var message = Assert.ThrowsException<TestPlatformException>(() => operationManager.SetupChannel([], DefaultRunSettings)).Message;
+        var message = Assert.ThrowsExactly<TestPlatformException>(() => operationManager.SetupChannel([], DefaultRunSettings)).Message;
         Equals("Canceling the operation as requested.", message);
     }
 
@@ -333,7 +333,7 @@ public class ProxyOperationManagerTests : ProxyBaseManagerTests
 
         var operationManager = new TestableProxyOperationManager(_mockRequestData.Object, _mockRequestSender.Object, _mockTestHostManager.Object);
 
-        var message = Assert.ThrowsException<TestPlatformException>(() => operationManager.SetupChannel([], DefaultRunSettings)).Message;
+        var message = Assert.ThrowsExactly<TestPlatformException>(() => operationManager.SetupChannel([], DefaultRunSettings)).Message;
         Assert.AreEqual(message, Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Resources.Resources.InitializationFailed);
     }
 
@@ -349,7 +349,7 @@ public class ProxyOperationManagerTests : ProxyBaseManagerTests
     {
         // Make the version check fail
         _mockRequestSender.Setup(rs => rs.CheckVersionWithTestHost()).Throws(new TestPlatformException("Version check failed"));
-        Assert.ThrowsException<TestPlatformException>(() => _testOperationManager.SetupChannel([], DefaultRunSettings));
+        Assert.ThrowsExactly<TestPlatformException>(() => _testOperationManager.SetupChannel([], DefaultRunSettings));
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyTestSessionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyTestSessionManagerTests.cs
@@ -398,12 +398,12 @@ public class ProxyTestSessionManagerTests
             Times.Once);
 
         // First call to DequeueProxy fails because of source mismatch.
-        Assert.ThrowsException<InvalidOperationException>(() => proxyManager.DequeueProxy(
+        Assert.ThrowsExactly<InvalidOperationException>(() => proxyManager.DequeueProxy(
             @"C:\temp\FakeTestAsset2.dll",
             testSessionCriteria.RunSettings));
 
         // Second call to DequeueProxy fails because of runsettings mismatch.
-        Assert.ThrowsException<InvalidOperationException>(() => proxyManager.DequeueProxy(
+        Assert.ThrowsExactly<InvalidOperationException>(() => proxyManager.DequeueProxy(
             testSessionCriteria.Sources[0],
             _runSettingsOneEnvVar));
 
@@ -414,7 +414,7 @@ public class ProxyTestSessionManagerTests
             mockProxyOperationManager.Object);
 
         // Fourth call to DequeueProxy fails because proxy became unavailable following successful deque.
-        Assert.ThrowsException<InvalidOperationException>(() => proxyManager.DequeueProxy(
+        Assert.ThrowsExactly<InvalidOperationException>(() => proxyManager.DequeueProxy(
             testSessionCriteria.Sources[0],
             testSessionCriteria.RunSettings));
     }
@@ -445,7 +445,7 @@ public class ProxyTestSessionManagerTests
                 testSessionCriteria.RunSettings),
             mockProxyOperationManager.Object);
 
-        Assert.AreEqual(proxyManager.EnqueueProxy(mockProxyOperationManager.Object.Id), true);
+        Assert.AreEqual(true, proxyManager.EnqueueProxy(mockProxyOperationManager.Object.Id));
 
         // Call to DequeueProxy succeeds when called with the same runsettings as before.
         Assert.AreEqual(proxyManager.DequeueProxy(
@@ -475,7 +475,7 @@ public class ProxyTestSessionManagerTests
             Times.Once);
 
         // This call to DequeueProxy fails because of runsettings mismatch.
-        Assert.ThrowsException<InvalidOperationException>(() => proxyManager.DequeueProxy(
+        Assert.ThrowsExactly<InvalidOperationException>(() => proxyManager.DequeueProxy(
             testSessionCriteria.Sources[0],
             _runSettingsTwoEnvVars));
     }
@@ -501,7 +501,7 @@ public class ProxyTestSessionManagerTests
             Times.Once);
 
         // This call to DequeueProxy fails because of runsettings mismatch.
-        Assert.ThrowsException<InvalidOperationException>(() => proxyManager.DequeueProxy(
+        Assert.ThrowsExactly<InvalidOperationException>(() => proxyManager.DequeueProxy(
             testSessionCriteria.Sources[0],
             _runSettingsOneEnvVar));
     }
@@ -527,7 +527,7 @@ public class ProxyTestSessionManagerTests
             Times.Once);
 
         // This call to DequeueProxy fails because of runsettings mismatch.
-        Assert.ThrowsException<InvalidOperationException>(() => proxyManager.DequeueProxy(
+        Assert.ThrowsExactly<InvalidOperationException>(() => proxyManager.DequeueProxy(
             testSessionCriteria.Sources[0],
             _runSettingsTwoEnvVarsAndDataCollectors));
     }
@@ -543,8 +543,8 @@ public class ProxyTestSessionManagerTests
         var proxyManager = CreateProxy(testSessionCriteria, mockProxyOperationManager.Object);
 
         // Validate sanity checks.
-        Assert.ThrowsException<ArgumentException>(() => proxyManager.EnqueueProxy(-1));
-        Assert.ThrowsException<ArgumentException>(() => proxyManager.EnqueueProxy(1));
+        Assert.ThrowsExactly<ArgumentException>(() => proxyManager.EnqueueProxy(-1));
+        Assert.ThrowsExactly<ArgumentException>(() => proxyManager.EnqueueProxy(1));
 
         // StartSession should succeed.
         Assert.IsTrue(proxyManager.StartSession(_mockEventsHandler.Object, _mockRequestData.Object));
@@ -557,7 +557,7 @@ public class ProxyTestSessionManagerTests
             Times.Once);
 
         // Call throws exception because proxy is already available.
-        Assert.ThrowsException<InvalidOperationException>(() => proxyManager.EnqueueProxy(0));
+        Assert.ThrowsExactly<InvalidOperationException>(() => proxyManager.EnqueueProxy(0));
 
         // Call succeeds.
         Assert.AreEqual(proxyManager.DequeueProxy(

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/InProcDataCollectionSinkTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/InProcDataCollectionSinkTests.cs
@@ -41,7 +41,7 @@ public class InProcDataCollectionSinkTests
     {
         _testCase.SetPropertyValue(TestCaseProperties.Id, Guid.NewGuid());
 
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () => _dataCollectionSink.SendData(_dataCollectionContext, null!, "DummyValue"));
     }
 
@@ -50,7 +50,7 @@ public class InProcDataCollectionSinkTests
     {
         _testCase.SetPropertyValue(TestCaseProperties.Id, Guid.NewGuid());
 
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () => _dataCollectionSink.SendData(_dataCollectionContext, "DummyKey", null!));
     }
 
@@ -58,7 +58,7 @@ public class InProcDataCollectionSinkTests
     // TODO : Currently this code hits when test case id is null for core projects. For that we don't have algorithm to generate the guid. It's not implemented exception now (Source Code : EqtHash.cs).
     public void SendDataShouldThrowArgumentExceptionIfTestCaseIdIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () => _dataCollectionSink.SendData(_dataCollectionContext, "DummyKey", "DummyValue"));
     }
 }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/ProxyDataCollectionManagerTests.cs
@@ -70,7 +70,7 @@ public class ProxyDataCollectionManagerTests
     {
         _mockDataCollectionRequestSender.Setup(x => x.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
 
-        var message = Assert.ThrowsException<TestPlatformException>(() => _proxyDataCollectionManager.Initialize()).Message;
+        var message = Assert.ThrowsExactly<TestPlatformException>(() => _proxyDataCollectionManager.Initialize()).Message;
         Assert.AreEqual(message, TimoutErrorMessage);
     }
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/EventHandlers/TestRequestHandlerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/EventHandlers/TestRequestHandlerTests.cs
@@ -534,11 +534,11 @@ public class TestableTestRequestHandler : TestRequestHandler
 
     private static void OnLaunchAdapterProcessWithDebuggerAttachedAckReceived(Message message)
     {
-        Assert.AreEqual(message.MessageType, MessageType.LaunchAdapterProcessWithDebuggerAttachedCallback);
+        Assert.AreEqual(MessageType.LaunchAdapterProcessWithDebuggerAttachedCallback, message.MessageType);
     }
 
     private static void OnAttachDebuggerAckRecieved(Message message)
     {
-        Assert.AreEqual(message.MessageType, MessageType.AttachDebuggerCallback);
+        Assert.AreEqual(MessageType.AttachDebuggerCallback, message.MessageType);
     }
 }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/BaseRunTestsTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/BaseRunTestsTests.cs
@@ -546,7 +546,7 @@ public class BaseRunTestsTests
         // verify TC.Source is updated with package
         foreach (var tr in _receivedRunStatusArgs.NewTestResults)
         {
-            Assert.AreEqual(tr.TestCase.Source, package);
+            Assert.AreEqual(package, tr.TestCase.Source);
         }
     }
 
@@ -566,7 +566,7 @@ public class BaseRunTestsTests
 
         foreach (var tc in _receivedRunStatusArgs.ActiveTests)
         {
-            Assert.AreEqual(tc.Source, package);
+            Assert.AreEqual(package, tc.Source);
         }
     }
 

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/PostProcessing/ArtifactProcessingTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/PostProcessing/ArtifactProcessingTests.cs
@@ -291,7 +291,7 @@ public class ArtifactProcessingTests
         _dataSerializer.Setup(x => x.DeserializeMessage(It.IsAny<string>())).Returns((string rawMessage) => throw new Exception("Malformed json"));
 
         // act
-        await Assert.ThrowsExceptionAsync<Exception>(() => _artifactProcessingManager.PostProcessArtifactsAsync());
+        await Assert.ThrowsExactlyAsync<Exception>(() => _artifactProcessingManager.PostProcessArtifactsAsync());
 
         // assert
         _fileHelperMock.Verify(x => x.DeleteDirectory(It.IsAny<string>(), It.IsAny<bool>()), Times.Once);

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestLoggerManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestLoggerManagerTests.cs
@@ -257,7 +257,7 @@ public class TestLoggerManagerTests
     public void AddLoggerShouldNotThrowExceptionIfUriIsNull()
     {
         var testLoggerManager = new DummyTestLoggerManager();
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () => testLoggerManager.InitializeLoggerByUri(null!, null));
     }
 
@@ -320,7 +320,7 @@ public class TestLoggerManagerTests
         var testLoggerManager = new DummyTestLoggerManager();
         testLoggerManager.Dispose();
 
-        Assert.ThrowsException<ObjectDisposedException>(
+        Assert.ThrowsExactly<ObjectDisposedException>(
             () => testLoggerManager.InitializeLoggerByUri(new Uri("some://uri"), null));
     }
 
@@ -330,7 +330,7 @@ public class TestLoggerManagerTests
     {
         var testLoggerManager = new DummyTestLoggerManager();
         testLoggerManager.Dispose();
-        Assert.ThrowsException<ObjectDisposedException>(
+        Assert.ThrowsExactly<ObjectDisposedException>(
             () => testLoggerManager.EnableLogging());
     }
 
@@ -706,7 +706,7 @@ public class TestLoggerManagerTests
 
         var testLoggerManager = new DummyTestLoggerManager(mockRequestData.Object);
 
-        Assert.ThrowsException<InvalidLoggerException>(() => testLoggerManager.Initialize(settingsXml));
+        Assert.ThrowsExactly<InvalidLoggerException>(() => testLoggerManager.Initialize(settingsXml));
         Assert.AreEqual(0, ValidLoggerWithParameters.Counter);
     }
 
@@ -733,7 +733,7 @@ public class TestLoggerManagerTests
 
         var testLoggerManager = new DummyTestLoggerManager(mockRequestData.Object);
 
-        Assert.ThrowsException<InvalidLoggerException>(() => testLoggerManager.Initialize(settingsXml));
+        Assert.ThrowsExactly<InvalidLoggerException>(() => testLoggerManager.Initialize(settingsXml));
         Assert.AreEqual(0, InvalidLogger.Counter);
     }
 
@@ -758,7 +758,7 @@ public class TestLoggerManagerTests
                 </RunSettings>";
 
         var testLoggerManager = new DummyTestLoggerManager(mockRequestData.Object);
-        Assert.ThrowsException<InvalidLoggerException>(() => testLoggerManager.Initialize(settingsXml));
+        Assert.ThrowsExactly<InvalidLoggerException>(() => testLoggerManager.Initialize(settingsXml));
         Assert.AreEqual(0, ValidLoggerWithParameters.Counter);
     }
 
@@ -785,7 +785,7 @@ public class TestLoggerManagerTests
 
         var testLoggerManager = new DummyTestLoggerManager(mockRequestData.Object);
 
-        Assert.ThrowsException<InvalidLoggerException>(() => testLoggerManager.Initialize(settingsXml));
+        Assert.ThrowsExactly<InvalidLoggerException>(() => testLoggerManager.Initialize(settingsXml));
         Assert.AreEqual(0, ValidLoggerWithParameters.Counter);
     }
 
@@ -876,7 +876,7 @@ public class TestLoggerManagerTests
 
         var testLoggerManager = new DummyTestLoggerManager(mockRequestData.Object);
 
-        Assert.ThrowsException<InvalidLoggerException>(() => testLoggerManager.Initialize(settingsXml));
+        Assert.ThrowsExactly<InvalidLoggerException>(() => testLoggerManager.Initialize(settingsXml));
     }
 
     [TestMethod]
@@ -902,7 +902,7 @@ public class TestLoggerManagerTests
 
         var testLoggerManager = new DummyTestLoggerManager(mockRequestData.Object);
         testLoggerManager.Dispose();
-        Assert.ThrowsException<ObjectDisposedException>(() => testLoggerManager.Initialize(settingsXml));
+        Assert.ThrowsExactly<ObjectDisposedException>(() => testLoggerManager.Initialize(settingsXml));
     }
 
     [TestMethod]
@@ -1424,7 +1424,7 @@ public class TestLoggerManagerTests
 
         var testLoggerManager = new DummyTestLoggerManager(mockRequestData.Object);
 
-        Assert.ThrowsException<InvalidLoggerException>(() => testLoggerManager.Initialize(settingsXml));
+        Assert.ThrowsExactly<InvalidLoggerException>(() => testLoggerManager.Initialize(settingsXml));
         Assert.AreEqual(0, ValidLoggerWithParameters.Counter);
     }
 

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameCollectorTests.cs
@@ -78,7 +78,7 @@ public class BlameCollectorTests
     [TestMethod]
     public void InitializeShouldThrowExceptionIfDataCollectionLoggerIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _blameDataCollector.Initialize(
+        Assert.ThrowsExactly<ArgumentNullException>(() => _blameDataCollector.Initialize(
             _configurationElement,
             _mockDataColectionEvents.Object,
             _mockDataCollectionSink.Object,

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/BlameLoggerTests.cs
@@ -41,7 +41,7 @@ public class BlameLoggerTests
     [TestMethod]
     public void InitializeShouldThrowExceptionIfEventsIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _blameLogger.Initialize(null!, string.Empty));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _blameLogger.Initialize(null!, string.Empty));
     }
 
     /// <summary>

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/ProcessDumpUtilityTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/ProcessDumpUtilityTests.cs
@@ -62,7 +62,7 @@ public class ProcessDumpUtilityTests
 
         processDumpUtility.StartTriggerBasedProcessDump(processId, testResultsDirectory, false, ".NETCoreApp,Version=v5.0", false, _ => { });
 
-        var ex = Assert.ThrowsException<FileNotFoundException>(() => processDumpUtility.GetDumpFiles(true, false));
+        var ex = Assert.ThrowsExactly<FileNotFoundException>(() => processDumpUtility.GetDumpFiles(true, false));
         Assert.AreEqual(ex.Message, Resources.Resources.DumpFileNotGeneratedErrorMessage);
     }
 }

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/XmlReaderWriterTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/XmlReaderWriterTests.cs
@@ -56,7 +56,7 @@ public class XmlReaderWriterTests
         _testCaseList.Add(_blameTestObject.Id);
         _testObjectDictionary.Add(_blameTestObject.Id, _blameTestObject);
 
-        Assert.ThrowsException<ArgumentNullException>(() => _xmlReaderWriter.WriteTestSequence(_testCaseList, _testObjectDictionary, null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _xmlReaderWriter.WriteTestSequence(_testCaseList, _testObjectDictionary, null!));
     }
 
     /// <summary>
@@ -68,7 +68,7 @@ public class XmlReaderWriterTests
         _testCaseList.Add(_blameTestObject.Id);
         _testObjectDictionary.Add(_blameTestObject.Id, _blameTestObject);
 
-        Assert.ThrowsException<ArgumentNullException>(() => _xmlReaderWriter.WriteTestSequence(_testCaseList, _testObjectDictionary, string.Empty));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _xmlReaderWriter.WriteTestSequence(_testCaseList, _testObjectDictionary, string.Empty));
     }
 
     /// <summary>
@@ -77,7 +77,7 @@ public class XmlReaderWriterTests
     [TestMethod]
     public void ReadTestSequenceShouldThrowExceptionIfFilePathIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _xmlReaderWriter.ReadTestSequence(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _xmlReaderWriter.ReadTestSequence(null!));
     }
 
     /// <summary>
@@ -88,7 +88,7 @@ public class XmlReaderWriterTests
     {
         _mockFileHelper.Setup(m => m.Exists(It.IsAny<string>())).Returns(false);
 
-        Assert.ThrowsException<FileNotFoundException>(() => _xmlReaderWriter.ReadTestSequence(string.Empty));
+        Assert.ThrowsExactly<FileNotFoundException>(() => _xmlReaderWriter.ReadTestSequence(string.Empty));
     }
 
     /// <summary>

--- a/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
@@ -55,7 +55,7 @@ public class HtmlLoggerTests
     [TestMethod]
     public void InitializeShouldThrowExceptionIfEventsIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () => _htmlLogger.Initialize(null!, _parameters));
     }
 
@@ -67,7 +67,7 @@ public class HtmlLoggerTests
 
         _htmlLogger.Initialize(events.Object, testResultDir);
 
-        Assert.AreEqual(_htmlLogger.TestResultsDirPath, testResultDir);
+        Assert.AreEqual(testResultDir, _htmlLogger.TestResultsDirPath);
         Assert.IsNotNull(_htmlLogger.TestRunDetails);
         Assert.IsNotNull(_htmlLogger.Results);
     }
@@ -75,7 +75,7 @@ public class HtmlLoggerTests
     [TestMethod]
     public void InitializeShouldThrowExceptionIfTestRunDirectoryIsEmptyOrNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () =>
             {
                 _events = new Mock<TestLoggerEvents>();
@@ -88,13 +88,13 @@ public class HtmlLoggerTests
     public void InitializeShouldThrowExceptionIfParametersAreEmpty()
     {
         var events = new Mock<TestLoggerEvents>();
-        Assert.ThrowsException<ArgumentException>(() => _htmlLogger.Initialize(events.Object, new Dictionary<string, string?>()));
+        Assert.ThrowsExactly<ArgumentException>(() => _htmlLogger.Initialize(events.Object, new Dictionary<string, string?>()));
     }
 
     [TestMethod]
     public void TestMessageHandlerShouldThrowExceptionIfEventArgsIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _htmlLogger.TestMessageHandler(new object(), default!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _htmlLogger.TestMessageHandler(new object(), default!));
     }
 
     #endregion
@@ -123,7 +123,7 @@ public class HtmlLoggerTests
     {
         Dictionary<string, string?>? parameters = null;
         var events = new Mock<TestLoggerEvents>();
-        Assert.ThrowsException<ArgumentNullException>(() => _htmlLogger.Initialize(events.Object, parameters!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _htmlLogger.Initialize(events.Object, parameters!));
     }
 
     [TestMethod]
@@ -495,7 +495,7 @@ public class HtmlLoggerTests
 
         _htmlLogger.Initialize(new Mock<TestLoggerEvents>().Object, parameters);
 
-        Assert.ThrowsException<KeyNotFoundException>(() => _htmlLogger.TestRunCompleteHandler(new object(), new TestRunCompleteEventArgs(null, false, true, null, null, null, TimeSpan.Zero)));
+        Assert.ThrowsExactly<KeyNotFoundException>(() => _htmlLogger.TestRunCompleteHandler(new object(), new TestRunCompleteEventArgs(null, false, true, null, null, null, TimeSpan.Zero)));
     }
 
     [TestMethod]
@@ -506,7 +506,7 @@ public class HtmlLoggerTests
         _parameters[HtmlLoggerConstants.LogFilePrefixKey] = "HtmlPrefix";
         _parameters[DefaultLoggerParameterNames.TargetFramework] = ".NETFramework,Version=4.5.1";
 
-        Assert.ThrowsException<ArgumentException>(() => _htmlLogger.Initialize(_events.Object, _parameters));
+        Assert.ThrowsExactly<ArgumentException>(() => _htmlLogger.Initialize(_events.Object, _parameters));
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -65,7 +65,7 @@ public class TrxLoggerTests
     [TestMethod]
     public void InitializeShouldThrowExceptionIfEventsIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () => _testableTrxLogger.Initialize(null!, _parameters));
     }
 
@@ -79,7 +79,7 @@ public class TrxLoggerTests
     [TestMethod]
     public void InitializeShouldThrowExceptionIfTestRunDirectoryIsEmptyOrNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () =>
             {
                 var events = new Mock<TestLoggerEvents>();
@@ -99,13 +99,13 @@ public class TrxLoggerTests
     public void InitializeShouldThrowExceptionIfParametersAreEmpty()
     {
         var events = new Mock<TestLoggerEvents>();
-        Assert.ThrowsException<ArgumentException>(() => _testableTrxLogger.Initialize(events.Object, new Dictionary<string, string?>()));
+        Assert.ThrowsExactly<ArgumentException>(() => _testableTrxLogger.Initialize(events.Object, new Dictionary<string, string?>()));
     }
 
     [TestMethod]
     public void TestMessageHandlerShouldThrowExceptionIfEventArgsIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _testableTrxLogger.TestMessageHandler(new object(), default!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _testableTrxLogger.TestMessageHandler(new object(), default!));
     }
 
     [TestMethod]
@@ -533,7 +533,7 @@ public class TrxLoggerTests
 
         _testableTrxLogger.TestRunCompleteHandler(new object(), new TestRunCompleteEventArgs(null, false, true, null, null, null, TimeSpan.Zero));
 
-        Assert.AreEqual(_testableTrxLogger.TestResultOutcome, TrxLoggerObjectModel.TestOutcome.Failed);
+        Assert.AreEqual(TrxLoggerObjectModel.TestOutcome.Failed, _testableTrxLogger.TestResultOutcome);
     }
 
     [TestMethod]
@@ -854,7 +854,7 @@ public class TrxLoggerTests
         _parameters[TrxLoggerConstants.LogFilePrefixKey] = trxPrefix;
         _parameters[DefaultLoggerParameterNames.TargetFramework] = ".NETFramework,Version=4.5.1";
 
-        Assert.ThrowsException<ArgumentException>(() => _testableTrxLogger.Initialize(_events.Object, _parameters));
+        Assert.ThrowsExactly<ArgumentException>(() => _testableTrxLogger.Initialize(_events.Object, _parameters));
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunConfigurationTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunConfigurationTests.cs
@@ -242,7 +242,7 @@ public class RunConfigurationTests
 
     [DataRow(true)]
     [DataRow(false)]
-    [DataTestMethod]
+    [TestMethod]
     public void RunConfigurationShouldReadValueForDesignMode(bool designModeValue)
     {
         string settingsXml = string.Format(
@@ -285,7 +285,7 @@ public class RunConfigurationTests
 
     [DataRow(true)]
     [DataRow(false)]
-    [DataTestMethod]
+    [TestMethod]
     public void RunConfigurationShouldReadValueForCollectSourceInformation(bool val)
     {
         string settingsXml = string.Format(
@@ -318,7 +318,7 @@ public class RunConfigurationTests
         Assert.AreEqual(runConfiguration.DesignMode, runConfiguration.ShouldCollectSourceInformation);
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(true)]
     [DataRow(false)]
     public void RunConfigurationToXmlShouldProvideCollectSourceInformationSameAsDesignMode(bool val)

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Utilities/FilterHelperTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Utilities/FilterHelperTests.cs
@@ -17,8 +17,8 @@ public class FilterHelpersTests
     [TestMethod]
     public void EscapeUnescapeNullThrowsArgumentNullException()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => FilterHelper.Escape(null!));
-        Assert.ThrowsException<ArgumentNullException>(() => FilterHelper.Unescape(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => FilterHelper.Escape(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => FilterHelper.Unescape(null!));
     }
 
     [TestMethod]
@@ -70,13 +70,13 @@ public class FilterHelpersTests
     public void UnescapeForInvalidStringThrowsArgumentException1()
     {
         var invalidString = @"TestClass\$""a %4 b""%2.TestMethod";
-        Assert.ThrowsException<ArgumentException>(() => FilterHelper.Unescape(invalidString), string.Format(CultureInfo.CurrentCulture, Resources.TestCaseFilterEscapeException, invalidString));
+        Assert.ThrowsExactly<ArgumentException>(() => FilterHelper.Unescape(invalidString), string.Format(CultureInfo.CurrentCulture, Resources.TestCaseFilterEscapeException, invalidString));
     }
 
     [TestMethod]
     public void UnescapeForInvalidStringThrowsArgumentException2()
     {
         var invalidString = @"TestClass\";
-        Assert.ThrowsException<ArgumentException>(() => FilterHelper.Unescape(invalidString), string.Format(CultureInfo.CurrentCulture, Resources.TestCaseFilterEscapeException, invalidString));
+        Assert.ThrowsExactly<ArgumentException>(() => FilterHelper.Unescape(invalidString), string.Format(CultureInfo.CurrentCulture, Resources.TestCaseFilterEscapeException, invalidString));
     }
 }

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Utilities/XmlRunSettingsUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Utilities/XmlRunSettingsUtilitiesTests.cs
@@ -203,7 +203,7 @@ public class XmlRunSettingsUtilitiesTests
                      </TestRunParameters>
                 </RunSettings>";
 
-        Assert.ThrowsException<SettingsException>(() => XmlRunSettingsUtilities.GetTestRunParameters(settingsXml));
+        Assert.ThrowsExactly<SettingsException>(() => XmlRunSettingsUtilities.GetTestRunParameters(settingsXml));
     }
 
     [TestMethod]
@@ -223,7 +223,7 @@ public class XmlRunSettingsUtilitiesTests
                      </TestRunParameters>
                 </RunSettings>";
 
-        Assert.ThrowsException<SettingsException>(() => XmlRunSettingsUtilities.GetTestRunParameters(settingsXml));
+        Assert.ThrowsExactly<SettingsException>(() => XmlRunSettingsUtilities.GetTestRunParameters(settingsXml));
     }
 
     [TestMethod]
@@ -281,7 +281,7 @@ public class XmlRunSettingsUtilitiesTests
                                     </InProcDataCollectionRunSettings>
                                 </RunSettings>";
 
-        Assert.ThrowsException<SettingsException>(
+        Assert.ThrowsExactly<SettingsException>(
             () => XmlRunSettingsUtilities.GetInProcDataCollectionRunSettings(settingsXml));
     }
     #endregion
@@ -1174,7 +1174,7 @@ public class XmlRunSettingsUtilitiesTests
     [TestMethod]
     public void GetDataCollectionRunSettingsShouldThrowOnMalformedDataCollectorSettings()
     {
-        Assert.ThrowsException<SettingsException>(() => XmlRunSettingsUtilities.GetDataCollectionRunSettings(_runSettingsXmlWithIncorrectDataCollectorSettings));
+        Assert.ThrowsExactly<SettingsException>(() => XmlRunSettingsUtilities.GetDataCollectionRunSettings(_runSettingsXmlWithIncorrectDataCollectorSettings));
     }
 
     #endregion

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -385,7 +385,7 @@ public class DefaultTestHostManagerTests
         CancellationTokenSource cancellationTokenSource = new();
         cancellationTokenSource.Cancel();
 
-        Assert.ThrowsException<OperationCanceledException>(() => _testableTestHostManager.LaunchTestHostAsync(GetDefaultStartInfo(), cancellationTokenSource.Token).Wait());
+        Assert.ThrowsExactly<OperationCanceledException>(() => _testableTestHostManager.LaunchTestHostAsync(GetDefaultStartInfo(), cancellationTokenSource.Token).Wait());
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -113,7 +113,7 @@ public class DotnetTestHostManagerTests
     {
         Action action = () => _dotnetHostManager.GetTestHostProcessStartInfo(null!, null, _defaultConnectionInfo);
 
-        Assert.ThrowsException<ArgumentNullException>(action);
+        Assert.ThrowsExactly<ArgumentNullException>(action);
     }
 
     [TestMethod]
@@ -122,7 +122,7 @@ public class DotnetTestHostManagerTests
         var sources = new[] { "test1.dll", "test2.dll" };
         Action action = () => _dotnetHostManager.GetTestHostProcessStartInfo(sources, null, _defaultConnectionInfo);
 
-        Assert.ThrowsException<InvalidOperationException>(action);
+        Assert.ThrowsExactly<InvalidOperationException>(action);
     }
 
     [TestMethod]
@@ -480,7 +480,7 @@ public class DotnetTestHostManagerTests
         CancellationTokenSource cancellationTokenSource = new();
         cancellationTokenSource.Cancel();
 
-        Assert.ThrowsException<OperationCanceledException>(() => _dotnetHostManager.LaunchTestHostAsync(startInfo, cancellationTokenSource.Token).Wait());
+        Assert.ThrowsExactly<OperationCanceledException>(() => _dotnetHostManager.LaunchTestHostAsync(startInfo, cancellationTokenSource.Token).Wait());
     }
 
     [TestMethod]
@@ -534,7 +534,7 @@ public class DotnetTestHostManagerTests
 
         Action action = () => GetDefaultStartInfo();
 
-        Assert.ThrowsException<TestPlatformException>(action);
+        Assert.ThrowsExactly<TestPlatformException>(action);
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -717,7 +717,7 @@ public class IntegrationTestBase
                 File.Create(logFilePath).Close();
             }
 
-            Console.WriteLine($"Logging diagnostics in {logFilePath}");
+            Console.WriteLine($"Logging diagnostics in {Path.GetDirectoryName(logFilePath)}");
             consoleParameters.LogFilePath = logFilePath;
         }
 

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -342,14 +342,16 @@ public class IntegrationTestBase
                 @"\d+",
                 @"\d+",
                 @"\d+");
-            StringAssert.DoesNotMatch(
-                _standardTestOutput,
-                new Regex(summaryStatus),
+            var errorSummary = string.Format(CultureInfo.InvariantCulture,
                 "Excepted: There should not be test summary{2}Actual: {0}{2}Standard Error: {1}{2}Arguments: {3}{2}",
                 _standardTestOutput,
                 _standardTestError,
                 Environment.NewLine,
                 _arguments);
+            StringAssert.DoesNotMatch(
+                _standardTestOutput,
+                new Regex(summaryStatus), errorSummary)
+               ;
         }
         else
         {
@@ -369,14 +371,16 @@ public class IntegrationTestBase
                 summaryStatus += string.Format(CultureInfo.CurrentCulture, SkippedTestsMessage, skipped);
             }
 
-            Assert.IsTrue(
-                _standardTestOutput.Contains(summaryStatus),
-                "The Test summary does not match.{3}Expected summary: {1}{3}Test Output: {0}{3}Standard Error: {2}{3}Arguments: {4}{3}",
+            var errorSummary = string.Format(CultureInfo.InvariantCulture, "The Test summary does not match.{3}Expected summary: {1}{3}Test Output: {0}{3}Standard Error: {2}{3}Arguments: {4}{3}",
                 _standardTestOutput,
                 summaryStatus,
                 _standardTestError,
                 Environment.NewLine,
                 _arguments);
+            Assert.IsTrue(
+                _standardTestOutput.Contains(summaryStatus),
+                errorSummary
+                );
         }
     }
 
@@ -393,14 +397,15 @@ public class IntegrationTestBase
         if (totalTestCount == 0)
         {
             // No test should be found/run
-            StringAssert.DoesNotMatch(
-                _standardTestOutput,
-                new Regex("Total tests\\:"),
-                "Excepted: There should not be test summary{2}Actual: {0}{2}Standard Error: {1}{2}Arguments: {3}{2}",
+            var errorSummary = string.Format(CultureInfo.InvariantCulture, "Excepted: There should not be test summary{2}Actual: {0}{2}Standard Error: {1}{2}Arguments: {3}{2}",
                 _standardTestOutput,
                 _standardTestError,
                 Environment.NewLine,
                 _arguments);
+            StringAssert.DoesNotMatch(
+                _standardTestOutput,
+                new Regex("Total tests\\:"),
+                errorSummary);
         }
         else
         {
@@ -420,30 +425,31 @@ public class IntegrationTestBase
                 summaryStatus += $" Skipped: {skipped}.";
             }
 
-            Assert.IsTrue(
-                _standardTestOutput.Contains(summaryStatus),
-                "The Test summary does not match.{3}Expected summary: {1}{3}Test Output: {0}{3}Standard Error: {2}{3}Arguments: {4}{3}",
+            var errorSummary = String.Format(CultureInfo.InvariantCulture, "The Test summary does not match.{3}Expected summary: {1}{3}Test Output: {0}{3}Standard Error: {2}{3}Arguments: {4}{3}",
                 _standardTestOutput,
                 summaryStatus,
                 _standardTestError,
                 Environment.NewLine,
                 _arguments);
+            Assert.IsTrue(
+                _standardTestOutput.Contains(summaryStatus),
+                errorSummary);
         }
     }
 
     public void StdErrorContains(string substring)
     {
-        Assert.IsTrue(_standardTestError.Contains(substring), "StdErrorOutput - [{0}] did not contain expected string '{1}'", _standardTestError, substring);
+        Assert.IsTrue(_standardTestError.Contains(substring), $"StdErrorOutput - [{_standardTestError}] did not contain expected string '{substring}'");
     }
 
     public void StdErrorRegexIsMatch(string pattern)
     {
-        Assert.IsTrue(Regex.IsMatch(_standardTestError, pattern), "StdErrorOutput - [{0}] did not contain expected pattern '{1}'", _standardTestError, pattern);
+        Assert.IsTrue(Regex.IsMatch(_standardTestError, pattern), $"StdErrorOutput - [{_standardTestError}] did not contain expected pattern '{pattern}'");
     }
 
     public void StdErrorDoesNotContains(string substring)
     {
-        Assert.IsFalse(_standardTestError.Contains(substring), "StdErrorOutput - [{0}] did not contain expected string '{1}'", _standardTestError, substring);
+        Assert.IsFalse(_standardTestError.Contains(substring), $"StdErrorOutput - [{_standardTestError}] did not contain expected string '{substring}'");
     }
 
     public void StdOutputContains(string substring)
@@ -671,7 +677,7 @@ public class IntegrationTestBase
         }
         else
         {
-            Assert.Fail("Unknown Runner framework - [{0}]", _testEnvironment.RunnerFramework);
+            Assert.Fail($"Unknown Runner framework - [{_testEnvironment.RunnerFramework}]");
         }
 
         Assert.IsTrue(File.Exists(consoleRunnerPath), "GetConsoleRunnerPath: Path not found: \"{0}\"", consoleRunnerPath);

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -621,7 +621,12 @@ public class IntegrationTestBase
         if (testFramework == UnitTestFramework.MSTest)
         {
             var version = IntegrationTestEnvironment.DependencyVersions["MSTestTestAdapterVersion"];
-            if (version.StartsWith("3"))
+            if (version.StartsWith("4"))
+            {
+                var tfm = _testEnvironment.TargetFramework.StartsWith("net4") ? "net462" : "net9.0";
+                adapterRelativePath = string.Format(CultureInfo.InvariantCulture, _msTestAdapterRelativePath, version, tfm);
+            }
+            else if (version.StartsWith("3"))
             {
                 var tfm = _testEnvironment.TargetFramework.StartsWith("net4") ? "net462" : "netcoreapp3.1";
                 adapterRelativePath = string.Format(CultureInfo.InvariantCulture, _msTestAdapterRelativePath, version, tfm);

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/ClientUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/ClientUtilitiesTests.cs
@@ -17,14 +17,14 @@ public class ClientUtilitiesTests
     [TestMethod]
     public void FixRelativePathsInRunSettingsShouldThrowIfDocumentIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => ClientUtilities.FixRelativePathsInRunSettings(null!, "c:\\temp"));
+        Assert.ThrowsExactly<ArgumentNullException>(() => ClientUtilities.FixRelativePathsInRunSettings(null!, "c:\\temp"));
     }
 
     [TestMethod]
     public void FixRelativePathsInRunSettingsShouldThrowIfPathIsNullOrEmpty()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => ClientUtilities.FixRelativePathsInRunSettings(new XmlDocument(), null!));
-        Assert.ThrowsException<ArgumentNullException>(() => ClientUtilities.FixRelativePathsInRunSettings(new XmlDocument(), ""));
+        Assert.ThrowsExactly<ArgumentNullException>(() => ClientUtilities.FixRelativePathsInRunSettings(new XmlDocument(), null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => ClientUtilities.FixRelativePathsInRunSettings(new XmlDocument(), ""));
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/CodeCoverageDataAttachmentsHandlerTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/CodeCoverageDataAttachmentsHandlerTests.cs
@@ -53,13 +53,21 @@ public class CodeCoverageDataAttachmentsHandlerTests
     [ClassInitialize]
     public static void ClassInitialize(TestContext context)
     {
-        // Copying test files to correct place,
-        var assemblyPath = AppDomain.CurrentDomain.BaseDirectory;
-        var testFilesDirectory = Path.Combine(context.DeploymentDirectory!, "TestFiles");
-        Directory.CreateDirectory(testFilesDirectory);
-        var files = Directory.GetFiles(Path.Combine(assemblyPath, "TestFiles"));
-        foreach (var file in files)
-            File.Copy(file, Path.Combine(testFilesDirectory, Path.GetFileName(file)));
+        // Annoyingly those paths are the same, but one does not end with slash,
+        // no matter how you compare, e.g. new DirectoryInfo(...).FullName, the slashes are not
+        // removed. And then you get obscure error: File already exists, or File is used by other process
+        // when you try to copy the file and provide both paths the same.
+        var assemblyPath = AppDomain.CurrentDomain.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
+        var deploymentDirectory = context.DeploymentDirectory!.TrimEnd(Path.DirectorySeparatorChar);
+        if (new DirectoryInfo(deploymentDirectory).FullName != new DirectoryInfo(assemblyPath).FullName)
+        {
+            // Copying test files to deployment directory place,
+            var testFilesDirectory = Path.Combine(deploymentDirectory!, "TestFiles");
+            Directory.CreateDirectory(testFilesDirectory);
+            var files = Directory.GetFiles(Path.Combine(assemblyPath, "TestFiles"));
+            foreach (var file in files)
+                File.Copy(file, Path.Combine(testFilesDirectory, Path.GetFileName(file)), overwrite: true);
+        }
     }
 
     [TestMethod]
@@ -189,7 +197,7 @@ public class CodeCoverageDataAttachmentsHandlerTests
             attachmentSet
         ];
 
-        await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () => await _coverageDataAttachmentsHandler.ProcessAttachmentSetsAsync(_configurationElement, attachment, _mockProgressReporter.Object, null, cts.Token));
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(async () => await _coverageDataAttachmentsHandler.ProcessAttachmentSetsAsync(_configurationElement, attachment, _mockProgressReporter.Object, null, cts.Token));
 
         Assert.AreEqual(2, attachment.Count);
 

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/InferRunSettingsHelperTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/InferRunSettingsHelperTests.cs
@@ -218,7 +218,7 @@ public class InferRunSettingsHelperTests
         Assert.AreEqual("False", GetValueOf(xmlDocument, "/RunSettings/RunConfiguration/CollectSourceInformation"));
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(true)]
     [DataRow(false)]
     public void UpdateDesignModeOrCsiShouldModifyXmlToValueProvided(bool val)

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/XmlUtilitiesTests.cs
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/XmlUtilitiesTests.cs
@@ -19,7 +19,7 @@ public class XmlUtilitiesTests
     [TestMethod]
     public void GetNodeXmlShouldThrowIfxmlDocumentIsNull()
     {
-        Assert.ThrowsException<NullReferenceException>(() => XmlUtilities.GetNodeXml(null!, @"/RunSettings/RunConfiguration"));
+        Assert.ThrowsExactly<NullReferenceException>(() => XmlUtilities.GetNodeXml(null!, @"/RunSettings/RunConfiguration"));
     }
 
     [TestMethod]
@@ -28,7 +28,7 @@ public class XmlUtilitiesTests
         var settingsXml = @"<RunSettings></RunSettings>";
         var xmlDocument = GetXmlDocument(settingsXml);
 
-        Assert.ThrowsException<XPathException>(() => XmlUtilities.GetNodeXml(xmlDocument.CreateNavigator()!, null!));
+        Assert.ThrowsExactly<XPathException>(() => XmlUtilities.GetNodeXml(xmlDocument.CreateNavigator()!, null!));
     }
 
     [TestMethod]
@@ -37,7 +37,7 @@ public class XmlUtilitiesTests
         var settingsXml = @"<RunSettings></RunSettings>";
         var xmlDocument = GetXmlDocument(settingsXml);
 
-        Assert.ThrowsException<XPathException>(() => XmlUtilities.GetNodeXml(xmlDocument.CreateNavigator()!, @"Rs\r"));
+        Assert.ThrowsExactly<XPathException>(() => XmlUtilities.GetNodeXml(xmlDocument.CreateNavigator()!, @"Rs\r"));
     }
 
     [TestMethod]

--- a/test/SettingsMigrator.UnitTests/MigratorTests.cs
+++ b/test/SettingsMigrator.UnitTests/MigratorTests.cs
@@ -105,28 +105,33 @@ public class MigratorTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(XmlException))]
     public void InvalidSettingsThrowsException()
     {
         _oldTestsettingsPath = Path.Combine(Path.GetTempPath(), "oldTestsettings.testsettings");
+        try
+        {
+            File.WriteAllText(_oldTestsettingsPath, InvalidSettings);
+            File.WriteAllText(_newRunsettingsPath, string.Empty);
 
-        File.WriteAllText(_oldTestsettingsPath, InvalidSettings);
-        File.WriteAllText(_newRunsettingsPath, string.Empty);
-
-        _migrator.Migrate(_oldTestsettingsPath, _newRunsettingsPath);
-
-        File.Delete(_oldTestsettingsPath);
+            Assert.ThrowsExactly<XmlException>(() => _migrator.Migrate(_oldTestsettingsPath, _newRunsettingsPath));
+        }
+        finally
+        {
+            if (File.Exists(_oldRunsettingsPath))
+            {
+                File.Delete(_oldRunsettingsPath);
+            }
+        }
     }
 
     [TestMethod]
-    // On some systems this throws file not found, on some it throws directory not found,
-    // I don't know why and it does not matter for the test. As long as it throws.
-    [ExpectedException(typeof(IOException), AllowDerivedTypes = true)]
     public void InvalidPathThrowsException()
     {
         string oldTestsettingsPath = @"X:\generatedRun,settings.runsettings";
 
-        _migrator.Migrate(oldTestsettingsPath, _newRunsettingsPath);
+        // On some systems this throws file not found, on some it throws directory not found,
+        // I don't know why and it does not matter for the test. As long as it throws. 
+        Assert.Throws<IOException>(() => _migrator.Migrate(oldTestsettingsPath, _newRunsettingsPath));
     }
 
     private static void Validate(string newRunsettingsPath)

--- a/test/TestAssets/CodeCoverageTest/UnitTest1.cs
+++ b/test/TestAssets/CodeCoverageTest/UnitTest1.cs
@@ -18,17 +18,17 @@ namespace CodeCoverageTest
         [TestMethod]
         public void TestAbs()
         {
-            Assert.AreEqual(_logic.Abs(0), 0);
-            Assert.AreEqual(_logic.Abs(-5), 5);
-            Assert.AreEqual(_logic.Abs(7), 7);
+            Assert.AreEqual(0, _logic.Abs(0));
+            Assert.AreEqual(5, _logic.Abs(-5));
+            Assert.AreEqual(7, _logic.Abs(7));
         }
 
         [TestMethod]
         public void TestSign()
         {
-            Assert.AreEqual(_logic.Sign(0), 0);
-            Assert.AreEqual(_logic.Sign(-5), -1);
-            Assert.AreEqual(_logic.Sign(7), 1);
+            Assert.AreEqual(0, _logic.Sign(0));
+            Assert.AreEqual(-1, _logic.Sign(-5));
+            Assert.AreEqual(1, _logic.Sign(7));
         }
 
         [TestMethod]
@@ -36,7 +36,7 @@ namespace CodeCoverageTest
         public void __CxxPureMSILEntry_Test()
 #pragma warning restore IDE1006 // Naming Styles
         {
-            Assert.AreEqual(_logic.Abs(0), 0);
+            Assert.AreEqual(0, _logic.Abs(0));
         }
     }
 }

--- a/test/TestAssets/DiscoveryTestProject/LongDiscoveryTestClass.cs
+++ b/test/TestAssets/DiscoveryTestProject/LongDiscoveryTestClass.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace DiscoveryTestProject3
@@ -25,7 +26,7 @@ namespace DiscoveryTestProject3
 
     internal class TestMethodWithDelayAttribute : TestMethodAttribute
     {
-        public TestMethodWithDelayAttribute()
+        public TestMethodWithDelayAttribute([CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) : base(callerFilePath, callerLineNumber)
         {
             // This will be multiplied by 3 because the framework will internally create this
             // attribute 3 times.

--- a/test/TestAssets/MSTestProject1/UnitTest1.cs
+++ b/test/TestAssets/MSTestProject1/UnitTest1.cs
@@ -11,13 +11,12 @@ public class UnitTest1
     [TestMethod]
     public void PassingTest()
     {
-        Assert.AreEqual(2, 2);
     }
 
     [TestMethod]
     public void FailingTest()
     {
-        Assert.AreEqual(2, 3);
+        Assert.Fail();
     }
 
     [Ignore]

--- a/test/TestAssets/MSTestProject2/UnitTest1.cs
+++ b/test/TestAssets/MSTestProject2/UnitTest1.cs
@@ -11,13 +11,12 @@ public class UnitTest1
     [TestMethod]
     public void PassingTest()
     {
-        Assert.AreEqual(2, 2);
     }
 
     [TestMethod]
     public void FailingTest()
     {
-        Assert.AreEqual(2, 3);
+        Assert.Fail();
     }
 
     [Ignore]

--- a/test/TestAssets/SimpleTestProject/UnitTest1.cs
+++ b/test/TestAssets/SimpleTestProject/UnitTest1.cs
@@ -22,7 +22,6 @@ namespace SampleUnitTestProject
         [TestMethod]
         public void PassingTest()
         {
-            Assert.AreEqual(2, 2);
         }
 
         /// <summary>
@@ -38,7 +37,7 @@ namespace SampleUnitTestProject
             var appDomainFilePath = Environment.GetEnvironmentVariable("TEST_ASSET_APPDOMAIN_TEST_PATH") ?? Path.Combine(Path.GetTempPath(), "appdomain_test.txt");
             File.WriteAllText(appDomainFilePath, "AppDomain FriendlyName: " + AppDomain.CurrentDomain.FriendlyName);
 #endif
-            Assert.AreEqual(2, 3);
+            Assert.Fail();
         }
 
         /// <summary>

--- a/test/TestAssets/SimpleTestProject2/UnitTest1.cs
+++ b/test/TestAssets/SimpleTestProject2/UnitTest1.cs
@@ -17,7 +17,6 @@ public class UnitTest1
     [TestMethod]
     public void PassingTest2()
     {
-        Assert.AreEqual(2, 2);
     }
 
     /// <summary>
@@ -26,7 +25,7 @@ public class UnitTest1
     [TestMethod]
     public void FailingTest2()
     {
-        Assert.AreEqual(2, 3);
+        Assert.Fail();
     }
 
     /// <summary>

--- a/test/TestAssets/SimpleTestProjectx86/UnitTest1.cs
+++ b/test/TestAssets/SimpleTestProjectx86/UnitTest1.cs
@@ -17,7 +17,6 @@ namespace SimpleTestProjectx86
         [TestMethod]
         public void PassingTestx86()
         {
-            Assert.AreEqual(2, 2);
         }
     }
 }

--- a/test/TestAssets/TerminalLoggerTestProject/UnitTest1.cs
+++ b/test/TestAssets/TerminalLoggerTestProject/UnitTest1.cs
@@ -21,7 +21,6 @@ namespace TerminalLoggerUnitTests
         [TestMethod]
         public void PassingTest()
         {
-            Assert.AreEqual(2, 2);
         }
 
         /// <summary>
@@ -31,7 +30,9 @@ namespace TerminalLoggerUnitTests
         public void FailingTest()
         {
             // test characters taken from https://pages.ucsd.edu/~dkjordan/chin/unitestuni.html
+#pragma warning disable MSTEST0025 // Use 'Assert.Fail' instead of an always-failing assert
             Assert.AreEqual("ğğğ𦮙我們剛才從𓋴𓅓𓏏𓇏𓇌𓀀", "not the same");
+#pragma warning restore MSTEST0025 // Use 'Assert.Fail' instead of an always-failing assert
         }
 
         /// <summary>

--- a/test/TestAssets/child-crash/child-crash.csproj
+++ b/test/TestAssets/child-crash/child-crash.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestTestAdapterVersion)" />
     <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestFrameworkVersion)" />
     <PackageReference Include="Microsoft.CodeCoverage" Version="$(PackageVersion)" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 

--- a/test/TestAssets/child-hang/child-hang.csproj
+++ b/test/TestAssets/child-hang/child-hang.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestTestAdapterVersion)" />
     <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestFrameworkVersion)" />
     <PackageReference Include="Microsoft.CodeCoverage" Version="$(PackageVersion)" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 

--- a/test/TestAssets/crash/crash.csproj
+++ b/test/TestAssets/crash/crash.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestTestAdapterVersion)" />
     <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestFrameworkVersion)" />
     <PackageReference Include="Microsoft.CodeCoverage" Version="$(PackageVersion)" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
 </Project>

--- a/test/TranslationLayer.UnitTests/ConsoleParametersTests.cs
+++ b/test/TranslationLayer.UnitTests/ConsoleParametersTests.cs
@@ -33,6 +33,6 @@ public class ConsoleParametersTests
     public void TraceLevelShouldHaveVerboseAsDefaultValue()
     {
         var consoleParameters = new ConsoleParameters(new FileHelper());
-        Assert.AreEqual(consoleParameters.TraceLevel, TraceLevel.Verbose);
+        Assert.AreEqual(TraceLevel.Verbose, consoleParameters.TraceLevel);
     }
 }

--- a/test/TranslationLayer.UnitTests/DiscoveryEventsHandleConverterTests.cs
+++ b/test/TranslationLayer.UnitTests/DiscoveryEventsHandleConverterTests.cs
@@ -24,7 +24,7 @@ public class DiscoveryEventsHandleConverterTests
     [TestMethod]
     public void ConstructorShouldThrowArgumentExceptionIfTestDiscoveryEventHandlerIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => new DiscoveryEventsHandleConverter(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => new DiscoveryEventsHandleConverter(null!));
     }
 
     [TestMethod]

--- a/test/TranslationLayer.UnitTests/VsTestConsoleRequestSenderTests.cs
+++ b/test/TranslationLayer.UnitTests/VsTestConsoleRequestSenderTests.cs
@@ -2552,7 +2552,7 @@ public class VsTestConsoleRequestSenderTests
                 MessageType.CustomTestHostLaunchCallback,
                 It.IsAny<CustomHostLaunchAckPayload>(),
                 _protocolVersion))
-            .Callback((string messageType, object payload, int version) => Assert.AreEqual(((CustomHostLaunchAckPayload)payload).HostProcessId, TesthostPid));
+            .Callback((string messageType, object payload, int version) => Assert.AreEqual(TesthostPid, ((CustomHostLaunchAckPayload)payload).HostProcessId));
         _mockCommunicationManager.Setup(cm => cm.ReceiveMessageAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<Message?>(launchMessage))
             .Callback(reconfigureAction);
@@ -2627,7 +2627,7 @@ public class VsTestConsoleRequestSenderTests
                 MessageType.CustomTestHostLaunchCallback,
                 It.IsAny<CustomHostLaunchAckPayload>(),
                 _protocolVersion))
-            .Callback((string messageType, object payload, int version) => Assert.AreEqual(((CustomHostLaunchAckPayload)payload).HostProcessId, TesthostPid));
+            .Callback((string messageType, object payload, int version) => Assert.AreEqual(TesthostPid, ((CustomHostLaunchAckPayload)payload).HostProcessId));
         _mockCommunicationManager.Setup(cm => cm.ReceiveMessageAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<Message?>(launchMessage))
             .Callback(reconfigureAction);

--- a/test/TranslationLayer.UnitTests/VsTestConsoleWrapperTests.cs
+++ b/test/TranslationLayer.UnitTests/VsTestConsoleWrapperTests.cs
@@ -84,7 +84,7 @@ public class VsTestConsoleWrapperTests
     {
         _mockRequestSender.Setup(rs => rs.InitializeCommunication()).Returns(-1);
 
-        Assert.ThrowsException<TransationLayerException>(() => _consoleWrapper.StartSession());
+        Assert.ThrowsExactly<TransationLayerException>(() => _consoleWrapper.StartSession());
     }
 
     [TestMethod]
@@ -272,7 +272,7 @@ public class VsTestConsoleWrapperTests
         _mockProcessHelper.Setup(x => x.GetCurrentProcessFileName()).Returns("DummyProcess");
         _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
 
-        var exception = Assert.ThrowsException<TransationLayerException>(() => _consoleWrapper.InitializeExtensions(new List<string> { "Hello", "World" }));
+        var exception = Assert.ThrowsExactly<TransationLayerException>(() => _consoleWrapper.InitializeExtensions(new List<string> { "Hello", "World" }));
         Assert.AreEqual("DummyProcess process failed to connect to vstest.console process after 90 seconds. This may occur due to machine slowness, please set environment variable VSTEST_CONNECTION_TIMEOUT to increase timeout.", exception.Message);
         _mockRequestSender.Verify(rs => rs.InitializeExtensions(It.IsAny<IEnumerable<string>>()), Times.Never);
     }
@@ -330,7 +330,7 @@ public class VsTestConsoleWrapperTests
         _mockProcessHelper.Setup(x => x.GetCurrentProcessFileName()).Returns("DummyProcess");
         _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
 
-        var exception = Assert.ThrowsException<TransationLayerException>(() => _consoleWrapper.DiscoverTests(new List<string> { "Hello", "World" }, null, null, new Mock<ITestDiscoveryEventsHandler2>().Object));
+        var exception = Assert.ThrowsExactly<TransationLayerException>(() => _consoleWrapper.DiscoverTests(new List<string> { "Hello", "World" }, null, null, new Mock<ITestDiscoveryEventsHandler2>().Object));
         Assert.AreEqual("DummyProcess process failed to connect to vstest.console process after 90 seconds. This may occur due to machine slowness, please set environment variable VSTEST_CONNECTION_TIMEOUT to increase timeout.", exception.Message);
         _mockRequestSender.Verify(rs => rs.DiscoverTests(It.IsAny<IEnumerable<string>>(), It.IsAny<string>(), null, null, It.IsAny<ITestDiscoveryEventsHandler2>()), Times.Never);
     }

--- a/test/datacollector.UnitTests/DataCollectionAttachmentManagerTests.cs
+++ b/test/datacollector.UnitTests/DataCollectionAttachmentManagerTests.cs
@@ -95,13 +95,13 @@ public class DataCollectionAttachmentManagerTests
     [TestMethod]
     public void InitializeShouldThrowExceptionIfSessionIdIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _attachmentManager.Initialize(null!, string.Empty, _messageSink.Object));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _attachmentManager.Initialize(null!, string.Empty, _messageSink.Object));
     }
 
     [TestMethod]
     public void InitializeShouldThrowExceptionIfMessageSinkIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _attachmentManager.Initialize(_sessionId, string.Empty, null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _attachmentManager.Initialize(_sessionId, string.Empty, null!));
     }
 
     [TestMethod]
@@ -263,7 +263,7 @@ public class DataCollectionAttachmentManagerTests
     [TestMethod]
     public void AddAttachmentShouldNotAddNewFileTransferIfNullIsPassed()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _attachmentManager.AddAttachment(null!, null, null!, null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _attachmentManager.AddAttachment(null!, null, null!, null!));
     }
 
     [TestMethod]

--- a/test/datacollector.UnitTests/DataCollectionEnvironmentVariableTests.cs
+++ b/test/datacollector.UnitTests/DataCollectionEnvironmentVariableTests.cs
@@ -14,7 +14,7 @@ public class DataCollectionEnvironmentVariableTests
     [TestMethod]
     public void ConstructorShouldThrowExceptionIfKeyValueIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () =>
             {
                 var envvariable = new DataCollectionEnvironmentVariable(default, null!);

--- a/test/datacollector.UnitTests/DataCollectionManagerTests.cs
+++ b/test/datacollector.UnitTests/DataCollectionManagerTests.cs
@@ -60,7 +60,7 @@ public class DataCollectionManagerTests
     [TestMethod]
     public void InitializeDataCollectorsShouldThrowExceptionIfSettingsXmlIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _dataCollectionManager.InitializeDataCollectors(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _dataCollectionManager.InitializeDataCollectors(null!));
     }
 
     [TestMethod]
@@ -142,14 +142,14 @@ public class DataCollectionManagerTests
     public void InitializeDataCollectorsShouldLoadDataCollectorIfFriendlyNameIsCorrectAndUriIsEmpty()
     {
         var dataCollectorSettingsWithEmptyUri = string.Format(CultureInfo.InvariantCulture, _defaultRunSettings, string.Format(CultureInfo.InvariantCulture, _defaultDataCollectionSettings, _friendlyName, string.Empty, _mockDataCollector.Object.GetType().AssemblyQualifiedName, typeof(DataCollectionManagerTests).Assembly.Location, string.Empty));
-        Assert.ThrowsException<ArgumentNullException>(() => _dataCollectionManager.InitializeDataCollectors(dataCollectorSettingsWithEmptyUri));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _dataCollectionManager.InitializeDataCollectors(dataCollectorSettingsWithEmptyUri));
     }
 
     [TestMethod]
     public void InitializeDataCollectorsShouldLoadDataCollectorIfFriendlyNameIsEmptyAndUriIsCorrect()
     {
         var dataCollectorSettingsWithEmptyFriendlyName = string.Format(CultureInfo.InvariantCulture, _defaultRunSettings, string.Format(CultureInfo.InvariantCulture, _defaultDataCollectionSettings, _friendlyName, string.Empty, _mockDataCollector.Object.GetType().AssemblyQualifiedName, typeof(DataCollectionManagerTests).Assembly.Location, string.Empty));
-        Assert.ThrowsException<ArgumentNullException>(() => _dataCollectionManager.InitializeDataCollectors(dataCollectorSettingsWithEmptyFriendlyName));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _dataCollectionManager.InitializeDataCollectors(dataCollectorSettingsWithEmptyFriendlyName));
     }
 
     [TestMethod]

--- a/test/datacollector.UnitTests/DataCollectorConfigTests.cs
+++ b/test/datacollector.UnitTests/DataCollectorConfigTests.cs
@@ -23,7 +23,7 @@ public class DataCollectorConfigTests
     [TestMethod]
     public void ConstructorShouldThrowExceptionIfTypeIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(
+        Assert.ThrowsExactly<ArgumentNullException>(
             () => new DataCollectorConfig(null!));
     }
 

--- a/test/datacollector.UnitTests/DataCollectorMainTests.cs
+++ b/test/datacollector.UnitTests/DataCollectorMainTests.cs
@@ -114,7 +114,7 @@ public class DataCollectorMainTests
     public void RunShouldThrowIfTimeoutOccured()
     {
         _mockDataCollectionRequestHandler.Setup(rh => rh.WaitForRequestSenderConnection(It.IsAny<int>())).Returns(false);
-        var message = Assert.ThrowsException<TestPlatformException>(() => _dataCollectorMain.Run(_args)).Message;
+        var message = Assert.ThrowsExactly<TestPlatformException>(() => _dataCollectorMain.Run(_args)).Message;
         Assert.AreEqual(TimeoutErrorMessage, message);
     }
 

--- a/test/datacollector.UnitTests/TestPlatformDataCollectionEventsTests.cs
+++ b/test/datacollector.UnitTests/TestPlatformDataCollectionEventsTests.cs
@@ -26,7 +26,7 @@ public class TestPlatformDataCollectionEventsTests
     [TestMethod]
     public void RaiseEventsShouldThrowExceptionIfEventArgsIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _events.RaiseEvent(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _events.RaiseEvent(null!));
     }
 
     [TestMethod]

--- a/test/datacollector.UnitTests/TestPlatformDataCollectionLoggerTests.cs
+++ b/test/datacollector.UnitTests/TestPlatformDataCollectionLoggerTests.cs
@@ -35,27 +35,27 @@ public class TestPlatformDataCollectionLoggerTests
     [TestMethod]
     public void LogErrorShouldThrowExceptionIfContextIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _logger.LogError(null!, string.Empty));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _logger.LogError(null!, string.Empty));
 
-        Assert.ThrowsException<ArgumentNullException>(() => _logger.LogError(null!, new Exception()));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _logger.LogError(null!, new Exception()));
 
-        Assert.ThrowsException<ArgumentNullException>(() => _logger.LogError(null!, string.Empty, new Exception()));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _logger.LogError(null!, string.Empty, new Exception()));
     }
 
     [TestMethod]
     public void LogErrorShouldThrowExceptionIfTextIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _logger.LogError(_context, (string)null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _logger.LogError(_context, (string)null!));
 
-        Assert.ThrowsException<ArgumentNullException>(() => _logger.LogError(_context, null!, new Exception()));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _logger.LogError(_context, null!, new Exception()));
     }
 
     [TestMethod]
     public void LogErrorShouldThrowExceptionIfExceptionIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _logger.LogError(_context, (Exception?)null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _logger.LogError(_context, (Exception?)null!));
 
-        Assert.ThrowsException<ArgumentNullException>(() => _logger.LogError(_context, string.Empty, null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _logger.LogError(_context, string.Empty, null!));
     }
 
     [TestMethod]

--- a/test/datacollector.UnitTests/TestPlatformDataCollectionSinkTests.cs
+++ b/test/datacollector.UnitTests/TestPlatformDataCollectionSinkTests.cs
@@ -41,7 +41,7 @@ public class TestPlatformDataCollectionSinkTests
     [TestMethod]
     public void SendFileAsyncShouldThrowExceptionIfFileTransferInformationIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _dataCollectionSink.SendFileAsync(default!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _dataCollectionSink.SendFileAsync(default!));
     }
 
     [TestMethod]

--- a/test/testhost.UnitTests/DefaultEngineInvokerTests.cs
+++ b/test/testhost.UnitTests/DefaultEngineInvokerTests.cs
@@ -81,7 +81,7 @@ public class DefaultEngineInvokerTests
     public void InvokeShouldThrowExceptionIfDataCollectorConnection()
     {
         _mockDataCollectionTestCaseEventSender.Setup(s => s.WaitForRequestSenderConnection(It.IsAny<int>())).Returns(false);
-        var message = Assert.ThrowsException<TestPlatformException>(() => _engineInvoker.Invoke(ArgsDictionary)).Message;
+        var message = Assert.ThrowsExactly<TestPlatformException>(() => _engineInvoker.Invoke(ArgsDictionary)).Message;
 
         Assert.AreEqual(message, TimeoutErrorMessage);
     }

--- a/test/testhost.UnitTests/TestHostTraceListenerTests.cs
+++ b/test/testhost.UnitTests/TestHostTraceListenerTests.cs
@@ -42,31 +42,27 @@ public class TestHostTraceListenerTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(DebugAssertException))]
     public void DebugAssertThrowsDebugAssertException()
     {
-        Debug.Assert(false);
+        Assert.ThrowsExactly<DebugAssertException>(() => Debug.Assert(false));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(DebugAssertException))]
     public void DebugFailThrowsDebugAssertException()
     {
-        Debug.Fail("fail");
+        Assert.ThrowsExactly<DebugAssertException>(() => Debug.Fail("fail"));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(DebugAssertException))]
     public void TraceAssertThrowsDebugAssertException()
     {
-        Trace.Assert(false);
+        Assert.ThrowsExactly<DebugAssertException>(() => Trace.Assert(false));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(DebugAssertException))]
     public void TraceFailThrowsDebugAssertException()
     {
-        Trace.Fail("fail");
+        Assert.ThrowsExactly<DebugAssertException>(() => Trace.Fail("fail"));
     }
 
     [TestMethod]

--- a/test/testhost.UnitTests/UnitTestClientTests.cs
+++ b/test/testhost.UnitTests/UnitTestClientTests.cs
@@ -59,7 +59,7 @@ public class UnitTestClientTests
         bool threadCultureWasSet = false;
 
         // Act - We have an exception because we are not passing the right args but that's ok for our test
-        Assert.ThrowsException<ArgumentException>(() => Program.Run(null, new(envVarMock.Object, lang => threadCultureWasSet = lang.Equals(culture))));
+        Assert.ThrowsExactly<ArgumentException>(() => Program.Run(null, new(envVarMock.Object, lang => threadCultureWasSet = lang.Equals(culture))));
 
         // Assert
         Assert.IsTrue(threadCultureWasSet, "DefaultThreadCurrentUICulture was not set");
@@ -81,7 +81,7 @@ public class UnitTestClientTests
         bool threadCultureWasSet = false;
 
         // Act - We have an exception because we are not passing the right args but that's ok for our test
-        Assert.ThrowsException<ArgumentException>(() => Program.Run(null, new(envVarMock.Object, lang => threadCultureWasSet = lang.Equals(culture))));
+        Assert.ThrowsExactly<ArgumentException>(() => Program.Run(null, new(envVarMock.Object, lang => threadCultureWasSet = lang.Equals(culture))));
 
         // Assert
         Assert.IsTrue(threadCultureWasSet, "DefaultThreadCurrentUICulture was not set");
@@ -102,7 +102,7 @@ public class UnitTestClientTests
         bool threadCultureWasSet = false;
 
         // Act - We have an exception because we are not passing the right args but that's ok for our test
-        Assert.ThrowsException<ArgumentException>(() => Program.Run(null, new(envVarMock.Object, lang => threadCultureWasSet = true)));
+        Assert.ThrowsExactly<ArgumentException>(() => Program.Run(null, new(envVarMock.Object, lang => threadCultureWasSet = true)));
 
         // Assert
         Assert.IsFalse(threadCultureWasSet, "DefaultThreadCurrentUICulture was set");

--- a/test/vstest.console.UnitTests/CommandLine/CommandLineOptionsTests.cs
+++ b/test/vstest.console.UnitTests/CommandLine/CommandLineOptionsTests.cs
@@ -42,7 +42,9 @@ public class CommandLineOptionsTests
     [TestMethod]
     public void CommandLineOptionsDiscoveryDefaultBatchSizeIsThousand()
     {
+#pragma warning disable MSTEST0025 // Use 'Assert.Fail' instead of an always-failing assert
         Assert.AreEqual(1000, CommandLineOptions.DefaultDiscoveryBatchSize);
+#pragma warning restore MSTEST0025 // Use 'Assert.Fail' instead of an always-failing assert
     }
 
     [TestMethod]
@@ -71,7 +73,7 @@ public class CommandLineOptionsTests
     [TestMethod]
     public void CommandLineOptionsAddSourceShouldThrowCommandLineExceptionForNullSource()
     {
-        Assert.ThrowsException<TestSourceException>(() => CommandLineOptions.Instance.AddSource(null!));
+        Assert.ThrowsExactly<TestSourceException>(() => CommandLineOptions.Instance.AddSource(null!));
     }
 
     [TestMethod]
@@ -89,7 +91,7 @@ public class CommandLineOptionsTests
     [TestMethod]
     public void CommandLineOptionsAddSourceShouldThrowCommandLineExceptionForInvalidSource()
     {
-        Assert.ThrowsException<TestSourceException>(() => CommandLineOptions.Instance.AddSource("DummySource"));
+        Assert.ThrowsExactly<TestSourceException>(() => CommandLineOptions.Instance.AddSource("DummySource"));
     }
 
     [TestMethod]

--- a/test/vstest.console.UnitTests/InProcessVsTestConsoleWrapperTests.cs
+++ b/test/vstest.console.UnitTests/InProcessVsTestConsoleWrapperTests.cs
@@ -87,7 +87,7 @@ public class InProcessVsTestConsoleWrapperTests
     {
         _mockRequestSender.Setup(rs => rs.InitializeCommunication()).Returns(-1);
 
-        Assert.ThrowsException<TransationLayerException>(() =>
+        Assert.ThrowsExactly<TransationLayerException>(() =>
             new InProcessVsTestConsoleWrapper(
                 new ConsoleParameters(),
                 _mockEnvironmentVariableHelper.Object,

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -61,7 +61,7 @@ public class ConsoleLoggerTests
     [TestMethod]
     public void InitializeShouldThrowExceptionIfEventsIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _consoleLogger.Initialize(null!, string.Empty));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _consoleLogger.Initialize(null!, string.Empty));
     }
 
     [TestMethod]
@@ -78,19 +78,19 @@ public class ConsoleLoggerTests
             { "param1", "value" },
         };
 
-        Assert.ThrowsException<ArgumentNullException>(() => _consoleLogger.Initialize(null!, parameters));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _consoleLogger.Initialize(null!, parameters));
     }
 
     [TestMethod]
     public void InitializeWithParametersShouldThrowExceptionIfParametersIsEmpty()
     {
-        Assert.ThrowsException<ArgumentException>(() => _consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, new Dictionary<string, string?>()));
+        Assert.ThrowsExactly<ArgumentException>(() => _consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, new Dictionary<string, string?>()));
     }
 
     [TestMethod]
     public void InitializeWithParametersShouldThrowExceptionIfParametersIsNull()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, (Dictionary<string, string?>)null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _consoleLogger.Initialize(new Mock<TestLoggerEvents>().Object, (Dictionary<string, string?>)null!));
     }
 
     [TestMethod]
@@ -159,7 +159,7 @@ public class ConsoleLoggerTests
         var loggerEvents = new InternalTestLoggerEvents(TestSessionMessageLogger.Instance);
         loggerEvents.EnableEvents();
 
-        Assert.ThrowsException<ArgumentNullException>(() => loggerEvents.RaiseTestRunMessage(default!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => loggerEvents.RaiseTestRunMessage(default!));
     }
 
     [TestMethod]
@@ -230,7 +230,7 @@ public class ConsoleLoggerTests
         var loggerEvents = new InternalTestLoggerEvents(TestSessionMessageLogger.Instance);
         loggerEvents.EnableEvents();
 
-        Assert.ThrowsException<ArgumentNullException>(() => loggerEvents.RaiseTestResult(default!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => loggerEvents.RaiseTestResult(default!));
     }
 
     [TestMethod]
@@ -781,7 +781,7 @@ public class ConsoleLoggerTests
     [DataRow("[1 h]", new int[5] { 0, 1, 0, 5, 78 })]
     [DataRow("[5 m]", new int[5] { 0, 0, 5, 0, 78 })]
     [DataRow("[4 s]", new int[5] { 0, 0, 0, 4, 0 })]
-    [DataTestMethod]
+    [TestMethod]
     public void TestResultHandlerForTestResultWithDurationShouldPrintDurationInfo(string expectedDuration, int[] timeSpanArgs)
     {
         var loggerEvents = new InternalTestLoggerEvents(TestSessionMessageLogger.Instance);
@@ -804,7 +804,7 @@ public class ConsoleLoggerTests
         _mockOutput.Verify(o => o.WriteLine("TestName " + expectedDuration, OutputLevel.Information), Times.Once());
     }
 
-    [DataTestMethod]
+    [TestMethod]
     public void TestResultHandlerForTestResultWithDurationLessThanOneMsShouldPrintDurationInfo()
     {
         var loggerEvents = new InternalTestLoggerEvents(TestSessionMessageLogger.Instance);

--- a/test/vstest.console.UnitTests/Internal/FilePatternParserTests.cs
+++ b/test/vstest.console.UnitTests/Internal/FilePatternParserTests.cs
@@ -111,7 +111,7 @@ public class FilePatternParserTests
         _mockFileHelper.Setup(x => x.Exists(TranslatePath(@"E:\path\to\project\tests\Blame.Tests\\abc.Tests.dll"))).Returns(false);
         _mockMatcherHelper.Setup(x => x.Execute(It.IsAny<DirectoryInfoWrapper>())).Returns(patternMatchingResult);
 
-        Assert.ThrowsException<TestSourceException>(() => _filePatternParser.GetMatchingFiles(TranslatePath(@"E:\path\to\project\tests\Blame.Tests\\abc.Tests.dll")));
+        Assert.ThrowsExactly<TestSourceException>(() => _filePatternParser.GetMatchingFiles(TranslatePath(@"E:\path\to\project\tests\Blame.Tests\\abc.Tests.dll")));
     }
 
     [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/AeDebuggerArgumentProcessorTest.cs
+++ b/test/vstest.console.UnitTests/Processors/AeDebuggerArgumentProcessorTest.cs
@@ -36,7 +36,9 @@ public class AeDebuggerArgumentProcessorTest
     [TestMethod]
     public void AeDebuggerArgumentProcessorCommandName()
     {
+#pragma warning disable MSTEST0032 // Assertion condition is always true
         Assert.AreEqual("/AeDebugger", AeDebuggerArgumentProcessor.CommandName);
+#pragma warning restore MSTEST0032 // Assertion condition is always true
     }
 
     [TestMethod]
@@ -59,11 +61,11 @@ public class AeDebuggerArgumentProcessorTest
     [TestMethod]
     public void AeDebuggerArgumentExecutor_InvalidCtor()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => new AeDebuggerArgumentExecutor(_environment.Object, _fileHelper.Object, _processHelper.Object, _output.Object, null!));
-        Assert.ThrowsException<ArgumentNullException>(() => new AeDebuggerArgumentExecutor(_environment.Object, _fileHelper.Object, _processHelper.Object, null!, _environmentVariableHelper.Object));
-        Assert.ThrowsException<ArgumentNullException>(() => new AeDebuggerArgumentExecutor(_environment.Object, _fileHelper.Object, null!, _output.Object, _environmentVariableHelper.Object));
-        Assert.ThrowsException<ArgumentNullException>(() => new AeDebuggerArgumentExecutor(_environment.Object, null!, _processHelper.Object, _output.Object, _environmentVariableHelper.Object));
-        Assert.ThrowsException<ArgumentNullException>(() => new AeDebuggerArgumentExecutor(null!, _fileHelper.Object, _processHelper.Object, _output.Object, _environmentVariableHelper.Object));
+        Assert.ThrowsExactly<ArgumentNullException>(() => new AeDebuggerArgumentExecutor(_environment.Object, _fileHelper.Object, _processHelper.Object, _output.Object, null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => new AeDebuggerArgumentExecutor(_environment.Object, _fileHelper.Object, _processHelper.Object, null!, _environmentVariableHelper.Object));
+        Assert.ThrowsExactly<ArgumentNullException>(() => new AeDebuggerArgumentExecutor(_environment.Object, _fileHelper.Object, null!, _output.Object, _environmentVariableHelper.Object));
+        Assert.ThrowsExactly<ArgumentNullException>(() => new AeDebuggerArgumentExecutor(_environment.Object, null!, _processHelper.Object, _output.Object, _environmentVariableHelper.Object));
+        Assert.ThrowsExactly<ArgumentNullException>(() => new AeDebuggerArgumentExecutor(null!, _fileHelper.Object, _processHelper.Object, _output.Object, _environmentVariableHelper.Object));
     }
 
     [TestMethod]
@@ -80,7 +82,7 @@ public class AeDebuggerArgumentProcessorTest
     public void AeDebuggerArgumentExecutor_WrongInstallUnistallCommand(string wrongCommand)
     {
         _executor.Initialize(wrongCommand);
-        Assert.ThrowsException<CommandLineException>(() => _executor.Execute());
+        Assert.ThrowsExactly<CommandLineException>(() => _executor.Execute());
     }
 
     [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/ArtifactProcessingCollectModeProcessorTest.cs
+++ b/test/vstest.console.UnitTests/Processors/ArtifactProcessingCollectModeProcessorTest.cs
@@ -14,7 +14,7 @@ public class ArtifactProcessingCollectModeProcessorTest
 {
     [TestMethod]
     public void ProcessorExecutorInitialize_ShouldFailIfNullCommandOption() =>
-        Assert.ThrowsException<ArgumentNullException>(() => new ArtifactProcessingCollectModeProcessorExecutor(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => new ArtifactProcessingCollectModeProcessorExecutor(null!));
 
     [TestMethod]
     public void ProcessorExecutorInitialize_ShouldNotFailIfNullArg()

--- a/test/vstest.console.UnitTests/Processors/ArtifactProcessingPostProcessModeProcessorTest.cs
+++ b/test/vstest.console.UnitTests/Processors/ArtifactProcessingPostProcessModeProcessorTest.cs
@@ -21,8 +21,8 @@ public class ArtifactProcessingPostProcessModeProcessorTest
     [TestMethod]
     public void ProcessorExecutorInitialize_ShouldFailIfNullCtor()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => new ArtifactProcessingPostProcessModeProcessorExecutor(null!, _artifactProcessingManagerMock.Object));
-        Assert.ThrowsException<ArgumentNullException>(() => new ArtifactProcessingPostProcessModeProcessorExecutor(new CommandLineOptions(), null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => new ArtifactProcessingPostProcessModeProcessorExecutor(null!, _artifactProcessingManagerMock.Object));
+        Assert.ThrowsExactly<ArgumentNullException>(() => new ArtifactProcessingPostProcessModeProcessorExecutor(new CommandLineOptions(), null!));
     }
 
     [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
@@ -157,7 +157,7 @@ public class CliRunSettingsArgumentProcessorTests
         var args = new string[] { arg };
         var str = CommandLineResources.MalformedRunSettingsKey;
 
-        CommandLineException ex = Assert.ThrowsException<CommandLineException>(() => _executor.Initialize(args));
+        CommandLineException ex = Assert.ThrowsExactly<CommandLineException>(() => _executor.Initialize(args));
 
         Assert.AreEqual(str, ex.Message);
     }
@@ -315,8 +315,8 @@ public class CliRunSettingsArgumentProcessorTests
         Assert.IsFalse(_commandLineOptions.FrameworkVersionSpecified);
     }
 
-    [DynamicData(nameof(TestRunParameterArgValidTestCases), DynamicDataSourceType.Method)]
-    [DataTestMethod]
+    [DynamicData(nameof(TestRunParameterArgValidTestCases))]
+    [TestMethod]
     public void InitializeShouldValidateTestRunParameter(string arg, string runSettingsWithTestRunParameters)
     {
         var args = new string[] { arg };
@@ -327,14 +327,14 @@ public class CliRunSettingsArgumentProcessorTests
         Assert.AreEqual(runSettingsWithTestRunParameters, _settingsProvider.ActiveRunSettings.SettingsXml);
     }
 
-    [DynamicData(nameof(TestRunParameterArgInvalidTestCases), DynamicDataSourceType.Method)]
-    [DataTestMethod]
+    [DynamicData(nameof(TestRunParameterArgInvalidTestCases))]
+    [TestMethod]
     public void InitializeShouldThrowErrorIfTestRunParameterNodeIsInValid(string arg)
     {
         var args = new string[] { arg };
         var str = string.Format(CultureInfo.CurrentCulture, CommandLineResources.InvalidTestRunParameterArgument, arg);
 
-        CommandLineException ex = Assert.ThrowsException<CommandLineException>(() => _executor.Initialize(args));
+        CommandLineException ex = Assert.ThrowsExactly<CommandLineException>(() => _executor.Initialize(args));
 
         Assert.AreEqual(str, ex.Message);
     }

--- a/test/vstest.console.UnitTests/Processors/CollectArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CollectArgumentProcessorTests.cs
@@ -86,19 +86,19 @@ public class CollectArgumentProcessorTests
     [TestMethod]
     public void InitializeShouldThrowIfArgumentIsNull()
     {
-        Assert.ThrowsException<CommandLineException>(() => _executor.Initialize(null));
+        Assert.ThrowsExactly<CommandLineException>(() => _executor.Initialize(null));
     }
 
     [TestMethod]
     public void InitializeShouldNotThrowIfArgumentIsEmpty()
     {
-        Assert.ThrowsException<CommandLineException>(() => _executor.Initialize(string.Empty));
+        Assert.ThrowsExactly<CommandLineException>(() => _executor.Initialize(string.Empty));
     }
 
     [TestMethod]
     public void InitializeShouldNotThrowIfArgumentIsWhiteSpace()
     {
-        Assert.ThrowsException<CommandLineException>(() => _executor.Initialize(" "));
+        Assert.ThrowsExactly<CommandLineException>(() => _executor.Initialize(" "));
     }
 
     [TestMethod]
@@ -597,7 +597,7 @@ public class CollectArgumentProcessorTests
         runsettings.LoadSettingsXml(runsettingsString);
         _settingsProvider.SetActiveRunSettings(runsettings);
 
-        Assert.ThrowsException<CommandLineException>(() => _executor.Initialize("MyDataCollector=SomeSetting"));
+        Assert.ThrowsExactly<CommandLineException>(() => _executor.Initialize("MyDataCollector=SomeSetting"));
     }
 
     [TestMethod]
@@ -608,7 +608,7 @@ public class CollectArgumentProcessorTests
         runsettings.LoadSettingsXml(runsettingsString);
         _settingsProvider.SetActiveRunSettings(runsettings);
 
-        Assert.ThrowsException<CommandLineException>(() => _executor.Initialize("MyDataCollector;SomeSetting"));
+        Assert.ThrowsExactly<CommandLineException>(() => _executor.Initialize("MyDataCollector;SomeSetting"));
     }
 
     [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/DisableAutoFakesArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/DisableAutoFakesArgumentProcessorTests.cs
@@ -34,14 +34,14 @@ public class DisableAutoFakesArgumentProcessorTests
     [TestMethod]
     public void DisableAutoFakesArgumentProcessorExecutorShouldThrowIfArgumentIsNullOrEmpty()
     {
-        Assert.ThrowsException<CommandLineException>(() => _disableAutoFakesArgumentProcessor.Executor!.Value.Initialize(string.Empty));
-        Assert.ThrowsException<CommandLineException>(() => _disableAutoFakesArgumentProcessor.Executor!.Value.Initialize(" "));
+        Assert.ThrowsExactly<CommandLineException>(() => _disableAutoFakesArgumentProcessor.Executor!.Value.Initialize(string.Empty));
+        Assert.ThrowsExactly<CommandLineException>(() => _disableAutoFakesArgumentProcessor.Executor!.Value.Initialize(" "));
     }
 
     [TestMethod]
     public void DisableAutoFakesArgumentProcessorExecutorShouldThrowIfArgumentIsNotBooleanString()
     {
-        Assert.ThrowsException<CommandLineException>(() => _disableAutoFakesArgumentProcessor.Executor!.Value.Initialize("DisableAutoFakes"));
+        Assert.ThrowsExactly<CommandLineException>(() => _disableAutoFakesArgumentProcessor.Executor!.Value.Initialize("DisableAutoFakes"));
     }
 
     [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/EnableBlameArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableBlameArgumentProcessorTests.cs
@@ -211,7 +211,6 @@ public class EnableBlameArgumentProcessorTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(CommandLineException))]
     public void InitializeShouldThrowIfInvalidParameterFormatIsSpecifiedForCollectDumpOption()
     {
         var invalidString = "CollectDump;sdf=sdg;;as;a=";
@@ -225,32 +224,7 @@ public class EnableBlameArgumentProcessorTests
         _mockEnvronment.Setup(x => x.Architecture)
             .Returns(PlatformArchitecture.X64);
 
-        _executor.Initialize(invalidString);
-        _mockOutput.Verify(x => x.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.InvalidBlameArgument, invalidString), OutputLevel.Warning));
-
-        Assert.IsNotNull(_settingsProvider.ActiveRunSettings);
-        Assert.AreEqual(string.Join(Environment.NewLine,
-                "<?xml version=\"1.0\" encoding=\"utf-16\"?>",
-                "<RunSettings>",
-                "  <DataCollectionRunSettings>",
-                "    <DataCollectors>",
-                "      <DataCollector friendlyName=\"blame\" enabled=\"True\">",
-                "        <Configuration>",
-                "          <ResultsDirectory>C:\\dir\\TestResults</ResultsDirectory>",
-                "        </Configuration>",
-                "      </DataCollector>",
-                "    </DataCollectors>",
-                "  </DataCollectionRunSettings>",
-                "  <RunConfiguration>",
-                "    <ResultsDirectory>C:\\dir\\TestResults</ResultsDirectory>",
-                "  </RunConfiguration>",
-                "  <LoggerRunSettings>",
-                "    <Loggers>",
-                "      <Logger friendlyName=\"blame\" enabled=\"True\" />",
-                "    </Loggers>",
-                "  </LoggerRunSettings>",
-                "</RunSettings>"),
-            _settingsProvider.ActiveRunSettings.SettingsXml);
+        Assert.ThrowsExactly<CommandLineException>(() => _executor.Initialize(invalidString));
     }
 
     [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/EnableDiagArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableDiagArgumentProcessorTests.cs
@@ -178,7 +178,7 @@ public class EnableDiagArgumentProcessorTests
 
     private void EnableDiagArgumentProcessorExecutorShouldThrowIfInvalidArgument(string argument, string exceptionMessage)
     {
-        var e = Assert.ThrowsException<CommandLineException>(() => _diagProcessor.Executor!.Value.Initialize(argument));
+        var e = Assert.ThrowsExactly<CommandLineException>(() => _diagProcessor.Executor!.Value.Initialize(argument));
         StringAssert.Contains(e.Message, exceptionMessage);
     }
 }

--- a/test/vstest.console.UnitTests/Processors/ListFullyQualifiedTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListFullyQualifiedTestsArgumentProcessorTests.cs
@@ -148,7 +148,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager, null);
 
-        Assert.ThrowsException<CommandLineException>(() => executor.Execute());
+        Assert.ThrowsExactly<CommandLineException>(() => executor.Execute());
     }
 
     [TestMethod]
@@ -166,7 +166,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
 
         var executor = GetExecutor(testRequestManager, null);
 
-        Assert.ThrowsException<TestPlatformException>(() => executor.Execute());
+        Assert.ThrowsExactly<TestPlatformException>(() => executor.Execute());
     }
 
     [TestMethod]
@@ -183,7 +183,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
 
         var listTestsArgumentExecutor = GetExecutor(testRequestManager, null);
 
-        Assert.ThrowsException<SettingsException>(() => listTestsArgumentExecutor.Execute());
+        Assert.ThrowsExactly<SettingsException>(() => listTestsArgumentExecutor.Execute());
     }
 
     [TestMethod]
@@ -202,7 +202,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
 
         var listTestsArgumentExecutor = GetExecutor(testRequestManager, null);
 
-        Assert.ThrowsException<InvalidOperationException>(() => listTestsArgumentExecutor.Execute());
+        Assert.ThrowsExactly<InvalidOperationException>(() => listTestsArgumentExecutor.Execute());
     }
 
     [TestMethod]
@@ -220,7 +220,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
 
         var executor = GetExecutor(testRequestManager, null);
 
-        Assert.ThrowsException<Exception>(() => executor.Execute());
+        Assert.ThrowsExactly<Exception>(() => executor.Execute());
     }
 
     [TestMethod]
@@ -255,14 +255,13 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
         Assert.IsFalse(fileOutput.Contains("Test2"));
     }
 
-    [ExpectedException(typeof(CommandLineException))]
     [TestMethod]
     public void ExecutorExecuteShouldThrowWhenListFullyQualifiedTestsTargetPathIsEmpty()
     {
         var mockDiscoveryRequest = new Mock<IDiscoveryRequest>();
         var mockConsoleOutput = new Mock<IOutput>();
 
-        RunListFullyQualifiedTestArgumentProcessorExecuteWithMockSetup(mockDiscoveryRequest, mockConsoleOutput, false);
+        Assert.ThrowsExactly<CommandLineException>(() => RunListFullyQualifiedTestArgumentProcessorExecuteWithMockSetup(mockDiscoveryRequest, mockConsoleOutput, false));
     }
 
     [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
@@ -151,7 +151,7 @@ public class ListTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager, null);
 
-        Assert.ThrowsException<CommandLineException>(() => executor.Execute());
+        Assert.ThrowsExactly<CommandLineException>(() => executor.Execute());
     }
 
     [TestMethod]
@@ -168,7 +168,7 @@ public class ListTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager, null);
 
-        Assert.ThrowsException<TestPlatformException>(() => executor.Execute());
+        Assert.ThrowsExactly<TestPlatformException>(() => executor.Execute());
     }
 
     [TestMethod]
@@ -185,7 +185,7 @@ public class ListTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var listTestsArgumentExecutor = GetExecutor(testRequestManager, null);
 
-        Assert.ThrowsException<SettingsException>(() => listTestsArgumentExecutor.Execute());
+        Assert.ThrowsExactly<SettingsException>(() => listTestsArgumentExecutor.Execute());
     }
 
     [TestMethod]
@@ -202,7 +202,7 @@ public class ListTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var listTestsArgumentExecutor = GetExecutor(testRequestManager, null);
 
-        Assert.ThrowsException<InvalidOperationException>(() => listTestsArgumentExecutor.Execute());
+        Assert.ThrowsExactly<InvalidOperationException>(() => listTestsArgumentExecutor.Execute());
     }
 
     [TestMethod]
@@ -219,7 +219,7 @@ public class ListTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager, null);
 
-        Assert.ThrowsException<Exception>(() => executor.Execute());
+        Assert.ThrowsExactly<Exception>(() => executor.Execute());
     }
 
     [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
@@ -164,7 +164,7 @@ public class PortArgumentProcessorTests
 
         int port = 2345;
         _executor.Initialize(port.ToString(CultureInfo.InvariantCulture));
-        Assert.ThrowsException<CommandLineException>(() => _executor.Execute());
+        Assert.ThrowsExactly<CommandLineException>(() => _executor.Execute());
 
         _testDesignModeClient.Verify(td => td.ConnectToClientAndProcessRequests(port, _testRequestManager.Object), Times.Once);
     }

--- a/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
@@ -124,7 +124,7 @@ public class RunSpecificTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
-        Assert.ThrowsException<CommandLineException>(() => executor.Initialize(null));
+        Assert.ThrowsExactly<CommandLineException>(() => executor.Initialize(null));
     }
 
     [TestMethod]
@@ -135,7 +135,7 @@ public class RunSpecificTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
-        Assert.ThrowsException<CommandLineException>(() => executor.Initialize(string.Empty));
+        Assert.ThrowsExactly<CommandLineException>(() => executor.Initialize(string.Empty));
     }
 
     [TestMethod]
@@ -146,7 +146,7 @@ public class RunSpecificTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
-        Assert.ThrowsException<CommandLineException>(() => executor.Initialize(" "));
+        Assert.ThrowsExactly<CommandLineException>(() => executor.Initialize(" "));
     }
 
     [TestMethod]
@@ -157,7 +157,7 @@ public class RunSpecificTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
-        Assert.ThrowsException<CommandLineException>(() => executor.Initialize(" , "));
+        Assert.ThrowsExactly<CommandLineException>(() => executor.Initialize(" , "));
     }
 
     [TestMethod]
@@ -168,7 +168,7 @@ public class RunSpecificTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
-        Assert.ThrowsException<CommandLineException>(() => executor.Execute());
+        Assert.ThrowsExactly<CommandLineException>(() => executor.Execute());
     }
 
     [TestMethod]
@@ -179,7 +179,7 @@ public class RunSpecificTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
-        Assert.ThrowsException<CommandLineException>(() => executor.Execute());
+        Assert.ThrowsExactly<CommandLineException>(() => executor.Execute());
     }
 
     [TestMethod]
@@ -229,7 +229,7 @@ public class RunSpecificTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
-        Assert.ThrowsException<TestPlatformException>(() => executor.Execute());
+        Assert.ThrowsExactly<TestPlatformException>(() => executor.Execute());
     }
 
     [TestMethod]
@@ -247,7 +247,7 @@ public class RunSpecificTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
-        Assert.ThrowsException<InvalidOperationException>(() => executor.Execute());
+        Assert.ThrowsExactly<InvalidOperationException>(() => executor.Execute());
     }
 
     [TestMethod]
@@ -265,7 +265,7 @@ public class RunSpecificTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
-        Assert.ThrowsException<SettingsException>(() => executor.Execute());
+        Assert.ThrowsExactly<SettingsException>(() => executor.Execute());
     }
 
     [TestMethod]
@@ -292,7 +292,7 @@ public class RunSpecificTestsArgumentProcessorTests
 
         executor.Initialize("Test1");
 
-        Assert.ThrowsException<TestPlatformException>(() => executor.Execute());
+        Assert.ThrowsExactly<TestPlatformException>(() => executor.Execute());
     }
 
     [TestMethod]
@@ -319,7 +319,7 @@ public class RunSpecificTestsArgumentProcessorTests
 
         executor.Initialize("Test1");
 
-        Assert.ThrowsException<SettingsException>(() => executor.Execute());
+        Assert.ThrowsExactly<SettingsException>(() => executor.Execute());
     }
 
     [TestMethod]
@@ -347,7 +347,7 @@ public class RunSpecificTestsArgumentProcessorTests
 
         executor.Initialize("Test1");
 
-        Assert.ThrowsException<InvalidOperationException>(() => executor.Execute());
+        Assert.ThrowsExactly<InvalidOperationException>(() => executor.Execute());
     }
 
     [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
@@ -133,7 +133,7 @@ public class RunTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
-        Assert.ThrowsException<CommandLineException>(() => executor.Execute());
+        Assert.ThrowsExactly<CommandLineException>(() => executor.Execute());
     }
 
     private RunTestsArgumentExecutor GetExecutor(ITestRequestManager testRequestManager)
@@ -163,7 +163,7 @@ public class RunTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
-        Assert.ThrowsException<TestPlatformException>(() => executor.Execute());
+        Assert.ThrowsExactly<TestPlatformException>(() => executor.Execute());
     }
 
     [TestMethod]
@@ -179,7 +179,7 @@ public class RunTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
-        Assert.ThrowsException<SettingsException>(() => executor.Execute());
+        Assert.ThrowsExactly<SettingsException>(() => executor.Execute());
     }
 
     [TestMethod]
@@ -195,7 +195,7 @@ public class RunTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
-        Assert.ThrowsException<InvalidOperationException>(() => executor.Execute());
+        Assert.ThrowsExactly<InvalidOperationException>(() => executor.Execute());
     }
 
     [TestMethod]
@@ -211,7 +211,7 @@ public class RunTestsArgumentProcessorTests
         var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
-        Assert.ThrowsException<Exception>(() => executor.Execute());
+        Assert.ThrowsExactly<Exception>(() => executor.Execute());
     }
 
     [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/ShowDeprecateDotnetVStestMessageArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ShowDeprecateDotnetVStestMessageArgumentProcessorTests.cs
@@ -13,7 +13,9 @@ public class ShowDeprecateDotnetVStestMessageArgumentProcessorTests
     [TestMethod]
     public void ShowDeprecateDotnetVStestMessageProcessorCommandName()
     {
+#pragma warning disable MSTEST0032 // Assertion condition is always true
         Assert.AreEqual("/ShowDeprecateDotnetVSTestMessage", ShowDeprecateDotnetVStestMessageArgumentProcessor.CommandName);
+#pragma warning restore MSTEST0032 // Assertion condition is always true
     }
 
     [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/TestSessionCorrelationIdProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestSessionCorrelationIdProcessorTests.cs
@@ -14,13 +14,13 @@ public class TestSessionCorrelationIdProcessorTests
 {
     [TestMethod]
     public void ProcessorExecutorInitialize_ShouldFailIfNullCommandOption() =>
-        Assert.ThrowsException<ArgumentNullException>(() => new TestSessionCorrelationIdProcessorModeProcessorExecutor(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => new TestSessionCorrelationIdProcessorModeProcessorExecutor(null!));
 
     [TestMethod]
     public void ProcessorExecutorInitialize_ShouldFailIfNullSession()
     {
         TestSessionCorrelationIdProcessorModeProcessorExecutor testSessionCorrelationIdProcessor = new(new CommandLineOptions());
-        Assert.ThrowsException<CommandLineException>(() => testSessionCorrelationIdProcessor.Initialize(null));
+        Assert.ThrowsExactly<CommandLineException>(() => testSessionCorrelationIdProcessor.Initialize(null));
     }
 
     [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/UseVsixExtensionsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/UseVsixExtensionsArgumentProcessorTests.cs
@@ -70,7 +70,7 @@ public class UseVsixExtensionsArgumentProcessorTests
     [TestMethod]
     public void InitializeShouldThrowExceptionIfArgumentIsNull()
     {
-        var message = Assert.ThrowsException<CommandLineException>(() => _executor.Initialize(null)).Message;
+        var message = Assert.ThrowsExactly<CommandLineException>(() => _executor.Initialize(null)).Message;
         Assert.AreEqual(@"The /UseVsixExtensions parameter requires a value. If 'true', the installed VSIX extensions (if any) will be used in the test run. If false, they will be ignored.   Example:  /UseVsixExtensions:true", message);
     }
 
@@ -79,7 +79,7 @@ public class UseVsixExtensionsArgumentProcessorTests
     {
         var invalidArg = "Foo";
 
-        var message = Assert.ThrowsException<CommandLineException>(() => _executor.Initialize(invalidArg)).Message;
+        var message = Assert.ThrowsExactly<CommandLineException>(() => _executor.Initialize(invalidArg)).Message;
         Assert.AreEqual(@"Argument Foo is not expected in the 'UseVsixExtensions' command. Specify the command indicating whether the vsix extensions should be used or skipped (Example: vstest.console.exe myTests.dll /UseVsixExtensions:true) and try again.", message);
     }
 

--- a/test/vstest.console.UnitTests/Processors/Utilities/ArgumentProcessorFactoryTests.cs
+++ b/test/vstest.console.UnitTests/Processors/Utilities/ArgumentProcessorFactoryTests.cs
@@ -168,7 +168,7 @@ public class ArgumentProcessorFactoryTests
         foreach (var processor in allProcessors)
         {
             var instance = Activator.CreateInstance(processor) as IArgumentProcessor;
-            Assert.IsNotNull(instance, "Unable to instantiate processor: {0}", processor);
+            Assert.IsNotNull(instance, $"Unable to instantiate processor: {processor}");
 
             var specialProcessor = instance.Metadata.Value.IsSpecialCommand;
             if ((specialCommandFilter && specialProcessor) || (!specialCommandFilter && !specialProcessor))

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -1290,52 +1290,52 @@ public class TestRequestManagerTests
     [TestMethod]
     public void RunTestsIfThrowsTestPlatformExceptionShouldThrowOut()
     {
-        Assert.ThrowsException<TestPlatformException>(() => RunTestsIfThrowsExceptionShouldThrowOut(new TestPlatformException("HelloWorld")));
+        Assert.ThrowsExactly<TestPlatformException>(() => RunTestsIfThrowsExceptionShouldThrowOut(new TestPlatformException("HelloWorld")));
     }
 
     [TestMethod]
     public void RunTestsIfThrowsSettingsExceptionShouldThrowOut()
     {
-        Assert.ThrowsException<SettingsException>(() => RunTestsIfThrowsExceptionShouldThrowOut(new SettingsException("HelloWorld")));
+        Assert.ThrowsExactly<SettingsException>(() => RunTestsIfThrowsExceptionShouldThrowOut(new SettingsException("HelloWorld")));
     }
 
     [TestMethod]
     public void RunTestsIfThrowsInvalidOperationExceptionShouldThrowOut()
     {
-        Assert.ThrowsException<InvalidOperationException>(() => RunTestsIfThrowsExceptionShouldThrowOut(new InvalidOperationException("HelloWorld")));
+        Assert.ThrowsExactly<InvalidOperationException>(() => RunTestsIfThrowsExceptionShouldThrowOut(new InvalidOperationException("HelloWorld")));
     }
 
     [TestMethod]
     public void RunTestsIfThrowsExceptionShouldThrowOut()
     {
-        Assert.ThrowsException<NotImplementedException>(() => RunTestsIfThrowsExceptionShouldThrowOut(new NotImplementedException("HelloWorld")));
+        Assert.ThrowsExactly<NotImplementedException>(() => RunTestsIfThrowsExceptionShouldThrowOut(new NotImplementedException("HelloWorld")));
     }
 
     [TestMethod]
     public void DiscoverTestsIfThrowsTestPlatformExceptionShouldThrowOut()
     {
-        Assert.ThrowsException<TestPlatformException>(() => DiscoverTestsIfThrowsExceptionShouldThrowOut(new TestPlatformException("HelloWorld")));
+        Assert.ThrowsExactly<TestPlatformException>(() => DiscoverTestsIfThrowsExceptionShouldThrowOut(new TestPlatformException("HelloWorld")));
     }
 
     [TestMethod]
     public void DiscoverTestsIfThrowsSettingsExceptionShouldThrowOut()
     {
-        Assert.ThrowsException<SettingsException>(() => DiscoverTestsIfThrowsExceptionShouldThrowOut(new SettingsException("HelloWorld")));
+        Assert.ThrowsExactly<SettingsException>(() => DiscoverTestsIfThrowsExceptionShouldThrowOut(new SettingsException("HelloWorld")));
     }
 
     [TestMethod]
     public void DiscoverTestsIfThrowsInvalidOperationExceptionShouldThrowOut()
     {
-        Assert.ThrowsException<InvalidOperationException>(() => DiscoverTestsIfThrowsExceptionShouldThrowOut(new InvalidOperationException("HelloWorld")));
+        Assert.ThrowsExactly<InvalidOperationException>(() => DiscoverTestsIfThrowsExceptionShouldThrowOut(new InvalidOperationException("HelloWorld")));
     }
 
     [TestMethod]
     public void DiscoverTestsIfThrowsExceptionShouldThrowOut()
     {
-        Assert.ThrowsException<NotImplementedException>(() => DiscoverTestsIfThrowsExceptionShouldThrowOut(new NotImplementedException("HelloWorld")));
+        Assert.ThrowsExactly<NotImplementedException>(() => DiscoverTestsIfThrowsExceptionShouldThrowOut(new NotImplementedException("HelloWorld")));
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(true)]
     [DataRow(false)]
     public void DiscoverTestsShouldUpdateDesignModeAndCollectSourceInformation(bool designModeValue)
@@ -1369,7 +1369,7 @@ public class TestRequestManagerTests
             tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.Is<DiscoveryCriteria>(dc => dc.RunSettings!.Contains(designmode)), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>()));
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(true)]
     [DataRow(false)]
     public void RunTestsShouldUpdateDesignModeIfRunnerIsInDesignMode(bool designModeValue)
@@ -1389,7 +1389,7 @@ public class TestRequestManagerTests
         _mockTestPlatform.Verify(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.Is<TestRunCriteria>(rc => rc.TestRunSettings!.Contains(designmode)), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>()));
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(true)]
     [DataRow(false)]
     public void DiscoverTestsShouldNotUpdateCollectSourceInformationIfUserHasSetItInRunSettings(bool val)
@@ -2561,10 +2561,10 @@ public class TestRequestManagerTests
                 Assert.IsNotNull(eventArgs.TestSessionInfo);
                 Assert.IsNotNull(eventArgs.Metrics);
                 Assert.AreEqual(eventArgs.TestSessionInfo, testSessionInfo);
-                Assert.AreEqual(eventArgs.IsStopped, false);
+                Assert.AreEqual(false, eventArgs.IsStopped);
             });
 
-        Assert.ThrowsException<Exception>(() =>
+        Assert.ThrowsExactly<Exception>(() =>
             _testRequestManager.StopTestSession(
                 new()
                 {


### PR DESCRIPTION
## Description

Moved to mstest 4.1, some edits were a bit annoying, with the formatting no longer working for assertions. Also the context moved to be the same directory as deploy, which caused a nice message saying that file is in use, but in reality I was saying 

var destination = samePath;
Copy(samePath, destination)

Fixed unit tests for communication utilities, to no longer reset the timeout to 90s when running in parallel, because then few tests that are unlucky will always run into it and wait 90s for timeout they test. 

Test.cmd before: 09m19s
Test.cmd after: 0m35s

