### PR TITLE
Optimize DotnetSDKSimulation_PostProcessing test (163s → 61s)

### DIFF
--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/PostProcessingTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/PostProcessingTests.cs
@@ -39,18 +39,20 @@ public class PostProcessingTests : AcceptanceTestBase
             .Add(new XElement("Configuration", new XElement("MergeFile", "MergedFile.txt")));
         runSettingsXml.Save(runSettings);
 
-        // Build and run tests like msbuild
-        Parallel.For(0, 5, i =>
+        // Create and build a single test project once, then reuse it for all parallel vstest runs.
+        string projectFolder = Path.Combine(TempDirectory.Path, "testproject");
+        ExecuteApplication(GetConsoleRunnerPath(), $"new mstest -o {projectFolder}", out string setupStdOut, out string setupStdError, out int setupExitCode);
+        Assert.AreEqual(0, setupExitCode);
+        ExecuteApplication(GetConsoleRunnerPath(), $"build {projectFolder} -c release", out setupStdOut, out setupStdError, out setupExitCode);
+        Assert.AreEqual(0, setupExitCode);
+
+        string testContainer = Directory.GetFiles(Path.Combine(projectFolder, "bin"), "testproject.dll", SearchOption.AllDirectories).Single();
+
+        // Run vstest 2 times in parallel to collect artifacts (minimum needed to verify merging)
+        Parallel.For(0, 2, i =>
         {
-            string projectFolder = Path.Combine(TempDirectory.Path, i.ToString(CultureInfo.InvariantCulture));
-            ExecuteApplication(GetConsoleRunnerPath(), $"new mstest -o {projectFolder}", out string stdOut, out string stdError, out int exitCode);
-            Assert.AreEqual(0, exitCode);
-            ExecuteApplication(GetConsoleRunnerPath(), $"build {projectFolder} -c release", out stdOut, out stdError, out exitCode);
-            Assert.AreEqual(0, exitCode);
-
-            string testContainer = Directory.GetFiles(Path.Combine(projectFolder, "bin"), $"{i}.dll", SearchOption.AllDirectories).Single();
-
-            ExecuteVsTestConsole($"{testContainer} --Collect:\"SampleDataCollector\" --TestAdapterPath:\"{extensionsPath}\" --ResultsDirectory:\"{Path.GetDirectoryName(testContainer)}\" --Settings:\"{runSettings}\" --ArtifactsProcessingMode-Collect --TestSessionCorrelationId:\"{correlationSessionId}\" --Diag:\"{TempDirectory.Path + '/'}\"", out stdOut, out stdError, out exitCode);
+            string resultsDirectory = Path.Combine(TempDirectory.Path, i.ToString(CultureInfo.InvariantCulture));
+            ExecuteVsTestConsole($"{testContainer} --Collect:\"SampleDataCollector\" --TestAdapterPath:\"{extensionsPath}\" --ResultsDirectory:\"{resultsDirectory}\" --Settings:\"{runSettings}\" --ArtifactsProcessingMode-Collect --TestSessionCorrelationId:\"{correlationSessionId}\" --Diag:\"{TempDirectory.Path + '/'}\"", out string stdOut, out string stdError, out int exitCode);
             Assert.AreEqual(0, exitCode);
         });
 
@@ -74,7 +76,7 @@ public class PostProcessingTests : AcceptanceTestBase
             fileContent.Add(line);
         }
 
-        Assert.AreEqual(5, fileContent.Distinct().Count());
+        Assert.AreEqual(2, fileContent.Distinct().Count());
     }
 
     private static string GetRunsettingsFilePath(string resultsDir)


### PR DESCRIPTION
## Summary

Optimizes the slowest acceptance test from **163s → 61s** (63% faster).

### Changes
- **Build once, reuse:** Instead of creating and building 5 separate MSTest projects in parallel (5× \dotnet new\ + 5× \dotnet build\), create and build one project once and reuse the DLL.
- **Reduce runs from 5 to 2:** The test validates artifact post-processing/merging — 2 runs is the minimum needed to verify merge behavior.

### Before/After
| Metric | Before | After |
|---|---|---|
| Duration | 163.4s | 61.1s |
| \dotnet new\ calls | 5 | 1 |
| \dotnet build\ calls | 5 | 1 |
| vstest runs | 5 | 2 |
