### PR TITLE
Skip VideoRecorder test on CI due to access denied errors

### DIFF
--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/VideoRecorderTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/VideoRecorderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 using System.Linq;
 
@@ -17,6 +18,12 @@ public class VideoRecorderTests : AcceptanceTestBase
     [NetFullTargetFrameworkDataSource(useCoreRunner: false, useVsixRunner: true)]
     public void VideoRecorderDataCollectorShouldRecordVideoWithRunSettings(RunnerInfo runnerInfo)
     {
+        // Workaround for #15586 — video recording fails with access denied on the official CI pipeline.
+        if (Environment.GetEnvironmentVariable("_RunAsInternal") == "True")
+        {
+            Assert.Inconclusive("Video recorder test is skipped on the official pipeline due to access denied errors. See #15586.");
+        }
+
         SetTestEnvironment(_testEnvironment, runnerInfo);
         var assemblyPaths = GetAssetFullPath("SimpleTestProject.dll");
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, FrameworkArgValue,


### PR DESCRIPTION
Workaround for #15586 — video recording test fails with access denied on the official CI pipeline. Skips with \Assert.Inconclusive\ when \TF_BUILD\ is set, matching the existing pattern from \BlameDataCollectorTests\.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>