### PR TITLE
Add VSIX runner to smoke tests

### DIFF
--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DiscoveryTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DiscoveryTests.cs
@@ -32,7 +32,7 @@ public class DiscoveryTests : AcceptanceTestBase
     }
 
     [TestMethod]
-    [NetFullTargetFrameworkDataSource(inIsolation: true, inProcess: true)]
+    [NetFullTargetFrameworkDataSource(inIsolation: true, inProcess: true, useVsixRunner: true)]
     [NetCoreTargetFrameworkDataSource]
     [TestCategory("Smoke")]
     public void MultipleSourcesDiscoverAllTests(RunnerInfo runnerInfo)

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
@@ -69,7 +69,7 @@ public class ExecutionTests : AcceptanceTestBase
     [TestMethod]
     [TestCategory("Windows-Review")]
     [TestCategory("Smoke")]
-    [NetFullTargetFrameworkDataSource(inIsolation: true, inProcess: true)]
+    [NetFullTargetFrameworkDataSource(inIsolation: true, inProcess: true, useVsixRunner: true)]
     [NetCoreTargetFrameworkDataSource]
     public void RunMultipleMSTestAssembliesOnVstestConsoleAndTesthostCombinations3(RunnerInfo runnerInfo)
     {

--- a/test/Microsoft.TestPlatform.Library.IntegrationTests/TranslationLayerTests/DiscoverTests.cs
+++ b/test/Microsoft.TestPlatform.Library.IntegrationTests/TranslationLayerTests/DiscoverTests.cs
@@ -87,6 +87,7 @@ public class DiscoverTests : AcceptanceTestBase
     [TestMethod]
     [TestCategory("Smoke")]
     [NetCoreTargetFrameworkDataSource]
+    [NetFullTargetFrameworkDataSource(useVsixRunner: true)]
     public void DiscoverTestsUsingDiscoveryEventHandler2AndTelemetryOptedIn(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);

--- a/test/Microsoft.TestPlatform.Library.IntegrationTests/TranslationLayerTests/RunTests.cs
+++ b/test/Microsoft.TestPlatform.Library.IntegrationTests/TranslationLayerTests/RunTests.cs
@@ -63,6 +63,7 @@ public class RunTests : AcceptanceTestBase
 
     [TestMethod]
     [NetCoreTargetFrameworkDataSource]
+    [NetFullTargetFrameworkDataSource(useVsixRunner: true)]
     [TestCategory("Smoke")]
     public void RunAllTestsFromDlls(RunnerInfo runnerInfo)
     {


### PR DESCRIPTION
Smoke tests were not running against the VSIX-packaged vstest.console that ships into Visual Studio. Added `useVsixRunner: true` to smoke test data source attributes so they also validate the VSIX runner path.

**Tests updated:**
- `MultipleSourcesDiscoverAllTests` (Acceptance - already had NetFull, added VSIX)
- `RunMultipleMSTestAssembliesOnVstestConsoleAndTesthostCombinations3` (Acceptance - already had NetFull, added VSIX)
- `RunAllTestsFromDlls` (Library - added new NetFull+VSIX data source)
- `DiscoverTestsUsingDiscoveryEventHandler2AndTelemetryOptedIn` (Library - added new NetFull+VSIX data source)

`RunDotnetTestWithCsproj` is skipped as it uses `dotnet test`, not vstest.console.

Fixes #15507
