### PR TITLE
Fix VsTestConsoleWrapper.EndSession double-dispose

### DIFF
--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
@@ -43,6 +43,8 @@ public class VsTestConsoleWrapper : IVsTestConsoleWrapper
 
     private bool _sessionStarted;
 
+    private bool _sessionEnded;
+
     /// <summary>
     /// Path to additional extensions to reinitialize vstest.console
     /// </summary>
@@ -651,6 +653,12 @@ public class VsTestConsoleWrapper : IVsTestConsoleWrapper
     /// <inheritdoc/>
     public void EndSession()
     {
+        if (_sessionEnded)
+        {
+            return;
+        }
+        _sessionEnded = true;
+
         EqtTrace.Info($"VsTestConsoleWrapper.EndSession: Ending VsTestConsoleWrapper session - process id:{_vstestConsoleProcessManager.ProcessId}");
 
         _requestSender.EndSession();

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
@@ -43,7 +43,7 @@ public class VsTestConsoleWrapper : IVsTestConsoleWrapper
 
     private bool _sessionStarted;
 
-    private bool _sessionEnded;
+    private int _sessionEnded;
 
     /// <summary>
     /// Path to additional extensions to reinitialize vstest.console
@@ -653,11 +653,11 @@ public class VsTestConsoleWrapper : IVsTestConsoleWrapper
     /// <inheritdoc/>
     public void EndSession()
     {
-        if (_sessionEnded)
+        if (Interlocked.Exchange(ref _sessionEnded, 1) == 1)
         {
+            EqtTrace.Info("VsTestConsoleWrapper.EndSession: Session already ended, skipping.");
             return;
         }
-        _sessionEnded = true;
 
         EqtTrace.Info($"VsTestConsoleWrapper.EndSession: Ending VsTestConsoleWrapper session - process id:{_vstestConsoleProcessManager.ProcessId}");
 
@@ -1192,6 +1192,7 @@ public class VsTestConsoleWrapper : IVsTestConsoleWrapper
             EqtTrace.Info("VsTestConsoleWrapper.EnsureInitialized: Process is not started.");
             StartSession();
             _sessionStarted = WaitForConnection();
+            Interlocked.Exchange(ref _sessionEnded, 0);
 
             if (_sessionStarted)
             {

--- a/test/TranslationLayer.UnitTests/VsTestConsoleWrapperTests.cs
+++ b/test/TranslationLayer.UnitTests/VsTestConsoleWrapperTests.cs
@@ -700,7 +700,7 @@ public class VsTestConsoleWrapperTests
     }
 
     [TestMethod]
-    public void EndSessionCalledTwiceShouldNotThrow()
+    public void EndSessionCalledTwiceShouldOnlyEndSessionOnce()
     {
         _consoleWrapper.EndSession();
         _consoleWrapper.EndSession();

--- a/test/TranslationLayer.UnitTests/VsTestConsoleWrapperTests.cs
+++ b/test/TranslationLayer.UnitTests/VsTestConsoleWrapperTests.cs
@@ -698,4 +698,15 @@ public class VsTestConsoleWrapperTests
         _mockRequestSender.Verify(rs => rs.Close(), Times.Once);
         _mockProcessManager.Verify(x => x.ShutdownProcess(), Times.Once);
     }
+
+    [TestMethod]
+    public void EndSessionCalledTwiceShouldNotThrow()
+    {
+        _consoleWrapper.EndSession();
+        _consoleWrapper.EndSession();
+
+        _mockRequestSender.Verify(rs => rs.EndSession(), Times.Once);
+        _mockRequestSender.Verify(rs => rs.Close(), Times.Once);
+        _mockProcessManager.Verify(x => x.ShutdownProcess(), Times.Once);
+    }
 }


### PR DESCRIPTION
Add a \_sessionEnded\ guard to \VsTestConsoleWrapper.EndSession()\ so that calling it multiple times is safe (idempotent). Previously, calling \EndSession()\ twice would attempt to send the session-end message, close the request sender, and shut down the process a second time.

Closes #15487