### PR TITLE
Add target framework to default TRX file name

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -541,7 +541,7 @@ public class TrxLogger : ITestLoggerWithParameters
 
         if (_parametersDictionary is not null
             && _parametersDictionary.TryGetValue(DefaultLoggerParameterNames.TargetFramework, out var framework)
-            && framework != null)
+            && !framework.IsNullOrWhiteSpace())
         {
             var shortName = Framework.FromString(framework)?.ShortName ?? framework;
             baseName = baseName + "_" + shortName;

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -536,7 +536,18 @@ public class TrxLogger : ITestLoggerWithParameters
         TPDebug.Assert(LoggerTestRun != null, "LoggerTestRun is null");
         TPDebug.Assert(LoggerTestRun.RunConfiguration != null, "LoggerTestRun.RunConfiguration is null");
         TPDebug.Assert(IsInitialized, "Logger is not initialized");
-        var defaultTrxFileName = LoggerTestRun.RunConfiguration.RunDeploymentRootDirectory + ".trx";
+
+        var baseName = LoggerTestRun.RunConfiguration.RunDeploymentRootDirectory;
+
+        if (_parametersDictionary is not null
+            && _parametersDictionary.TryGetValue(DefaultLoggerParameterNames.TargetFramework, out var framework)
+            && framework != null)
+        {
+            var shortName = Framework.FromString(framework)?.ShortName ?? framework;
+            baseName = baseName + "_" + shortName;
+        }
+
+        var defaultTrxFileName = baseName + ".trx";
 
         return TrxFileHelper.GetNextIterationFileName(_testResultsDirPath, defaultTrxFileName, false);
     }

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ArgumentProcessorTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ArgumentProcessorTests.cs
@@ -18,7 +18,8 @@ public class ArgumentProcessorTests : AcceptanceTestBase
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        InvokeVsTest(null);
+        // Don't add --diag, it changes the output and prevents help from showing.
+        InvokeVsTest(null, collectDiagnostics: false);
 
         //Check for help usage, description and arguments text.
         StdOutputContains("Usage: vstest.console.exe");

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -631,6 +631,34 @@ public class TrxLoggerTests
     }
 
     [TestMethod]
+    public void DefaultTrxFileNameShouldIncludeFrameworkWhenAvailable()
+    {
+        _parameters.Remove(TrxLoggerConstants.LogFileNameKey);
+        _parameters[DefaultLoggerParameterNames.TargetFramework] = ".NETCoreApp,Version=v10.0";
+        _testableTrxLogger.Initialize(_events.Object, _parameters);
+
+        MakeTestRunComplete();
+
+        var fileName = Path.GetFileName(_testableTrxLogger.TrxFile);
+        Assert.IsNotNull(fileName);
+        Assert.IsTrue(fileName.Contains("_net10.0"), $"Expected TFM 'net10.0' in filename but got: {fileName}");
+        Assert.IsTrue(fileName.EndsWith(".trx"), $"Expected .trx extension but got: {fileName}");
+    }
+
+    [TestMethod]
+    public void DefaultTrxFileNameShouldWorkWithoutFramework()
+    {
+        _parameters.Remove(TrxLoggerConstants.LogFileNameKey);
+        _testableTrxLogger.Initialize(_events.Object, _parameters);
+
+        MakeTestRunComplete();
+
+        var fileName = Path.GetFileName(_testableTrxLogger.TrxFile);
+        Assert.IsNotNull(fileName);
+        Assert.IsTrue(fileName.EndsWith(".trx"), $"Expected .trx extension but got: {fileName}");
+    }
+
+    [TestMethod]
     public void DefaultTrxFileNameVerification()
     {
         _parameters.Remove(TrxLoggerConstants.LogFileNameKey);

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -659,6 +659,21 @@ public class TrxLoggerTests
     }
 
     [TestMethod]
