### PR TITLE
Fix attachVS when used for debugging integration tests

### DIFF
--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
@@ -262,6 +263,8 @@ public class IntegrationTestBase
 
         if (_testEnvironment.DebugInfo != null)
         {
+            environmentVariables["VSTEST_DEBUG_ATTACHVS_PATH"] =
+                Path.Combine(Path.GetDirectoryName(Assembly.GetCallingAssembly().Location)!, "AttachVS.exe");
             if (_testEnvironment.DebugInfo.DebugVSTestConsole)
             {
                 environmentVariables["VSTEST_RUNNER_DEBUG_ATTACHVS"] = "1";

--- a/test/Microsoft.TestPlatform.TestUtilities/Microsoft.TestPlatform.TestUtilities.csproj
+++ b/test/Microsoft.TestPlatform.TestUtilities/Microsoft.TestPlatform.TestUtilities.csproj
@@ -17,6 +17,7 @@
     <Compile Include="..\..\shared\NullableAttributes.cs" Link="NullableAttributes.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\AttachVS\AttachVS.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.Common\Microsoft.TestPlatform.Common.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.ObjectModel\Microsoft.TestPlatform.ObjectModel.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.TestPlatform.CoreUtilities\Microsoft.TestPlatform.CoreUtilities.csproj">


### PR DESCRIPTION
## Description

You can specify
<img width="699" height="50" alt="image" src="https://github.com/user-attachments/assets/bf78f3d0-4913-4f2d-b6af-2be56020c42b" />

`DebugVSTestConsole = true` and similar values to data source attributes to debug tests in integration tests, avoiding manually juggling the projects etc.

This fixes how we resolve attach vs to automatically attach back to VS.

