### PR TITLE
Make TestAssets.sln buildable locally

### DIFF
--- a/test/TestAssets/Directory.Build.props
+++ b/test/TestAssets/Directory.Build.props
@@ -32,5 +32,10 @@
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <_LocalVSTestPackagesDirectory>$(RepoRoot)artifacts/packages/$(Configuration)/Shipping</_LocalVSTestPackagesDirectory>
+    <RestoreAdditionalProjectSources Condition="Exists('$(_LocalVSTestPackagesDirectory)')">$(RestoreAdditionalProjectSources);$(_LocalVSTestPackagesDirectory)</RestoreAdditionalProjectSources>
+  </PropertyGroup>
+
   <Import Project="$(RepoRoot)eng/Versions.props" />
 </Project>

--- a/test/TestAssets/Directory.Build.targets
+++ b/test/TestAssets/Directory.Build.targets
@@ -3,4 +3,7 @@
   <!-- We don't want these projects to be Arcade projects, because they are
   test projects for testing, and most people don't use Arcade, so we don't want the details of
   arcade to go into them. -->
+  <PropertyGroup>
+    <PackageVersion>$(Version)-dev</PackageVersion>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Description

- Considers artifacts/packages/CONFIGURATION/Shipping as package source
- Also considers `$(Version)-dev` which is the version generated in most local builds.
- When actually running the integration tests, the version is set by https://github.com/microsoft/vstest/blob/3ae44f08f99674ea2fa9bb198304574645da2338/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Build.cs#L62

## Related issue

Kindly link any related issues. E.g. Fixes #xyz.

- [ ] I have ensured that there is a previously discussed and approved issue.
