### PR TITLE
Fix HTML logger parallel file collision with atomic file creation

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
@@ -34,7 +34,6 @@ public class HtmlLogger : ITestLoggerWithParameters
     private readonly IFileHelper _fileHelper;
     private readonly XmlObjectSerializer _xmlSerializer;
     private readonly IHtmlTransformer _htmlTransformer;
-    private static readonly object FileCreateLockObject = new();
     private Dictionary<string, string?>? _parametersDictionary;
 
     public HtmlLogger()
@@ -293,7 +292,7 @@ public class HtmlLogger : ITestLoggerWithParameters
                 logFilePrefixValue = logFilePrefixValue + "_" + framework;
             }
 
-            logFilePrefixValue = logFilePrefixValue + DateTime.Now.ToString("_yyyyMMddHHmmss", DateTimeFormatInfo.InvariantInfo) + $".{HtmlLoggerConstants.HtmlFileExtension}";
+            logFilePrefixValue = logFilePrefixValue + DateTime.Now.ToString("_yyyyMMdd_HHmmss.fffffff", DateTimeFormatInfo.InvariantInfo) + $".{HtmlLoggerConstants.HtmlFileExtension}";
             HtmlFilePath = Path.Combine(TestResultsDirPath!, logFilePrefixValue);
         }
         else
@@ -356,13 +355,14 @@ public class HtmlLogger : ITestLoggerWithParameters
         {
             var fileNameWithIter = i == 0 ? fileName : Path.GetFileNameWithoutExtension(fileName) + $"[{i}]";
             fullFilePath = Path.Combine(TestResultsDirPath!, $"TestResult_{fileNameWithIter}.{fileExtension}");
-            lock (FileCreateLockObject)
+            try
             {
-                if (!File.Exists(fullFilePath))
-                {
-                    using var _ = File.Create(fullFilePath);
-                    return fullFilePath;
-                }
+                using var _ = new FileStream(fullFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+                return fullFilePath;
+            }
+            catch (IOException) when (File.Exists(fullFilePath))
+            {
+                // File already exists (another process created it), try next iteration.
             }
         }
 
@@ -371,7 +371,7 @@ public class HtmlLogger : ITestLoggerWithParameters
 
     private static string FormatDateTimeForRunName(DateTime timeStamp)
     {
-        return timeStamp.ToString("yyyyMMdd_HHmmss", DateTimeFormatInfo.InvariantInfo);
+        return timeStamp.ToString("yyyyMMdd_HHmmss.fffffff", DateTimeFormatInfo.InvariantInfo);
     }
 
     /// <summary>

--- a/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
@@ -591,6 +591,21 @@ public class HtmlLoggerTests
         Assert.AreEqual(0, _htmlLogger.TestRunDetails.Summary.PassPercentage);
     }
 
+    [TestMethod]
+    public void XmlFilePathShouldContainFractionalSecondsForCrossProcessUniqueness()
+    {
+        _htmlLogger.TestRunCompleteHandler(new object(), new TestRunCompleteEventArgs(null, false, true, null, null, null, TimeSpan.Zero));
+
+        Assert.IsNotNull(_htmlLogger.XmlFilePath);
+        var fileName = Path.GetFileNameWithoutExtension(_htmlLogger.XmlFilePath);
+
+        // The filename should contain a fractional-seconds timestamp: yyyyMMdd_HHmmss.fffffff
+        // e.g., TestResult_user_MACHINE_20260324_065512.1234567
+        StringAssert.Matches(fileName, new System.Text.RegularExpressions.Regex(
+            @"\d{8}_\d{6}\.\d{7}$"),
+            $"Filename should end with yyyyMMdd_HHmmss.fffffff pattern: {fileName}");
+    }
+
     private static TestCase CreateTestCase(string testCaseName)
     {
         return new TestCase(testCaseName, new Uri("some://uri"), "DummySourceFileName");


### PR DESCRIPTION
## Summary

Fix cross-process race condition in HTML logger file creation that causes collisions when multiple test processes run in parallel.

This is a cleaned-up version of #15435.

## Changes

- **Atomic file creation**: Replace lock + File.Exists check with FileMode.CreateNew in GenerateUniqueFilePath. The lock only protected within a single process; FileMode.CreateNew is atomic at the OS level across all processes.
- **Fractional-second timestamps**: Add fractional seconds (\ffffff\) to the timestamp format in both \FormatDateTimeForRunName\ and the \LogFilePrefix\ path, providing better uniqueness when multiple processes start near-simultaneously.
- **Remove dead code**: Remove the now-unnecessary static \FileCreateLockObject\.
- **Add test**: Verify the generated filename contains the fractional-seconds timestamp pattern.

Closes #15404