### PR TITLE
Review simplify compatibility sources, deduplicate tests

### DIFF
--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/AcceptanceTestBase.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/AcceptanceTestBase.cs
@@ -48,7 +48,9 @@ public class AcceptanceTestBase : IntegrationTestBase
     /// Our current defaults for .NET and .NET Framework.
     /// </summary>
     public const string DEFAULT_HOST_NETFX_AND_NET = "net462;net8.0";
+    public const string DEFAULT_HOST_NET = "net8.0";
     public const string DEFAULT_RUNNER_NETFX_AND_NET = "net48;net10.0";
+    public const string DEFAULT_RUNNER_NET = "net10.0";
     public const string LATEST_TO_LEGACY = "Latest;LatestPreview;LatestStable;RecentStable;MostDownloaded;PreviousStable;LegacyStable";
     public const string LATESTPREVIEW_TO_LEGACY = "LatestPreview;LatestStable;RecentStable;MostDownloaded;PreviousStable;LegacyStable";
     public const string LATEST = "Latest";

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
@@ -22,8 +22,8 @@ public class ExecutionTests : AcceptanceTestBase
     //TODO: It looks like the first 3 tests would be useful to multiply by all 3 test frameworks, should we make the test even more generic, or duplicate them?
     [TestMethod]
     [TestCategory("Windows-Review")]
