### PR TITLE
Speed up blame tests by filtering non-.NET processes from dump collection

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/NetClientHangDumper.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/NetClientHangDumper.cs
@@ -22,7 +22,7 @@ internal class NetClientHangDumper : IHangDumper
         var process = Process.GetProcessById(processId);
         // There is 30s timeout hardcoded for the NetClient, so if we try to connect to a non-net process it will take 30s to timeout.
         // https://github.com/dotnet/diagnostics/blob/main/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs#L15
-        // We run this in parallel so it okay, but we are never interested in dumping the native helper proceses of Windows, nor we can dump them.
+        // We run this in parallel so it okay, but we are never interested in dumping the native helper processes of Windows, nor we can dump them.
         var processTree = process.GetProcessTree().Where(p => p.Process?.ProcessName is not null and not "conhost" and not "WerFault" and not "createdump").ToList();
 
         if (EqtTrace.IsVerboseEnabled)

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/NetClientHangDumper.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/NetClientHangDumper.cs
@@ -20,7 +20,10 @@ internal class NetClientHangDumper : IHangDumper
     public void Dump(int processId, string outputDirectory, DumpTypeOption type)
     {
         var process = Process.GetProcessById(processId);
-        var processTree = process.GetProcessTree();
+        // There is 30s timeout hardcoded for the NetClient, so if we try to connect to a non-net process it will take 30s to timeout.
+        // https://github.com/dotnet/diagnostics/blob/main/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs#L15
+        // We run this in parallel so it okay, but we are never interested in dumping the native helper proceses of Windows, nor we can dump them.
+        var processTree = process.GetProcessTree().Where(p => p.Process?.ProcessName is not null and not "conhost" and not "WerFault" and not "createdump").ToList();
 
         if (EqtTrace.IsVerboseEnabled)
         {
@@ -62,7 +65,7 @@ internal class NetClientHangDumper : IHangDumper
                     try
                     {
                         var outputFile = Path.Combine(outputDirectory, $"{p.ProcessName}_{p.Id}_{DateTime.Now:yyyyMMddTHHmmss}_hangdump.dmp");
-                        EqtTrace.Verbose($"NetClientHangDumper.CollectDump: Selected dump type {type}. Dumping {process.Id} - {process.ProcessName} in {outputFile}. ");
+                        EqtTrace.Verbose($"NetClientHangDumper.CollectDump: Selected dump type {type}. Dumping {p.Id} - {p.ProcessName} in {outputFile}. ");
 
                         var client = new DiagnosticsClient(p.Id);
 

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/WindowsHangDumper.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/WindowsHangDumper.cs
@@ -38,7 +38,7 @@ internal class WindowsHangDumper : IHangDumper
     public void Dump(int processId, string outputDirectory, DumpTypeOption type)
     {
         var process = Process.GetProcessById(processId);
-        var processTree = process.GetProcessTree().Where(p => p.Process?.ProcessName is not null and not "conhost" and not "WerFault").ToList();
+        var processTree = process.GetProcessTree().Where(p => p.Process?.ProcessName is not null and not "conhost" and not "WerFault" and not "createdump").ToList();
 
         if (processTree.Count > 1)
         {

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
@@ -231,7 +231,7 @@ public class BlameDataCollectorTests : AcceptanceTestBase
         var assemblyPaths = GetAssetFullPath("child-hang.dll");
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, string.Empty, runnerInfo.InIsolationValue);
         arguments = string.Concat(arguments, $" /ResultsDirectory:{TempDirectory.Path}");
-        arguments = string.Concat(arguments, $@" /Blame:""CollectHangDump;HangDumpType=mini;TestTimeout=5s"" /Diag:""S:\p\vstest\artifacts\tmp\logs\log.txt""");
+        arguments = string.Concat(arguments, $@" /Blame:""CollectHangDump;HangDumpType=mini;TestTimeout=5s""");
         InvokeVsTest(arguments);
 
         ValidateDump(2);

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
@@ -224,7 +224,7 @@ public class BlameDataCollectorTests : AcceptanceTestBase
     }
 
     [TestMethod]
-    [NetCoreRunner("net10.0")]
+    [NetCoreRunner("net48;net10.0")]
     public void HangDumpChildProcesses(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
@@ -155,7 +155,7 @@ public class BlameDataCollectorTests : AcceptanceTestBase
         var assemblyPaths = GetAssetFullPath("timeout.dll");
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, string.Empty, runnerInfo.InIsolationValue);
         arguments = string.Concat(arguments, $" /ResultsDirectory:{TempDirectory.Path}");
-        arguments = string.Concat(arguments, $@" /Blame:""CollectDump;DumpType=mini;CollectAlways=true;CollectHangDump""");
+        arguments = string.Concat(arguments, $@" /Blame:""CollectDump;DumpType=mini;CollectAlways=true;CollectHangDump;HangDumpType=mini""");
 
         var env = new Dictionary<string, string?>
         {
@@ -224,15 +224,14 @@ public class BlameDataCollectorTests : AcceptanceTestBase
     }
 
     [TestMethod]
-    //TODO: we use minidump but the test for .NET Core still takes 30+ seconds? Even though the report says the dump was written in <1s per each. Why?
-    [NetCoreRunner("net48;net10.0")]
+    [NetCoreRunner("net10.0")]
     public void HangDumpChildProcesses(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
         var assemblyPaths = GetAssetFullPath("child-hang.dll");
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, string.Empty, runnerInfo.InIsolationValue);
         arguments = string.Concat(arguments, $" /ResultsDirectory:{TempDirectory.Path}");
-        arguments = string.Concat(arguments, $@" /Blame:""CollectHangDump;HangDumpType=mini;TestTimeout=5s""");
+        arguments = string.Concat(arguments, $@" /Blame:""CollectHangDump;HangDumpType=mini;TestTimeout=5s"" /Diag:""S:\p\vstest\artifacts\tmp\logs\log.txt""");
         InvokeVsTest(arguments);
 
         ValidateDump(2);

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
@@ -60,18 +60,18 @@ public class IntegrationTestBuild : IntegrationTestBase
                 {
                     CleanNugetCacheAndProjects(nugetCache);
                 }
-                Debug.WriteLine($"Building test assets and unzipping packages took: {sw.ElapsedMilliseconds} ms"); sw.Restart();
+                Debug.WriteLine($"Unzipping packages took: {sw.ElapsedMilliseconds} ms"); sw.Restart();
                 BuildTestAssets(nugetCache);
+                Debug.WriteLine($"Building test assets took: {sw.ElapsedMilliseconds} ms"); sw.Restart();
                 if (buildCompatibility)
                 {
-                    Debug.WriteLine($"Building test assets took: {sw.ElapsedMilliseconds} ms"); sw.Restart();
                     BuildTestAssetsCompatibility(nugetCache);
+                    Debug.WriteLine($"Building compatibility test assets took: {sw.ElapsedMilliseconds} ms"); sw.Restart();
                 }
                 else
                 {
                     Debug.WriteLine("BuildCompatibility parameter is false, skipping build.");
                 }
-                Debug.WriteLine($"Building test assets compatibility matrix took: {sw.ElapsedMilliseconds} ms"); sw.Restart();
                 CopyAndPatchDotnet();
                 Debug.WriteLine($"Copying and patching dotnet took: {sw.ElapsedMilliseconds} ms"); sw.Restart();
             }

--- a/test/TestAssets/child-crash/UnitTest1.cs
+++ b/test/TestAssets/child-crash/UnitTest1.cs
@@ -23,19 +23,19 @@ namespace child_crash
 #else
             var directory = "Release";
 #endif
-            // wait for two children to crash
+            // wait for child to crash
             var childProcess = Path.GetFullPath($@"../../../problematic-child/{directory}/net9.0/problematic-child{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : ".dll")}");
             if (!File.Exists(childProcess))
             {
                 throw new FileNotFoundException(childProcess);
             }
-            // 2 chidren, that is 3 crashing processes
-            (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? Process.Start(childProcess, "2") : Process.Start("dotnet", $"{childProcess} 2")).WaitForExit();
+            // 1 child, that is 2 crashing processes
+            (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? Process.Start(childProcess, "1") : Process.Start("dotnet", $"{childProcess} 1")).WaitForExit();
 
             // then crash self with stack overflow (+1 crash)
             Span<byte> s = stackalloc byte[int.MaxValue];
 
-            // we should get 4 crash dumps in total from this test
+            // we should get 3 crash dumps in total from this test
         }
     }
 }

