### PR TITLE
Enable CA1067 analyzer and fix violations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -239,6 +239,9 @@ dotnet_diagnostic.CA1050.severity = warning # not default, increased severity to
 # CA1061: Do not hide base class methods
 dotnet_diagnostic.CA1061.severity = warning # not default, increased severity to ensure it is applied
 
+# CA1067: Override Object.Equals when implementing IEquatable<T>
+dotnet_diagnostic.CA1067.severity = warning # not default, increased severity to ensure it is applied
+
 # CA1069: Enums should not have duplicate values
 dotnet_diagnostic.CA1069.severity = warning # not default, increased severity to ensure it is applied
 

--- a/src/Microsoft.TestPlatform.ObjectModel/Nuget.Frameworks/OneWayCompatibilityMappingEntry.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Nuget.Frameworks/OneWayCompatibilityMappingEntry.cs
@@ -49,6 +49,16 @@ namespace NuGetClone.Frameworks
             return Comparer.Equals(this, other);
         }
 
+        public override bool Equals(object? obj)
+        {
+            return Equals(obj as OneWayCompatibilityMappingEntry);
+        }
+
+        public override int GetHashCode()
+        {
+            return Comparer.GetHashCode(this);
+        }
+
         public override string ToString()
         {
             return String.Format(CultureInfo.InvariantCulture, "{0} -> {1}", TargetFrameworkRange.ToString(), SupportedFrameworkRange.ToString());

--- a/src/Microsoft.TestPlatform.ObjectModel/Nuget.Frameworks/OneWayCompatibilityMappingEntry.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Nuget.Frameworks/OneWayCompatibilityMappingEntry.cs
@@ -51,7 +51,7 @@ namespace NuGetClone.Frameworks
 
         public override bool Equals(object? obj)
         {
-            return Equals(obj as OneWayCompatibilityMappingEntry);
+            return obj is OneWayCompatibilityMappingEntry other && Equals(other);
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
Enable the CA1067 analyzer rule (Override Object.Equals when implementing IEquatable<T>) as a warning and fix the single existing violation in OneWayCompatibilityMappingEntry.

Closes #15371