### PR TITLE
docs: add git worktree and upstream sync workflow to copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,34 @@ In addition to the rules enforced by `.editorconfig`, you SHOULD:
 
 You MUST minimize adding public API surface area but any newly added public API MUST be declared in the related `PublicAPI.Unshipped.txt` file.
 
+## Working with Git Worktrees
+
+This repository uses git worktrees to work on multiple things at the same time. Worktrees live in `../vstest-tree/<branch>` relative to the main clone at `c:\p\vstest`.
+
+The following global git aliases are configured:
+
+```shell
+git config --global alias.wta '!f() { mkdir -p "$(git rev-parse --show-toplevel)/../vstest-tree" 2>/dev/null; git worktree add -b "$1" "../vstest-tree/$1"; }; f'
+git config --global alias.wtr '!f() { git worktree remove "../vstest-tree/$1"; }; f'
+git config --global alias.wtl '!f() { git worktree list; }; f'
+```
+
+Usage:
+
+```shell
+git wta my-feature-branch   # creates c:\p\vstest-tree\my-feature-branch
+git wtl                     # list all active worktrees
+git wtr my-feature-branch   # remove worktree when done
+```
+
+The upstream remote `upstream` points to `https://github.com/microsoft/vstest`. To sync with upstream:
+
+```shell
+git fetch upstream
+git checkout main
+git merge upstream/main
+```
+
 ## Localization Guidelines
 
 Anytime you add a new localization resource, you MUST:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,56 +5,13 @@ platform.
 
 ## Prerequisites
 
-Fork [microsoft/vstest](https://github.com/microsoft/vstest) on GitHub, then clone your fork to a local directory. Rest of this article assumes `C:\p\vstest` as the location where you cloned the repo.
+Clone the repository to a local directory. Rest of this article assumes
+`C:\source\vstest` as the location where you cloned the repo.
 
 ```shell
-> cd C:\p
-> git clone https://github.com/<your-github-username>/vstest.git
+> cd C:\source
+> git clone https://github.com/Microsoft/vstest.git
 ```
-
-### Keeping up to date with upstream
-
-Add the upstream remote so you can regularly pull in changes from the main repository:
-
-```shell
-> cd C:\p\vstest
-> git remote add upstream https://github.com/microsoft/vstest.git
-```
-
-To update your local `main` branch with the latest upstream changes:
-
-```shell
-> git fetch upstream
-> git checkout main
-> git merge upstream/main
-```
-
-### Working on multiple things at the same time with git worktrees
-
-Instead of juggling branches on a single checkout, use [git worktrees](https://git-scm.com/docs/git-worktree) to have multiple branches checked out simultaneously, each in its own directory under `C:\p\vstest-tree\`.
-
-Set up these global git aliases once:
-
-```shell
-> git config --global alias.wta '!f() { mkdir -p "$(git rev-parse --show-toplevel)/../vstest-tree" 2>/dev/null; git worktree add -b "$1" "../vstest-tree/$1"; }; f'
-> git config --global alias.wtr '!f() { git worktree remove "../vstest-tree/$1"; }; f'
-> git config --global alias.wtl '!f() { git worktree list; }; f'
-```
-
-Then use them:
-
-```shell
-# Create a new worktree for a branch (checkout appears at C:\p\vstest-tree\<branch>)
-> git wta my-feature-branch
-
-# List all active worktrees
-> git wtl
-
-# Remove a worktree when done
-> git wtr my-feature-branch
-```
-
-Each worktree is a full independent checkout sharing the same `.git` store — no stashing needed when switching contexts.
 
 ### Windows requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,13 +5,56 @@ platform.
 
 ## Prerequisites
 
-Clone the repository to a local directory. Rest of this article assumes
-`C:\source\vstest` as the location where you cloned the repo.
+Fork [microsoft/vstest](https://github.com/microsoft/vstest) on GitHub, then clone your fork to a local directory. Rest of this article assumes `C:\p\vstest` as the location where you cloned the repo.
 
 ```shell
-> cd C:\source
-> git clone https://github.com/Microsoft/vstest.git
+> cd C:\p
+> git clone https://github.com/<your-github-username>/vstest.git
 ```
+
+### Keeping up to date with upstream
+
+Add the upstream remote so you can regularly pull in changes from the main repository:
+
+```shell
+> cd C:\p\vstest
+> git remote add upstream https://github.com/microsoft/vstest.git
+```
+
+To update your local `main` branch with the latest upstream changes:
+
+```shell
+> git fetch upstream
+> git checkout main
+> git merge upstream/main
+```
+
+### Working on multiple things at the same time with git worktrees
+
+Instead of juggling branches on a single checkout, use [git worktrees](https://git-scm.com/docs/git-worktree) to have multiple branches checked out simultaneously, each in its own directory under `C:\p\vstest-tree\`.
+
+Set up these global git aliases once:
+
+```shell
+> git config --global alias.wta '!f() { mkdir -p "$(git rev-parse --show-toplevel)/../vstest-tree" 2>/dev/null; git worktree add -b "$1" "../vstest-tree/$1"; }; f'
+> git config --global alias.wtr '!f() { git worktree remove "../vstest-tree/$1"; }; f'
+> git config --global alias.wtl '!f() { git worktree list; }; f'
+```
+
+Then use them:
+
+```shell
+# Create a new worktree for a branch (checkout appears at C:\p\vstest-tree\<branch>)
+> git wta my-feature-branch
+
+# List all active worktrees
+> git wtl
+
+# Remove a worktree when done
+> git wtr my-feature-branch
+```
+
+Each worktree is a full independent checkout sharing the same `.git` store — no stashing needed when switching contexts.
 
 ### Windows requirements
 


### PR DESCRIPTION
Adds a **Working with Git Worktrees** section to .github/copilot-instructions.md covering:

- Global git aliases (wta/wtr/wtl) for creating/removing/listing worktrees under ../vstest-tree/<branch>
- Upstream remote setup pointing to microsoft/vstest
- Steps for syncing with upstream (git fetch upstream && git merge upstream/main)

This is Copilot-specific guidance (not contributor docs), so it lives in copilot-instructions.md rather than CONTRIBUTING.md.