### PR TITLE
[don't merge] Try filtering out tests fails on net9

### DIFF
--- a/dotnet.config
+++ b/dotnet.config
@@ -1,2 +1,0 @@
-[dotnet.test.runner]
-name = "Microsoft.Testing.Platform"

--- a/global.json
+++ b/global.json
@@ -40,5 +40,8 @@
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26127.1"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
@@ -22,6 +22,8 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 // this whole thing is complicated and depends on versions of OS and the target runtime
 // keeping this for later
 [TestCategory("Windows-Review")]
+[TestCategory("aaa")]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class BlameDataCollectorTests : AcceptanceTestBase
 {
     public const string NETCOREANDFX = "net462;net472;net8.0";
@@ -41,6 +43,7 @@ public class BlameDataCollectorTests : AcceptanceTestBase
     }
 
     [TestMethod]
+    [TestCategory("aaa")]
     [TestCategory("Windows-Review")]
     [NetFullTargetFrameworkDataSource]
     [NetCoreTargetFrameworkDataSource]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
@@ -19,11 +19,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-// this whole thing is complicated and depends on versions of OS and the target runtime
-// keeping this for later
 [TestCategory("Windows-Review")]
-[TestCategory("aaa")]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class BlameDataCollectorTests : AcceptanceTestBase
 {
     public const string NETCOREANDFX = "net462;net472;net8.0";

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/CodeCoverageTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/CodeCoverageTests.cs
@@ -45,7 +45,7 @@ internal struct TestParameters
 [TestClass]
 //Code coverage only supported on windows (based on the message in output)
 [TestCategory("Windows-Review")]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class CodeCoverageTests : CodeCoverageAcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/CodeCoverageTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/CodeCoverageTests.cs
@@ -45,6 +45,7 @@ internal struct TestParameters
 [TestClass]
 //Code coverage only supported on windows (based on the message in output)
 [TestCategory("Windows-Review")]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class CodeCoverageTests : CodeCoverageAcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectionTests.cs
@@ -17,7 +17,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class DataCollectionTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectionTests.cs
@@ -17,6 +17,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class DataCollectionTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectorAttachmentsProcessorsFactoryTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectorAttachmentsProcessorsFactoryTests.cs
@@ -22,7 +22,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests.DataCollectorAttachmentsProcessorsFactoryTests;
 
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class DataCollectorAttachmentsProcessorsFactoryTests : AcceptanceTestBase
 {
     private readonly DataCollectorAttachmentsProcessorsFactory _dataCollectorAttachmentsProcessorsFactory = new();

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectorAttachmentsProcessorsFactoryTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectorAttachmentsProcessorsFactoryTests.cs
@@ -22,6 +22,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests.DataCollectorAttachmentsProcessorsFactoryTests;
 
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class DataCollectorAttachmentsProcessorsFactoryTests : AcceptanceTestBase
 {
     private readonly DataCollectorAttachmentsProcessorsFactory _dataCollectorAttachmentsProcessorsFactory = new();

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectorTests.Coverlet.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectorTests.Coverlet.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class DataCollectorTestsCoverlets : IntegrationTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectorTests.Coverlet.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectorTests.Coverlet.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class DataCollectorTestsCoverlets : IntegrationTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DebugAssertTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DebugAssertTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 public class DebugAssertTests : AcceptanceTestBase
 {
     [TestMethod]
-    [TestCategory("Windows-Skip-NETFXTFM")]
+    [SkipIntegrationTestOnNetCondition]
     // this is core only, there is nothing we can do about TPDebug.Assert crashing the process on framework
     [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
     public void RunningTestWithAFailingDebugAssertDoesNotCrashTheHostingProcess(RunnerInfo runnerInfo)

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DebugAssertTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DebugAssertTests.cs
@@ -10,6 +10,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 public class DebugAssertTests : AcceptanceTestBase
 {
     [TestMethod]
+    [TestCategory("Windows-Skip-NETFXTFM")]
     // this is core only, there is nothing we can do about TPDebug.Assert crashing the process on framework
     [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
     public void RunningTestWithAFailingDebugAssertDoesNotCrashTheHostingProcess(RunnerInfo runnerInfo)

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DeprecateExtensionsPathWarningTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DeprecateExtensionsPathWarningTests.cs
@@ -11,6 +11,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
 [TestCategory("Windows-Review")]
+// TODO: but where are some tests? :D
 public class DeprecateExtensionsPathWarningTests : AcceptanceTestBase
 {
     private readonly IList<string> _adapterDependencies;

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DifferentTestFrameworkSimpleTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DifferentTestFrameworkSimpleTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
 [TestCategory("Windows-Review")]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class DifferentTestFrameworkSimpleTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DifferentTestFrameworkSimpleTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DifferentTestFrameworkSimpleTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
 [TestCategory("Windows-Review")]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class DifferentTestFrameworkSimpleTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DisableAppdomainTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DisableAppdomainTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
 [TestCategory("Windows")]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class DisableAppdomainTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DisableAppdomainTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DisableAppdomainTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
 [TestCategory("Windows")]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class DisableAppdomainTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DiscoveryTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DiscoveryTests.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class DiscoveryTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DiscoveryTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DiscoveryTests.cs
@@ -15,7 +15,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class DiscoveryTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetArchitectureSwitchTests.Windows.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetArchitectureSwitchTests.Windows.cs
@@ -18,6 +18,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
 [TestCategory("Windows-Review")]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class DotnetArchitectureSwitchTestsWindowsOnly : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetArchitectureSwitchTests.Windows.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetArchitectureSwitchTests.Windows.cs
@@ -18,7 +18,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
 [TestCategory("Windows-Review")]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class DotnetArchitectureSwitchTestsWindowsOnly : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetHostArchitectureVerifierTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetHostArchitectureVerifierTests.cs
@@ -17,6 +17,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 [TestClass]
 // On Linux/Mac we don't download the same .NET SDK bundles
 [TestCategory("Windows-Review")]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class DotnetHostArchitectureVerifierTests : IntegrationTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetHostArchitectureVerifierTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetHostArchitectureVerifierTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 [TestClass]
 // On Linux/Mac we don't download the same .NET SDK bundles
 [TestCategory("Windows-Review")]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class DotnetHostArchitectureVerifierTests : IntegrationTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestMSBuildOutputTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestMSBuildOutputTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 /// Running dotnet test + csproj and using MSBuild for the output.
 /// </summary>
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class DotnetTestMSBuildOutputTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestMSBuildOutputTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestMSBuildOutputTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 /// Running dotnet test + csproj and using MSBuild for the output.
 /// </summary>
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class DotnetTestMSBuildOutputTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestTests.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class DotnetTestTests : AcceptanceTestBase
 {
     private static string GetFinalVersion(string version)

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestTests.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class DotnetTestTests : AcceptanceTestBase
 {
     private static string GetFinalVersion(string version)

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/EventLogCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/EventLogCollectorTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
 [TestCategory("Windows-Review")]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class EventLogCollectorTests : AcceptanceTestBase
 {
     // Fails randomly https://ci.dot.net/job/Microsoft_vstest/job/master/job/Windows_NT_Release_prtest/2084/console

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/EventLogCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/EventLogCollectorTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
 [TestCategory("Windows-Review")]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class EventLogCollectorTests : AcceptanceTestBase
 {
     // Fails randomly https://ci.dot.net/job/Microsoft_vstest/job/master/job/Windows_NT_Release_prtest/2084/console

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
@@ -16,6 +16,7 @@ using FluentAssertions;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class ExecutionTests : AcceptanceTestBase
 {
     //TODO: It looks like the first 3 tests would be useful to multiply by all 3 test frameworks, should we make the test even more generic, or duplicate them?

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
@@ -16,7 +16,7 @@ using FluentAssertions;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class ExecutionTests : AcceptanceTestBase
 {
     //TODO: It looks like the first 3 tests would be useful to multiply by all 3 test frameworks, should we make the test even more generic, or duplicate them?

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionThreadApartmentStateTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionThreadApartmentStateTests.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
 [TestCategory("Windows-Review")]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class ExecutionThreadApartmentStateTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionThreadApartmentStateTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionThreadApartmentStateTests.cs
@@ -8,6 +8,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
 [TestCategory("Windows-Review")]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class ExecutionThreadApartmentStateTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/FilePatternParserTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/FilePatternParserTests.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class FilePatternParserTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/FilePatternParserTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/FilePatternParserTests.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class FilePatternParserTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/FrameworkTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/FrameworkTests.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class FrameworkTests : AcceptanceTestBase
 {
 

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/FrameworkTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/FrameworkTests.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class FrameworkTests : AcceptanceTestBase
 {
 

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ListExtensionsTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ListExtensionsTests.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 [TestClass]
 // this is tested only on .NET Framework
 [TestCategory("Windows-Review")]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class ListExtensionsTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ListExtensionsTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ListExtensionsTests.cs
@@ -8,6 +8,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 [TestClass]
 // this is tested only on .NET Framework
 [TestCategory("Windows-Review")]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class ListExtensionsTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/LoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/LoggerTests.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class LoggerTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/LoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/LoggerTests.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class LoggerTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/MultitargetingTestHostTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/MultitargetingTestHostTests.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class MultitargetingTestHostTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/MultitargetingTestHostTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/MultitargetingTestHostTests.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class MultitargetingTestHostTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/PlatformTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/PlatformTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 [TestClass]
 // monitoring the processes does not work correctly
 [TestCategory("Windows-Review")]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class PlatformTests : AcceptanceTestBase
 {
     /// <summary>

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/PlatformTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/PlatformTests.cs
@@ -9,6 +9,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 [TestClass]
 // monitoring the processes does not work correctly
 [TestCategory("Windows-Review")]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class PlatformTests : AcceptanceTestBase
 {
     /// <summary>

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/PortableNugetPackageTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/PortableNugetPackageTests.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class PortableNugetPackageTests : AcceptanceTestBase
 {
     private static string s_portablePackageFolder = string.Empty;

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/PortableNugetPackageTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/PortableNugetPackageTests.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class PortableNugetPackageTests : AcceptanceTestBase
 {
     private static string s_portablePackageFolder = string.Empty;

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/PostProcessingTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/PostProcessingTests.cs
@@ -20,6 +20,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class PostProcessingTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/PostProcessingTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/PostProcessingTests.cs
@@ -20,7 +20,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class PostProcessingTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ProcessesInteractionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ProcessesInteractionTests.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class ProcessesInteractionTests : AcceptanceTestBase
 {
     /// <summary>

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ProcessesInteractionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ProcessesInteractionTests.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class ProcessesInteractionTests : AcceptanceTestBase
 {
     /// <summary>

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/RecursiveResourcesLookupTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/RecursiveResourcesLookupTests.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class RecursiveResourcesLookupTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/RecursiveResourcesLookupTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/RecursiveResourcesLookupTests.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class RecursiveResourcesLookupTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ResultsDirectoryTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ResultsDirectoryTests.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class ResultsDirectoryTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ResultsDirectoryTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ResultsDirectoryTests.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class ResultsDirectoryTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/RunsettingsTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/RunsettingsTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 [TestClass]
 // monitoring the processes does not work correctly
 [TestCategory("Windows-Review")]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class RunsettingsTests : AcceptanceTestBase
 {
     #region Runsettings precedence tests

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/RunsettingsTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/RunsettingsTests.cs
@@ -14,6 +14,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 [TestClass]
 // monitoring the processes does not work correctly
 [TestCategory("Windows-Review")]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class RunsettingsTests : AcceptanceTestBase
 {
     #region Runsettings precedence tests

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/SelfContainedAppTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/SelfContainedAppTests.cs
@@ -13,6 +13,7 @@ public class SelfContainedAppTests : AcceptanceTestBase
 {
     [TestMethod]
     [TestCategory("Windows-Review")]
+    [TestCategory("Windows-Skip-NETFXTFM")]
     [NetCoreTargetFrameworkDataSourceAttribute(useDesktopRunner: false)]
     public void RunningApplicationThatIsBuiltAsSelfContainedWillNotFailToFindHostpolicyDll(RunnerInfo runnerInfo)
     {

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/SelfContainedAppTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/SelfContainedAppTests.cs
@@ -13,7 +13,7 @@ public class SelfContainedAppTests : AcceptanceTestBase
 {
     [TestMethod]
     [TestCategory("Windows-Review")]
-    [TestCategory("Windows-Skip-NETFXTFM")]
+    [SkipIntegrationTestOnNetCondition]
     [NetCoreTargetFrameworkDataSourceAttribute(useDesktopRunner: false)]
     public void RunningApplicationThatIsBuiltAsSelfContainedWillNotFailToFindHostpolicyDll(RunnerInfo runnerInfo)
     {

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/SkipIntegrationTestOnNetConditionAttribute.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/SkipIntegrationTestOnNetConditionAttribute.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.TestPlatform.AcceptanceTests;
+
+public class SkipIntegrationTestOnNetConditionAttribute : ConditionBaseAttribute
+{
+    private readonly bool _include;
+
+    public SkipIntegrationTestOnNetConditionAttribute() : base(ConditionMode.Include)
+    {
+        _include = RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework");
+        IgnoreMessage = "Test was skipped to avoid duplication of the same out-of-process tests between .NET and .NET Framework.";
+    }
+
+    public override string GroupName => "tfm";
+
+    public override bool IsConditionMet => _include;
+}

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TelemetryTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TelemetryTests.cs
@@ -13,7 +13,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class TelemetryTests : AcceptanceTestBase
 {
     private const string TELEMETRY_OPTEDIN = "VSTEST_TELEMETRY_OPTEDIN";

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TelemetryTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TelemetryTests.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class TelemetryTests : AcceptanceTestBase
 {
     private const string TELEMETRY_OPTEDIN = "VSTEST_TELEMETRY_OPTEDIN";

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TestCaseFilterTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TestCaseFilterTests.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class TestCaseFilterTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TestCaseFilterTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TestCaseFilterTests.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class TestCaseFilterTests : AcceptanceTestBase
 {
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TestPlatformNugetPackageTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TestPlatformNugetPackageTests.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
+[TestCategory("Windows-Skip-NETFXTFM")]
 public class TestPlatformNugetPackageTests : CodeCoverageAcceptanceTestBase
 {
     private static string s_nugetPackageFolder = string.Empty;

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TestPlatformNugetPackageTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TestPlatformNugetPackageTests.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-[TestCategory("Windows-Skip-NETFXTFM")]
+[SkipIntegrationTestOnNetCondition]
 public class TestPlatformNugetPackageTests : CodeCoverageAcceptanceTestBase
 {
     private static string s_nugetPackageFolder = string.Empty;

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -202,12 +202,27 @@ public class IntegrationTestBase
     /// <param name="workingDirectory"></param>
     public void InvokeDotnetTest(string arguments, Dictionary<string, string?>? environmentVariables = null, string? workingDirectory = null)
     {
-        if (workingDirectory is not null && !File.Exists(Path.Combine(workingDirectory, "dotnet.config")))
+        string globalJsonPath = Path.Combine(workingDirectory!, "global.json");
+        if (workingDirectory is not null && !File.Exists(globalJsonPath))
         {
-            File.WriteAllText(Path.Combine(workingDirectory, "dotnet.config"), """
-                [dotnet.test.runner]
-                name = "VSTest"
+            // Add global.json to the working directory, to ensure we use vstest to run tests,
+            // global.json is resolved from the working directory, and its parents, so this just makes sure we enforce vstest,
+            // even though we use TestingPlatform to run unit tests.
+            File.WriteAllText(Path.Combine(workingDirectory, "global.json"), """
+                {
+                  "test": {
+                    "runner": "vstest",
+                    }
+                }
                 """);
+        }
+        else
+        {
+            string globalJsonText = File.ReadAllText(globalJsonPath);
+            if (!globalJsonText.Contains("\"runner\": \"vstest\""))
+            {
+                throw new InvalidOperationException($"Custom global.json in path '{globalJsonPath}' does not specify test runner as VSTest.\nContent:\n{globalJsonText}");
+            }
         }
 
         var debugEnvironmentVariables = AddDebugEnvironmentVariables(environmentVariables);


### PR DESCRIPTION
I see local failures in unexpected place locally, trying if that will fail also in ci. if not something is very wrong.

```
RunTestsShouldThrowOnStackOverflowException

        var errorMessage = runnerInfo.TargetFramework == "net462"
            ? $"The active test run was aborted. Reason: Test host process crashed : Process is terminated due to StackOverflowException.{Environment.NewLine}"
            : $"The active test run was aborted. Reason: Test host process crashed : Stack overflow.{Environment.NewLine}";
  ```         
   
<img width="2183" height="294" alt="image" src="https://github.com/user-attachments/assets/c4e2f1a8-e413-4929-9f3c-8d028d43a5a1" />

<img width="2244" height="133" alt="image" src="https://github.com/user-attachments/assets/256290bd-269f-4db4-8400-b0441947fed1" />
