### PR TITLE
Set DOTNET_ROOT in test.sh for local Linux usage

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,4 +13,5 @@ while [[ -h $source ]]; do
 done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+export DOTNET_ROOT="$scriptroot/.dotnet"
 "$scriptroot/eng/common/build.sh" --build --restore $@

--- a/build.sh
+++ b/build.sh
@@ -13,5 +13,7 @@ while [[ -h $source ]]; do
 done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
-export DOTNET_ROOT="$scriptroot/.dotnet"
+if [[ -z "${DOTNET_ROOT:-}" && -d "$scriptroot/.dotnet" ]]; then
+  export DOTNET_ROOT="$scriptroot/.dotnet"
+fi
 "$scriptroot/eng/common/build.sh" --build --restore $@

--- a/build.sh
+++ b/build.sh
@@ -16,4 +16,4 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 if [[ -z "${DOTNET_ROOT:-}" && -d "$scriptroot/.dotnet" ]]; then
   export DOTNET_ROOT="$scriptroot/.dotnet"
 fi
-"$scriptroot/eng/common/build.sh" --build --restore $@
+"$scriptroot/eng/common/build.sh" --build --restore "$@"

--- a/restore.sh
+++ b/restore.sh
@@ -13,5 +13,7 @@ while [[ -h $source ]]; do
 done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
-export DOTNET_ROOT="$scriptroot/.dotnet"
-"$scriptroot/eng/common/build.sh" --restore $@
+if [ -z "${DOTNET_ROOT:-}" ]; then
+  export DOTNET_ROOT="$scriptroot/.dotnet"
+fi
+"$scriptroot/eng/common/build.sh" --restore "$@"

--- a/restore.sh
+++ b/restore.sh
@@ -13,4 +13,5 @@ while [[ -h $source ]]; do
 done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+export DOTNET_ROOT="$scriptroot/.dotnet"
 "$scriptroot/eng/common/build.sh" --restore $@

--- a/test.sh
+++ b/test.sh
@@ -14,4 +14,4 @@ done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 export DOTNET_ROOT="$scriptroot/.dotnet"
-"$scriptroot/eng/common/build.sh" --test $@
+"$scriptroot/eng/common/build.sh" --test "$@"

--- a/test.sh
+++ b/test.sh
@@ -13,4 +13,5 @@ while [[ -h $source ]]; do
 done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+export DOTNET_ROOT="$scriptroot/.dotnet"
 "$scriptroot/eng/common/build.sh" --test $@

--- a/test.sh
+++ b/test.sh
@@ -13,5 +13,7 @@ while [[ -h $source ]]; do
 done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
-export DOTNET_ROOT="$scriptroot/.dotnet"
+if [[ -z "${DOTNET_ROOT:-}" && -d "$scriptroot/.dotnet" ]]; then
+  export DOTNET_ROOT="$scriptroot/.dotnet"
+fi
 "$scriptroot/eng/common/build.sh" --test "$@"


### PR DESCRIPTION
Closes #15510

Export DOTNET_ROOT pointing to the local .dotnet SDK directory in test.sh, build.sh, and restore.sh. This matches the pipeline configuration in azure-pipelines.yml and ensures tests can find the dotnet SDK when running locally on Linux.