### PR TITLE
Fix integration test build collision with mutex + EventWaitHandle

### DIFF
--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ArgumentProcessorTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ArgumentProcessorTests.cs
@@ -18,7 +18,8 @@ public class ArgumentProcessorTests : AcceptanceTestBase
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        InvokeVsTest(null);
+        // Don't add --diag, it changes the output and prevents help from showing.
+        InvokeVsTest(null, collectDiagnostics: false);
 
         //Check for help usage, description and arguments text.
         StdOutputContains("Usage: vstest.console.exe");

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Build.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Build.cs
@@ -22,4 +22,10 @@ public static class Build
 
         IntegrationTestBuild.BuildTestAssetsForIntegrationTests(testContext);
     }
+
+    [AssemblyCleanup]
+    public static void AssemblyCleanup()
+    {
+        IntegrationTestBuild.CleanupTestAssets();
+    }
 }

--- a/test/Microsoft.TestPlatform.Library.IntegrationTests/Build.cs
+++ b/test/Microsoft.TestPlatform.Library.IntegrationTests/Build.cs
@@ -22,4 +22,10 @@ public static class Build
 
         IntegrationTestBuild.BuildTestAssetsForIntegrationTests(testContext);
     }
+
+    [AssemblyCleanup]
+    public static void AssemblyCleanup()
+    {
+        IntegrationTestBuild.CleanupTestAssets();
+    }
 }

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
@@ -27,10 +27,9 @@ public class IntegrationTestBuild : IntegrationTestBase
     private static readonly string DotnetDir = Path.GetFullPath(Path.Combine(Root, ".dotnet"));
     private static readonly string Dotnet = Path.GetFullPath(Path.Combine(Root, ".dotnet", OSUtils.IsWindows ? "dotnet.exe" : "dotnet"));
 
-    // Short-lived mutex held only during the build phase to serialize builds.
-    private static Mutex? s_buildMutex;
-    // Path to a marker file used to signal that the build is complete (cross-platform replacement for named EventWaitHandle).
-    private static string? s_buildCompleteMarkerPath;
+    // Session mutex: held for the entire test session (build + tests).
+    // The process that creates it (createdNew=true) is the builder.
+    private static Mutex? s_sessionMutex;
 
     public static void BuildTestAssetsForIntegrationTests(TestContext context)
     {
@@ -50,44 +49,18 @@ public class IntegrationTestBuild : IntegrationTestBase
         var baseName = "VSTest_AcceptanceTests_" + IntegrationTestEnvironment.RepoRootDirectory!
             .Replace('\\', '-').Replace('/', '-').Replace(':', '-');
 
-        s_buildMutex = new Mutex(initiallyOwned: false, baseName + "_Build");
-        s_buildCompleteMarkerPath = Path.Combine(
-            IntegrationTestEnvironment.ArtifactsTempDirectory,
-            baseName + "_BuildComplete.marker");
+        // Session mutex: the process that creates it is the builder.
+        // Held for the entire session (build + tests), destroyed in CleanupTestAssets.
+        s_sessionMutex = CreateMutex(baseName + "_Session", out bool isBuilder);
 
-        // Acquire the build mutex to serialize the build phase.
-        try
+        if (isBuilder)
         {
-            var minutes = 15;
-            Debug.WriteLine($"Waiting for build mutex: {baseName}_Build");
-            if (!s_buildMutex.WaitOne(TimeSpan.FromMinutes(minutes)))
-            {
-                throw new TimeoutException($"Timed out after {minutes} minutes waiting for the build mutex '{baseName}_Build'.");
-            }
-        }
-        catch (AbandonedMutexException)
-        {
-            // Previous holder crashed — we own the mutex now and need to rebuild.
-            if (s_buildCompleteMarkerPath != null && File.Exists(s_buildCompleteMarkerPath))
-            {
-                File.Delete(s_buildCompleteMarkerPath);
-            }
-            Debug.WriteLine("Previous build was interrupted (abandoned mutex), rebuilding.");
-        }
+            // We are the builder. Create a build mutex to signal "build in progress"
+            // to other processes. It exists while we're building, then we destroy it.
+            Debug.WriteLine("Session mutex created — we are the builder.");
+            using var buildMutex = CreateMutex(baseName + "_Build", out _);
 
-        try
-        {
-            // If another assembly already completed the build, just proceed to tests.
-            if (File.Exists(s_buildCompleteMarkerPath))
-            {
-                Debug.WriteLine("Build already completed by another process, proceeding to tests.");
-                return;
-            }
-
-            // We need to build.
-            Debug.WriteLine("Starting to build.");
             var sw = Stopwatch.StartNew();
-
             var nugetCache = IntegrationTestEnvironment.TestAssetsNuGetCacheDirectory;
             var packagesAreNew = UnzipExecutablePackages();
             if (packagesAreNew)
@@ -107,24 +80,102 @@ public class IntegrationTestBuild : IntegrationTestBase
                 Debug.WriteLine("BuildCompatibility parameter is false, skipping build.");
             }
             CopyAndPatchDotnet();
-            Debug.WriteLine($"Copying and patching dotnet took: {sw.ElapsedMilliseconds} ms"); sw.Restart();
+            Debug.WriteLine($"Copying and patching dotnet took: {sw.ElapsedMilliseconds} ms");
 
-            // Signal that the build is complete so waiting assemblies can proceed to tests.
-            File.WriteAllText(s_buildCompleteMarkerPath!, DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture));
-            Debug.WriteLine("Build completed, signaled other processes.");
+            // Build mutex is disposed here (end of using), signaling to other processes
+            // that the build is done.
+            Debug.WriteLine("Build complete, releasing build mutex.");
         }
