### PR TITLE
Update post-build template parameters

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -361,9 +361,3 @@ extends:
             LclPackageId: 'LCL-JUNO-PROD-VSTEST'
 
     - template: eng\common\templates-official\post-build\post-build.yml@self
-      parameters:
-        publishingInfraVersion: 3
-        SDLValidationParameters:
-          enable: false
-          continueOnError: false
-          params: ' -SourceToolsList @("policheck","credscan")'


### PR DESCRIPTION
Removed SDL validation parameters from post-build template. Testfx does not have them either and vstest main fails on those parameters being unexpected. If we need this for some report, compliance will tag us.

## Description

Please add a meaningful description for this change.
Ensure the PR has required unit tests.

## Related issue

Kindly link any related issues. E.g. Fixes #xyz.

- [ ] I have ensured that there is a previously discussed and approved issue.
