### PR TITLE
Reduce blame test flakiness: increase hang dump timeout to 10s

### DIFF
--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
@@ -133,7 +133,8 @@ public class BlameDataCollectorTests : AcceptanceTestBase
         var assemblyPaths = GetAssetFullPath("timeout.dll");
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, string.Empty, runnerInfo.InIsolationValue);
         arguments = string.Concat(arguments, $" /ResultsDirectory:{TempDirectory.Path}");
-        arguments = string.Concat(arguments, $@" /Blame:""CollectHangDump;HangDumpType=mini;TestTimeout=3s"" /Diag:{TempDirectory.Path}/log.txt");
+        // Don't reduce this, 10s is about the safe minimum to not have flakiness.
+        arguments = string.Concat(arguments, $@" /Blame:""CollectHangDump;HangDumpType=mini;TestTimeout=10s"" /Diag:{TempDirectory.Path}/log.txt");
 
         var env = new Dictionary<string, string?>
         {
@@ -231,7 +232,8 @@ public class BlameDataCollectorTests : AcceptanceTestBase
         var assemblyPaths = GetAssetFullPath("child-hang.dll");
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, string.Empty, runnerInfo.InIsolationValue);
         arguments = string.Concat(arguments, $" /ResultsDirectory:{TempDirectory.Path}");
-        arguments = string.Concat(arguments, $@" /Blame:""CollectHangDump;HangDumpType=mini;TestTimeout=5s""");
+        // Don't reduce this, 10s is about the safe minimum to not have flakiness.
+        arguments = string.Concat(arguments, $@" /Blame:""CollectHangDump;HangDumpType=mini;TestTimeout=10s""");
         InvokeVsTest(arguments);
 
         ValidateDump(2);


### PR DESCRIPTION
## Problem

\HangDumpOnTimeout\ (3s timeout) and \HangDumpChildProcesses\ (5s timeout) are flaky in CI because process startup can be slow on hosted agents. \HangDumpChildProcesses\ is currently failing across **6 open PRs**.

## Fix

Increase both timeouts to 10s — the safe minimum to avoid flakiness without making tests unnecessarily slow.

## Failing PRs this unblocks

- #15565, #15573, #15578, #15581, #15583 (all have \HangDumpChildProcesses\ failure)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>