### PR TITLE
Unify target framework checks with IsNetFrameworkTarget/IsNetTarget

### DIFF
--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
@@ -191,7 +191,7 @@ public class ExecutionTests : AcceptanceTestBase
         InvokeVsTest(arguments);
 
         var errorMessage = "Process is terminated due to StackOverflowException.";
-        if (!runnerInfo.IsNetTarget)
+        if (runnerInfo.IsNetTarget)
         {
             errorMessage = "Test host process crashed : Stack overflow.";
         }

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
@@ -191,7 +191,7 @@ public class ExecutionTests : AcceptanceTestBase
         InvokeVsTest(arguments);
 
         var errorMessage = "Process is terminated due to StackOverflowException.";
-        if (!runnerInfo.TargetFramework.StartsWith("net4"))
+        if (!runnerInfo.IsNetTarget)
         {
             errorMessage = "Test host process crashed : Stack overflow.";
         }
@@ -221,7 +221,7 @@ public class ExecutionTests : AcceptanceTestBase
         InvokeVsTest(arguments);
 
         var errorFirstLine =
-            !runnerInfo.TargetFramework.StartsWith("net4")
+            runnerInfo.IsNetTarget
             ? "Test host standard error line: Unhandled exception. System.InvalidOperationException: Operation is not valid due to the current state of the object."
             : "Test host standard error line: Unhandled Exception: System.InvalidOperationException: Operation is not valid due to the current state of the object.";
         FileAssert.Contains(diagLogFilePath, errorFirstLine);

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/FrameworkTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/FrameworkTests.cs
@@ -50,7 +50,7 @@ public class FrameworkTests : AcceptanceTestBase
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
         var arguments = PrepareArguments(GetSampleTestAssembly(), string.Empty, string.Empty, string.Empty, resultsDirectory: TempDirectory.Path);
-        if (runnerInfo.TargetFramework.Contains("netcore"))
+        if (runnerInfo.IsNetTarget)
         {
             arguments = string.Concat(arguments, " ", "/Framework:Framework45");
         }
@@ -60,7 +60,7 @@ public class FrameworkTests : AcceptanceTestBase
         }
         InvokeVsTest(arguments);
 
-        if (runnerInfo.TargetFramework.Contains("netcore"))
+        if (runnerInfo.IsNetTarget)
         {
             StdOutputContains("No test is available");
         }

--- a/test/Microsoft.TestPlatform.Library.IntegrationTests/TranslationLayerTests/RunTests.cs
+++ b/test/Microsoft.TestPlatform.Library.IntegrationTests/TranslationLayerTests/RunTests.cs
@@ -180,7 +180,7 @@ public class RunTests : AcceptanceTestBase
             new TestPlatformOptions() { TestCaseFilter = "ExitWithStackoverFlow" },
             _runEventHandler);
 
-        var errorMessagePattern = runnerInfo.TargetFramework.StartsWith("net4")
+        var errorMessagePattern = runnerInfo.IsNetFrameworkTarget
             ? $"The active test run was aborted. Reason: Test host process crashed : Process is terminated due to StackOverflowException.*"
             : $"The active test run was aborted. Reason: Test host process crashed : Stack overflow.*";
 

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -668,12 +668,12 @@ public class IntegrationTestBase
             var version = IntegrationTestEnvironment.DependencyVersions["MSTestTestAdapterVersion"];
             if (version.StartsWith("4"))
             {
-                var tfm = _testEnvironment.TargetFramework.StartsWith("net4") ? "net462" : "net9.0";
+                var tfm = _testEnvironment.IsNetFrameworkTarget ? "net462" : "net9.0";
                 adapterRelativePath = string.Format(CultureInfo.InvariantCulture, _msTestAdapterRelativePath, version, tfm);
             }
             else if (version.StartsWith("3"))
             {
-                var tfm = _testEnvironment.TargetFramework.StartsWith("net4") ? "net462" : "netcoreapp3.1";
+                var tfm = _testEnvironment.IsNetFrameworkTarget ? "net462" : "netcoreapp3.1";
                 adapterRelativePath = string.Format(CultureInfo.InvariantCulture, _msTestAdapterRelativePath, version, tfm);
             }
             else
@@ -687,7 +687,7 @@ public class IntegrationTestBase
         }
         else if (testFramework == UnitTestFramework.XUnit)
         {
-            var tfm = _testEnvironment.TargetFramework.StartsWith("net4") ? "net462" : "netcoreapp3.1";
+            var tfm = _testEnvironment.IsNetFrameworkTarget ? "net462" : "netcoreapp3.1";
             adapterRelativePath = string.Format(CultureInfo.InvariantCulture, _xUnitTestAdapterRelativePath, IntegrationTestEnvironment.DependencyVersions["XUnitAdapterVersion"], tfm);
         }
 

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestEnvironment.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestEnvironment.cs
@@ -115,6 +115,11 @@ public class IntegrationTestEnvironment
     public string? TargetFramework { get; set; }
 
     /// <summary>
+    /// Is targeting .NET Framework testhost?
+    /// </summary>
+    public bool IsNetFrameworkTarget => TargetFramework!.StartsWith("net4", StringComparison.InvariantCultureIgnoreCase);
+
+    /// <summary>
     /// Gets the target runtime.
     /// Supported values = <c>win7-x64</c>.
     /// </summary>


### PR DESCRIPTION
Replace ad-hoc string checks on runnerInfo.TargetFramework and _testEnvironment.TargetFramework with the existing IsNetFrameworkTarget and IsNetTarget properties. Add IsNetFrameworkTarget property to IntegrationTestEnvironment for consistency with RunnerInfo.

Fixes #15462