-        finally
+        else
         {
-            // Release the build mutex so other assemblies can check the event.
-            s_buildMutex.ReleaseMutex();
+            // We are NOT the builder. Check if a build is in progress.
+            Debug.WriteLine("Session mutex already exists — another process is the builder.");
+            var buildMutex = TryOpenMutex(baseName + "_Build");
+            if (buildMutex is not null)
+            {
+                // Build mutex exists — build is in progress. Wait for it to be destroyed.
+                Debug.WriteLine("Build in progress, waiting for it to finish...");
+                using (buildMutex)
+                {
+                    // Wait to acquire it (builder will release/destroy it when done).
+                    try
+                    {
+                        if (!buildMutex.WaitOne(TimeSpan.FromMinutes(15)))
+                        {
+                            throw new TimeoutException("Timed out waiting for the build to complete.");
+                        }
+                    }
+                    catch (AbandonedMutexException)
+                    {
+                        // Builder crashed — we got the mutex. Destroy it and retry
+                        // as a fresh session (we might become the builder).
+                        Debug.WriteLine("Build mutex was abandoned (builder crashed). Retrying.");
+                    }
+                }
+                // Build mutex destroyed. Build is done (or builder crashed and we'll
+                // see a stale state — but test assets should still be usable).
+                Debug.WriteLine("Build finished, proceeding to tests.");
+            }
+            else
+            {
+                // Build mutex doesn't exist — build already completed.
+                Debug.WriteLine("No build mutex found — build already done, proceeding to tests.");
+            }
         }
+    }
+
+    /// <summary>
+    /// Create a named mutex. If abandoned by a previous process, destroy and retry.
+    /// </summary>
+    private static Mutex CreateMutex(string name, out bool createdNew)
+    {
+        while (true)
+        {
+            var mutex = new Mutex(initiallyOwned: true, name, out createdNew);
+            if (!createdNew)
+            {
+                try
+                {
+                    // We didn't create it, try to acquire to check if it's alive.
+                    mutex.WaitOne(0);
+                    mutex.ReleaseMutex();
+                }
+                catch (AbandonedMutexException)
+                {
+                    // Previous owner crashed. Destroy and retry.
+                    Debug.WriteLine($"Mutex '{name}' was abandoned, destroying and retrying.");
+                    mutex.Dispose();
+                    continue;
+                }
+            }
+            return mutex;
+        }
+    }
+
+    /// <summary>
+    /// Try to open an existing named mutex. Returns null if it doesn't exist.
+    /// </summary>
+    private static Mutex? TryOpenMutex(string name)
+    {
+        var mutex = new Mutex(initiallyOwned: false, name, out bool createdNew);
+        if (createdNew)
+        {
+            // We created it — meaning it didn't exist. Destroy it and return null.
+            mutex.Dispose();
+            return null;
+        }
+        return mutex;
     }
 
     public static void CleanupTestAssets()
     {
-        s_buildMutex?.Dispose();
-        s_buildMutex = null;
-        s_buildCompleteMarkerPath = null;
+        // Destroy session mutex — signals that this test session is done.
+        if (s_sessionMutex is not null)
+        {
+            try { s_sessionMutex.ReleaseMutex(); } catch (ApplicationException) { }
+            s_sessionMutex.Dispose();
+            s_sessionMutex = null;
+        }
     }
 
     private static void BuildTestAssets(string nugetCache)

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
@@ -27,6 +27,11 @@ public class IntegrationTestBuild : IntegrationTestBase
     private static readonly string DotnetDir = Path.GetFullPath(Path.Combine(Root, ".dotnet"));
     private static readonly string Dotnet = Path.GetFullPath(Path.Combine(Root, ".dotnet", OSUtils.IsWindows ? "dotnet.exe" : "dotnet"));
 
