### PR TITLE
feat: new async vstest client with STJ serialization

### DIFF
--- a/src/Microsoft.TestPlatform.Client.Async/AsyncTestSession.cs
+++ b/src/Microsoft.TestPlatform.Client.Async/AsyncTestSession.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.TestPlatform.Client.Async.Internal;
+
+namespace Microsoft.TestPlatform.Client.Async;
+
+/// <summary>
+/// Represents an active connection to a vstest.console process.
+/// Owns the process and socket connection for its lifetime.
+/// </summary>
+internal sealed class AsyncTestSession : IAsyncTestSession
+{
+    internal readonly AsyncRequestSender Sender;
+    internal readonly ProcessManager Process;
+    private volatile bool _isConnected;
+
+    internal AsyncTestSession(AsyncRequestSender sender, ProcessManager process)
+    {
+        Sender = sender;
+        Process = process;
+        _isConnected = true;
+
+        // Monitor process exit to update IsConnected.
+        _ = MonitorProcessAsync();
+    }
+
+    /// <inheritdoc />
+    public int ProcessId => Process.ProcessId;
+
+    /// <inheritdoc />
+    public bool IsConnected => _isConnected && !Process.HasExited;
+
+    /// <inheritdoc />
+    public async Task EndSessionAsync(CancellationToken cancellationToken)
+    {
+        if (!_isConnected) return;
+        _isConnected = false;
+
+        try
+        {
+            await Sender.SendMessageAsync(ProtocolConstants.SessionEnd, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Process may have already exited.
+        }
+
+        // Wait briefly for graceful exit.
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        try
+        {
+            var cancelTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var registration = linkedCts.Token.Register(() => cancelTcs.TrySetResult(true));
+            await Task.WhenAny(Process.ExitedTask, cancelTcs.Task).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+        {
+            // Timeout waiting for graceful exit — will be killed in Dispose.
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await EndSessionAsync(CancellationToken.None).ConfigureAwait(false);
+        Sender.Dispose();
+        Process.Dispose();
+    }
+
+    private async Task MonitorProcessAsync()
+    {
+        await Process.ExitedTask.ConfigureAwait(false);
+        _isConnected = false;
+    }
+}

--- a/src/Microsoft.TestPlatform.Client.Async/AsyncVsTestClient.cs
+++ b/src/Microsoft.TestPlatform.Client.Async/AsyncVsTestClient.cs
@@ -1,0 +1,385 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.TestPlatform.Client.Async.Internal;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+
+namespace Microsoft.TestPlatform.Client.Async;
+
+/// <summary>
+/// Async client for communicating with vstest.console processes.
+/// Each instance is stateless — all shared state lives in <see cref="AsyncTestSession"/>.
+/// Multiple sessions can be active concurrently.
+/// </summary>
+public sealed class AsyncVsTestClient : IAsyncVsTestClient
+{
+    /// <summary>
+    /// Creates a new instance of the async vstest client.
+    /// </summary>
+    public AsyncVsTestClient()
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<IAsyncTestSession> StartSessionAsync(
+        string vstestConsolePath,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(vstestConsolePath))
+        {
+            throw new ArgumentException("Path to vstest.console must not be empty.", nameof(vstestConsolePath));
+        }
+
+        var sender = new AsyncRequestSender();
+        sender.StartListening();
+
+        ProcessManager? process = null;
+        try
+        {
+            process = ProcessManager.Launch(vstestConsolePath, sender.Port);
+            await sender.WaitForConnectionAsync(process, cancellationToken).ConfigureAwait(false);
+
+            // Send empty extension initialization (no custom extensions).
+            await sender.SendMessageAsync(
+                ProtocolConstants.ExecutionInitialize,
+                Array.Empty<string>(),
+                cancellationToken).ConfigureAwait(false);
+
+            return new AsyncTestSession(sender, process);
+        }
+        catch
+        {
+            process?.Dispose();
+            sender.Dispose();
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<DiscoveryResult> DiscoverTestsAsync(
+        IAsyncTestSession session,
+        IEnumerable<string> sources,
+        string? runSettings = null,
+        CancellationToken cancellationToken = default)
+    {
+        var s = GetSession(session);
+        ThrowIfDisconnected(s);
+
+        // Initialize discovery extensions.
+        await s.Sender.SendMessageAsync(
+            ProtocolConstants.DiscoveryInitialize,
+            Array.Empty<string>(),
+            cancellationToken).ConfigureAwait(false);
+
+        // Send discovery request.
+        var payload = new DiscoveryRequestPayloadDto
+        {
+            Sources = sources.ToList(),
+            RunSettings = runSettings,
+        };
+
+        await s.Sender.SendMessageAsync(
+            ProtocolConstants.StartDiscovery,
+            payload,
+            cancellationToken).ConfigureAwait(false);
+
+        // Collect results.
+        var testCases = new List<TestCase>();
+        long totalCount = 0;
+        bool isAborted = false;
+
+        while (true)
+        {
+            var message = await s.Sender.ReceiveMessageAsync(s.Process, cancellationToken).ConfigureAwait(false);
+            if (message == null) break;
+
+            switch (message.MessageType)
+            {
+                case ProtocolConstants.TestCasesFound:
+                    if (message.Payload.HasValue)
+                    {
+                        foreach (var element in message.Payload.Value.EnumerateArray())
+                        {
+                            testCases.Add(TestObjectDeserializer.DeserializeTestCase(element));
+                        }
+                    }
+                    break;
+
+                case ProtocolConstants.DiscoveryComplete:
+                    if (message.Payload.HasValue)
+                    {
+                        var payload2 = message.Payload.Value;
+                        if (payload2.TryGetProperty("TotalTests", out var totalElem))
+                        {
+                            totalCount = totalElem.GetInt64();
+                        }
+                        if (payload2.TryGetProperty("IsAborted", out var abortedElem))
+                        {
+                            isAborted = abortedElem.GetBoolean();
+                        }
+                        // Collect any last chunk of discovered tests.
+                        if (payload2.TryGetProperty("LastDiscoveredTests", out var lastTests) &&
+                            lastTests.ValueKind == JsonValueKind.Array)
+                        {
+                            foreach (var element in lastTests.EnumerateArray())
+                            {
+                                testCases.Add(TestObjectDeserializer.DeserializeTestCase(element));
+                            }
+                        }
+                    }
+                    return new DiscoveryResult(testCases, totalCount, isAborted);
+
+                case ProtocolConstants.TestMessage:
+                    // Diagnostic messages from the server — skip for now.
+                    break;
+
+                default:
+                    // Unknown message type — skip.
+                    break;
+            }
+        }
+
+        return new DiscoveryResult(testCases, totalCount, isAborted: true);
+    }
+
+    /// <inheritdoc />
+    public Task<TestRunResult> RunTestsAsync(
+        IAsyncTestSession session,
+        IEnumerable<string> sources,
+        string? runSettings = null,
+        IProgress<TestRunChangedEventArgs>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var payload = new TestRunRequestPayloadDto
+        {
+            Sources = sources.ToList(),
+            RunSettings = runSettings,
+            KeepAlive = false,
+        };
+
+        return RunTestsCoreAsync(session, payload, progress, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<TestRunResult> RunTestsAsync(
+        IAsyncTestSession session,
+        IEnumerable<TestCase> testCases,
+        string? runSettings = null,
+        IProgress<TestRunChangedEventArgs>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var payload = new TestRunRequestPayloadDto
+        {
+            TestCases = testCases.Select(TestCaseDto.FromTestCase).ToList(),
+            RunSettings = runSettings,
+            KeepAlive = false,
+        };
+
+        return RunTestsCoreAsync(session, payload, progress, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync()
+    {
+        // The client itself holds no state — sessions are disposed individually.
+        return default;
+    }
+
+    private static async Task<TestRunResult> RunTestsCoreAsync(
+        IAsyncTestSession session,
+        TestRunRequestPayloadDto payload,
+        IProgress<TestRunChangedEventArgs>? progress,
+        CancellationToken cancellationToken)
+    {
+        var s = GetSession(session);
+        ThrowIfDisconnected(s);
+
+        // Initialize execution extensions.
+        await s.Sender.SendMessageAsync(
+            ProtocolConstants.ExecutionInitialize,
+            Array.Empty<string>(),
+            cancellationToken).ConfigureAwait(false);
+
+        // Send run request.
+        await s.Sender.SendMessageAsync(
+            ProtocolConstants.TestRunAllSourcesWithDefaultHost,
+            payload,
+            cancellationToken).ConfigureAwait(false);
+
+        // Collect results.
+        var testResults = new List<TestResult>();
+        ITestRunStatistics? statistics = null;
+        bool isCanceled = false;
+        bool isAborted = false;
+        TimeSpan elapsedTime = TimeSpan.Zero;
+
+        while (true)
+        {
+            var message = await s.Sender.ReceiveMessageAsync(s.Process, cancellationToken).ConfigureAwait(false);
+            if (message == null) break;
+
+            switch (message.MessageType)
+            {
+                case ProtocolConstants.TestRunStatsChange:
+                    if (message.Payload.HasValue)
+                    {
+                        var changedResults = DeserializeTestRunChangedResults(message.Payload.Value);
+                        testResults.AddRange(changedResults);
+
+                        if (progress != null)
+                        {
+                            var eventArgs = new TestRunChangedEventArgs(
+                                null, changedResults, Enumerable.Empty<TestCase>());
+                            progress.Report(eventArgs);
+                        }
+                    }
+                    break;
+
+                case ProtocolConstants.ExecutionComplete:
+                    if (message.Payload.HasValue)
+                    {
+                        ParseExecutionComplete(
+                            message.Payload.Value,
+                            testResults,
+                            out statistics,
+                            out isCanceled,
+                            out isAborted,
+                            out elapsedTime);
+                    }
+                    return new TestRunResult(testResults, statistics, isCanceled, isAborted, elapsedTime);
+
+                case ProtocolConstants.TestMessage:
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        return new TestRunResult(testResults, statistics, isCanceled, isAborted: true, elapsedTime);
+    }
+
+    private static List<TestResult> DeserializeTestRunChangedResults(JsonElement payload)
+    {
+        var results = new List<TestResult>();
+
+        if (payload.TryGetProperty("NewTestResults", out var newResults) &&
+            newResults.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var element in newResults.EnumerateArray())
+            {
+                results.Add(TestObjectDeserializer.DeserializeTestResult(element));
+            }
+        }
+
+        return results;
+    }
+
+    private static void ParseExecutionComplete(
+        JsonElement payload,
+        List<TestResult> testResults,
+        out ITestRunStatistics? statistics,
+        out bool isCanceled,
+        out bool isAborted,
+        out TimeSpan elapsedTime)
+    {
+        statistics = null;
+        isCanceled = false;
+        isAborted = false;
+        elapsedTime = TimeSpan.Zero;
+
+        // Collect any last test results.
+        if (payload.TryGetProperty("LastRunTests", out var lastRunTests) &&
+            lastRunTests.ValueKind == JsonValueKind.Object)
+        {
+            if (lastRunTests.TryGetProperty("NewTestResults", out var lastNewResults) &&
+                lastNewResults.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var element in lastNewResults.EnumerateArray())
+                {
+                    testResults.Add(TestObjectDeserializer.DeserializeTestResult(element));
+                }
+            }
+        }
+
+        if (payload.TryGetProperty("TestRunCompleteArgs", out var completeArgs))
+        {
+            if (completeArgs.TryGetProperty("IsCanceled", out var canceledElem))
+            {
+                isCanceled = canceledElem.GetBoolean();
+            }
+            if (completeArgs.TryGetProperty("IsAborted", out var abortedElem))
+            {
+                isAborted = abortedElem.GetBoolean();
+            }
+            if (completeArgs.TryGetProperty("ElapsedTimeInRunningTests", out var elapsedElem))
+            {
+                string? elapsedStr = elapsedElem.GetString();
+                if (elapsedStr != null && TimeSpan.TryParse(elapsedStr, out var parsed))
+                {
+                    elapsedTime = parsed;
+                }
+            }
+            if (completeArgs.TryGetProperty("TestRunStatistics", out var statsElem) &&
+                statsElem.ValueKind == JsonValueKind.Object)
+            {
+                statistics = DeserializeTestRunStatistics(statsElem);
+            }
+        }
+    }
+
+    private static ITestRunStatistics? DeserializeTestRunStatistics(JsonElement statsElem)
+    {
+        long executedTests = 0;
+        var stats = new Dictionary<TestOutcome, long>();
+
+        if (statsElem.TryGetProperty("ExecutedTests", out var execElem))
+        {
+            executedTests = execElem.GetInt64();
+        }
+
+        if (statsElem.TryGetProperty("Stats", out var statsDict) &&
+            statsDict.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var prop in statsDict.EnumerateObject())
+            {
+                if (int.TryParse(prop.Name, out int outcomeInt) &&
+                    Enum.IsDefined(typeof(TestOutcome), outcomeInt))
+                {
+                    stats[(TestOutcome)outcomeInt] = prop.Value.GetInt64();
+                }
+            }
+        }
+
+        return new TestRunStatistics(executedTests, stats);
+    }
+
+    private static AsyncTestSession GetSession(IAsyncTestSession session)
+    {
+        if (session is not AsyncTestSession asyncSession)
+        {
+            throw new ArgumentException("Session was not created by this client.", nameof(session));
+        }
+        return asyncSession;
+    }
+
+    private static void ThrowIfDisconnected(AsyncTestSession session)
+    {
+        if (!session.IsConnected)
+        {
+            throw new InvalidOperationException(
+                "The vstest.console session is no longer connected. " +
+                (session.Process.HasExited
+                    ? $"Process exited with code {session.Process.ExitCode}. {session.Process.ErrorOutput}"
+                    : "Connection was closed."));
+        }
+    }
+}

--- a/src/Microsoft.TestPlatform.Client.Async/DiscoveryResult.cs
+++ b/src/Microsoft.TestPlatform.Client.Async/DiscoveryResult.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+namespace Microsoft.TestPlatform.Client.Async;
+
+/// <summary>
+/// Result of a test discovery operation.
+/// </summary>
+public class DiscoveryResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DiscoveryResult"/> class.
+    /// </summary>
+    public DiscoveryResult(IReadOnlyList<TestCase> testCases, long totalCount, bool isAborted)
+    {
+        TestCases = testCases;
+        TotalCount = totalCount;
+        IsAborted = isAborted;
+    }
+
+    /// <summary>
+    /// The discovered test cases.
+    /// </summary>
+    public IReadOnlyList<TestCase> TestCases { get; }
+
+    /// <summary>
+    /// The total number of tests reported by the server.
+    /// </summary>
+    public long TotalCount { get; }
+
+    /// <summary>
+    /// Whether discovery was aborted.
+    /// </summary>
+    public bool IsAborted { get; }
+}

--- a/src/Microsoft.TestPlatform.Client.Async/IAsyncTestSession.cs
+++ b/src/Microsoft.TestPlatform.Client.Async/IAsyncTestSession.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.TestPlatform.Client.Async;
+
+/// <summary>
+/// Represents an active connection to a vstest.console process.
+/// </summary>
+public interface IAsyncTestSession : IAsyncDisposable
+{
+    /// <summary>
+    /// The process ID of the vstest.console process.
+    /// </summary>
+    int ProcessId { get; }
+
+    /// <summary>
+    /// Whether the session is still connected to the vstest.console process.
+    /// </summary>
+    bool IsConnected { get; }
+
+    /// <summary>
+    /// End the session and terminate the vstest.console process.
+    /// </summary>
+    Task EndSessionAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Microsoft.TestPlatform.Client.Async/IAsyncVsTestClient.cs
+++ b/src/Microsoft.TestPlatform.Client.Async/IAsyncVsTestClient.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+
+namespace Microsoft.TestPlatform.Client.Async;
+
+/// <summary>
+/// Async client for communicating with vstest.console processes.
+/// Supports multiple concurrent sessions with no shared static state.
+/// </summary>
+public interface IAsyncVsTestClient : IAsyncDisposable
+{
+    /// <summary>
+    /// Start a vstest.console session by launching the process and establishing a socket connection.
+    /// </summary>
+    /// <param name="vstestConsolePath">Path to vstest.console.exe or vstest.console.dll.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A connected test session.</returns>
+    Task<IAsyncTestSession> StartSessionAsync(
+        string vstestConsolePath,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Discover tests in the given sources.
+    /// </summary>
+    Task<DiscoveryResult> DiscoverTestsAsync(
+        IAsyncTestSession session,
+        IEnumerable<string> sources,
+        string? runSettings = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Run tests in the given sources.
+    /// </summary>
+    Task<TestRunResult> RunTestsAsync(
+        IAsyncTestSession session,
+        IEnumerable<string> sources,
+        string? runSettings = null,
+        IProgress<TestRunChangedEventArgs>? progress = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Run specific test cases.
+    /// </summary>
+    Task<TestRunResult> RunTestsAsync(
+        IAsyncTestSession session,
+        IEnumerable<TestCase> testCases,
+        string? runSettings = null,
+        IProgress<TestRunChangedEventArgs>? progress = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Microsoft.TestPlatform.Client.Async/Internal/AsyncRequestSender.cs
+++ b/src/Microsoft.TestPlatform.Client.Async/Internal/AsyncRequestSender.cs
@@ -1,0 +1,258 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.TestPlatform.Client.Async.Internal;
+
+/// <summary>
+/// Sends and receives vstest protocol messages over a TCP socket.
+/// Uses length-prefixed framing (BinaryWriter/BinaryReader) matching the
+/// LengthPrefixCommunicationChannel in the existing vstest codebase.
+/// All I/O is fully async with CancellationToken support.
+/// </summary>
+internal sealed class AsyncRequestSender : IDisposable
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = null, // use exact property names
+    };
+
+    private readonly TcpListener _listener;
+    private TcpClient? _client;
+    private BinaryReader? _reader;
+    private BinaryWriter? _writer;
+    private int _negotiatedVersion;
+
+    public AsyncRequestSender()
+    {
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+    }
+
+    /// <summary>
+    /// The port the server is listening on.
+    /// </summary>
+    public int Port
+    {
+        get
+        {
+            var endpoint = (IPEndPoint)_listener.LocalEndpoint;
+            return endpoint.Port;
+        }
+    }
+
+    /// <summary>
+    /// Start listening for the vstest.console process to connect.
+    /// </summary>
+    public void StartListening()
+    {
+        _listener.Start();
+    }
+
+    /// <summary>
+    /// Wait for the vstest.console process to connect and perform the version handshake.
+    /// </summary>
+    public async Task WaitForConnectionAsync(ProcessManager processManager, CancellationToken cancellationToken)
+    {
+        // Wait for either the connection or process exit.
+        // AcceptTcpClientAsync() does not accept CancellationToken on netstandard2.0;
+        // we handle cancellation via WhenAny with a cancellation TCS instead.
+#pragma warning disable CA2016
+        var acceptTask = _listener.AcceptTcpClientAsync();
+#pragma warning restore CA2016
+        var exitTask = processManager.ExitedTask;
+        var cancelTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var registration = cancellationToken.Register(() => cancelTcs.TrySetResult(true));
+
+        var completed = await Task.WhenAny(acceptTask, exitTask, cancelTcs.Task).ConfigureAwait(false);
+
+        if (completed == cancelTcs.Task)
+        {
+            _listener.Stop();
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        if (completed == exitTask)
+        {
+            _listener.Stop();
+            throw processManager.CreateExitException("connection");
+        }
+
+        _client = await acceptTask.ConfigureAwait(false);
+        _listener.Stop();
+
+        var stream = new BufferedStream(_client.GetStream(), 65536);
+        _reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+        _writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+
+        await PerformHandshakeAsync(processManager, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Send a protocol message with a typed payload.
+    /// </summary>
+    public Task SendMessageAsync<T>(string messageType, T payload, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var message = new
+        {
+            MessageType = messageType,
+            Version = _negotiatedVersion,
+            Payload = payload,
+        };
+
+        string json = JsonSerializer.Serialize(message, JsonOptions);
+        WriteString(json);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Send a protocol message with no payload.
+    /// </summary>
+    public Task SendMessageAsync(string messageType, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var message = new
+        {
+            MessageType = messageType,
+            Version = _negotiatedVersion,
+        };
+
+        string json = JsonSerializer.Serialize(message, JsonOptions);
+        WriteString(json);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Receive the next protocol message. Returns null if the connection is closed.
+    /// This monitors the process for unexpected exits and throws immediately if it dies.
+    /// </summary>
+    public async Task<ProtocolMessage?> ReceiveMessageAsync(ProcessManager processManager, CancellationToken cancellationToken)
+    {
+        // BinaryReader.ReadString() is synchronous. Run it on a thread pool thread
+        // so we can race it against process exit and cancellation.
+        var readTask = Task.Run(() =>
+        {
+            try
+            {
+                string json = ReadString();
+                return json;
+            }
+            catch (EndOfStreamException)
+            {
+                return null;
+            }
+            catch (IOException)
+            {
+                return null;
+            }
+        }, CancellationToken.None);
+
+        var exitTask = processManager.ExitedTask;
+        var cancelTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = cancellationToken.Register(() => cancelTcs.TrySetResult(true));
+
+        var completed = await Task.WhenAny(readTask, exitTask, cancelTcs.Task).ConfigureAwait(false);
+
+        if (completed == cancelTcs.Task)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        // If the process exited, wait briefly for the read to finish (may have final message).
+        if (completed == exitTask)
+        {
+            var delayTask = Task.Delay(500, CancellationToken.None);
+            var readOrDelay = await Task.WhenAny(readTask, delayTask).ConfigureAwait(false);
+            if (readOrDelay == readTask && readTask.Result != null)
+            {
+                return JsonSerializer.Deserialize<ProtocolMessage>(readTask.Result, JsonOptions);
+            }
+
+            throw processManager.CreateExitException("message receive");
+        }
+
+        string? result = await readTask.ConfigureAwait(false);
+        if (result == null)
+        {
+            return null;
+        }
+
+        return JsonSerializer.Deserialize<ProtocolMessage>(result, JsonOptions);
+    }
+
+    public void Dispose()
+    {
+        _reader?.Dispose();
+        _writer?.Dispose();
+        _client?.Dispose();
+
+        try
+        {
+            _listener.Stop();
+        }
+        catch
+        {
+            // Listener may already be stopped.
+        }
+    }
+
+    private async Task PerformHandshakeAsync(ProcessManager processManager, CancellationToken cancellationToken)
+    {
+        // Step 1: Wait for SessionConnected message.
+        var connectedMsg = await ReceiveMessageAsync(processManager, cancellationToken).ConfigureAwait(false);
+        if (connectedMsg == null || connectedMsg.MessageType != ProtocolConstants.SessionConnected)
+        {
+            throw new InvalidOperationException(
+                $"Expected '{ProtocolConstants.SessionConnected}' message but got '{connectedMsg?.MessageType ?? "null"}'.");
+        }
+
+        // Step 2: Send VersionCheck with our protocol version.
+        await SendMessageAsync(ProtocolConstants.VersionCheck, ProtocolConstants.ProtocolVersion, cancellationToken).ConfigureAwait(false);
+
+        // Step 3: Receive version response.
+        var versionMsg = await ReceiveMessageAsync(processManager, cancellationToken).ConfigureAwait(false);
+        if (versionMsg == null)
+        {
+            throw new InvalidOperationException("Connection closed during version negotiation.");
+        }
+
+        if (versionMsg.MessageType == ProtocolConstants.VersionCheck)
+        {
+            _negotiatedVersion = versionMsg.Payload?.GetInt32() ?? ProtocolConstants.ProtocolVersion;
+        }
+        else if (versionMsg.MessageType == ProtocolConstants.ProtocolError)
+        {
+            throw new InvalidOperationException(
+                $"Protocol version negotiation failed: {versionMsg.Payload?.GetRawText() ?? "unknown error"}");
+        }
+        else
+        {
+            throw new InvalidOperationException(
+                $"Unexpected message during version negotiation: '{versionMsg.MessageType}'.");
+        }
+    }
+
+    private void WriteString(string value)
+    {
+        if (_writer == null) throw new ObjectDisposedException(nameof(AsyncRequestSender));
+        _writer.Write(value);
+        _writer.Flush();
+    }
+
+    private string ReadString()
+    {
+        if (_reader == null) throw new ObjectDisposedException(nameof(AsyncRequestSender));
+        return _reader.ReadString();
+    }
+}

--- a/src/Microsoft.TestPlatform.Client.Async/Internal/ProcessManager.cs
+++ b/src/Microsoft.TestPlatform.Client.Async/Internal/ProcessManager.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.TestPlatform.Client.Async.Internal;
+
+/// <summary>
+/// Manages a vstest.console child process. Captures stderr asynchronously
+/// and detects process exit immediately without blocking.
+/// </summary>
+internal sealed class ProcessManager : IDisposable
+{
+    private readonly Process _process;
+    private readonly StringBuilder _errorOutput = new();
+    private readonly TaskCompletionSource<int> _exitTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private ProcessManager(Process process)
+    {
+        _process = process;
+    }
+
+    public int ProcessId => _process.Id;
+
+    public bool HasExited => _process.HasExited;
+
+    public int? ExitCode => HasExited ? _process.ExitCode : null;
+
+    public string ErrorOutput
+    {
+        get
+        {
+            lock (_errorOutput)
+            {
+                return _errorOutput.ToString();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Task that completes when the process exits. The result is the exit code.
+    /// </summary>
+    public Task<int> ExitedTask => _exitTcs.Task;
+
+    /// <summary>
+    /// Launch a vstest.console process in design mode, connecting back to the given port.
+    /// </summary>
+    public static ProcessManager Launch(string vstestConsolePath, int port)
+    {
+        int parentPid;
+        using (var currentProcess = Process.GetCurrentProcess())
+        {
+            parentPid = currentProcess.Id;
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+        };
+
+        if (vstestConsolePath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+        {
+            startInfo.FileName = "dotnet";
+            startInfo.Arguments = $"\"{vstestConsolePath}\" /Port:{port} /ParentProcessId:{parentPid}";
+        }
+        else
+        {
+            startInfo.FileName = vstestConsolePath;
+            startInfo.Arguments = $"/Port:{port} /ParentProcessId:{parentPid}";
+        }
+
+        var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+        var manager = new ProcessManager(process);
+
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data != null)
+            {
+                lock (manager._errorOutput)
+                {
+                    manager._errorOutput.AppendLine(e.Data);
+                }
+            }
+        };
+
+        // Drain stdout to avoid blocking the child process.
+        process.OutputDataReceived += (_, _) => { };
+
+        process.Exited += (_, _) =>
+        {
+            manager._exitTcs.TrySetResult(process.ExitCode);
+        };
+
+        process.Start();
+        process.BeginErrorReadLine();
+        process.BeginOutputReadLine();
+
+        return manager;
+    }
+
+    /// <summary>
+    /// Create a <see cref="VsTestProcessExitedException"/> from the current process state.
+    /// </summary>
+    public VsTestProcessExitedException CreateExitException(string context)
+    {
+        string stderr = ErrorOutput;
+        string message = string.IsNullOrWhiteSpace(stderr)
+            ? $"vstest.console process (PID {ProcessId}) exited with code {ExitCode} during {context}."
+            : $"vstest.console process (PID {ProcessId}) exited with code {ExitCode} during {context}. Stderr: {stderr.Trim()}";
+        return new VsTestProcessExitedException(message, ExitCode ?? -1);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (!_process.HasExited)
+            {
+                _process.Kill();
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Process already exited.
+        }
+
+        _process.Dispose();
+    }
+}
+
+/// <summary>
+/// Exception thrown when vstest.console exits unexpectedly.
+/// </summary>
+public class VsTestProcessExitedException : Exception
+{
+    public VsTestProcessExitedException(string message, int exitCode)
+        : base(message)
+    {
+        ExitCode = exitCode;
+    }
+
+    /// <summary>
+    /// The exit code of the vstest.console process.
+    /// </summary>
+    public int ExitCode { get; }
+}

--- a/src/Microsoft.TestPlatform.Client.Async/Internal/ProtocolConstants.cs
+++ b/src/Microsoft.TestPlatform.Client.Async/Internal/ProtocolConstants.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.TestPlatform.Client.Async.Internal;
+
+/// <summary>
+/// Protocol constants matching the vstest.console design mode protocol.
+/// These mirror the MessageType values from CommunicationUtilities but are
+/// defined here to avoid taking a dependency on that assembly.
+/// </summary>
+internal static class ProtocolConstants
+{
+    // Latest protocol version supported by this client.
+    public const int ProtocolVersion = 7;
+
+    // Session messages
+    public const string SessionConnected = "TestSession.Connected";
+    public const string SessionEnd = "TestSession.Terminate";
+    public const string TestMessage = "TestSession.Message";
+
+    // Version negotiation
+    public const string VersionCheck = "ProtocolVersion";
+    public const string ProtocolError = "ProtocolError";
+
+    // Discovery
+    public const string DiscoveryInitialize = "TestDiscovery.Initialize";
+    public const string StartDiscovery = "TestDiscovery.Start";
+    public const string TestCasesFound = "TestDiscovery.TestFound";
+    public const string DiscoveryComplete = "TestDiscovery.Completed";
+
+    // Execution
+    public const string ExecutionInitialize = "TestExecution.Initialize";
+    public const string TestRunAllSourcesWithDefaultHost = "TestExecution.RunAllWithDefaultHost";
+    public const string TestRunStatsChange = "TestExecution.StatsChange";
+    public const string ExecutionComplete = "TestExecution.Completed";
+}

--- a/src/Microsoft.TestPlatform.Client.Async/Internal/ProtocolMessage.cs
+++ b/src/Microsoft.TestPlatform.Client.Async/Internal/ProtocolMessage.cs
@@ -1,0 +1,353 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+namespace Microsoft.TestPlatform.Client.Async.Internal;
+
+/// <summary>
+/// Represents a versioned protocol message sent over the vstest socket connection.
+/// Format: {"MessageType":"...","Version":N,"Payload":...}
+/// </summary>
+internal sealed class ProtocolMessage
+{
+    [JsonPropertyName("MessageType")]
+    public string MessageType { get; set; } = string.Empty;
+
+    [JsonPropertyName("Version")]
+    public int Version { get; set; }
+
+    [JsonPropertyName("Payload")]
+    public JsonElement? Payload { get; set; }
+}
+
+/// <summary>
+/// Payload sent for discovery requests.
+/// </summary>
+internal sealed class DiscoveryRequestPayloadDto
+{
+    [JsonPropertyName("Sources")]
+    public List<string> Sources { get; set; } = new();
+
+    [JsonPropertyName("RunSettings")]
+    public string? RunSettings { get; set; }
+
+    [JsonPropertyName("TestPlatformOptions")]
+    public object? TestPlatformOptions { get; set; }
+
+    [JsonPropertyName("TestSessionInfo")]
+    public object? TestSessionInfo { get; set; }
+}
+
+/// <summary>
+/// Payload sent for test run requests.
+/// </summary>
+internal sealed class TestRunRequestPayloadDto
+{
+    [JsonPropertyName("Sources")]
+    public List<string>? Sources { get; set; }
+
+    [JsonPropertyName("TestCases")]
+    public List<TestCaseDto>? TestCases { get; set; }
+
+    [JsonPropertyName("RunSettings")]
+    public string? RunSettings { get; set; }
+
+    [JsonPropertyName("KeepAlive")]
+    public bool KeepAlive { get; set; }
+
+    [JsonPropertyName("DebuggingEnabled")]
+    public bool DebuggingEnabled { get; set; }
+
+    [JsonPropertyName("TestPlatformOptions")]
+    public object? TestPlatformOptions { get; set; }
+
+    [JsonPropertyName("TestSessionInfo")]
+    public object? TestSessionInfo { get; set; }
+}
+
+/// <summary>
+/// Lightweight TestCase DTO for serialization over the wire.
+/// Uses the vstest property-bag format: { "Properties": [ { "Key": {...}, "Value": ... }, ... ] }
+/// </summary>
+internal sealed class TestCaseDto
+{
+    [JsonPropertyName("Properties")]
+    public List<TestPropertyPair> Properties { get; set; } = new();
+
+    public static TestCaseDto FromTestCase(TestCase testCase)
+    {
+        var dto = new TestCaseDto();
+
+        dto.AddProperty("TestCase.Id", "Id", typeof(Guid), TestPropertyAttributes.Hidden, testCase.Id.ToString());
+        dto.AddProperty("TestCase.FullyQualifiedName", "FullyQualifiedName", typeof(string), TestPropertyAttributes.Hidden, testCase.FullyQualifiedName);
+        dto.AddProperty("TestCase.ExecutorUri", "Executor Uri", typeof(Uri), TestPropertyAttributes.Hidden, testCase.ExecutorUri.OriginalString);
+        dto.AddProperty("TestCase.Source", "Source", typeof(string), TestPropertyAttributes.None, testCase.Source);
+        dto.AddProperty("TestCase.DisplayName", "Name", typeof(string), TestPropertyAttributes.None, testCase.DisplayName);
+
+        if (testCase.CodeFilePath != null)
+        {
+            dto.AddProperty("TestCase.CodeFilePath", "File Path", typeof(string), TestPropertyAttributes.None, testCase.CodeFilePath);
+        }
+
+        if (testCase.LineNumber >= 0)
+        {
+            dto.AddProperty("TestCase.LineNumber", "Line Number", typeof(int), TestPropertyAttributes.Hidden, testCase.LineNumber);
+        }
+
+        return dto;
+    }
+
+    private void AddProperty(string id, string label, Type valueType, TestPropertyAttributes attributes, object value)
+    {
+        Properties.Add(new TestPropertyPair
+        {
+            Key = new TestPropertyKey
+            {
+                Id = id,
+                Label = label,
+                Category = string.Empty,
+                Description = string.Empty,
+                Attributes = (int)attributes,
+                ValueType = valueType.FullName!,
+            },
+            Value = JsonSerializer.SerializeToElement(value),
+        });
+    }
+}
+
+/// <summary>
+/// A single property in the vstest property-bag format.
+/// </summary>
+internal sealed class TestPropertyPair
+{
+    [JsonPropertyName("Key")]
+    public TestPropertyKey Key { get; set; } = new();
+
+    [JsonPropertyName("Value")]
+    public JsonElement Value { get; set; }
+}
+
+/// <summary>
+/// The key portion of a property-bag entry.
+/// </summary>
+internal sealed class TestPropertyKey
+{
+    [JsonPropertyName("Id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("Label")]
+    public string Label { get; set; } = string.Empty;
+
+    [JsonPropertyName("Category")]
+    public string Category { get; set; } = string.Empty;
+
+    [JsonPropertyName("Description")]
+    public string Description { get; set; } = string.Empty;
+
+    [JsonPropertyName("Attributes")]
+    public int Attributes { get; set; }
+
+    [JsonPropertyName("ValueType")]
+    public string ValueType { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Handles deserialization of TestCase and TestResult from the vstest property-bag wire format.
+/// </summary>
+internal static class TestObjectDeserializer
+{
+    public static TestCase DeserializeTestCase(JsonElement element)
+    {
+        string? fullyQualifiedName = null;
+        string? executorUri = null;
+        string? source = null;
+        string? displayName = null;
+        string? id = null;
+        string? codeFilePath = null;
+        int lineNumber = -1;
+        var customProperties = new List<(TestPropertyKey key, JsonElement value)>();
+
+        if (element.TryGetProperty("Properties", out var propertiesElement))
+        {
+            foreach (var prop in propertiesElement.EnumerateArray())
+            {
+                if (!prop.TryGetProperty("Key", out var keyElement) ||
+                    !prop.TryGetProperty("Value", out var valueElement))
+                {
+                    continue;
+                }
+
+                string propId = keyElement.GetProperty("Id").GetString() ?? string.Empty;
+
+                switch (propId)
+                {
+                    case "TestCase.FullyQualifiedName":
+                        fullyQualifiedName = GetStringValue(valueElement);
+                        break;
+                    case "TestCase.ExecutorUri":
+                        executorUri = GetStringValue(valueElement);
+                        break;
+                    case "TestCase.Source":
+                        source = GetStringValue(valueElement);
+                        break;
+                    case "TestCase.DisplayName":
+                        displayName = GetStringValue(valueElement);
+                        break;
+                    case "TestCase.Id":
+                        id = GetStringValue(valueElement);
+                        break;
+                    case "TestCase.CodeFilePath":
+                        codeFilePath = GetStringValue(valueElement);
+                        break;
+                    case "TestCase.LineNumber":
+                        lineNumber = GetIntValue(valueElement);
+                        break;
+                    default:
+                        var key = JsonSerializer.Deserialize<TestPropertyKey>(keyElement.GetRawText())!;
+                        customProperties.Add((key, valueElement));
+                        break;
+                }
+            }
+        }
+
+        var testCase = new TestCase(
+            fullyQualifiedName ?? "Unknown",
+            new Uri(executorUri ?? "executor://unknown"),
+            source ?? "unknown");
+
+        if (displayName != null) testCase.DisplayName = displayName;
+        if (id != null) testCase.Id = Guid.Parse(id);
+        if (codeFilePath != null) testCase.CodeFilePath = codeFilePath;
+        if (lineNumber >= 0) testCase.LineNumber = lineNumber;
+
+        foreach (var (key, value) in customProperties)
+        {
+            var testProperty = TestProperty.Register(
+                key.Id,
+                key.Label,
+                key.Category,
+                key.Description,
+                GetTypeFromName(key.ValueType),
+                null,
+                (TestPropertyAttributes)key.Attributes,
+                typeof(TestObject));
+            testCase.SetPropertyValue(testProperty, GetStringValue(value));
+        }
+
+        return testCase;
+    }
+
+    public static TestResult DeserializeTestResult(JsonElement element)
+    {
+        TestCase testCase;
+
+        if (element.TryGetProperty("TestCase", out var testCaseElement))
+        {
+            testCase = DeserializeTestCase(testCaseElement);
+        }
+        else
+        {
+            testCase = new TestCase("Unknown", new Uri("executor://unknown"), "unknown");
+        }
+
+        var result = new TestResult(testCase);
+
+        if (element.TryGetProperty("Properties", out var propertiesElement))
+        {
+            foreach (var prop in propertiesElement.EnumerateArray())
+            {
+                if (!prop.TryGetProperty("Key", out var keyElement) ||
+                    !prop.TryGetProperty("Value", out var valueElement))
+                {
+                    continue;
+                }
+
+                string propId = keyElement.GetProperty("Id").GetString() ?? string.Empty;
+
+                switch (propId)
+                {
+                    case "TestResult.Outcome":
+                        result.Outcome = (TestOutcome)GetIntValue(valueElement);
+                        break;
+                    case "TestResult.ErrorMessage":
+                        result.ErrorMessage = GetStringValue(valueElement);
+                        break;
+                    case "TestResult.ErrorStackTrace":
+                        result.ErrorStackTrace = GetStringValue(valueElement);
+                        break;
+                    case "TestResult.DisplayName":
+                        result.DisplayName = GetStringValue(valueElement);
+                        break;
+                    case "TestResult.Duration":
+                        var durationStr = GetStringValue(valueElement);
+                        if (durationStr != null && TimeSpan.TryParse(durationStr, CultureInfo.InvariantCulture, out var duration))
+                        {
+                            result.Duration = duration;
+                        }
+                        break;
+                    case "TestResult.StartTime":
+                        var startStr = GetStringValue(valueElement);
+                        if (startStr != null && DateTimeOffset.TryParse(startStr, CultureInfo.InvariantCulture, DateTimeStyles.None, out var startTime))
+                        {
+                            result.StartTime = startTime;
+                        }
+                        break;
+                    case "TestResult.EndTime":
+                        var endStr = GetStringValue(valueElement);
+                        if (endStr != null && DateTimeOffset.TryParse(endStr, CultureInfo.InvariantCulture, DateTimeStyles.None, out var endTime))
+                        {
+                            result.EndTime = endTime;
+                        }
+                        break;
+                    case "TestResult.ComputerName":
+                        result.ComputerName = GetStringValue(valueElement) ?? string.Empty;
+                        break;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static string? GetStringValue(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Null => null,
+            _ => element.GetRawText().Trim('"'),
+        };
+    }
+
+    private static int GetIntValue(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Number => element.GetInt32(),
+            JsonValueKind.String => int.TryParse(element.GetString(), out var v) ? v : 0,
+            _ => 0,
+        };
+    }
+
+    private static Type GetTypeFromName(string typeName)
+    {
+        return typeName switch
+        {
+            "System.String" => typeof(string),
+            "System.Int32" => typeof(int),
+            "System.Boolean" => typeof(bool),
+            "System.Guid" => typeof(Guid),
+            "System.Uri" => typeof(Uri),
+            "System.TimeSpan" => typeof(TimeSpan),
+            "System.DateTimeOffset" => typeof(DateTimeOffset),
+            _ => typeof(string),
+        };
+    }
+}

--- a/src/Microsoft.TestPlatform.Client.Async/Microsoft.TestPlatform.Client.Async.csproj
+++ b/src/Microsoft.TestPlatform.Client.Async/Microsoft.TestPlatform.Client.Async.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <RootNamespace>Microsoft.TestPlatform.Client.Async</RootNamespace>
+    <AssemblyName>Microsoft.TestPlatform.Client.Async</AssemblyName>
+    <!-- New project - public API surface not yet finalized -->
+    <NoWarn>$(NoWarn);RS0016;RS0026;RS0037</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.TestPlatform.Client.Async.UnitTests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.TestPlatform.ObjectModel\Microsoft.TestPlatform.ObjectModel.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.TestPlatform.Client.Async/TestRunResult.cs
+++ b/src/Microsoft.TestPlatform.Client.Async/TestRunResult.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+
+namespace Microsoft.TestPlatform.Client.Async;
+
+/// <summary>
+/// Result of a test run operation.
+/// </summary>
+public class TestRunResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestRunResult"/> class.
+    /// </summary>
+    public TestRunResult(
+        IReadOnlyList<TestResult> testResults,
+        ITestRunStatistics? statistics,
+        bool isCanceled,
+        bool isAborted,
+        TimeSpan elapsedTime)
+    {
+        TestResults = testResults;
+        Statistics = statistics;
+        IsCanceled = isCanceled;
+        IsAborted = isAborted;
+        ElapsedTime = elapsedTime;
+    }
+
+    /// <summary>
+    /// The test results collected during the run.
+    /// </summary>
+    public IReadOnlyList<TestResult> TestResults { get; }
+
+    /// <summary>
+    /// Test run statistics (pass/fail/skip counts).
+    /// </summary>
+    public ITestRunStatistics? Statistics { get; }
+
+    /// <summary>
+    /// Whether the test run was canceled.
+    /// </summary>
+    public bool IsCanceled { get; }
+
+    /// <summary>
+    /// Whether the test run was aborted.
+    /// </summary>
+    public bool IsAborted { get; }
+
+    /// <summary>
+    /// Total elapsed time for the test run.
+    /// </summary>
+    public TimeSpan ElapsedTime { get; }
+}

--- a/test/Microsoft.TestPlatform.Client.Async.UnitTests/AsyncVsTestClientTests.cs
+++ b/test/Microsoft.TestPlatform.Client.Async.UnitTests/AsyncVsTestClientTests.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.TestPlatform.Client.Async.UnitTests;
+
+[TestClass]
+public class AsyncVsTestClientTests
+{
+    [TestMethod]
+    public void Constructor_CreatesInstance()
+    {
+        var client = new AsyncVsTestClient();
+        Assert.IsNotNull(client);
+    }
+
+    [TestMethod]
+    public async Task DisposeAsync_CanBeCalledMultipleTimes()
+    {
+        var client = new AsyncVsTestClient();
+        await client.DisposeAsync();
+        await client.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task StartSessionAsync_NullPath_ThrowsArgumentException()
+    {
+        var client = new AsyncVsTestClient();
+        try
+        {
+            await Assert.ThrowsExactlyAsync<ArgumentException>(
+                () => client.StartSessionAsync(null!));
+        }
+        finally
+        {
+            await client.DisposeAsync();
+        }
+    }
+
+    [TestMethod]
+    public async Task StartSessionAsync_EmptyPath_ThrowsArgumentException()
+    {
+        var client = new AsyncVsTestClient();
+        try
+        {
+            await Assert.ThrowsExactlyAsync<ArgumentException>(
+                () => client.StartSessionAsync(string.Empty));
+        }
+        finally
+        {
+            await client.DisposeAsync();
+        }
+    }
+
+    [TestMethod]
+    public async Task StartSessionAsync_WhitespacePath_ThrowsArgumentException()
+    {
+        var client = new AsyncVsTestClient();
+        try
+        {
+            await Assert.ThrowsExactlyAsync<ArgumentException>(
+                () => client.StartSessionAsync("   "));
+        }
+        finally
+        {
+            await client.DisposeAsync();
+        }
+    }
+}

--- a/test/Microsoft.TestPlatform.Client.Async.UnitTests/DiscoveryResultTests.cs
+++ b/test/Microsoft.TestPlatform.Client.Async.UnitTests/DiscoveryResultTests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.TestPlatform.Client.Async.UnitTests;
+
+[TestClass]
+public class DiscoveryResultTests
+{
+    [TestMethod]
+    public void Constructor_SetsProperties()
+    {
+        var testCases = new List<TestCase>
+        {
+            new("Test1", new Uri("executor://test"), "source.dll"),
+            new("Test2", new Uri("executor://test"), "source.dll"),
+        };
+
+        var result = new DiscoveryResult(testCases, totalCount: 5, isAborted: false);
+
+        Assert.AreEqual(2, result.TestCases.Count);
+        Assert.AreEqual(5, result.TotalCount);
+        Assert.IsFalse(result.IsAborted);
+    }
+
+    [TestMethod]
+    public void Constructor_Aborted_SetsFlag()
+    {
+        var result = new DiscoveryResult(Array.Empty<TestCase>(), totalCount: 0, isAborted: true);
+
+        Assert.IsTrue(result.IsAborted);
+        Assert.AreEqual(0, result.TestCases.Count);
+    }
+}

--- a/test/Microsoft.TestPlatform.Client.Async.UnitTests/Microsoft.TestPlatform.Client.Async.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.Client.Async.UnitTests/Microsoft.TestPlatform.Client.Async.UnitTests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TestProject>true</TestProject>
+    <IsTestProject>true</IsTestProject>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>Microsoft.TestPlatform.Client.Async.UnitTests</AssemblyName>
+    <RootNamespace>Microsoft.TestPlatform.Client.Async.UnitTests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.TestPlatform.Client.Async\Microsoft.TestPlatform.Client.Async.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Microsoft.TestPlatform.Client.Async.UnitTests/TestObjectDeserializerTests.cs
+++ b/test/Microsoft.TestPlatform.Client.Async.UnitTests/TestObjectDeserializerTests.cs
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.Json;
+
+using Microsoft.TestPlatform.Client.Async.Internal;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.TestPlatform.Client.Async.UnitTests;
+
+[TestClass]
+public class TestObjectDeserializerTests
+{
+    [TestMethod]
+    public void DeserializeTestCase_BasicProperties()
+    {
+        string json = """
+        {
+          "Properties": [
+            {
+              "Key": { "Id": "TestCase.FullyQualifiedName", "Label": "FullyQualifiedName", "Category": "", "Description": "", "Attributes": 1, "ValueType": "System.String" },
+              "Value": "MyNamespace.MyClass.TestMethod1"
+            },
+            {
+              "Key": { "Id": "TestCase.ExecutorUri", "Label": "Executor Uri", "Category": "", "Description": "", "Attributes": 1, "ValueType": "System.Uri" },
+              "Value": "executor://mstest/v2"
+            },
+            {
+              "Key": { "Id": "TestCase.Source", "Label": "Source", "Category": "", "Description": "", "Attributes": 0, "ValueType": "System.String" },
+              "Value": "C:\\tests\\MyTests.dll"
+            },
+            {
+              "Key": { "Id": "TestCase.DisplayName", "Label": "Name", "Category": "", "Description": "", "Attributes": 0, "ValueType": "System.String" },
+              "Value": "TestMethod1"
+            },
+            {
+              "Key": { "Id": "TestCase.Id", "Label": "Id", "Category": "", "Description": "", "Attributes": 1, "ValueType": "System.Guid" },
+              "Value": "11111111-1111-1111-1111-111111111111"
+            }
+          ]
+        }
+        """;
+
+        var element = JsonDocument.Parse(json).RootElement;
+        var testCase = TestObjectDeserializer.DeserializeTestCase(element);
+
+        Assert.AreEqual("MyNamespace.MyClass.TestMethod1", testCase.FullyQualifiedName);
+        Assert.AreEqual("executor://mstest/v2", testCase.ExecutorUri.OriginalString);
+        Assert.AreEqual("C:\\tests\\MyTests.dll", testCase.Source);
+        Assert.AreEqual("TestMethod1", testCase.DisplayName);
+        Assert.AreEqual(new Guid("11111111-1111-1111-1111-111111111111"), testCase.Id);
+    }
+
+    [TestMethod]
+    public void DeserializeTestCase_WithCodeFileAndLineNumber()
+    {
+        string json = """
+        {
+          "Properties": [
+            {
+              "Key": { "Id": "TestCase.FullyQualifiedName", "Label": "FullyQualifiedName", "Category": "", "Description": "", "Attributes": 1, "ValueType": "System.String" },
+              "Value": "MyNamespace.MyClass.TestMethod2"
+            },
+            {
+              "Key": { "Id": "TestCase.ExecutorUri", "Label": "Executor Uri", "Category": "", "Description": "", "Attributes": 1, "ValueType": "System.Uri" },
+              "Value": "executor://nunit"
+            },
+            {
+              "Key": { "Id": "TestCase.Source", "Label": "Source", "Category": "", "Description": "", "Attributes": 0, "ValueType": "System.String" },
+              "Value": "tests.dll"
+            },
+            {
+              "Key": { "Id": "TestCase.CodeFilePath", "Label": "File Path", "Category": "", "Description": "", "Attributes": 0, "ValueType": "System.String" },
+              "Value": "C:\\src\\Tests.cs"
+            },
+            {
+              "Key": { "Id": "TestCase.LineNumber", "Label": "Line Number", "Category": "", "Description": "", "Attributes": 1, "ValueType": "System.Int32" },
+              "Value": 42
+            }
+          ]
+        }
+        """;
+
+        var element = JsonDocument.Parse(json).RootElement;
+        var testCase = TestObjectDeserializer.DeserializeTestCase(element);
+
+        Assert.AreEqual("C:\\src\\Tests.cs", testCase.CodeFilePath);
+        Assert.AreEqual(42, testCase.LineNumber);
+    }
+
+    [TestMethod]
+    public void DeserializeTestCase_EmptyProperties_ReturnsDefaultTestCase()
+    {
+        string json = """{ "Properties": [] }""";
+
+        var element = JsonDocument.Parse(json).RootElement;
+        var testCase = TestObjectDeserializer.DeserializeTestCase(element);
+
+        // With no properties, the deserializer creates a TestCase with empty defaults.
+        Assert.IsNotNull(testCase);
+    }
+
+    [TestMethod]
+    public void DeserializeTestResult_BasicProperties()
+    {
+        string json = """
+        {
+          "TestCase": {
+            "Properties": [
+              {
+                "Key": { "Id": "TestCase.FullyQualifiedName", "Label": "FullyQualifiedName", "Category": "", "Description": "", "Attributes": 1, "ValueType": "System.String" },
+                "Value": "MyTest"
+              },
+              {
+                "Key": { "Id": "TestCase.ExecutorUri", "Label": "Executor Uri", "Category": "", "Description": "", "Attributes": 1, "ValueType": "System.Uri" },
+                "Value": "executor://mstest/v2"
+              },
+              {
+                "Key": { "Id": "TestCase.Source", "Label": "Source", "Category": "", "Description": "", "Attributes": 0, "ValueType": "System.String" },
+                "Value": "test.dll"
+              }
+            ]
+          },
+          "Properties": [
+            {
+              "Key": { "Id": "TestResult.Outcome", "Label": "Outcome", "Category": "", "Description": "", "Attributes": 0, "ValueType": "Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome" },
+              "Value": 2
+            },
+            {
+              "Key": { "Id": "TestResult.ErrorMessage", "Label": "Error Message", "Category": "", "Description": "", "Attributes": 0, "ValueType": "System.String" },
+              "Value": "Assert.AreEqual failed."
+            },
+            {
+              "Key": { "Id": "TestResult.Duration", "Label": "Duration", "Category": "", "Description": "", "Attributes": 0, "ValueType": "System.TimeSpan" },
+              "Value": "00:00:01.500"
+            }
+          ]
+        }
+        """;
+
+        var element = JsonDocument.Parse(json).RootElement;
+        var result = TestObjectDeserializer.DeserializeTestResult(element);
+
+        Assert.AreEqual("MyTest", result.TestCase.FullyQualifiedName);
+        Assert.AreEqual(TestOutcome.Failed, result.Outcome);
+        Assert.AreEqual("Assert.AreEqual failed.", result.ErrorMessage);
+        Assert.AreEqual(TimeSpan.FromSeconds(1.5), result.Duration);
+    }
+
+    [TestMethod]
+    public void DeserializeTestResult_PassedTest()
+    {
+        string json = """
+        {
+          "TestCase": {
+            "Properties": [
+              {
+                "Key": { "Id": "TestCase.FullyQualifiedName", "Label": "FullyQualifiedName", "Category": "", "Description": "", "Attributes": 1, "ValueType": "System.String" },
+                "Value": "PassingTest"
+              },
+              {
+                "Key": { "Id": "TestCase.ExecutorUri", "Label": "Executor Uri", "Category": "", "Description": "", "Attributes": 1, "ValueType": "System.Uri" },
+                "Value": "executor://mstest/v2"
+              },
+              {
+                "Key": { "Id": "TestCase.Source", "Label": "Source", "Category": "", "Description": "", "Attributes": 0, "ValueType": "System.String" },
+                "Value": "test.dll"
+              }
+            ]
+          },
+          "Properties": [
+            {
+              "Key": { "Id": "TestResult.Outcome", "Label": "Outcome", "Category": "", "Description": "", "Attributes": 0, "ValueType": "Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome" },
+              "Value": 1
+            }
+          ]
+        }
+        """;
+
+        var element = JsonDocument.Parse(json).RootElement;
+        var result = TestObjectDeserializer.DeserializeTestResult(element);
+
+        Assert.AreEqual(TestOutcome.Passed, result.Outcome);
+    }
+
+    [TestMethod]
+    public void TestCaseDto_FromTestCase_RoundTrips()
+    {
+        var original = new TestCase("Ns.Class.Method", new Uri("executor://test"), "test.dll")
+        {
+            DisplayName = "My Test",
+            CodeFilePath = "test.cs",
+            LineNumber = 10,
+        };
+
+        var dto = TestCaseDto.FromTestCase(original);
+
+        // Serialize and deserialize.
+        string json = JsonSerializer.Serialize(dto);
+        var element = JsonDocument.Parse(json).RootElement;
+        var deserialized = TestObjectDeserializer.DeserializeTestCase(element);
+
+        Assert.AreEqual(original.FullyQualifiedName, deserialized.FullyQualifiedName);
+        Assert.AreEqual(original.ExecutorUri.OriginalString, deserialized.ExecutorUri.OriginalString);
+        Assert.AreEqual(original.Source, deserialized.Source);
+        Assert.AreEqual(original.DisplayName, deserialized.DisplayName);
+        Assert.AreEqual(original.Id, deserialized.Id);
+        Assert.AreEqual(original.CodeFilePath, deserialized.CodeFilePath);
+        Assert.AreEqual(original.LineNumber, deserialized.LineNumber);
+    }
+}

--- a/test/Microsoft.TestPlatform.Client.Async.UnitTests/TestRunResultTests.cs
+++ b/test/Microsoft.TestPlatform.Client.Async.UnitTests/TestRunResultTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using ObjectModelTestResult = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult;
+
+namespace Microsoft.TestPlatform.Client.Async.UnitTests;
+
+[TestClass]
+public class TestRunResultTests
+{
+    [TestMethod]
+    public void Constructor_SetsAllProperties()
+    {
+        var testCase = new TestCase("Test1", new Uri("executor://test"), "source.dll");
+        var testResults = new List<ObjectModelTestResult>
+        {
+            new(testCase) { Outcome = TestOutcome.Passed },
+        };
+        var stats = new TestRunStatistics(1, new Dictionary<TestOutcome, long>
+        {
+            [TestOutcome.Passed] = 1,
+        });
+        var elapsed = TimeSpan.FromSeconds(2.5);
+
+        var result = new TestRunResult(testResults, stats, isCanceled: false, isAborted: false, elapsed);
+
+        Assert.AreEqual(1, result.TestResults.Count);
+        Assert.IsNotNull(result.Statistics);
+        Assert.IsFalse(result.IsCanceled);
+        Assert.IsFalse(result.IsAborted);
+        Assert.AreEqual(elapsed, result.ElapsedTime);
+    }
+
+    [TestMethod]
+    public void Constructor_CanceledRun_SetsFlags()
+    {
+        var result = new TestRunResult(
+            Array.Empty<ObjectModelTestResult>(),
+            statistics: null,
+            isCanceled: true,
+            isAborted: false,
+            TimeSpan.Zero);
+
+        Assert.IsTrue(result.IsCanceled);
+        Assert.IsFalse(result.IsAborted);
+        Assert.IsNull(result.Statistics);
+    }
+}


### PR DESCRIPTION
Initial implementation for #15570

## Summary
New async vstest client library (\Microsoft.TestPlatform.Client.Async\) designed from scratch with modern patterns.

### Key features:
- **Async APIs** — all operations return Task, no blocking
- **Reports errors from processes when they exit** — throws immediately with stderr content
- **Non-blocking async I/O** — child process output captured asynchronously
- **Multiple concurrent sessions** — no shared static state
- **System.Text.Json** — no Newtonsoft.Json dependency
- **Minimal dependencies** — only ObjectModel + System.Text.Json
- **Core operations**: StartSession, EndSession, DiscoverTests, RunTests

### Architecture:
- \AsyncVsTestClient\ — main client class implementing \IAsyncVsTestClient\
- \AsyncTestSession\ — represents a connection to vstest.console
- \AsyncRequestSender\ — length-prefixed TCP protocol communication
- \ProcessManager\ — async process lifecycle management  
- \TestObjectDeserializer\ — STJ-based property-bag deserialization for TestCase/TestResult

### New files:
\\\
src/Microsoft.TestPlatform.Client.Async/
├── Microsoft.TestPlatform.Client.Async.csproj
├── IAsyncVsTestClient.cs / IAsyncTestSession.cs
├── AsyncVsTestClient.cs / AsyncTestSession.cs
├── DiscoveryResult.cs / TestRunResult.cs
└── Internal/
    ├── AsyncRequestSender.cs
    ├── ProcessManager.cs
    ├── ProtocolConstants.cs
    └── ProtocolMessage.cs (includes TestObjectDeserializer)

test/Microsoft.TestPlatform.Client.Async.UnitTests/
├── AsyncVsTestClientTests.cs
├── DiscoveryResultTests.cs
├── TestRunResultTests.cs
└── TestObjectDeserializerTests.cs
\\\

All 15 unit tests pass.