### PR TITLE
Add README.md to NuGet packages

### DIFF
--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -17,19 +17,19 @@ Add-Type -AssemblyName System.IO.Compression.FileSystem
 function Verify-Nuget-Packages {
     Write-Host "Starting Verify-Nuget-Packages."
     $expectedNumOfFiles = @{
-        "Microsoft.CodeCoverage"                      = 75
-        "Microsoft.NET.Test.Sdk"                      = 25
-        "Microsoft.TestPlatform"                      = 544
+        "Microsoft.CodeCoverage"                      = 76
+        "Microsoft.NET.Test.Sdk"                      = 26
+        "Microsoft.TestPlatform"                      = 545
         "Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI" = 388
-        "Microsoft.TestPlatform.Build"                = 20
-        "Microsoft.TestPlatform.CLI"                  = 482
-        "Microsoft.TestPlatform.Extensions.TrxLogger" = 34
-        "Microsoft.TestPlatform.ObjectModel"          = 92
-        "Microsoft.TestPlatform.AdapterUtilities"     = 61
-        "Microsoft.TestPlatform.Portable"             = 608
-        "Microsoft.TestPlatform.TestHost"             = 63
-        "Microsoft.TestPlatform.TranslationLayer"     = 174
-        "Microsoft.TestPlatform.Internal.Uwp"         = 38
+        "Microsoft.TestPlatform.Build"                = 21
+        "Microsoft.TestPlatform.CLI"                  = 483
+        "Microsoft.TestPlatform.Extensions.TrxLogger" = 35
+        "Microsoft.TestPlatform.ObjectModel"          = 93
+        "Microsoft.TestPlatform.AdapterUtilities"     = 62
+        "Microsoft.TestPlatform.Portable"             = 609
+        "Microsoft.TestPlatform.TestHost"             = 64
+        "Microsoft.TestPlatform.TranslationLayer"     = 175
+        "Microsoft.TestPlatform.Internal.Uwp"         = 39
     }
 
     $packageDirectory = Resolve-Path "$PSScriptRoot/../artifacts/packages/$configuration"

--- a/src/Microsoft.TestPlatform.AdapterUtilities/Microsoft.TestPlatform.AdapterUtilities.nuspec
+++ b/src/Microsoft.TestPlatform.AdapterUtilities/Microsoft.TestPlatform.AdapterUtilities.nuspec
@@ -2,6 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     $CommonMetadataElements$
+    <readme>README.md</readme>
 
     <dependencies>
       <group targetFramework="netstandard2.0" />
@@ -13,6 +14,7 @@
 
   <files>
     $CommonFileElements$
+    <file src="$ProjectDirectory$\README.md" target="" />
 
     <file src="netstandard2.0\Microsoft.TestPlatform.AdapterUtilities.dll" target="lib\netstandard2.0" />
     <file src="net462\Microsoft.TestPlatform.AdapterUtilities.dll" target="lib\net462" />

--- a/src/Microsoft.TestPlatform.AdapterUtilities/README.md
+++ b/src/Microsoft.TestPlatform.AdapterUtilities/README.md
@@ -1,0 +1,23 @@
+# Microsoft.TestPlatform.AdapterUtilities
+
+Utility helpers for test adapters targeting the Visual Studio Test Platform. Provides support for modern functionality such as standardized fully qualified names and hierarchical test case names.
+
+## Usage
+
+Add this package to your test adapter project:
+
+```xml
+<PackageReference Include="Microsoft.TestPlatform.AdapterUtilities" Version="x.y.z" />
+```
+
+## Key Features
+
+- `TestIdProvider` — generates stable, unique test IDs
+- `ManagedNameHelper` — converts between method info and managed type/method name pairs
+- Hierarchical test case name support for Test Explorer
+
+## Links
+
+- [Visual Studio Test Platform Documentation](https://github.com/microsoft/vstest)
+- [Adapter Extensibility](https://github.com/microsoft/vstest/blob/main/docs/RFCs/0004-Adapter-Extensibility.md)
+- [License (MIT)](https://github.com/microsoft/vstest/blob/main/LICENSE)

--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.nuspec
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.nuspec
@@ -2,6 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     $CommonMetadataElements$
+    <readme>README.md</readme>
 
     <dependencies>
       <group targetFramework="netstandard2.0" />
@@ -10,6 +11,7 @@
 
   <files>
     $CommonFileElements$
+    <file src="$ProjectDirectory$\README.md" target="" />
 
     <file src="netstandard2.0/Microsoft.TestPlatform.targets" target="runtimes/any/native" />
     <file src="netstandard2.0/Microsoft.TestPlatform.Build.dll" target="lib/netstandard2.0" />

--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.sourcebuild.nuspec
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.sourcebuild.nuspec
@@ -2,6 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     $CommonMetadataElements$
+    <readme>README.md</readme>
 
     <dependencies>
       <group targetFramework="$SourceBuildTfmCurrent$" />
@@ -10,6 +11,7 @@
 
   <files>
     $CommonFileElements$
+    <file src="$ProjectDirectory$\README.md" target="" />
 
     <file src="$SourceBuildTfmCurrent$/Microsoft.TestPlatform.targets" target="runtimes/any/native" />
     <file src="$SourceBuildTfmCurrent$/Microsoft.TestPlatform.Build.dll" target="lib/$SourceBuildTfmCurrent$" />

--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.sourcebuild.product.nuspec
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.Build.sourcebuild.product.nuspec
@@ -2,6 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     $CommonMetadataElements$
+    <readme>README.md</readme>
 
     <dependencies>
       <group targetFramework="$SourceBuildTfmCurrent$" />
@@ -10,6 +11,7 @@
 
   <files>
     $CommonFileElements$
+    <file src="$ProjectDirectory$\README.md" target="" />
 
     <file src="$SourceBuildTfmCurrent$/Microsoft.TestPlatform.targets" target="runtimes/any/native" />
     <file src="$SourceBuildTfmCurrent$/Microsoft.TestPlatform.Build.dll" target="lib/$SourceBuildTfmCurrent$" />

--- a/src/Microsoft.TestPlatform.Build/README.md
+++ b/src/Microsoft.TestPlatform.Build/README.md
@@ -4,7 +4,7 @@ Build tasks and targets for running tests with the Visual Studio Test Platform. 
 
 ## Usage
 
-This package is typically referenced indirectly through `Microsoft.NET.Test.Sdk`. Direct references are needed only for advanced build customization scenarios.
+This package is consumed by .NET SDK. Direct references are needed only for advanced build customization scenarios.
 
 ```xml
 <PackageReference Include="Microsoft.TestPlatform.Build" Version="x.y.z" />

--- a/src/Microsoft.TestPlatform.Build/README.md
+++ b/src/Microsoft.TestPlatform.Build/README.md
@@ -1,0 +1,17 @@
+# Microsoft.TestPlatform.Build
+
+Build tasks and targets for running tests with the Visual Studio Test Platform. This package provides MSBuild integration that enables `dotnet test` to discover and execute tests.
+
+## Usage
+
+This package is typically referenced indirectly through `Microsoft.NET.Test.Sdk`. Direct references are needed only for advanced build customization scenarios.
+
+```xml
+<PackageReference Include="Microsoft.TestPlatform.Build" Version="x.y.z" />
+```
+
+## Links
+
+- [Visual Studio Test Platform Documentation](https://github.com/microsoft/vstest)
+- [Test Platform Architecture](https://github.com/microsoft/vstest/blob/main/docs/RFCs/0001-Test-Platform-Architecture.md)
+- [License (MIT)](https://github.com/microsoft/vstest/blob/main/LICENSE)

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Microsoft.TestPlatform.Extensions.TrxLogger.nuspec
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Microsoft.TestPlatform.Extensions.TrxLogger.nuspec
@@ -2,6 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     $CommonMetadataElements$
+    <readme>README.md</readme>
 
     <dependencies>
       <group targetFramework="net462">
@@ -24,6 +25,7 @@
 
   <files>
     $CommonFileElements$
+    <file src="$ProjectDirectory$\README.md" target="" />
 
     <!-- Add a third party notice file -->
     <file src="$SrcPackageFolder$ThirdPartyNotices.txt" target="" />

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/README.md
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/README.md
@@ -1,0 +1,22 @@
+# Microsoft.TestPlatform.Extensions.TrxLogger
+
+The TRX (Visual Studio Test Results) logger for the Visual Studio Test Platform. This package enables generating `.trx` result files from test runs.
+
+## Usage
+
+```xml
+<PackageReference Include="Microsoft.TestPlatform.Extensions.TrxLogger" Version="x.y.z" />
+```
+
+Run tests with the TRX logger:
+
+```sh
+dotnet test --logger trx
+dotnet test --logger "trx;LogFileName=results.trx"
+```
+
+## Links
+
+- [Visual Studio Test Platform Documentation](https://github.com/microsoft/vstest)
+- [Loggers Information From RunSettings](https://github.com/microsoft/vstest/blob/main/docs/RFCs/0016-Loggers-Information-From-RunSettings.md)
+- [License (MIT)](https://github.com/microsoft/vstest/blob/main/LICENSE)

--- a/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.nuspec
+++ b/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.nuspec
@@ -2,6 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     $CommonMetadataElements$
+    <readme>README.md</readme>
 
     <dependencies>
       <group targetFramework="net462">
@@ -31,6 +32,7 @@
 
   <files>
     $CommonFileElements$
+    <file src="$ProjectDirectory$\README.md" target="" />
 
     <!-- net462 -->
     <file src="net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" target="lib\net462\" />

--- a/src/Microsoft.TestPlatform.ObjectModel/README.md
+++ b/src/Microsoft.TestPlatform.ObjectModel/README.md
@@ -1,13 +1,13 @@
 # Microsoft.TestPlatform.ObjectModel
 
-The object model for the Visual Studio Test Platform. This package provides the public API surface for creating test adapters, loggers, and other test platform extensions.
+The object model for the Visual Studio Test Platform. This package provides the public API surface for creating test adapters, loggers, and other test platform extensions. This package is typically used as a reference.
 
 ## Usage
 
 Add this package to your test adapter or extension project:
 
 ```xml
-<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="x.y.z" />
+<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="x.y.z" PrivateAssets="All" />
 ```
 
 ## Key Types

--- a/src/Microsoft.TestPlatform.ObjectModel/README.md
+++ b/src/Microsoft.TestPlatform.ObjectModel/README.md
@@ -1,0 +1,24 @@
+# Microsoft.TestPlatform.ObjectModel
+
+The object model for the Visual Studio Test Platform. This package provides the public API surface for creating test adapters, loggers, and other test platform extensions.
+
+## Usage
+
+Add this package to your test adapter or extension project:
+
+```xml
+<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="x.y.z" />
+```
+
+## Key Types
+
+- `Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase` — represents a discovered test
+- `Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult` — represents the result of a test execution
+- `Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter.ITestDiscoverer` — interface for test discovery
+- `Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter.ITestExecutor` — interface for test execution
+
+## Links
+
+- [Visual Studio Test Platform Documentation](https://github.com/microsoft/vstest)
+- [Adapter Extensibility](https://github.com/microsoft/vstest/blob/main/docs/RFCs/0004-Adapter-Extensibility.md)
+- [License (MIT)](https://github.com/microsoft/vstest/blob/main/LICENSE)

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.nuspec
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.nuspec
@@ -2,6 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     $CommonMetadataElements$
+    <readme>README.md</readme>
 
     <dependencies>
       <group targetFramework="net462">
@@ -29,6 +30,7 @@
 
   <files>
     $CommonFileElements$
+    <file src="$ProjectDirectory$\README.md" target="" />
 
     <!-- Add a third party notice file -->
     <file src="$SrcPackageFolder$ThirdPartyNotices.txt" target="" />

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/README.md
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/README.md
@@ -1,0 +1,31 @@
+# Microsoft.TestPlatform.TranslationLayer
+
+The C# SDK for the Visual Studio Test Platform protocol. Use this package to programmatically discover and execute tests from IDEs, editors, or custom tools by communicating with `vstest.console`.
+
+## Usage
+
+```xml
+<PackageReference Include="Microsoft.TestPlatform.TranslationLayer" Version="x.y.z" />
+```
+
+## Example
+
+```csharp
+var vstestConsolePath = "<path to vstest.console>";
+var consoleWrapper = new VsTestConsoleWrapper(vstestConsolePath);
+
+consoleWrapper.StartSession();
+consoleWrapper.InitializeExtensions(extensionPaths);
+
+// Discover tests
+consoleWrapper.DiscoverTests(testAssemblies, settings, discoveryHandler);
+
+// Run tests
+consoleWrapper.RunTests(testAssemblies, settings, executionHandler);
+```
+
+## Links
+
+- [Visual Studio Test Platform Documentation](https://github.com/microsoft/vstest)
+- [Translation Layer](https://github.com/microsoft/vstest/blob/main/docs/RFCs/0008-TranslationLayer.md)
+- [License (MIT)](https://github.com/microsoft/vstest/blob/main/LICENSE)

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/README.md
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/README.md
@@ -11,7 +11,7 @@ The C# SDK for the Visual Studio Test Platform protocol. Use this package to pro
 ## Example
 
 ```csharp
-var vstestConsolePath = "<path to vstest.console>";
+var vstestConsolePath = "<path to vstest.console.exe or .dll>";
 var consoleWrapper = new VsTestConsoleWrapper(vstestConsolePath);
 
 consoleWrapper.StartSession();

--- a/src/package/Microsoft.CodeCoverage/Microsoft.CodeCoverage.nuspec
+++ b/src/package/Microsoft.CodeCoverage/Microsoft.CodeCoverage.nuspec
@@ -2,6 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     $CommonMetadataElements$
+    <readme>README.md</readme>
 
     <dependencies>
       <group targetFramework="net462"></group>
@@ -11,6 +12,7 @@
 
   <files>
     $CommonFileElements$
+    <file src="$ProjectDirectory$\README.md" target="" />
 
     <file src="net462\ThirdPartyNoticesCodeCoverage.txt" target="ThirdPartyNotices.txt" />
     <file src="net462\ThirdPartyNoticesCodeCoverage.txt" target="build\netstandard2.0\ThirdPartyNotices.txt" />

--- a/src/package/Microsoft.CodeCoverage/README.md
+++ b/src/package/Microsoft.CodeCoverage/README.md
@@ -1,0 +1,23 @@
+# Microsoft.CodeCoverage
+
+Code coverage infrastructure for the Visual Studio Test Platform. This package enables collecting code coverage data from `vstest.console.exe` and `dotnet test`.
+
+## Usage
+
+This package is typically referenced indirectly through `Microsoft.NET.Test.Sdk`. For standalone usage:
+
+```xml
+<PackageReference Include="Microsoft.CodeCoverage" Version="x.y.z" />
+```
+
+Collect code coverage during a test run:
+
+```sh
+dotnet test --collect "Code Coverage"
+```
+
+## Links
+
+- [Visual Studio Test Platform Documentation](https://github.com/microsoft/vstest)
+- [Code Coverage for .NET Core](https://github.com/microsoft/vstest/blob/main/docs/RFCs/0021-CodeCoverageForNetCore.md)
+- [License (MIT)](https://github.com/microsoft/vstest/blob/main/LICENSE)

--- a/src/package/Microsoft.NET.Test.Sdk/Microsoft.NET.Test.Sdk.nuspec
+++ b/src/package/Microsoft.NET.Test.Sdk/Microsoft.NET.Test.Sdk.nuspec
@@ -2,6 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     $CommonMetadataElements$
+    <readme>README.md</readme>
 
     <dependencies>
       <group targetFramework="net8.0">
@@ -22,6 +23,7 @@
 
   <files>
     $CommonFileElements$
+    <file src="$ProjectDirectory$\README.md" target="" />
 
     <file src="netstandard2.0\netcoreapp\*" target="build\net8.0\" />
     <file src="netstandard2.0\netfx\*" target="build\net462\" />

--- a/src/package/Microsoft.NET.Test.Sdk/README.md
+++ b/src/package/Microsoft.NET.Test.Sdk/README.md
@@ -1,0 +1,33 @@
+# Microsoft.NET.Test.Sdk
+
+The MSBuild targets and properties for building .NET test projects. This package is required for any .NET test project to integrate with the Visual Studio Test Platform.
+
+## Usage
+
+Add this package to your test project:
+
+```xml
+<PackageReference Include="Microsoft.NET.Test.Sdk" Version="x.y.z" />
+```
+
+This package works alongside a test framework adapter (e.g., MSTest, xUnit, NUnit) to enable test discovery and execution via `dotnet test` or Visual Studio Test Explorer.
+
+## Example
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="x.y.z" />
+    <PackageReference Include="MSTest" Version="3.x.y" />
+  </ItemGroup>
+</Project>
+```
+
+## Links
+
+- [Visual Studio Test Platform Documentation](https://github.com/microsoft/vstest)
+- [Test Platform SDK](https://github.com/microsoft/vstest/blob/main/docs/RFCs/0005-Test-Platform-SDK.md)
+- [License (MIT)](https://github.com/microsoft/vstest/blob/main/LICENSE)

--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.nuspec
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.nuspec
@@ -2,6 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     $CommonMetadataElements$
+    <readme>README.md</readme>
 
     <contentFiles>
       <files include="**/*.*" copyToOutput="true" flatten="false" buildAction="None" />
@@ -9,6 +10,7 @@
   </metadata>
   <files>
     $CommonFileElements$
+    <file src="$ProjectDirectory$\README.md" target="" />
 
     <!-- Add a third party notice file -->
     <file src="$SrcPackageFolder$ThirdPartyNotices.txt" target="" />

--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.sourcebuild.nuspec
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.sourcebuild.nuspec
@@ -2,6 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     $CommonMetadataElements$
+    <readme>README.md</readme>
 
     <contentFiles>
       <files include="**/*.*" copyToOutput="true" flatten="false" buildAction="None" />
@@ -9,6 +10,7 @@
   </metadata>
   <files>
     $CommonFileElements$
+    <file src="$ProjectDirectory$\README.md" target="" />
 
     <!-- Add a third party notice file -->
     <file src="$SrcPackageFolder$ThirdPartyNotices.txt" target="" />

--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.sourcebuild.product.nuspec
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.sourcebuild.product.nuspec
@@ -2,6 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     $CommonMetadataElements$
+    <readme>README.md</readme>
 
     <contentFiles>
       <files include="**/*.*" copyToOutput="true" flatten="false" buildAction="None" />
@@ -9,6 +10,7 @@
   </metadata>
   <files>
     $CommonFileElements$
+    <file src="$ProjectDirectory$\README.md" target="" />
 
     <!-- Add a third party notice file -->
     <file src="$SrcPackageFolder$ThirdPartyNotices.txt" target="" />

--- a/src/package/Microsoft.TestPlatform.CLI/README.md
+++ b/src/package/Microsoft.TestPlatform.CLI/README.md
@@ -1,0 +1,18 @@
+# Microsoft.TestPlatform.CLI
+
+The cross-platform command-line interface for the Visual Studio Test Platform. This package provides `vstest.console.dll` and associated tooling for discovering and executing tests from the command line.
+
+## Usage
+
+This package is typically consumed by the .NET SDK and is not directly referenced in most test projects. For direct usage:
+
+```xml
+<PackageReference Include="Microsoft.TestPlatform.CLI" Version="x.y.z" />
+```
+
+## Links
+
+- [Visual Studio Test Platform Documentation](https://github.com/microsoft/vstest)
+- [Test Platform Architecture](https://github.com/microsoft/vstest/blob/main/docs/RFCs/0001-Test-Platform-Architecture.md)
+- [Packaging](https://github.com/microsoft/vstest/blob/main/docs/RFCs/0014-Packaging.md)
+- [License (MIT)](https://github.com/microsoft/vstest/blob/main/LICENSE)

--- a/src/package/Microsoft.TestPlatform.Internal.Uwp/Microsoft.TestPlatform.Internal.Uwp.nuspec
+++ b/src/package/Microsoft.TestPlatform.Internal.Uwp/Microsoft.TestPlatform.Internal.Uwp.nuspec
@@ -2,6 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     $CommonMetadataElements$
+    <readme>README.md</readme>
 
     <dependencies>
       <group targetFramework="netstandard2.0"></group>
@@ -9,6 +10,7 @@
   </metadata>
   <files>
     $CommonFileElements$
+    <file src="$ProjectDirectory$\README.md" target="" />
 
     <file src="netstandard2.0\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" target="lib\netstandard2.0\" />
     <file src="netstandard2.0\cs\Microsoft.VisualStudio.TestPlatform.ObjectModel.*resources.dll" target="lib\netstandard2.0\cs" />

--- a/src/package/Microsoft.TestPlatform.Internal.Uwp/README.md
+++ b/src/package/Microsoft.TestPlatform.Internal.Uwp/README.md
@@ -1,0 +1,16 @@
+# Microsoft.TestPlatform.Internal.Uwp
+
+Internal test platform libraries for the UWP (Universal Windows Platform) test runner. This package provides the test platform binaries needed to run tests in UWP applications.
+
+> **Note:** This is an internal package. Most test projects should reference `Microsoft.NET.Test.Sdk` instead.
+
+## Usage
+
+```xml
+<PackageReference Include="Microsoft.TestPlatform.Internal.Uwp" Version="x.y.z" />
+```
+
+## Links
+
+- [Visual Studio Test Platform Documentation](https://github.com/microsoft/vstest)
+- [License (MIT)](https://github.com/microsoft/vstest/blob/main/LICENSE)

--- a/src/package/Microsoft.TestPlatform.Portable/Microsoft.TestPlatform.Portable.nuspec
+++ b/src/package/Microsoft.TestPlatform.Portable/Microsoft.TestPlatform.Portable.nuspec
@@ -2,10 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     $CommonMetadataElements$
+    <readme>README.md</readme>
   </metadata>
 
   <files>
     $CommonFileElements$
+    <file src="$ProjectDirectory$\README.md" target="" />
 
     <!-- Add a third party notice file -->
     <file src="$SrcPackageFolder$ThirdPartyNotices.txt" target="" />

--- a/src/package/Microsoft.TestPlatform.Portable/README.md
+++ b/src/package/Microsoft.TestPlatform.Portable/README.md
@@ -1,0 +1,18 @@
+# Microsoft.TestPlatform.Portable
+
+A portable subset of binaries for the Visual Studio Test Platform (vstest). This package contains the test platform toolset for cross-platform test execution scenarios, including `vstest.console`, test hosts, and data collectors.
+
+## Usage
+
+```xml
+<PackageReference Include="Microsoft.TestPlatform.Portable" Version="x.y.z" />
+```
+
+> **Note:** Most test projects should reference `Microsoft.NET.Test.Sdk` instead. This package is intended for scenarios that require the portable test platform toolset directly.
+
+## Links
+
+- [Visual Studio Test Platform Documentation](https://github.com/microsoft/vstest)
+- [Test Platform Architecture](https://github.com/microsoft/vstest/blob/main/docs/RFCs/0001-Test-Platform-Architecture.md)
+- [Packaging](https://github.com/microsoft/vstest/blob/main/docs/RFCs/0014-Packaging.md)
+- [License](https://github.com/microsoft/vstest/blob/main/LICENSE)

--- a/src/package/Microsoft.TestPlatform.Portable/README.md
+++ b/src/package/Microsoft.TestPlatform.Portable/README.md
@@ -8,7 +8,6 @@ A portable subset of binaries for the Visual Studio Test Platform (vstest). This
 <PackageReference Include="Microsoft.TestPlatform.Portable" Version="x.y.z" />
 ```
 
-> **Note:** Most test projects should reference `Microsoft.NET.Test.Sdk` instead. This package is intended for scenarios that require the portable test platform toolset directly.
 
 ## Links
 

--- a/src/package/Microsoft.TestPlatform.TestHost/Microsoft.TestPlatform.TestHost.nuspec
+++ b/src/package/Microsoft.TestPlatform.TestHost/Microsoft.TestPlatform.TestHost.nuspec
@@ -2,6 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     $CommonMetadataElements$
+    <readme>README.md</readme>
 
     <dependencies>
       <group targetFramework="net8.0">
@@ -15,6 +16,7 @@
 
   <files>
     $CommonFileElements$
+    <file src="$ProjectDirectory$\README.md" target="" />
 
     <!-- Add a third party notice file -->
     <file src="$SrcPackageFolder$ThirdPartyNotices.txt" target="" />

--- a/src/package/Microsoft.TestPlatform.TestHost/README.md
+++ b/src/package/Microsoft.TestPlatform.TestHost/README.md
@@ -1,0 +1,17 @@
+# Microsoft.TestPlatform.TestHost
+
+The test host process for the Visual Studio Test Platform. This package hosts the test execution engine and communicates with the test runner to discover and execute tests in the target process.
+
+## Usage
+
+This package is typically referenced indirectly through `Microsoft.NET.Test.Sdk`. Direct references are only needed in advanced hosting scenarios.
+
+```xml
+<PackageReference Include="Microsoft.TestPlatform.TestHost" Version="x.y.z" />
+```
+
+## Links
+
+- [Visual Studio Test Platform Documentation](https://github.com/microsoft/vstest)
+- [Test Platform Architecture](https://github.com/microsoft/vstest/blob/main/docs/RFCs/0001-Test-Platform-Architecture.md)
+- [License (MIT)](https://github.com/microsoft/vstest/blob/main/LICENSE)

--- a/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.nuspec
+++ b/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.nuspec
@@ -2,10 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     $CommonMetadataElements$
+    <readme>README.md</readme>
   </metadata>
 
   <files>
     $CommonFileElements$
+    <file src="$ProjectDirectory$\README.md" target="" />
 
     <!-- Add a third party notice file -->
     <file src="$SrcPackageFolder$ThirdPartyNotices.txt" target="" />

--- a/src/package/Microsoft.TestPlatform/README.md
+++ b/src/package/Microsoft.TestPlatform/README.md
@@ -8,7 +8,6 @@ The full set of binaries for the Visual Studio Test Platform (vstest). This pack
 <PackageReference Include="Microsoft.TestPlatform" Version="x.y.z" />
 ```
 
-> **Note:** Most test projects should reference `Microsoft.NET.Test.Sdk` instead, which provides a lighter-weight integration. This package is intended for scenarios that require the full test platform toolset.
 
 ## Links
 

--- a/src/package/Microsoft.TestPlatform/README.md
+++ b/src/package/Microsoft.TestPlatform/README.md
@@ -1,0 +1,18 @@
+# Microsoft.TestPlatform
+
+The full set of binaries for the Visual Studio Test Platform (vstest). This package contains the complete test platform including `vstest.console`, test hosts, data collectors, and extensions for both .NET and .NET Framework.
+
+## Usage
+
+```xml
+<PackageReference Include="Microsoft.TestPlatform" Version="x.y.z" />
+```
+
+> **Note:** Most test projects should reference `Microsoft.NET.Test.Sdk` instead, which provides a lighter-weight integration. This package is intended for scenarios that require the full test platform toolset.
+
+## Links
+
+- [Visual Studio Test Platform Documentation](https://github.com/microsoft/vstest)
+- [Test Platform Architecture](https://github.com/microsoft/vstest/blob/main/docs/RFCs/0001-Test-Platform-Architecture.md)
+- [Packaging](https://github.com/microsoft/vstest/blob/main/docs/RFCs/0014-Packaging.md)
+- [License](https://github.com/microsoft/vstest/blob/main/LICENSE)


### PR DESCRIPTION
## Summary

Add README.md files to all NuGet packages produced by vstest to resolve the 'missing a readme' warnings during \uild.cmd -pack\.

Closes #15549

## Changes

- Created README.md for 12 packages: Microsoft.NET.Test.Sdk, Microsoft.TestPlatform.Build, Microsoft.TestPlatform.ObjectModel, Microsoft.TestPlatform.TestHost, Microsoft.TestPlatform.AdapterUtilities, Microsoft.TestPlatform.TranslationLayer, Microsoft.TestPlatform.Extensions.TrxLogger, Microsoft.CodeCoverage, Microsoft.TestPlatform, Microsoft.TestPlatform.CLI, Microsoft.TestPlatform.Portable, Microsoft.TestPlatform.Internal.Uwp
- Updated all .nuspec files (including sourcebuild variants) with \<readme>\ metadata and \<file>\ entries referencing the README via \\\$\
- Updated \ng/verify-nupkgs.ps1\ expected file counts (+1 per package for the new README.md)

Each README includes a package description, usage information, and links to the main repository documentation.

## Verification

- \uild.cmd -pack\ passes with 0 errors and no 'missing a readme' warnings