### PR TITLE
Enable parallelization for blame data collector tests

### DIFF
--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
@@ -20,7 +20,6 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
 [TestCategory("Windows-Review")]
-[DoNotParallelize] // Blame tests collect crash/hang dumps from child processes and race when run in parallel.
 public class BlameDataCollectorTests : AcceptanceTestBase
 {
     public const string NETCOREANDFX = "net462;net472;net8.0";
@@ -240,6 +239,7 @@ public class BlameDataCollectorTests : AcceptanceTestBase
 
     [TestMethod]
     [TestCategory("Windows-Review")]
+    [DoNotParallelize] // Installs/uninstalls procdump as machine-wide postmortem debugger via HKLM registry.
     [NetFullTargetFrameworkDataSource]
     [NetCoreTargetFrameworkDataSource]
     public void BlameDataCollectorAeDebuggerShouldCollectDump(RunnerInfo runnerInfo)


### PR DESCRIPTION
## Summary

Move `[DoNotParallelize]` from class level to only the `BlameDataCollectorAeDebuggerShouldCollectDump` test method.

## Investigation (Fixes #15530)

PR #15526 added `[DoNotParallelize]` to the entire `BlameDataCollectorTests` class with the comment *"Blame tests collect crash/hang dumps from child processes and race when run in parallel."* This is overly broad.

### Why most blame tests CAN parallelize

Each blame test method:
- Creates a **unique TempDirectory** (via `RandomId.Next()`)
- Launches its **own vstest.console process** with `/Blame` options
- Each vstest.console creates its **own testhost process**
- Procdump is attached **per-process** with unique file names (`{processName}_{processId}_{timestamp}`)
- Named events use unique process IDs (`ProcDump-{targetProcessId}`)
- `PROCDUMP_PATH` is passed as a **per-process environment variable**
- `BlameCollector` uses only **instance fields** — no static mutable state

There is no shared state between parallel runs of these tests.

### Why one test CANNOT parallelize

`BlameDataCollectorAeDebuggerShouldCollectDump` modifies **machine-wide registry state** by installing/uninstalling procdump as the Windows postmortem debugger (`HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug`). Multiple parallel executions would race on this global registry key.

### Change

- Removed class-level `[DoNotParallelize]`
- Added method-level `[DoNotParallelize]` only to `BlameDataCollectorAeDebuggerShouldCollectDump`
- All 88 blame unit tests pass
- Integration test project builds successfully