+    // Short-lived mutex held only during the build phase to serialize builds.
+    private static Mutex? s_buildMutex;
+    // Signaled once the build is complete so other assemblies can proceed to tests immediately.
+    private static EventWaitHandle? s_buildCompleteEvent;
+
     public static void BuildTestAssetsForIntegrationTests(TestContext context)
     {
         // This is common setup that should happen even when build will not run.
@@ -41,57 +46,84 @@ public class IntegrationTestBuild : IntegrationTestBase
 
         var buildCompatibility = GetTestParameter(context, "BuildCompatibility");
 
-        // Mostly just want to avoid using the same mutex across two clones of this repo.
-        var mutexName = "VSTest Acceptance Tests build " + IntegrationTestEnvironment.RepoRootDirectory!.Replace('\\', '-').Replace('/', '-').Replace(':', '-');
+        // Avoid collisions across different clones of this repo.
+        var baseName = "VSTest_AcceptanceTests_" + IntegrationTestEnvironment.RepoRootDirectory!
+            .Replace('\\', '-').Replace('/', '-').Replace(':', '-');
 
-        using var buildMutex = new Mutex(initiallyOwned: true, mutexName, out bool createdNew);
+        s_buildMutex = new Mutex(initiallyOwned: false, baseName + "_Build");
+        s_buildCompleteEvent = new EventWaitHandle(
+            initialState: false,
+            mode: EventResetMode.ManualReset,
+            name: baseName + "_BuildComplete");
+
+        // Acquire the build mutex to serialize the build phase.
         try
         {
-            Debug.WriteLine($"is mutex new: {createdNew}, name: {mutexName}");
-            if (createdNew)
+            var minutes = 15;
+            Debug.WriteLine($"Waiting for build mutex: {baseName}_Build");
+            if (!s_buildMutex.WaitOne(TimeSpan.FromMinutes(minutes)))
             {
-                // We are the first one of the parallel runs to do this. Build the projects and setup everything.
-                Debug.WriteLine("Starting to build.");
-                var sw = Stopwatch.StartNew();
+                throw new TimeoutException($"Timed out after {minutes} minutes waiting for the build mutex '{baseName}_Build'.");
+            }
+        }
+        catch (AbandonedMutexException)
+        {
+            // Previous holder crashed — we own the mutex now and need to rebuild.
+            s_buildCompleteEvent.Reset();
+            Debug.WriteLine("Previous build was interrupted (abandoned mutex), rebuilding.");
+        }
 
-                var nugetCache = IntegrationTestEnvironment.TestAssetsNuGetCacheDirectory;
-                var packagesAreNew = UnzipExecutablePackages();
-                if (packagesAreNew)
-                {
-                    CleanNugetCacheAndProjects(nugetCache);
-                }
-                Debug.WriteLine($"Unzipping packages took: {sw.ElapsedMilliseconds} ms"); sw.Restart();
-                BuildTestAssets(nugetCache);
-                Debug.WriteLine($"Building test assets took: {sw.ElapsedMilliseconds} ms"); sw.Restart();
-                if (buildCompatibility)
-                {
-                    BuildTestAssetsCompatibility(nugetCache);
-                    Debug.WriteLine($"Building compatibility test assets took: {sw.ElapsedMilliseconds} ms"); sw.Restart();
-                }
-                else
-                {
-                    Debug.WriteLine("BuildCompatibility parameter is false, skipping build.");
-                }
-                CopyAndPatchDotnet();
-                Debug.WriteLine($"Copying and patching dotnet took: {sw.ElapsedMilliseconds} ms"); sw.Restart();
+        try
+        {
+            // If another assembly already completed the build, just proceed to tests.
+            if (s_buildCompleteEvent.WaitOne(0))
+            {
+                Debug.WriteLine("Build already completed by another process, proceeding to tests.");
+                return;
+            }
+
+            // We need to build.
+            Debug.WriteLine("Starting to build.");
+            var sw = Stopwatch.StartNew();
+
+            var nugetCache = IntegrationTestEnvironment.TestAssetsNuGetCacheDirectory;
+            var packagesAreNew = UnzipExecutablePackages();
+            if (packagesAreNew)
+            {
+                CleanNugetCacheAndProjects(nugetCache);
+            }
+            Debug.WriteLine($"Unzipping packages took: {sw.ElapsedMilliseconds} ms"); sw.Restart();
+            BuildTestAssets(nugetCache);
+            Debug.WriteLine($"Building test assets took: {sw.ElapsedMilliseconds} ms"); sw.Restart();
+            if (buildCompatibility)
+            {
+                BuildTestAssetsCompatibility(nugetCache);
+                Debug.WriteLine($"Building compatibility test assets took: {sw.ElapsedMilliseconds} ms"); sw.Restart();
             }
             else
             {
-                // Build is already in progress. Wait for it to finish.
-                var minutes = 15;
-                Debug.WriteLine("Other project is building, waiting for mutex to release.");
-                var gotOne = buildMutex.WaitOne(TimeSpan.FromMinutes(minutes));
-                if (!gotOne)
-                {
-                    throw new TimeoutException($"Timed out after {minutes} minutes, waiting for the other project to finish building. Mutex name: '{mutexName}'");
-                }
-                Debug.WriteLine("Other project is done building, I can start running tests now.");
+                Debug.WriteLine("BuildCompatibility parameter is false, skipping build.");
             }
+            CopyAndPatchDotnet();
+            Debug.WriteLine($"Copying and patching dotnet took: {sw.ElapsedMilliseconds} ms"); sw.Restart();
+
+            // Signal that the build is complete so waiting assemblies can proceed to tests.
+            s_buildCompleteEvent.Set();
+            Debug.WriteLine("Build completed, signaled other processes.");
         }
         finally
         {
-            buildMutex.ReleaseMutex();
+            // Release the build mutex so other assemblies can check the event.
+            s_buildMutex.ReleaseMutex();
         }
+    }
+
+    public static void CleanupTestAssets()
+    {
+        s_buildMutex?.Dispose();
+        s_buildMutex = null;
+        s_buildCompleteEvent?.Dispose();
+        s_buildCompleteEvent = null;
     }
 
     private static void BuildTestAssets(string nugetCache)

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
@@ -30,6 +30,7 @@ public class IntegrationTestBuild : IntegrationTestBase
     // Session mutex: held for the entire test session (build + tests).
     // The process that creates it (createdNew=true) is the builder.
     private static Mutex? s_sessionMutex;
