### PR TITLE
Deduplicate package extraction between verify-nupkgs and IntegrationTestBuild

### DIFF
--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -71,10 +71,14 @@ function Verify-Nuget-Packages {
         $nugetPackages += $vsix
     }
 
-    Write-Host "Unzipping NuGet packages to '$tmpDirectory'."
+    # Extract into the same location that IntegrationTestBuild.cs expects
+    # (artifacts/tmp/{Config}/extractedPackages/{PackageFileName}), so integration
+    # tests can reuse these extractions via the .cache marker files written below.
+    $extractedPackagesDir = Join-Path $tmpDirectory "extractedPackages"
+    Write-Host "Unzipping NuGet packages to '$extractedPackagesDir'."
     $unzipNugetPackageDirs = @()
     foreach ($nugetPackage in $nugetPackages) {
-        $unzipNugetPackageDir = Join-Path $tmpDirectory $nugetPackage.BaseName
+        $unzipNugetPackageDir = Join-Path $extractedPackagesDir $nugetPackage.Name
         $unzipNugetPackageDirs += $unzipNugetPackageDir
 
         if (Test-Path -Path $unzipNugetPackageDir) {
@@ -87,33 +91,38 @@ function Verify-Nuget-Packages {
     Write-Host "Verify NuGet packages files."
     $errors = @()
     foreach ($unzipNugetPackageDir in $unzipNugetPackageDirs) {
-        try {
-            $packageBaseName = (Get-Item $unzipNugetPackageDir).BaseName
-            $packageKey = $packageBaseName.Replace([string]".$version", [string]"")
-            Write-Host "Verifying package '$packageBaseName'."
+        # Directory is named after the package file (e.g. "Microsoft.TestPlatform.18.6.0-dev.nupkg"),
+        # so strip the extension to get the base name for key derivation.
+        $packageBaseName = [System.IO.Path]::GetFileNameWithoutExtension((Get-Item $unzipNugetPackageDir).Name)
+        $packageKey = $packageBaseName.Replace([string]".$version", [string]"")
+        Write-Host "Verifying package '$packageBaseName'."
 
-            $actualNumOfFiles = (Get-ChildItem -Recurse -File -Path $unzipNugetPackageDir | Where-Object { $_.Name -ne '.signature.p7s' }).Count
-            if (-not $expectedNumOfFiles.ContainsKey($packageKey)) {
-                $errors += "Package '$packageKey' is not present in file expectedNumOfFiles table. Is that package known?"
-                continue
-            }
-            if ($expectedNumOfFiles[$packageKey] -ne $actualNumOfFiles) {
-                $errors += "Number of files are not equal for '$packageBaseName', expected: $($expectedNumOfFiles[$packageKey]) actual: $actualNumOfFiles"
-            }
-
-            if ($packageKey -eq "Microsoft.TestPlatform") {
-                Verify-Version -nugetDir $unzipNugetPackageDir -errors $errors
-            }
+        $actualNumOfFiles = (Get-ChildItem -Recurse -File -Path $unzipNugetPackageDir | Where-Object { $_.Name -ne '.signature.p7s' }).Count
+        if (-not $expectedNumOfFiles.ContainsKey($packageKey)) {
+            $errors += "Package '$packageKey' is not present in file expectedNumOfFiles table. Is that package known?"
+            continue
         }
-        finally {
-            # if ($null -ne $unzipNugetPackageDir -and (Test-Path $unzipNugetPackageDir)) {
-            #     Remove-Item -Force -Recurse $unzipNugetPackageDir | Out-Null
-            # }
+        if ($expectedNumOfFiles[$packageKey] -ne $actualNumOfFiles) {
+            $errors += "Number of files are not equal for '$packageBaseName', expected: $($expectedNumOfFiles[$packageKey]) actual: $actualNumOfFiles"
+        }
+
+        if ($packageKey -eq "Microsoft.TestPlatform") {
+            Verify-Version -nugetDir $unzipNugetPackageDir -errors $errors
         }
     }
 
     if ($errors) {
         Write-Error "There are $($errors.Count) errors:`n$($errors -join "`n")"
+    }
+
+    # Write .cache marker files so IntegrationTestBuild.cs detects these
+    # extractions and skips re-extracting the same packages during test init.
+    Write-Host "Writing cache markers for extracted packages."
+    foreach ($nugetPackage in $nugetPackages) {
+        $unzipNugetPackageDir = Join-Path $extractedPackagesDir $nugetPackage.Name
+        $cacheMarkerPath = Join-Path $unzipNugetPackageDir ($nugetPackage.Name + ".cache")
+        $lastWriteTimeUtc = $nugetPackage.LastWriteTimeUtc.ToString([System.Globalization.CultureInfo]::InvariantCulture)
+        [System.IO.File]::WriteAllText($cacheMarkerPath, $lastWriteTimeUtc)
     }
 
     Write-Host "Completed Verify-Nuget-Packages."

--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -75,6 +75,7 @@ function Verify-Nuget-Packages {
     # (artifacts/tmp/{Config}/extractedPackages/{PackageFileName}), so integration
     # tests can reuse these extractions via the .cache marker files written below.
     $extractedPackagesDir = Join-Path $tmpDirectory "extractedPackages"
+    New-Item -ItemType Directory -Path $extractedPackagesDir -Force | Out-Null
     Write-Host "Unzipping NuGet packages to '$extractedPackagesDir'."
     $unzipNugetPackageDirs = @()
     foreach ($nugetPackage in $nugetPackages) {
@@ -121,7 +122,7 @@ function Verify-Nuget-Packages {
     foreach ($nugetPackage in $nugetPackages) {
         $unzipNugetPackageDir = Join-Path $extractedPackagesDir $nugetPackage.Name
         $cacheMarkerPath = Join-Path $unzipNugetPackageDir ($nugetPackage.Name + ".cache")
-        $lastWriteTimeUtc = $nugetPackage.LastWriteTimeUtc.ToString([System.Globalization.CultureInfo]::InvariantCulture)
+        $lastWriteTimeUtc = $nugetPackage.LastWriteTimeUtc.ToString("o", [System.Globalization.CultureInfo]::InvariantCulture)
         [System.IO.File]::WriteAllText($cacheMarkerPath, $lastWriteTimeUtc)
     }
 

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
@@ -452,7 +452,7 @@ public class IntegrationTestBuild : IntegrationTestBase
             var cacheMarkerPath = Path.Combine(unzipPath, packageName + ".cache");
             if (File.Exists(cacheMarkerPath))
             {
-                if (File.ReadAllText(cacheMarkerPath) == File.GetLastWriteTimeUtc(packagePath).ToString(CultureInfo.InvariantCulture))
+                if (File.ReadAllText(cacheMarkerPath) == File.GetLastWriteTimeUtc(packagePath).ToString("o", CultureInfo.InvariantCulture))
                 {
                     // Already extracted and using the latest built packages.
                     continue;
@@ -468,7 +468,7 @@ public class IntegrationTestBuild : IntegrationTestBase
             }
 
             ZipFile.ExtractToDirectory(packagePath, unzipPath);
-            File.WriteAllText(cacheMarkerPath, File.GetLastWriteTimeUtc(packagePath).ToString(CultureInfo.InvariantCulture));
+            File.WriteAllText(cacheMarkerPath, File.GetLastWriteTimeUtc(packagePath).ToString("o", CultureInfo.InvariantCulture));
         }
 
         return packagesAreNew;


### PR DESCRIPTION
Aligns \ng/verify-nupkgs.ps1\ extraction to use the same directory convention as \IntegrationTestBuild.cs\, eliminating duplicate extraction of 5 NuGet packages + VSIX.

**Before:** Packages extracted twice:
- \rtifacts/tmp/{Config}/{BaseName}\ (by verify-nupkgs during pack)
- \rtifacts/tmp/{Config}/extractedPackages/{FileName}\ (by IntegrationTestBuild during test init)

**After:** verify-nupkgs extracts to \xtractedPackages/{FileName}\ and writes \.cache\ markers. IntegrationTestBuild detects the cache and skips re-extraction.

IntegrationTestBuild retains its own extraction logic as a fallback (e.g., on Linux where \uild.cmd -pack\ isn't run, or when running tests without packing first).

Closes #15456

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>