+    public void DefaultTrxFileNameShouldUseRawStringWhenFrameworkCannotBeParsed()
+    {
+        _parameters.Remove(TrxLoggerConstants.LogFileNameKey);
+        _parameters[DefaultLoggerParameterNames.TargetFramework] = "SomeCustomFramework";
+        _testableTrxLogger.Initialize(_events.Object, _parameters);
+
+        MakeTestRunComplete();
+
+        var fileName = Path.GetFileName(_testableTrxLogger.TrxFile);
+        Assert.IsNotNull(fileName);
+        Assert.IsTrue(fileName.Contains("_SomeCustomFramework"), $"Expected raw framework string in filename but got: {fileName}");
+        Assert.IsTrue(fileName.EndsWith(".trx"), $"Expected .trx extension but got: {fileName}");
+    }
+
+    [TestMethod]
     public void DefaultTrxFileNameVerification()
     {
         _parameters.Remove(TrxLoggerConstants.LogFileNameKey);

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -641,8 +641,8 @@ public class TrxLoggerTests
 
         var fileName = Path.GetFileName(_testableTrxLogger.TrxFile);
         Assert.IsNotNull(fileName);
-        Assert.IsTrue(fileName.Contains("_net10.0"), $"Expected TFM 'net10.0' in filename but got: {fileName}");
-        Assert.IsTrue(fileName.EndsWith(".trx"), $"Expected .trx extension but got: {fileName}");
+        Assert.Contains(fileName, "_net10.0", $"Expected TFM 'net10.0' in filename but got: {fileName}");
+        Assert.EndsWith(fileName, ".trx", $"Expected .trx extension but got: {fileName}");
     }
 
     [TestMethod]
@@ -655,7 +655,7 @@ public class TrxLoggerTests
 
         var fileName = Path.GetFileName(_testableTrxLogger.TrxFile);
         Assert.IsNotNull(fileName);
-        Assert.IsTrue(fileName.EndsWith(".trx"), $"Expected .trx extension but got: {fileName}");
+        Assert.EndsWith(fileName, ".trx", $"Expected .trx extension but got: {fileName}");
     }
 
     [TestMethod]
@@ -669,8 +669,8 @@ public class TrxLoggerTests
 
         var fileName = Path.GetFileName(_testableTrxLogger.TrxFile);
         Assert.IsNotNull(fileName);
-        Assert.IsTrue(fileName.Contains("_SomeCustomFramework"), $"Expected raw framework string in filename but got: {fileName}");
-        Assert.IsTrue(fileName.EndsWith(".trx"), $"Expected .trx extension but got: {fileName}");
+        Assert.Contains(fileName, "_SomeCustomFramework", $"Expected raw framework string in filename but got: {fileName}");
+        Assert.EndsWith(fileName, ".trx", $"Expected .trx extension but got: {fileName}");
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -641,8 +641,8 @@ public class TrxLoggerTests
 
         var fileName = Path.GetFileName(_testableTrxLogger.TrxFile);
         Assert.IsNotNull(fileName);
-        Assert.Contains(fileName, "_net10.0", $"Expected TFM 'net10.0' in filename but got: {fileName}");
-        Assert.EndsWith(fileName, ".trx", $"Expected .trx extension but got: {fileName}");
+        Assert.Contains("_net10.0", fileName, $"Expected TFM 'net10.0' in filename but got: {fileName}");
+        Assert.EndsWith(".trx", fileName, $"Expected .trx extension but got: {fileName}");
     }
 
     [TestMethod]
@@ -655,7 +655,7 @@ public class TrxLoggerTests
 
         var fileName = Path.GetFileName(_testableTrxLogger.TrxFile);
         Assert.IsNotNull(fileName);
-        Assert.EndsWith(fileName, ".trx", $"Expected .trx extension but got: {fileName}");
+        Assert.EndsWith(".trx", fileName, $"Expected .trx extension but got: {fileName}");
     }
 
     [TestMethod]
@@ -669,8 +669,8 @@ public class TrxLoggerTests
 
         var fileName = Path.GetFileName(_testableTrxLogger.TrxFile);
         Assert.IsNotNull(fileName);
-        Assert.Contains(fileName, "_SomeCustomFramework", $"Expected raw framework string in filename but got: {fileName}");
-        Assert.EndsWith(fileName, ".trx", $"Expected .trx extension but got: {fileName}");
+        Assert.Contains("_SomeCustomFramework", fileName, $"Expected raw framework string in filename but got: {fileName}");
+        Assert.EndsWith(".trx", fileName, $"Expected .trx extension but got: {fileName}");
     }
 
     [TestMethod]


### PR DESCRIPTION
When running multi-TFM tests, TRX files were overwritten because the default filename did not include the target framework. The TFM was already appended when using the `LogFilePrefix` parameter, but not for the default auto-generated filename.

This change appends the framework short name (e.g. `net10.0`) to the default TRX filename, matching the existing behavior for `LogFilePrefix`.

**Before:** `username_MACHINE_2026-03-24_07_51_08.trx`
**After:**  `username_MACHINE_2026-03-24_07_51_08_net10.0.trx`

Closes #15506