### PR TITLE
Build isolated test assets for single TFM instead of 7

### DIFF
--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestMSBuildOutputTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestMSBuildOutputTests.cs
@@ -23,7 +23,7 @@ public class DotnetTestMSBuildOutputTests : AcceptanceTestBase
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        var projectPath = GetIsolatedTestAsset("TerminalLoggerTestProject.csproj");
+        var projectPath = GetIsolatedTestAsset("TerminalLoggerTestProject.csproj", runnerInfo.TargetFramework);
         // Forcing terminal logger so we can see the output when it is redirected
         InvokeDotnetTest($@"{projectPath} -tl:on -nodereuse:false /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}", workingDirectory: Path.GetDirectoryName(projectPath));
 
@@ -53,7 +53,7 @@ public class DotnetTestMSBuildOutputTests : AcceptanceTestBase
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        var projectPath = GetIsolatedTestAsset("TerminalLoggerTestProject.csproj");
+        var projectPath = GetIsolatedTestAsset("TerminalLoggerTestProject.csproj", runnerInfo.TargetFramework);
         InvokeDotnetTest($@"{projectPath} -nodereuse:false /p:VsTestUseMSBuildOutput=false /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}", workingDirectory: Path.GetDirectoryName(projectPath));
 
         // Check that we see the summary that is printed from the console logger, meaning the new output is disabled.
@@ -73,7 +73,7 @@ public class DotnetTestMSBuildOutputTests : AcceptanceTestBase
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        var projectPath = GetIsolatedTestAsset("TerminalLoggerTestProject.csproj");
+        var projectPath = GetIsolatedTestAsset("TerminalLoggerTestProject.csproj", runnerInfo.TargetFramework);
         InvokeDotnetTest($@"{projectPath} -nodereuse:false /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}", environmentVariables: new Dictionary<string, string?> { ["MSBUILDENSURESTDOUTFORTASKPROCESSES"] = "1" }, workingDirectory: Path.GetDirectoryName(projectPath));
 
         // Check that we see the summary that is printed from the console logger, meaning the new output is disabled.

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestTests.cs
@@ -26,7 +26,7 @@ public class DotnetTestTests : AcceptanceTestBase
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        var projectPath = GetIsolatedTestAsset("SimpleTestProject.csproj");
+        var projectPath = GetIsolatedTestAsset("SimpleTestProject.csproj", runnerInfo.TargetFramework);
         InvokeDotnetTest($@"{projectPath} -tl:off /p:VSTestNoLogo=false --logger:""Console;Verbosity=normal"" /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}", workingDirectory: Path.GetDirectoryName(projectPath));
 
         // ensure our dev version is used
@@ -60,7 +60,7 @@ public class DotnetTestTests : AcceptanceTestBase
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        var projectPath = GetIsolatedTestAsset("ParametrizedTestProject.csproj");
+        var projectPath = GetIsolatedTestAsset("ParametrizedTestProject.csproj", runnerInfo.TargetFramework);
         InvokeDotnetTest($@"{projectPath} --logger:""Console;Verbosity=normal"" -tl:off /p:VSTestNoLogo=false /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion} -- TestRunParameters.Parameter(name =\""weburl\"", value=\""http://localhost//def\"")", workingDirectory: Path.GetDirectoryName(projectPath));
 
         // ensure our dev version is used

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/RunsettingsTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/RunsettingsTests.cs
@@ -510,7 +510,7 @@ public class RunsettingsTests : AcceptanceTestBase
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
         var projectName = "ProjectFileRunSettingsTestProject.csproj";
-        var projectPath = GetIsolatedTestAsset(projectName);
+        var projectPath = GetIsolatedTestAsset(projectName, runnerInfo.TargetFramework);
         InvokeDotnetTest($@"{projectPath} /p:VSTestUseMSBuildOutput=false --logger:""Console;Verbosity=normal"" /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}", workingDirectory: Path.GetDirectoryName(projectPath));
         ValidateSummaryStatus(0, 1, 0);
 

--- a/test/Microsoft.TestPlatform.TestUtilities/AcceptanceTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/AcceptanceTestBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.TestPlatform.TestUtilities;
 
@@ -137,7 +138,7 @@ public class AcceptanceTestBase : IntegrationTestBase
         return runSettingsXml;
     }
 
-    protected string GetIsolatedTestAsset(string assetName)
+    protected string GetIsolatedTestAsset(string assetName, string targetFramework)
     {
         var projectPath = GetProjectFullPath(assetName);
 
@@ -147,6 +148,13 @@ public class AcceptanceTestBase : IntegrationTestBase
 
             if (file.Extension.Equals(".csproj", StringComparison.OrdinalIgnoreCase))
             {
+                // Build just for the given tfm
+                var projFile = Path.Combine(TempDirectory.Path, Path.GetFileName(file.FullName));
+                var csprojContent = File.ReadAllText(projFile);
+                csprojContent = Regex.Replace(csprojContent, "<TargetFramework>.*?</TargetFramework>", $"<TargetFramework>{targetFramework}</TargetFramework>");
+                csprojContent = Regex.Replace(csprojContent, "<TargetFrameworks>.*?</TargetFrameworks>", $"<TargetFramework>{targetFramework}</TargetFramework>");
+                File.WriteAllText(projFile, csprojContent);
+
                 string root = IntegrationTestEnvironment.RepoRootDirectory;
                 var testAssetsRoot = Path.GetFullPath(Path.Combine(root, "test", "TestAssets"));
 


### PR DESCRIPTION
## Summary

\GetIsolatedTestAsset\ now takes a \	argetFramework\ parameter and rewrites the csproj to build only that TFM. Previously, test assets built for all **7 target frameworks** (\
et462;net472;net48;net8.0;net9.0;net10.0;net11.0\) even though the test assertions only need output from one.

### Before/After (measured)

| Test | Before | After | Savings |
|---|---|---|---|
| \MSBuildLoggerCanBeEnabledByBuildPropertyAndDoesNotEatSpecialChars\ | 76.1s | 14.6s | **81%** |
| \RunDotnetTestWithCsprojPassInlineSettings\ | 61.7s | 14.5s | **77%** |
| \MSBuildLoggerCanBeDisabledByEnvironmentVariableProperty\ | 82.5s | 66.1s | **20%** |

### Changes
- **\AcceptanceTestBase.GetIsolatedTestAsset\** — new overload accepts \	argetFramework\, rewrites \<TargetFrameworks>\ → \<TargetFramework>\ in the copied csproj
- **6 callers updated** in \DotnetTestMSBuildOutputTests\, \DotnetTestTests\, \RunsettingsTests\ to pass \unnerInfo.TargetFramework\
