### PR TITLE
Fix MSTEST0046: use Assert.MatchesRegex instead of StringAssert.Matches

### DIFF
--- a/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
@@ -598,8 +598,9 @@ public class HtmlLoggerTests
 
         // The filename should contain a fractional-seconds timestamp: yyyyMMdd_HHmmss.fffffff
         // e.g., TestResult_user_MACHINE_20260324_065512.1234567
-        StringAssert.Matches(fileName, new System.Text.RegularExpressions.Regex(
-            @"\d{8}_\d{6}\.\d{7}$"),
+        Assert.MatchesRegex(
+            @"\d{8}_\d{6}\.\d{7}$",
+            fileName,
             $"Filename should end with yyyyMMdd_HHmmss.fffffff pattern: {fileName}");
     }
 


### PR DESCRIPTION
Closes #15574

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>