### PR TITLE
Fix silent hang in message processing loop when deserialization fails

### DIFF
--- a/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
+++ b/src/Microsoft.TestPlatform.Client/DesignMode/DesignModeClient.cs
@@ -291,6 +291,18 @@ public class DesignModeClient : IDesignModeClient
             catch (Exception ex)
             {
                 EqtTrace.Error("DesignModeClient: Error processing request: {0}", ex);
+
+                // Notify the caller (IDE) about the error so it does not hang
+                // waiting for a response that will never come.
+                try
+                {
+                    _communicationManager.SendMessage(MessageType.ProtocolError, ex.Message);
+                }
+                catch (Exception sendEx)
+                {
+                    EqtTrace.Error("DesignModeClient: Failed to send ProtocolError to client: {0}", sendEx);
+                }
+
                 Stop();
             }
         }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
@@ -324,6 +324,32 @@ public class TestRequestHandler : ITestRequestHandler, IDeploymentAwareTestReque
 
     public void OnMessageReceived(object? sender, MessageReceivedEventArgs messageReceivedArgs)
     {
+        try
+        {
+            OnMessageReceivedCore(messageReceivedArgs);
+        }
+        catch (Exception ex)
+        {
+            EqtTrace.Error("TestRequestHandler.OnMessageReceived: Failed to process message, sending ProtocolError and closing session: {0}", ex);
+
+            // Notify the caller about the error so it does not hang
+            // waiting for a response that will never come.
+            try
+            {
+                SendData(_dataSerializer.SerializePayload(MessageType.ProtocolError, ex.Message));
+            }
+            catch (Exception sendEx)
+            {
+                EqtTrace.Error("TestRequestHandler.OnMessageReceived: Failed to send ProtocolError: {0}", sendEx);
+            }
+
+            _sessionCompleted.Set();
+            Close();
+        }
+    }
+
+    private void OnMessageReceivedCore(MessageReceivedEventArgs messageReceivedArgs)
+    {
         var message = _dataSerializer.DeserializeMessage(messageReceivedArgs.Data!);
         EqtTrace.Info("TestRequestHandler.OnMessageReceived: received message: {0}", message);
 


### PR DESCRIPTION
When message processing throws an exception (e.g. during deserialization when System.Text.Json dependencies cannot be loaded), the message loop would either silently exit or swallow the error, leaving the caller hanging indefinitely waiting for a response that never comes.

This fix updates both **DesignModeClient.ProcessRequests** (vstest.console side) and **TestRequestHandler.OnMessageReceived** (testhost side) to send a `ProtocolError` message back to the caller before stopping, so the caller gets notified of the error instead of hanging.

Closes #15577