### PR TITLE
Add azure-pipelines-official.yml to pipeline files

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,7 @@ pr:
       - CONTRIBUTING.md
       - README.md
       - SECURITY.md
+      - azure-pipelines-official.yml
 
 variables:
   # Cannot use key:value syntax in root defined variables


### PR DESCRIPTION
Skip build when we edit only the internal pipeline, it has no effect on public build and avoids force merging or other annoying workflows
