### PR TITLE
Fix PassingNoArguments test: disable --diag to preserve help output

### DIFF
--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ArgumentProcessorTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ArgumentProcessorTests.cs
@@ -18,7 +18,8 @@ public class ArgumentProcessorTests : AcceptanceTestBase
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        InvokeVsTest(null);
+        // Don't add --diag, it changes the output and prevents help from showing.
+        InvokeVsTest(null, collectDiagnostics: false);
 
         //Check for help usage, description and arguments text.
         StdOutputContains("Usage: vstest.console.exe");


### PR DESCRIPTION
#15572 added automatic \--diag\ to \InvokeVsTest\ (default \	rue\). The \PassingNoArgumentsToVsTestConsoleShouldPrintHelpMessage\ test passes no arguments to vstest.console and checks for help text, but \--diag\ changes the output and truncates the help message.

Fix: pass \collectDiagnostics: false\ to preserve the expected output.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>