### PR TITLE
Build just once when tfms run in parallel

### DIFF
--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Build.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Build.cs
@@ -35,13 +35,13 @@ public class Build : IntegrationTestBase
         // Mostly just want to avoid using the same mutex across two clones of this repo.
         var mutexName = "VSTest Acceptance Tests build " + IntegrationTestEnvironment.RepoRootDirectory!.Replace('\\', '-').Replace('/', '-').Replace(':', '-');
 
-        var buildMutex = new Mutex(initiallyOwned: true, mutexName, out bool createdNew);
-        Debug.WriteLine($"is mutex new: {createdNew}, name: {mutexName}");
-        if (createdNew)
+        using var buildMutex = new Mutex(initiallyOwned: true, mutexName, out bool createdNew);
+        try
         {
-            // We are the first one of the parallel runs to do this. Build the projects and setup everything.
-            try
+            Debug.WriteLine($"is mutex new: {createdNew}, name: {mutexName}");
+            if (createdNew)
             {
+                // We are the first one of the parallel runs to do this. Build the projects and setup everything.
                 Debug.WriteLine("Starting to build.");
                 var sw = Stopwatch.StartNew();
                 SetDotnetEnvironment();
@@ -63,22 +63,22 @@ public class Build : IntegrationTestBase
                 CopyAndPatchDotnet();
                 Debug.WriteLine($"Copying and patching dotnet took: {sw.ElapsedMilliseconds} ms");
             }
-            finally
+            else
             {
-                buildMutex.ReleaseMutex();
+                // Build is already in progress. Wait for it to finish.
+                var minutes = 15;
+                Debug.WriteLine("Other project is building, waiting for mutex to release.");
+                var gotOne = buildMutex.WaitOne(TimeSpan.FromMinutes(minutes));
+                if (!gotOne)
+                {
+                    throw new TimeoutException($"Timed out after {minutes} minutes, waiting for the other project to finish building. Mutex name: '{mutexName}'");
+                }
+                Debug.WriteLine("Other project is done building, I can start running tests now.");
             }
         }
-        else
+        finally
         {
-            // Build is already in progress. Wait for it to finish.
-            var minutes = 15;
-            Debug.WriteLine("Other project is building, waiting for mutex to release.");
-            var gotOne = buildMutex.WaitOne(TimeSpan.FromMinutes(minutes));
-            if (!gotOne)
-            {
-                throw new TimeoutException($"Timed out after {minutes} minutes, waiting for the other project to finish building. Mutex name: '{mutexName}'");
-            }
-            Debug.WriteLine("Other project is done building, I can start running tests now.");
+            buildMutex.ReleaseMutex();
         }
     }
 

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Build.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Build.cs
@@ -11,6 +11,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Xml.Linq;
 
 using Microsoft.TestPlatform.TestUtilities;
@@ -31,25 +32,54 @@ public class Build : IntegrationTestBase
     [AssemblyInitialize]
     public static void AssemblyInitialize(TestContext _)
     {
-        var sw = Stopwatch.StartNew();
-        SetDotnetEnvironment();
-        Debug.WriteLine($"Setting dotnet environment took: {sw.ElapsedMilliseconds} ms");
-        sw.Restart();
+        // Mostly just want to avoid using the same mutex across two clones of this repo.
+        var mutexName = "VSTest Acceptance Tests build " + IntegrationTestEnvironment.RepoRootDirectory!.Replace('\\', '-').Replace('/', '-').Replace(':', '-');
 
-        var nugetCache = Path.GetFullPath(Path.Combine(Root, ".packages"));
-        var packagesAreNew = UnzipExecutablePackages();
-        if (packagesAreNew)
+        var buildMutex = new Mutex(initiallyOwned: true, mutexName, out bool createdNew);
+        Debug.WriteLine($"is mutex new: {createdNew}, name: {mutexName}");
+        if (createdNew)
         {
-            CleanNugetCacheAndProjects(nugetCache);
+            // We are the first one of the parallel runs to do this. Build the projects and setup everything.
+            try
+            {
+                Debug.WriteLine("Starting to build.");
+                var sw = Stopwatch.StartNew();
+                SetDotnetEnvironment();
+                Debug.WriteLine($"Setting dotnet environment took: {sw.ElapsedMilliseconds} ms");
+                sw.Restart();
+
+                var nugetCache = Path.GetFullPath(Path.Combine(Root, ".packages"));
+                var packagesAreNew = UnzipExecutablePackages();
+                if (packagesAreNew)
+                {
+                    CleanNugetCacheAndProjects(nugetCache);
+                }
+                Debug.WriteLine($"Building test assets and unzipping packages took: {sw.ElapsedMilliseconds} ms");
+                sw.Restart();
+                BuildTestAssets(nugetCache);
+                BuildTestAssetsCompatibility(nugetCache);
+                Debug.WriteLine($"Building test assets compatibility matrix took: {sw.ElapsedMilliseconds} ms");
+                sw.Restart();
+                CopyAndPatchDotnet();
+                Debug.WriteLine($"Copying and patching dotnet took: {sw.ElapsedMilliseconds} ms");
+            }
+            finally
+            {
+                buildMutex.ReleaseMutex();
+            }
         }
-        Debug.WriteLine($"Building test assets and unzipping packages took: {sw.ElapsedMilliseconds} ms");
-        sw.Restart();
-        BuildTestAssets(nugetCache);
-        BuildTestAssetsCompatibility(nugetCache);
-        Debug.WriteLine($"Building test assets compatibility matrix took: {sw.ElapsedMilliseconds} ms");
-        sw.Restart();
-        CopyAndPatchDotnet();
-        Debug.WriteLine($"Copying and patching dotnet took: {sw.ElapsedMilliseconds} ms");
+        else
+        {
+            // Build is already in progress. Wait for it to finish.
+            var minutes = 15;
+            Debug.WriteLine("Other project is building, waiting for mutex to release.");
+            var gotOne = buildMutex.WaitOne(TimeSpan.FromMinutes(minutes));
+            if (!gotOne)
+            {
+                throw new TimeoutException($"Timed out after {minutes} minutes, waiting for the other project to finish building. Mutex name: '{mutexName}'");
+            }
+            Debug.WriteLine("Other project is done building, I can start running tests now.");
+        }
     }
 
     private static void BuildTestAssets(string nugetCache)


### PR DESCRIPTION
## Description

Running dotnet test would trigger build of assets from two places at the same time, which does more work, and also fails occasionally when they run into each other.

## Related issue

Fix #15453