+    private static bool s_isSessionMutexOwner;
 
     public static void BuildTestAssetsForIntegrationTests(TestContext context)
     {
@@ -52,6 +53,7 @@ public class IntegrationTestBuild : IntegrationTestBase
         // Session mutex: the process that creates it is the builder.
         // Held for the entire session (build + tests), destroyed in CleanupTestAssets.
         s_sessionMutex = CreateMutex(baseName + "_Session", out bool isBuilder);
+        s_isSessionMutexOwner = isBuilder;
 
         if (isBuilder)
         {
@@ -169,10 +171,12 @@ public class IntegrationTestBuild : IntegrationTestBase
 
     public static void CleanupTestAssets()
     {
-        // Destroy session mutex — signals that this test session is done.
         if (s_sessionMutex is not null)
         {
-            try { s_sessionMutex.ReleaseMutex(); } catch (ApplicationException) { }
+            if (s_isSessionMutexOwner)
+            {
+                try { s_sessionMutex.ReleaseMutex(); } catch (ApplicationException) { }
+            }
             s_sessionMutex.Dispose();
             s_sessionMutex = null;
         }

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
@@ -29,8 +29,8 @@ public class IntegrationTestBuild : IntegrationTestBase
 
     // Short-lived mutex held only during the build phase to serialize builds.
     private static Mutex? s_buildMutex;
-    // Signaled once the build is complete so other assemblies can proceed to tests immediately.
-    private static EventWaitHandle? s_buildCompleteEvent;
+    // Path to a marker file used to signal that the build is complete (cross-platform replacement for named EventWaitHandle).
+    private static string? s_buildCompleteMarkerPath;
 
     public static void BuildTestAssetsForIntegrationTests(TestContext context)
     {
@@ -51,10 +51,9 @@ public class IntegrationTestBuild : IntegrationTestBase
             .Replace('\\', '-').Replace('/', '-').Replace(':', '-');
 
         s_buildMutex = new Mutex(initiallyOwned: false, baseName + "_Build");
-        s_buildCompleteEvent = new EventWaitHandle(
-            initialState: false,
-            mode: EventResetMode.ManualReset,
-            name: baseName + "_BuildComplete");
+        s_buildCompleteMarkerPath = Path.Combine(
+            IntegrationTestEnvironment.ArtifactsTempDirectory,
+            baseName + "_BuildComplete.marker");
 
         // Acquire the build mutex to serialize the build phase.
         try
@@ -69,14 +68,17 @@ public class IntegrationTestBuild : IntegrationTestBase
         catch (AbandonedMutexException)
         {
             // Previous holder crashed — we own the mutex now and need to rebuild.
-            s_buildCompleteEvent.Reset();
+            if (s_buildCompleteMarkerPath != null && File.Exists(s_buildCompleteMarkerPath))
+            {
+                File.Delete(s_buildCompleteMarkerPath);
+            }
             Debug.WriteLine("Previous build was interrupted (abandoned mutex), rebuilding.");
         }
 
         try
         {
             // If another assembly already completed the build, just proceed to tests.
-            if (s_buildCompleteEvent.WaitOne(0))
+            if (File.Exists(s_buildCompleteMarkerPath))
             {
                 Debug.WriteLine("Build already completed by another process, proceeding to tests.");
                 return;
@@ -108,7 +110,7 @@ public class IntegrationTestBuild : IntegrationTestBase
             Debug.WriteLine($"Copying and patching dotnet took: {sw.ElapsedMilliseconds} ms"); sw.Restart();
 
             // Signal that the build is complete so waiting assemblies can proceed to tests.
-            s_buildCompleteEvent.Set();
+            File.WriteAllText(s_buildCompleteMarkerPath!, DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture));
             Debug.WriteLine("Build completed, signaled other processes.");
         }
         finally
@@ -122,8 +124,7 @@ public class IntegrationTestBuild : IntegrationTestBase
     {
         s_buildMutex?.Dispose();
         s_buildMutex = null;
-        s_buildCompleteEvent?.Dispose();
-        s_buildCompleteEvent = null;
+        s_buildCompleteMarkerPath = null;
     }
 
     private static void BuildTestAssets(string nugetCache)

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
@@ -139,8 +139,12 @@ public class IntegrationTestBuild : IntegrationTestBase
                 try
                 {
                     // We didn't create it, try to acquire to check if it's alive.
-                    mutex.WaitOne(0);
-                    mutex.ReleaseMutex();
+                    if (mutex.WaitOne(0))
+                    {
+                        // We acquired it — previous owner released. Release and return.
+                        mutex.ReleaseMutex();
+                    }
+                    // If WaitOne returned false, mutex is held by another process — that's fine.
                 }
                 catch (AbandonedMutexException)
                 {


### PR DESCRIPTION
Fixes the race condition where two test assemblies (Acceptance + Library integration tests) can interfere with each other's build/test phases.

**Before:** Single mutex held only during build, released immediately — second assembly could start rebuilding while first is still running tests.

**After:** Two synchronization primitives:
- **Build mutex** — short-lived, held only during the build phase
- **Build-complete EventWaitHandle** (ManualReset) — signaled once after build completes, stays signaled so subsequent assemblies proceed immediately to tests

Handles process cancellation gracefully via \AbandonedMutexException\ — if the building process crashes, the next one detects the abandoned mutex and triggers a rebuild.

Closes #15566

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>