### PR TITLE
Fix no test results with terminal logger and MTP integration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,22 @@ Additional tests that can be run locally, but typically you would run just the o
 > ⚠️Smoke, Integration, Compatibility and Performance tests do use the build packages that are produced by running `build.cmd -pack`, if you touch the production code (in src, e.g. in vstest.console) you should re-build before running these tests.
 > If you however touched just the integration test code, or test assets (in test/TestAssets) you can do `./build.cmd` for faster build (without -pack), or run the tests from IDE directly. The test assets will automatically re-build, but since you did not re-pack, there is no reason to fully clean and restore the dev packages, making it much faster to startup the integration tests.
 
+### Seeing raw test output
+
+By default, test output is captured into log files under `artifacts/log/`. When tests fail, the error message will show the path to the log file with the full output. If you prefer to see raw test output directly in the console, disable the MSBuild terminal logger by appending `-tl:off`:
+
+```powershell
+# Windows
+test.cmd -tl:off
+test.cmd -integrationTest -filter blame -tl:off
+```
+
+```bash
+# Linux / macOS
+./test.sh -tl:off
+./test.sh --integrationTest -tl:off
+```
+
 ### Running a specific test
 
 With integration tests you typically want to run all integration tests that affect a particular component, for example when changing blame data collector you want to run all tests for blame. This can be done by providing a parameter `-filter` to the test run, providing part of the test name, or providing a more complete filter using [MSTest filter syntax](https://learn.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=mstest)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -138,8 +138,14 @@
     <TestRunnerAdditionalArguments Condition=" '$(TestRunnerExternalArguments)' != ''">$(TestRunnerExternalArguments)</TestRunnerAdditionalArguments>
     <!-- Skip windows only tests on non-windows systems. -->
     <TestRunnerAdditionalArguments Condition=" '$(OS)' != 'Windows_NT' ">$(TestRunnerAdditionalArguments) --filter "TestCategory!=Windows&amp;TestCategory!=Windows-Review"</TestRunnerAdditionalArguments>
-    <!-- Allow us to see errors instead of capturing everything into files. -->
-    <TestCaptureOutput>false</TestCaptureOutput>
+    <!--
+      Allow Arcade to capture test output into log files (the default behavior).
+      When tests fail, the error message will reference the log file path, so the file must exist.
+      Setting this to false breaks the local dev experience when MSBuild terminal logger is active
+      (the default in .NET 8+), because terminal logger eats the console output and the log files
+      are never created. See https://github.com/microsoft/vstest/issues/15509
+      To see raw test output in the console, pass -tl:off to your test command.
+    -->
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Problem

When running tests locally, the MSBuild terminal logger (default in .NET 8+) captures and hides test runner output. Combined with \TestCaptureOutput=false\ in \Directory.Build.props\, the log files referenced in failure messages don't exist, leaving developers with no way to see what failed.

## Root Cause

Three things interact:
1. \TestCaptureOutput=false\ prevents Arcade from redirecting output to \.log\ files
2. Terminal logger aggregates all Exec task output (hiding test details)
3. Arcade's error messages reference \.log\ files that were never created

## Fix

- **Remove \TestCaptureOutput=false\** — let Arcade capture output to \rtifacts/log/*.log\ (default). Error messages now point to real files.
- **Add \-tl:off\ documentation** to CONTRIBUTING.md for devs who want live console output.

Fixes #15509