### PR TITLE
Improve CompatibilityRowsBuilder error message with diagnostic details

### DIFF
--- a/test/Microsoft.TestPlatform.TestUtilities/CompatibilityRowsBuilder.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/CompatibilityRowsBuilder.cs
@@ -178,7 +178,7 @@ public class CompatibilityRowsBuilder
                 + $"Runner version range: [{afterRunnerVersion}, {beforeRunnerVersion}), "
                 + $"TestHost version range: [{afterTestHostVersion}, {beforeTestHostVersion}), "
                 + $"Adapter version range: [{afterAdapterVersion}, {beforeAdapterVersion}). "
-                + $"Total candidate rows before filtering: {dataRows.Count}, after version filtering: {rows.Count}.");
+                + $"Total candidate rows before filtering: {dataRows.Count}, after version filtering: {rows.Count}, after deduping: {distinctRows.Count}.");
         }
 
         var allRows = distinctRows.Values.ToList();

--- a/test/Microsoft.TestPlatform.TestUtilities/CompatibilityRowsBuilder.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/CompatibilityRowsBuilder.cs
@@ -173,8 +173,12 @@ public class CompatibilityRowsBuilder
 
         if (distinctRows.Count == 0)
         {
-            // TODO: This needs to be way more specific about what happened. And possibly propagate as inconclusive state if we decide to update versions automatically?
-            throw new InvalidOperationException("There were no rows that matched the specified criteria.");
+            throw new InvalidOperationException(
+                $"No compatibility rows matched the specified criteria. "
+                + $"Runner version range: [{afterRunnerVersion}, {beforeRunnerVersion}), "
+                + $"TestHost version range: [{afterTestHostVersion}, {beforeTestHostVersion}), "
+                + $"Adapter version range: [{afterAdapterVersion}, {beforeAdapterVersion}). "
+                + $"Total candidate rows before filtering: {dataRows.Count}, after version filtering: {rows.Count}.");
         }
 
         var allRows = distinctRows.Values.ToList();


### PR DESCRIPTION
Include version ranges and row counts in the exception message thrown when no compatibility test rows match the specified criteria. This helps diagnose configuration issues much faster than the previous generic message.

Part of #15489
