### PR TITLE
Change integration test parallelization from ClassLevel to MethodLevel

### DIFF
--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
@@ -20,6 +20,7 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
 [TestCategory("Windows-Review")]
+[DoNotParallelize] // Blame tests collect crash/hang dumps from child processes and race when run in parallel.
 public class BlameDataCollectorTests : AcceptanceTestBase
 {
     public const string NETCOREANDFX = "net462;net472;net8.0";

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Properties/AssemblyInfo.cs
@@ -3,5 +3,6 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-// Enable IAP at class level with as many threads as possible based on CPU and core count.
-[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.ClassLevel)]
+// Enable IAP at method level with as many threads as possible based on CPU and core count.
+// Method level is safe because integration tests offload work to child processes (vstest.console, testhost).
+[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]

--- a/test/Microsoft.TestPlatform.Library.IntegrationTests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.TestPlatform.Library.IntegrationTests/Properties/AssemblyInfo.cs
@@ -3,5 +3,6 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-// Enable IAP at class level with as many threads as possible based on CPU and core count.
-[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.ClassLevel)]
+// Enable IAP at method level with as many threads as possible based on CPU and core count.
+// Method level is safe because integration tests offload work to child processes (vstest.console, testhost).
+[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]


### PR DESCRIPTION
Integration tests offload work to child processes (vstest.console, testhost), so there is no shared in-process state between test methods in the same class. ClassLevel parallelization was unnecessarily conservative - switching to MethodLevel allows more tests to run concurrently, improving overall test execution time.

Each test method creates its own TempDirectory and invokes vstest.console independently, so concurrent execution within a class is safe.

Fixes #15488
