### PR TITLE
Reduce test wall-clock time by increasing minThreads

### DIFF
--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Build.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Build.cs
@@ -12,6 +12,14 @@ public class Build : IntegrationTestBase
     [AssemblyInitialize]
     public static void AssemblyInitialize(TestContext testContext)
     {
+        // Increase the ThreadPool minimum threads to avoid starvation during parallel test
+        // execution. Each test class spawns vstest.console and testhost processes — the async
+        // process management and I/O redirection callbacks need ThreadPool threads to complete
+        // promptly.
+        var additionalThreadsCount = System.Environment.ProcessorCount * 4;
+        System.Threading.ThreadPool.GetMinThreads(out var workerThreads, out var completionPortThreads);
+        System.Threading.ThreadPool.SetMinThreads(workerThreads + additionalThreadsCount, completionPortThreads + additionalThreadsCount);
+
         IntegrationTestBuild.BuildTestAssetsForIntegrationTests(testContext);
     }
 }

--- a/test/Microsoft.TestPlatform.Library.IntegrationTests/Build.cs
+++ b/test/Microsoft.TestPlatform.Library.IntegrationTests/Build.cs
@@ -12,6 +12,14 @@ public class Build : IntegrationTestBase
     [AssemblyInitialize]
     public static void AssemblyInitialize(TestContext testContext)
     {
+        // Increase the ThreadPool minimum threads to avoid starvation during parallel test
+        // execution. Each test class spawns vstest.console and testhost processes via the
+        // TranslationLayer — the socket-based communication blocks ThreadPool threads during
+        // connection setup, causing starvation with the default MinThreads.
+        var additionalThreadsCount = System.Environment.ProcessorCount * 4;
+        System.Threading.ThreadPool.GetMinThreads(out var workerThreads, out var completionPortThreads);
+        System.Threading.ThreadPool.SetMinThreads(workerThreads + additionalThreadsCount, completionPortThreads + additionalThreadsCount);
+
         IntegrationTestBuild.BuildTestAssetsForIntegrationTests(testContext);
     }
 }


### PR DESCRIPTION
This PR reduces wall-clock time for several test projects by addressing three root causes of slow CI test runs: oversized test classes blocking parallelism, ThreadPool starvation under parallel execution, and unnecessarily long Thread.Sleep/Task.Delay values.

Changes

1. Reduce excessive sleep/delay values in unit tests
2. Enable class-level parallelism for 3 unit test projects
3. Split large acceptance test classes to unblock parallel execution
4. Increase ThreadPool MinThreads for integration test projects