### PR TITLE
Fix CI failure when GeneratedTestAssets directory doesn't exist

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -220,7 +220,7 @@ extends:
               # and some of them use dependencies that are now vulnerable.
               # We don't depend on those vulnerable versions anymore, but need to keep restoring them to ensure backwards compatibility.
               - pwsh: |
-                  Remove-Item -Path $(Build.SourcesDirectory)/artifacts/tmp/GeneratedTestAssets -Recurse -Force
+                  Remove-Item -Path $(Build.SourcesDirectory)/artifacts/tmp/GeneratedTestAssets -Recurse -Force -ErrorAction SilentlyContinue
                 displayName: Remove artifacts/tmp/GeneratedTestAssets
 
             - task: 1ES.PublishBuildArtifacts@1
@@ -274,7 +274,7 @@ extends:
                 # and some of them use dependencies that are now vulnerable.
                 # We don't depend on those vulnerable versions anymore, but need to keep restoring them to ensure backwards compatibility.
                 - pwsh: |
-                    Remove-Item -Path $(Build.SourcesDirectory)/artifacts/tmp/GeneratedTestAssets -Recurse -Force
+                    Remove-Item -Path $(Build.SourcesDirectory)/artifacts/tmp/GeneratedTestAssets -Recurse -Force -ErrorAction SilentlyContinue
                   displayName: Remove artifacts/tmp/GeneratedTestAssets
 
                 # This step is only helpful for diagnosing some issues with vstest/test host that would not appear

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -220,7 +220,9 @@ extends:
               # and some of them use dependencies that are now vulnerable.
               # We don't depend on those vulnerable versions anymore, but need to keep restoring them to ensure backwards compatibility.
               - pwsh: |
-                  Remove-Item -Path $(Build.SourcesDirectory)/artifacts/tmp/GeneratedTestAssets -Recurse -Force -ErrorAction SilentlyContinue
+                  if (Test-Path -LiteralPath "$(Build.SourcesDirectory)/artifacts/tmp/GeneratedTestAssets") {
+                    Remove-Item -LiteralPath "$(Build.SourcesDirectory)/artifacts/tmp/GeneratedTestAssets" -Recurse -Force
+                  }
                 displayName: Remove artifacts/tmp/GeneratedTestAssets
 
             - task: 1ES.PublishBuildArtifacts@1
@@ -274,7 +276,10 @@ extends:
                 # and some of them use dependencies that are now vulnerable.
                 # We don't depend on those vulnerable versions anymore, but need to keep restoring them to ensure backwards compatibility.
                 - pwsh: |
-                    Remove-Item -Path $(Build.SourcesDirectory)/artifacts/tmp/GeneratedTestAssets -Recurse -Force -ErrorAction SilentlyContinue
+                    $generatedAssetsPath = "$(Build.SourcesDirectory)/artifacts/tmp/GeneratedTestAssets"
+                    if (Test-Path -LiteralPath $generatedAssetsPath) {
+                      Remove-Item -LiteralPath $generatedAssetsPath -Recurse -Force
+                    }
                   displayName: Remove artifacts/tmp/GeneratedTestAssets
 
                 # This step is only helpful for diagnosing some issues with vstest/test host that would not appear


### PR DESCRIPTION
We don't always run with generated test assets, don't fail when they don't exist.