-    [MSTestCompatibilityDataSource(InProcess = true)]
-    public void RunMultipleTestAssemblies(RunnerInfo runnerInfo)
+    [MSTestCompatibilityDataSource()]
+    public void RunMultipleTestAssemblies1(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
@@ -32,23 +32,6 @@ public class ExecutionTests : AcceptanceTestBase
         InvokeVsTestForExecution(assemblyPaths, testAdapterPath: null, FrameworkArgValue, string.Empty);
 
         ValidateSummaryStatus(2, 2, 2);
-        ExitCodeEquals(1); // failing tests
-        StdErrHasTestRunFailedMessageButNoOtherError();
-        StdOutHasNoWarnings();
-    }
-
-    [TestMethod]
-    [TestCategory("Windows-Review")]
-    [TestPlatformCompatibilityDataSource]
-    public void RunTestsFromMultipleMSTestAssemblies(RunnerInfo runnerInfo)
-    {
-        SetTestEnvironment(_testEnvironment, runnerInfo);
-
-        var assemblyPaths = BuildMultipleAssemblyPath("MSTestProject1.dll", "MSTestProject2.dll");
-
-        InvokeVsTestForExecution(assemblyPaths, testAdapterPath: null, FrameworkArgValue, string.Empty);
-
-        ValidateSummaryStatus(passed: 2, failed: 2, skipped: 2);
         ExitCodeEquals(1); // failing tests
         StdErrHasTestRunFailedMessageButNoOtherError();
         StdOutHasNoWarnings();

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
@@ -23,7 +23,7 @@ public class ExecutionTests : AcceptanceTestBase
     [TestMethod]
     [TestCategory("Windows-Review")]
     [MSTestCompatibilityDataSource()]
-    public void RunMultipleTestAssemblies1(RunnerInfo runnerInfo)
+    public void RunMultipleTestAssemblies(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/CompatibilityRowsBuilder.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/CompatibilityRowsBuilder.cs
@@ -261,6 +261,11 @@ public class CompatibilityRowsBuilder
     private void AddRow(List<RunnerInfo> dataRows, string batch,
         string runnerVersion, string runnerFramework, string hostVersion, string hostFramework, string adapterVersion, string adapter, bool inIsolation)
     {
+        if (adapter != AcceptanceTestBase.MSTEST)
+        {
+            throw new NotSupportedException($"Adapter {adapter} is not supported. Only {AcceptanceTestBase.MSTEST} is supported.");
+        }
+
         RunnerInfo runnerInfo = GetRunnerInfo(batch, runnerFramework, hostFramework, inIsolation);
         runnerInfo.DebugInfo = GetDebugInfo();
         runnerInfo.VSTestConsoleInfo = GetVSTestConsoleInfo(runnerVersion, runnerInfo);

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/CompatibilityRowsBuilder.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/CompatibilityRowsBuilder.cs
@@ -40,7 +40,7 @@ public class CompatibilityRowsBuilder
     }
 
     /// <summary>
-    /// Add run for in-process using the selected .NET Framework runners, and and all selected adapters.
+    /// Add run for in-process using the selected .NET Framework runners, and all selected adapters.
     /// </summary>
     public bool WithInProcess { get; set; }
     // Add runner from VSIX to check the shipment we make into VisualStudio.

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/CompatibilityRowsBuilder.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/CompatibilityRowsBuilder.cs
@@ -261,10 +261,7 @@ public class CompatibilityRowsBuilder
     private void AddRow(List<RunnerInfo> dataRows, string batch,
         string runnerVersion, string runnerFramework, string hostVersion, string hostFramework, string adapterVersion, string adapter, bool inIsolation)
     {
-        if (adapter != AcceptanceTestBase.MSTEST)
-        {
-            throw new NotSupportedException($"Adapter {adapter} is not supported.");
-        }
+
         RunnerInfo runnerInfo = GetRunnerInfo(batch, runnerFramework, hostFramework, inIsolation);
         runnerInfo.DebugInfo = GetDebugInfo();
         runnerInfo.VSTestConsoleInfo = GetVSTestConsoleInfo(runnerVersion, runnerInfo);

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/CompatibilityRowsBuilder.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/CompatibilityRowsBuilder.cs
@@ -261,7 +261,6 @@ public class CompatibilityRowsBuilder
     private void AddRow(List<RunnerInfo> dataRows, string batch,
         string runnerVersion, string runnerFramework, string hostVersion, string hostFramework, string adapterVersion, string adapter, bool inIsolation)
     {
-
         RunnerInfo runnerInfo = GetRunnerInfo(batch, runnerFramework, hostFramework, inIsolation);
         runnerInfo.DebugInfo = GetDebugInfo();
         runnerInfo.VSTestConsoleInfo = GetVSTestConsoleInfo(runnerVersion, runnerInfo);

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/CompatibilityRowsBuilder.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/CompatibilityRowsBuilder.cs
@@ -7,9 +7,9 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 
-using NuGet.Versioning;
-
 using Microsoft.TestPlatform.TestUtilities;
+
+using NuGet.Versioning;
 
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
@@ -17,18 +17,19 @@ public class CompatibilityRowsBuilder
 {
     private static XmlDocument? s_depsXml;
     private readonly string[] _runnerFrameworks;
-    private readonly string[] _runnerVersions;
     private readonly string[] _hostFrameworks;
-    private readonly string[] _adapterVersions;
     private readonly string[] _adapters;
-    private readonly string[] _hostVersions;
 
-    public CompatibilityRowsBuilder(string runnerFrameworks = AcceptanceTestBase.DEFAULT_HOST_NETFX_AND_NET,
-        string runnerVersions = AcceptanceTestBase.LATEST_TO_LEGACY,
-        string hostFrameworks = AcceptanceTestBase.DEFAULT_HOST_NETFX_AND_NET,
-        string hostVersions = AcceptanceTestBase.LATEST_TO_LEGACY,
-        string adapterVersions = AcceptanceTestBase.LATESTPREVIEW_TO_LEGACY,
-        string adapters = AcceptanceTestBase.MSTEST)
+    private readonly string[] _runnerVersions;
+    private readonly string[] _hostVersions;
+    private readonly string[] _adapterVersions;
+
+    public CompatibilityRowsBuilder(string runnerVersions,
+        string runnerFrameworks,
+        string hostVersions,
+        string hostFrameworks,
+        string adapterVersions,
+        string adapters)
     {
         _runnerFrameworks = runnerFrameworks.Split(';');
         _runnerVersions = runnerVersions.Split(';');
@@ -41,13 +42,9 @@ public class CompatibilityRowsBuilder
     /// <summary>
     /// Add run for in-process using the selected .NET Framework runners, and and all selected adapters.
     /// </summary>
-    public bool WithInProcess { get; set; } = true;
-    public bool WithEveryVersionOfRunner { get; set; } = true;
-    public bool WithEveryVersionOfHost { get; set; } = true;
-    public bool WithEveryVersionOfAdapter { get; set; } = true;
-    public bool WithOlderConfigurations { get; set; } = true;
+    public bool WithInProcess { get; set; }
     // Add runner from VSIX to check the shipment we make into VisualStudio.
-    public bool WithVSIXRunner { get; set; } = true;
+    public bool WithVSIXRunner { get; set; }
 
     public string? BeforeRunnerFeature { get; set; }
     public string? AfterRunnerFeature { get; set; }
@@ -66,23 +63,13 @@ public class CompatibilityRowsBuilder
     {
         var dataRows = new List<RunnerInfo>();
 
-        if (WithEveryVersionOfRunner)
-            AddEveryVersionOfRunner(dataRows);
-
-        if (WithEveryVersionOfHost)
-            AddEveryVersionOfHost(dataRows);
-
-        if (WithEveryVersionOfAdapter)
-            AddEveryVersionOfAdapter(dataRows);
-
-        if (WithOlderConfigurations)
-            AddOlderConfigurations(dataRows);
+        AddRows(dataRows);
 
         if (WithInProcess)
             AddInProcess(dataRows);
 
         if (WithVSIXRunner)
-            AddVsix(dataRows);
+            AddVsix(dataRows, WithInProcess);
 
         var minVersion = ParseAndPatchSemanticVersion("0.0.0-alpha.1");
         var maxVersion = ParseAndPatchSemanticVersion("9999.0.0");
@@ -145,9 +132,44 @@ public class CompatibilityRowsBuilder
             && r.TestHostInfo != null && isInRange(ParseAndPatchSemanticVersion(r.TestHostInfo.Version), beforeTestHostVersion, afterTestHostVersion)
             && r.AdapterInfo != null && isInRange(ParseAndPatchSemanticVersion(r.AdapterInfo.Version), beforeAdapterVersion, afterAdapterVersion)).ToList();
 
-        // We use ToString to determine which values are unique. Not great solution, but works better than using records.
+        // Figure out the distinct rows, and shrink the values, so if we have multiple rows that use the same versions and same setup, and only differ in how the version types
+        // are called (e.g. Latest and LatestStable have the same version), then we get just single row, with description for both.
+        // like RunMultipleTestAssemblies1 (Row: 0, Matrix, Runner = net10.0, TargetFramework = net462, InIsolation,  vstest.console = 18.6.0-dev [Latest],  Testhost = 18.6.0-dev [Latest],  MSTest = 3.9.3 [LatestPreview, LatestStable])
         var distinctRows = new Dictionary<string, RunnerInfo>();
-        rows.ForEach(r => distinctRows[r.ToString()] = r);
+        foreach (var r in rows)
+        {
+            var key = $"{r.Batch}|{r.RunnerFramework}|{r.VSTestConsoleInfo!.Version}|{r.TargetFramework}|{r.TestHostInfo!.Version}|{r.InIsolationValue}|{r.AdapterInfo!.Name}|{r.AdapterInfo.Version}";
+            if (distinctRows.TryGetValue(key, out var value))
+            {
+                if (value.VSTestConsoleInfo!.Version == r.VSTestConsoleInfo.Version)
+                {
+                    value.VSTestConsoleInfo.VersionType += $",{r.VSTestConsoleInfo.VersionType}";
+                }
+
+                if (value.TestHostInfo!.Version == r.TestHostInfo.Version)
+                {
+                    value.TestHostInfo.VersionType += $",{r.TestHostInfo.VersionType}";
+                }
+
+                if (r.AdapterInfo!.Version == value.AdapterInfo!.Version)
+                {
+                    value.AdapterInfo.VersionType += $",{r.AdapterInfo.VersionType}";
+                }
+            }
+            else
+            {
+                distinctRows.Add(key, r);
+            }
+        }
+
+        // We added all the version types together (would have been better to have this property as array originally, but that would complicate other code), now deduplicate the names to make it less confusing for user.
+        // Latest, Latest, Latest, LatestPreview -> Latest, LatestPreview
+        foreach (var r in distinctRows.Values)
+        {
+            r.VSTestConsoleInfo!.VersionType = string.Join(", ", r.VSTestConsoleInfo!.VersionType!.Split(',').Distinct());
+            r.TestHostInfo!.VersionType = string.Join(", ", r.TestHostInfo!.VersionType!.Split(',').Distinct());
+            r.AdapterInfo!.VersionType = string.Join(", ", r.AdapterInfo!.VersionType!.Split(',').Distinct());
+        }
 
         if (distinctRows.Count == 0)
         {
@@ -172,6 +194,33 @@ public class CompatibilityRowsBuilder
         return SemanticVersion.Parse(v?.TrimStart('v'));
     }
 
+    private void AddRows(List<RunnerInfo> dataRows)
+    {
+        foreach (var runnerVersion in _runnerVersions)
+        {
+            foreach (var runnerFramework in _runnerFrameworks)
+            {
+                foreach (var hostFramework in _hostFrameworks)
+                {
+                    var isNetFramework = hostFramework.StartsWith("net4");
+                    // .NET Framework testhost ships with the runner, and the version from the
+                    // runner directory is always selected, otherwise select the newest version from _hostFrameworks.
+                    var hostVersions = isNetFramework ? [runnerVersion] : _hostVersions;
+                    foreach (var hostVersion in hostVersions)
+                    {
+                        foreach (var adapterVersion in _adapterVersions)
+                        {
+                            foreach (var adapter in _adapters)
+                            {
+                                AddRow(dataRows, "Matrix", runnerVersion, runnerFramework, hostVersion, hostFramework, adapterVersion, adapter, inIsolation: true);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     private void AddInProcess(List<RunnerInfo> dataRows)
     {
         foreach (var runnerFramework in _runnerFrameworks)
@@ -187,118 +236,35 @@ public class CompatibilityRowsBuilder
                 {
                     foreach (var adapterVersion in _adapterVersions)
                     {
-                        AddRow(dataRows, "In process", runnerVersion, runnerFramework, runnerVersion, runnerFramework, adapterVersion, inIsolation: false);
+                        AddRow(dataRows, "In process", runnerVersion, runnerFramework, runnerVersion, runnerFramework, adapterVersion, adapter, inIsolation: false);
                     }
                 }
             }
         }
     }
 
-    private void AddVsix(List<RunnerInfo> dataRows)
+    private void AddVsix(List<RunnerInfo> dataRows, bool inProcess)
     {
+        // Runs outside of process, test both tfms of testhost.
         foreach (var hostFramework in _hostFrameworks)
         {
-            AddRow(dataRows, "VSIX", AcceptanceTestBase.LATESTVSIX, AcceptanceTestBase.DEFAULT_RUNNER_NETFX, AcceptanceTestBase.LATEST, hostFramework, AcceptanceTestBase.LATESTSTABLE, inIsolation: true);
-            AddRow(dataRows, "VSIX", AcceptanceTestBase.LATESTVSIX, AcceptanceTestBase.DEFAULT_RUNNER_NETFX, AcceptanceTestBase.LATEST, hostFramework, AcceptanceTestBase.LATESTSTABLE, inIsolation: false);
+            AddRow(dataRows, "VSIX", AcceptanceTestBase.LATESTVSIX, AcceptanceTestBase.DEFAULT_RUNNER_NETFX, AcceptanceTestBase.LATEST, hostFramework, AcceptanceTestBase.LATESTSTABLE, AcceptanceTestBase.MSTEST, inIsolation: true);
         }
-    }
 
-    private void AddOlderConfigurations(List<RunnerInfo> dataRows)
-    {
-        // Older configurations where the runner, host and adapter version are the same.
-        // We already added the row where all are newest when adding combination with all runners.
-        foreach (var runnerVersion in _runnerVersions)
+        if (inProcess)
         {
-            foreach (var runnerFramework in _runnerFrameworks)
-            {
-                foreach (var hostFramework in _hostFrameworks)
-                {
-                    var isNetFramework = hostFramework.StartsWith("net4");
-                    var hostVersion = runnerVersion;
-                    foreach (var _ in _adapters)
-                    {
-                        var adapterVersion = _adapterVersions[0];
-                        AddRow(dataRows, "Older", runnerVersion, runnerFramework, hostVersion, hostFramework, adapterVersion, inIsolation: true);
-                    }
-                }
-            }
-        }
-    }
-
-    private void AddEveryVersionOfAdapter(List<RunnerInfo> dataRows)
-    {
-        var runnerVersion = _runnerVersions[0];
-        foreach (var runnerFramework in _runnerFrameworks)
-        {
-            foreach (var hostFramework in _hostFrameworks)
-            {
-                var isNetFramework = hostFramework.StartsWith("net4");
-                // .NET Framework testhost ships with the runner, and the version from the
-                // runner directory is always selected, otherwise select the newest version from _hostFrameworks.
-                var hostVersion = isNetFramework ? runnerVersion : _hostVersions[0];
-                foreach (var adapter in _adapters)
-                {
-                    foreach (var adapterVersion in _adapterVersions)
-                    {
-                        AddRow(dataRows, "Every adapter", runnerVersion, runnerFramework, hostVersion, hostFramework, adapterVersion, inIsolation: true);
-                    }
-                }
-            }
-        }
-    }
-
-    private void AddEveryVersionOfHost(List<RunnerInfo> dataRows)
-    {
-        var runnerVersion = _runnerVersions[0];
-
-        foreach (var runnerFramework in _runnerFrameworks)
-        {
-            foreach (var hostFramework in _hostFrameworks)
-            {
-                var isNetFramework = hostFramework.StartsWith("net4");
-                // .NET Framework testhost ships with the runner, and the version from the
-                // runner directory is always the same as the runner. There are no variations
-                // so we just need to add host versions for .NET testhosts.
-                var hostVersions = isNetFramework ? [] : _hostVersions.ToArray();
-                foreach (var hostVersion in hostVersions)
-                {
-                    foreach (var _ in _adapters)
-                    {
-                        // use the newest
-                        var adapterVersion = _adapterVersions[0];
-                        AddRow(dataRows, "Every host", runnerVersion, runnerFramework, hostVersion, hostFramework, adapterVersion, inIsolation: true);
-                    }
-                }
-            }
-        }
-    }
-
-    private void AddEveryVersionOfRunner(List<RunnerInfo> dataRows)
-    {
-        foreach (var runnerVersion in _runnerVersions)
-        {
-            foreach (var runnerFramework in _runnerFrameworks)
-            {
-                foreach (var hostFramework in _hostFrameworks)
-                {
-                    var isNetFramework = hostFramework.StartsWith("net4");
-                    // .NET Framework testhost ships with the runner, and the version from the
-                    // runner directory is always selected, otherwise select the newest version from _hostFrameworks.
-                    var hostVersion = isNetFramework ? runnerVersion : _hostVersions[0];
-                    foreach (var _ in _adapters)
-                    {
-                        // use the newest
-                        var adapterVersion = _adapterVersions[0];
-                        AddRow(dataRows, "Every runner", runnerVersion, runnerFramework, hostVersion, hostFramework, adapterVersion, inIsolation: true);
-                    }
-                }
-            }
+            // Runs in process. We specify the testhost, but it has no impact.
+            AddRow(dataRows, "VSIX", AcceptanceTestBase.LATESTVSIX, AcceptanceTestBase.DEFAULT_RUNNER_NETFX, AcceptanceTestBase.LATEST, AcceptanceTestBase.DEFAULT_HOST_NETFX, AcceptanceTestBase.LATESTSTABLE, AcceptanceTestBase.MSTEST, inIsolation: false);
         }
     }
 
     private void AddRow(List<RunnerInfo> dataRows, string batch,
-        string runnerVersion, string runnerFramework, string hostVersion, string hostFramework, string adapterVersion, bool inIsolation)
+        string runnerVersion, string runnerFramework, string hostVersion, string hostFramework, string adapterVersion, string adapter, bool inIsolation)
     {
+        if (adapter != AcceptanceTestBase.MSTEST)
+        {
+            throw new NotSupportedException($"Adapter {adapter} is not supported.");
+        }
         RunnerInfo runnerInfo = GetRunnerInfo(batch, runnerFramework, hostFramework, inIsolation);
         runnerInfo.DebugInfo = GetDebugInfo();
         runnerInfo.VSTestConsoleInfo = GetVSTestConsoleInfo(runnerVersion, runnerInfo);

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/CustomCompatibilityDataSource.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/CustomCompatibilityDataSource.cs
@@ -6,27 +6,14 @@ using System.Reflection;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 /// <summary>
-/// A data source that provides a huge mix of runners, hosts and mstest adapter, to add up >100 tests.
-/// You can control which runner versions, host versions, and adapter versions will be used. This should be
-/// used only to test the most common scenarios, or special configurations that are candidates for their own
-/// specialized source.
-///
-/// By default net462 and net8.0 are used for both runner and host. (4 combinations)
-/// Then run with every version of runner is added.
-/// Then run with every version of test.sdk is added.
-/// Then run with every combination of testhost and adapter is added.
-/// And then run in process is added.
-///
-/// All of those are filtered down to have no duplicates, and to pass the
-/// Before and After platform version filters, and adapter filters.
-///
-/// When that adds up to no configuration exception is thrown.
+/// A data source that provides a custom mix of runners, hosts and mstest adapter. You can control everything,
+/// so be careful how many tests you generate. This is meant to be used for experimentation, and only when <see cref="WrapperCompatibilityDataSource"/>, <see cref="RunnerCompatibilityDataSource"/>, <see cref="TestHostCompatibilityDataSource"/> or <see cref="MSTestCompatibilityDataSource"/> do not fit the need.
 /// </summary>
-public class TestPlatformCompatibilityDataSource : TestDataSourceAttribute<RunnerInfo>
+public class CustomCompatibilityDataSource : TestDataSourceAttribute<RunnerInfo>
 {
     private readonly CompatibilityRowsBuilder _builder;
 
-    public TestPlatformCompatibilityDataSource(
+    public CustomCompatibilityDataSource(
         string runnerFrameworks = AcceptanceTestBase.DEFAULT_RUNNER_NETFX_AND_NET,
         string runnerVersions = AcceptanceTestBase.LATEST_TO_LEGACY,
         string hostFrameworks = AcceptanceTestBase.DEFAULT_HOST_NETFX_AND_NET,
@@ -34,9 +21,6 @@ public class TestPlatformCompatibilityDataSource : TestDataSourceAttribute<Runne
         string adapterVersions = AcceptanceTestBase.LATESTPREVIEW_TO_LEGACY,
         string adapters = AcceptanceTestBase.MSTEST)
     {
-        // TODO: We actually don't generate values to use different translation layers, because we don't have a good way to do
-        // that right now. Translation layer is loaded directly into the acceptance test, and so we don't have easy way to substitute it.
-
         _builder = new CompatibilityRowsBuilder(runnerFrameworks, runnerVersions, hostFrameworks, hostVersions, adapterVersions, adapters);
         // Do not generate the data rows here, properties (e.g. DebugVSTestConsole) are not populated until after constructor is done.
     }
@@ -51,13 +35,6 @@ public class TestPlatformCompatibilityDataSource : TestDataSourceAttribute<Runne
     /// </summary>
     public bool WithInProcess { get; set; } = true;
 
-    public bool WithEveryVersionOfRunner { get; set; } = true;
-
-    public bool WithEveryVersionOfHost { get; set; } = true;
-
-    public bool WithEveryVersionOfAdapter { get; set; } = true;
-
-    public bool WithOlderConfigurations { get; set; } = true;
     public bool WithVSIXRunner { get; set; } = true;
 
     public string? BeforeRunnerFeature { get; set; }
@@ -71,10 +48,6 @@ public class TestPlatformCompatibilityDataSource : TestDataSourceAttribute<Runne
 
     public override void CreateData(MethodInfo methodInfo)
     {
-        _builder.WithEveryVersionOfRunner = WithEveryVersionOfRunner;
-        _builder.WithEveryVersionOfHost = WithEveryVersionOfHost;
-        _builder.WithEveryVersionOfAdapter = WithEveryVersionOfAdapter;
-        _builder.WithOlderConfigurations = WithOlderConfigurations;
         _builder.WithVSIXRunner = WithVSIXRunner;
         _builder.WithInProcess = WithInProcess;
 

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/MSTestCompatibilityDataSource.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/MSTestCompatibilityDataSource.cs
@@ -15,7 +15,7 @@ public class MSTestCompatibilityDataSource : TestDataSourceAttribute<RunnerInfo>
     public MSTestCompatibilityDataSource()
     {
         // 1 runner version and 1 testhost version
-        // This tests diferent mstest versions against our latest runner and testhost.
+        // This tests different mstest versions against our latest runner and testhost.
 
         _builder = new CompatibilityRowsBuilder(
             // runner, use just .NET, because the adapter runs in the testhost, and we will add InProcess and VSIX, that will test running with the Runner.

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/RunnerCompatibilityDataSource.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/RunnerCompatibilityDataSource.cs
@@ -6,7 +6,8 @@ using System.Reflection;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 /// <summary>
-/// A data source that provides every version of runner.
+/// A data source that provides every version of runner, with VSIX, and in process.
+/// Use for testing features specific to vstest.console. Or for interaction between runner and testhost.
 /// 
 /// When that adds up to no configuration exception is thrown.
 /// </summary>
@@ -14,23 +15,17 @@ public class RunnerCompatibilityDataSource : TestDataSourceAttribute<RunnerInfo>
 {
     private readonly CompatibilityRowsBuilder _builder;
 
-    public RunnerCompatibilityDataSource(
-        string runnerFrameworks = AcceptanceTestBase.DEFAULT_RUNNER_NETFX_AND_NET,
-        string runnerVersions = AcceptanceTestBase.LATEST_TO_LEGACY,
-        string hostFrameworks = AcceptanceTestBase.DEFAULT_HOST_NETFX_AND_NET)
+    public RunnerCompatibilityDataSource()
     {
-        // TODO: We actually don't generate values to use different translation layers, because we don't have a good way to do
-        // that right now. Translation layer is loaded directly into the acceptance test, and so we don't have easy way to substitute it.
-
         _builder = new CompatibilityRowsBuilder(
-            runnerFrameworks,
-            runnerVersions,
-            hostFrameworks,
-            // host versions
+            // runner
+            AcceptanceTestBase.LATEST_TO_LEGACY,
+            AcceptanceTestBase.DEFAULT_RUNNER_NETFX_AND_NET,
+            // host
             AcceptanceTestBase.LATEST,
-            // adapter versions
+            AcceptanceTestBase.DEFAULT_HOST_NETFX_AND_NET,
+            // adapter
             AcceptanceTestBase.LATESTSTABLE,
-            // adapters
             AcceptanceTestBase.MSTEST);
 
         // Do not generate the data rows here, properties (e.g. DebugVSTestConsole) are not populated until after constructor is done.
@@ -41,11 +36,6 @@ public class RunnerCompatibilityDataSource : TestDataSourceAttribute<RunnerInfo>
     public bool DebugDataCollector { get; set; }
     public bool DebugStopAtEntrypoint { get; set; }
     public int JustRow { get; set; } = -1;
-
-    /// <summary>
-    /// Add run for in-process using the selected .NET Framework runners, and and all selected adapters.
-    /// </summary>
-    public bool InProcess { get; set; }
 
     public string? BeforeFeature { get; set; }
     public string? AfterFeature { get; set; }
@@ -58,12 +48,8 @@ public class RunnerCompatibilityDataSource : TestDataSourceAttribute<RunnerInfo>
 
     public override void CreateData(MethodInfo methodInfo)
     {
-        _builder.WithEveryVersionOfRunner = true;
         _builder.WithVSIXRunner = true;
-        _builder.WithEveryVersionOfHost = false;
-        _builder.WithEveryVersionOfAdapter = false;
-        _builder.WithOlderConfigurations = false;
-        _builder.WithInProcess = InProcess;
+        _builder.WithInProcess = true;
 
         _builder.BeforeRunnerFeature = BeforeFeature;
         _builder.AfterRunnerFeature = AfterFeature;
@@ -85,4 +71,3 @@ public class RunnerCompatibilityDataSource : TestDataSourceAttribute<RunnerInfo>
         data.ForEach(AddData);
     }
 }
-

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/TesthostCompatibilityDataSource.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/TesthostCompatibilityDataSource.cs
@@ -15,22 +15,18 @@ public class TestHostCompatibilityDataSource : TestDataSourceAttribute<RunnerInf
     private readonly CompatibilityRowsBuilder _builder;
 
     public TestHostCompatibilityDataSource(
-        string runnerFrameworks = AcceptanceTestBase.DEFAULT_RUNNER_NETFX_AND_NET,
         string hostFrameworks = AcceptanceTestBase.DEFAULT_HOST_NETFX_AND_NET,
         string hostVersions = AcceptanceTestBase.LATEST_TO_LEGACY)
     {
-        // TODO: We actually don't generate values to use different translation layers, because we don't have a good way to do
-        // that right now. Translation layer is loaded directly into the acceptance test, and so we don't have easy way to substitute it.
-
         _builder = new CompatibilityRowsBuilder(
-            runnerFrameworks,
-            // runner versions
+            // runner
             AcceptanceTestBase.LATEST,
-            hostFrameworks,
+            AcceptanceTestBase.DEFAULT_RUNNER_NET,
+            // host
             hostVersions,
-            // adapter versions
-            AcceptanceTestBase.LATESTSTABLE,
+            hostFrameworks,
             // adapter
+            AcceptanceTestBase.LATESTSTABLE,
             AcceptanceTestBase.MSTEST);
 
         // Do not generate the data rows here, properties (e.g. DebugVSTestConsole) are not populated until after constructor is done.
@@ -46,13 +42,6 @@ public class TestHostCompatibilityDataSource : TestDataSourceAttribute<RunnerInf
 
     public override void CreateData(MethodInfo methodInfo)
     {
-        _builder.WithEveryVersionOfRunner = false;
-        _builder.WithEveryVersionOfHost = true;
-        _builder.WithEveryVersionOfAdapter = false;
-        _builder.WithOlderConfigurations = false;
-        _builder.WithInProcess = false;
-        _builder.WithVSIXRunner = false;
-
         _builder.BeforeTestHostFeature = BeforeFeature;
         _builder.AfterTestHostFeature = AfterFeature;
 

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/WrapperCompatibilityDataSource.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/WrapperCompatibilityDataSource.cs
@@ -6,10 +6,10 @@ using System.Reflection;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 /// <summary>
-/// A data source that provides every version of runner. Use for testing features specific to VSTestConsoleWrapper.
-/// 
-/// When that adds up to no configuration exception is thrown.
-/// </summary>
+/// A data source that provides compatibility rows for VSTestConsoleWrapper, using all runner
+/// versions from <see cref="AcceptanceTestBase.LATEST_TO_LEGACY"/> together with the latest host
+/// and default adapter configuration. If the selected filters (features, debug options, or row
+/// restrictions) result in no valid configuration, the underlying compatibility builder throws an exception.
 public class WrapperCompatibilityDataSource : TestDataSourceAttribute<RunnerInfo>
 {
     private readonly CompatibilityRowsBuilder _builder;

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/WrapperCompatibilityDataSource.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/WrapperCompatibilityDataSource.cs
@@ -10,6 +10,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 /// versions from <see cref="AcceptanceTestBase.LATEST_TO_LEGACY"/> together with the latest host
 /// and default adapter configuration. If the selected filters (features, debug options, or row
 /// restrictions) result in no valid configuration, the underlying compatibility builder throws an exception.
+/// </summary>
 public class WrapperCompatibilityDataSource : TestDataSourceAttribute<RunnerInfo>
 {
     private readonly CompatibilityRowsBuilder _builder;

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/WrapperCompatibilityDataSource.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Extension/WrapperCompatibilityDataSource.cs
@@ -6,26 +6,25 @@ using System.Reflection;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 /// <summary>
-/// Test MSTest adapter compatibility with .NET and .NET Framework testhost, and running in vstest.console process.
+/// A data source that provides every version of runner. Use for testing features specific to VSTestConsoleWrapper.
+/// 
+/// When that adds up to no configuration exception is thrown.
 /// </summary>
-public class MSTestCompatibilityDataSource : TestDataSourceAttribute<RunnerInfo>
+public class WrapperCompatibilityDataSource : TestDataSourceAttribute<RunnerInfo>
 {
     private readonly CompatibilityRowsBuilder _builder;
 
-    public MSTestCompatibilityDataSource()
+    public WrapperCompatibilityDataSource()
     {
-        // 1 runner version and 1 testhost version
-        // This tests diferent mstest versions against our latest runner and testhost.
-
         _builder = new CompatibilityRowsBuilder(
-            // runner, use just .NET, because the adapter runs in the testhost, and we will add InProcess and VSIX, that will test running with the Runner.
-            AcceptanceTestBase.LATEST,
-            AcceptanceTestBase.DEFAULT_RUNNER_NET,
+            // runner
+            AcceptanceTestBase.LATEST_TO_LEGACY,
+            AcceptanceTestBase.DEFAULT_RUNNER_NETFX_AND_NET,
             // host
             AcceptanceTestBase.LATEST,
-            AcceptanceTestBase.DEFAULT_HOST_NETFX_AND_NET,
+            AcceptanceTestBase.DEFAULT_HOST_NET,
             // adapter
-            AcceptanceTestBase.LATESTPREVIEW_TO_LEGACY,
+            AcceptanceTestBase.LATESTSTABLE,
             AcceptanceTestBase.MSTEST);
 
         // Do not generate the data rows here, properties (e.g. DebugVSTestConsole) are not populated until after constructor is done.
@@ -35,26 +34,27 @@ public class MSTestCompatibilityDataSource : TestDataSourceAttribute<RunnerInfo>
     public bool DebugTestHost { get; set; }
     public bool DebugDataCollector { get; set; }
     public bool DebugStopAtEntrypoint { get; set; }
+    public int JustRow { get; set; } = -1;
 
-    public string? BeforeRunnerFeature { get; set; }
-    public string? AfterRunnerFeature { get; set; }
+    public string? BeforeFeature { get; set; }
+    public string? AfterFeature { get; set; }
 
-    public string? BeforeTestHostFeature { get; set; }
-    public string? AfterTestHostFeature { get; set; }
+    //public string? BeforeTestHostFeature { get; set; }
+    //public string? AfterTestHostFeature { get; set; }
 
     public string? BeforeAdapterFeature { get; set; }
     public string? AfterAdapterFeature { get; set; }
 
     public override void CreateData(MethodInfo methodInfo)
     {
-        _builder.WithInProcess = true;
         _builder.WithVSIXRunner = true;
+        _builder.WithInProcess = false;
 
-        _builder.BeforeRunnerFeature = BeforeRunnerFeature;
-        _builder.AfterRunnerFeature = AfterRunnerFeature;
+        _builder.BeforeRunnerFeature = BeforeFeature;
+        _builder.AfterRunnerFeature = AfterFeature;
 
-        _builder.BeforeTestHostFeature = BeforeTestHostFeature;
-        _builder.AfterTestHostFeature = AfterTestHostFeature;
+        //_builder.BeforeTestHostFeature = BeforeTestHostFeature;
+        //_builder.AfterTestHostFeature = AfterTestHostFeature;
 
         _builder.BeforeAdapterFeature = BeforeAdapterFeature;
         _builder.AfterAdapterFeature = AfterAdapterFeature;
@@ -64,7 +64,10 @@ public class MSTestCompatibilityDataSource : TestDataSourceAttribute<RunnerInfo>
         _builder.DebugTestHost = DebugTestHost;
         _builder.DebugStopAtEntrypoint = DebugStopAtEntrypoint;
 
+        _builder.JustRow = JustRow < 0 ? null : JustRow;
+
         var data = _builder.CreateData();
         data.ForEach(AddData);
     }
 }
+

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/CustomTestHostTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/CustomTestHostTests.cs
@@ -34,7 +34,7 @@ public class CustomTestHostTests : AcceptanceTestBase
 
     [TestMethod]
     [TestCategory("Windows-Review")]
-    [RunnerCompatibilityDataSource(BeforeFeature = Features.ATTACH_DEBUGGER_FLOW)]
+    [WrapperCompatibilityDataSource(BeforeFeature = Features.ATTACH_DEBUGGER_FLOW)]
     // This does not work with testhosts that are earlier than when the feature was introduced,
     // when latest runner is used, because the latest runner does not downgrade the messages when
     // older testhost launcher is used.
@@ -63,8 +63,7 @@ public class CustomTestHostTests : AcceptanceTestBase
 
     [TestMethod]
     [TestCategory("Windows-Review")]
-    // [RunnerCompatibilityDataSource(BeforeFeature = Features.ATTACH_DEBUGGER_FLOW)]
-    [TestHostCompatibilityDataSource(DEFAULT_RUNNER_NETFX, DEFAULT_RUNNER_NETCORE, "LegacyStable", BeforeFeature = Features.ATTACH_DEBUGGER_FLOW, DebugVSTestConsole = true)]
+    [WrapperCompatibilityDataSource(BeforeFeature = Features.ATTACH_DEBUGGER_FLOW)]
     [Ignore("This is not working for any testhost prior 16.7.0 where the change was introduced. The launch testhost flow was replaced with AttachDebugger in runner, and the new callback to AttachDebugger happens in testhost."
         + "But any testhost prior 16.7.0 where the change was introduced does not know to call back AttachDebugger, and the call never happens.")]
     // You can confirm that the functionality broke between runner and testhost, past this point by using newer runners, against older testhosts.
@@ -93,7 +92,7 @@ public class CustomTestHostTests : AcceptanceTestBase
 
     [TestMethod]
     [TestCategory("Windows-Review")]
-    [RunnerCompatibilityDataSource(AfterFeature = Features.ATTACH_DEBUGGER_FLOW)]
+    [WrapperCompatibilityDataSource(AfterFeature = Features.ATTACH_DEBUGGER_FLOW)]
     // [TestHostCompatibilityDataSource(AfterFeature = Features.ATTACH_DEBUGGER_FLOW)]
     public void RunTestsWithCustomTestHostLauncherAttachesToDebuggerUsingTheProvidedLauncher(RunnerInfo runnerInfo)
     {
@@ -120,7 +119,7 @@ public class CustomTestHostTests : AcceptanceTestBase
     [Ignore("This is not working. The compatibility code only checks the protocol version (in handler), which is dictated by testhost. "
         + "It sees 6 but does not realize that the provided CustomTesthostLauncher is not supporting the new feature, it ends up calling back to EditoAttachDebugger" +
         "in translation layer, and that just silently skips the call.")]
-    [RunnerCompatibilityDataSource(AfterFeature = Features.ATTACH_DEBUGGER_FLOW)]
+    [WrapperCompatibilityDataSource(AfterFeature = Features.ATTACH_DEBUGGER_FLOW)]
     [TestHostCompatibilityDataSource(AfterFeature = Features.ATTACH_DEBUGGER_FLOW)]
     public void RunTestsWithCustomTestHostLauncherUsesLaunchWhenGivenAnOutdatedITestHostLauncher(RunnerInfo runnerInfo)
     {
@@ -144,7 +143,7 @@ public class CustomTestHostTests : AcceptanceTestBase
     [TestCategory("Windows-Review")]
     [TestCategory("Feature")]
     // "Just row" used here because mstest does not cooperate with older versions of vstest.console correctly, so we test with just the latest version available..
-    [RunnerCompatibilityDataSource(AfterFeature = Features.MULTI_TFM, JustRow = 0)]
+    [WrapperCompatibilityDataSource(AfterFeature = Features.MULTI_TFM, JustRow = 0)]
     public void RunAllTestsWithMixedTFMsWillProvideAdditionalInformationToTheDebugger(RunnerInfo runnerInfo)
     {
         // Arrange
@@ -196,7 +195,7 @@ public class CustomTestHostTests : AcceptanceTestBase
     [TestCategory("BackwardCompatibilityWithRunner")]
     // "Just row" used here because mstest does not cooperate with older versions of vstest.console correctly, so we test with just the single version available
     // before the multi tfm feature.
-    [RunnerCompatibilityDataSource(BeforeFeature = Features.MULTI_TFM, JustRow = 0)]
+    [WrapperCompatibilityDataSource(BeforeFeature = Features.MULTI_TFM, JustRow = 0)]
     public void RunAllTestsCallsBackToTestHostLauncherV3EvenWhenRunnerDoesNotSupportMultiTfmOrTheNewAttachDebugger2MessageYet(RunnerInfo runnerInfo)
     {
         // Arrange

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/DiscoverTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/DiscoverTests.cs
@@ -44,7 +44,7 @@ public class DiscoverTests : AcceptanceTestBase
 
     [TestMethod]
     [TestCategory("Windows-Review")]
-    [RunnerCompatibilityDataSource]
+    [WrapperCompatibilityDataSource]
     public void DiscoverTestsUsingDiscoveryEventHandler1(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
@@ -62,7 +62,7 @@ public class DiscoverTests : AcceptanceTestBase
 
     [TestMethod]
     [TestCategory("Windows-Review")]
-    [RunnerCompatibilityDataSource]
+    [WrapperCompatibilityDataSource]
     public void DiscoverTestsUsingDiscoveryEventHandler2AndTelemetryOptedOut(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/RunTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/RunTests.cs
@@ -43,7 +43,7 @@ public class RunTests : AcceptanceTestBase
 
     [TestMethod]
     [TestCategory("Windows-Review")]
-    [RunnerCompatibilityDataSource]
+    [WrapperCompatibilityDataSource]
     public void RunAllTests(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
@@ -61,7 +61,7 @@ public class RunTests : AcceptanceTestBase
 
     [TestMethod]
     [TestCategory("Windows-Review")]
-    [RunnerCompatibilityDataSource(BeforeFeature = Features.MULTI_TFM)]
+    [WrapperCompatibilityDataSource(BeforeFeature = Features.MULTI_TFM)]
     public void RunAllTestsWithMixedTFMsWillFailToRunTestsFromTheIncompatibleTFMDll(RunnerInfo runnerInfo)
     {
         // Arrange
@@ -84,7 +84,7 @@ public class RunTests : AcceptanceTestBase
     [TestMethod]
     [TestCategory("Windows-Review")]
     [TestHostCompatibilityDataSource]
-    [RunnerCompatibilityDataSource(AfterFeature = Features.MULTI_TFM)]
+    [WrapperCompatibilityDataSource(AfterFeature = Features.MULTI_TFM)]
     public void RunAllTestsWithMixedTFMsWillRunTestsFromAllProvidedDllEvenWhenTheyMixTFMs(RunnerInfo runnerInfo)
     {
         // Arrange

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/RunTestsWithFilterTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TranslationLayerTests/RunTestsWithFilterTests.cs
@@ -36,7 +36,7 @@ public class RunTestsWithFilterTests : AcceptanceTestBase
 
     [TestMethod]
     [TestCategory("Windows-Review")]
-    [RunnerCompatibilityDataSource]
+    [WrapperCompatibilityDataSource]
     public void RunTestsWithTestCaseFilter(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);


### PR DESCRIPTION
## Description

Split the compatibility sources to 4 levels, wrapper, runner, testhost and adapter. Review how tests are generated, and reduce the number of tests generated. E.g. mstest source was generating 40 tests for each runner and host, instead of just combination of adapter versions and hosts, which is where adapter runs.

On the other hand RunnerCompatibilitySource generates by default tests for VSIX and inProcess.

## Related issue

Related #15464
Related #15470
Fix #15454