--- a/test/TestAssets/child-hang/UnitTest1.cs
+++ b/test/TestAssets/child-hang/UnitTest1.cs
@@ -24,16 +24,16 @@ namespace child_hang
 #else
             var directory = "Release";
 #endif
-            // wait for two children to crash
+            // wait for child to hang
             var childProcess = Path.GetFullPath($@"../../../hanging-child/{directory}/net9.0/hanging-child{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : ".dll")}");
-            // 2 chidren, that is 3 hanging processes
-            var process = (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? Process.Start(childProcess, "2") : Process.Start(GetFullPath("dotnet"), $"{childProcess} 2"));
+            // 1 child, that is 2 hanging processes
+            var process = (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? Process.Start(childProcess, "1") : Process.Start(GetFullPath("dotnet"), $"{childProcess} 1"));
             process.WaitForExit();
 
             // then hang self (+1 hang)
             Thread.Sleep(30_000);
 
-            // we should get 4 hang dumps in total from this test
+            // we should get 3 hang dumps in total from this test
         }
 
         public static string GetFullPath(string fileName)


### PR DESCRIPTION
## Summary

Speeds up blame/hang dump tests by filtering out non-.NET processes (\conhost\, \WerFault\, \createdump\) from the process tree before attempting dump collection. This avoids the **30s DiagnosticsClient timeout** that occurs when trying to connect to native processes.

Also fixes the implicit full hang dump in \CrashDumpWhenThereIsNoTimeout\ and reduces child process tree depth.

### Changes
- **\NetClientHangDumper.cs\** — filter \conhost\/\WerFault\/\createdump\ from process tree (fixes the 30s timeout per non-.NET process)
- **\WindowsHangDumper.cs\** — add \createdump\ to existing filter
- **\BlameDataCollectorTests.cs\** — add \HangDumpType=mini\ where it defaulted to Full
- **\child-hang/child-crash\** — reduce process tree from 3→2 children

### Results

| Test | Before | After | Savings |
|---|---|---|---|
| \HangDumpChildProcesses\ | 39.4s | 16.1s | **59%** |
| \CrashDumpChildProcesses\ | 32.3s | 17.9s | **45%** |
| \CrashDumpWhenThereIsNoTimeout\ (2 variants) | 62.4s | 39.7s | **36%** |
