### PR TITLE
Track when vstest provides Newtonsoft.Json for extensions in telemetry

### DIFF
--- a/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
+++ b/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
@@ -441,13 +441,36 @@ public class TestRunRequest : ITestRunRequest, IInternalTestRunEventsHandler
                 // Fill in the time taken to complete the run
                 _requestData.MetricsCollection.Add(TelemetryDataConstants.TimeTakenInSecForRun, executionTotalTimeTaken.TotalSeconds);
 
-                // Record assemblies that vstest provided from its own directory
-                var providedDeps = AssemblyResolver.GetProvidedDependencies();
-                foreach (var dep in providedDeps)
+                // Record assemblies that vstest provided from its search directories.
+                // Telemetry gets 2 properties: assemblies resolved for user code (count only,
+                // no user assembly names), and assemblies resolved for Microsoft/System code (names ok).
+                var (userAssemblies, userCount, msAssemblies, msCount) = AssemblyResolver.GetProvidedDependencySummary();
+                if (userCount > 0)
                 {
-                    _requestData.MetricsCollection.Add(
-                        $"{TelemetryDataConstants.ProvidedAssemblyDependency}.{dep.Key}",
-                        dep.Value);
+                    _requestData.MetricsCollection.Add(TelemetryDataConstants.ProvidedDependenciesForUser, userAssemblies);
+                    _requestData.MetricsCollection.Add(TelemetryDataConstants.ProvidedDependenciesForUserCount, userCount);
+                }
+                if (msCount > 0)
+                {
+                    _requestData.MetricsCollection.Add(TelemetryDataConstants.ProvidedDependenciesForMicrosoft, msAssemblies);
+                    _requestData.MetricsCollection.Add(TelemetryDataConstants.ProvidedDependenciesForMicrosoftCount, msCount);
+                }
+
+                // Opt-in warning: show all provided assemblies in summary when feature flag is set.
+                if ((userCount > 0 || msCount > 0) && FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_OPTIN_WARN_MISSING_EXTENSIONS_DEPENDENCIES))
+                {
+                    var allAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var kvp in AssemblyResolver.GetProvidedDependencies())
+                    {
+                        allAssemblies.Add(kvp.Key);
+                    }
+
+                    var message = $"The test platform provided the following assemblies to resolve dependencies of test extensions "
+                        + $"that did not ship their own copy: {string.Join(", ", allAssemblies)}. "
+                        + "Test extensions should ship all their dependencies.";
+
+                    LoggerManager.HandleTestRunMessage(
+                        new TestRunMessageEventArgs(TestMessageLevel.Warning, message));
                 }
 
                 // Fill in the Metrics From Test Host Process

--- a/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
+++ b/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.TestPlatform.Common;
 using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
 using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework.Utilities;
 using Microsoft.VisualStudio.TestPlatform.Common.Telemetry;
+using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
@@ -439,6 +440,15 @@ public class TestRunRequest : ITestRunRequest, IInternalTestRunEventsHandler
 
                 // Fill in the time taken to complete the run
                 _requestData.MetricsCollection.Add(TelemetryDataConstants.TimeTakenInSecForRun, executionTotalTimeTaken.TotalSeconds);
+
+                // Record assemblies that vstest provided from its own directory
+                var providedDeps = AssemblyResolver.GetProvidedDependencies();
+                foreach (var dep in providedDeps)
+                {
+                    _requestData.MetricsCollection.Add(
+                        $"{TelemetryDataConstants.ProvidedAssemblyDependency}.{dep.Key}",
+                        dep.Value);
+                }
 
                 // Fill in the Metrics From Test Host Process
                 var metrics = runCompleteArgs.Metrics;

--- a/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
+++ b/src/Microsoft.TestPlatform.Client/Execution/TestRunRequest.cs
@@ -457,7 +457,10 @@ public class TestRunRequest : ITestRunRequest, IInternalTestRunEventsHandler
                 }
 
                 // Opt-in warning: show all provided assemblies in summary when feature flag is set.
-                if ((userCount > 0 || msCount > 0) && FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_OPTIN_WARN_MISSING_EXTENSIONS_DEPENDENCIES))
+                // Disable flag takes precedence over opt-in.
+                if ((userCount > 0 || msCount > 0)
+                    && !FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_DISABLE_WARN_MISSING_EXTENSIONS_DEPENDENCIES)
+                    && FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_OPTIN_WARN_MISSING_EXTENSIONS_DEPENDENCIES))
                 {
                     var allAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                     foreach (var kvp in AssemblyResolver.GetProvidedDependencies())
@@ -465,9 +468,10 @@ public class TestRunRequest : ITestRunRequest, IInternalTestRunEventsHandler
                         allAssemblies.Add(kvp.Key);
                     }
 
-                    var message = $"The test platform provided the following assemblies to resolve dependencies of test extensions "
-                        + $"that did not ship their own copy: {string.Join(", ", allAssemblies)}. "
-                        + "Test extensions should ship all their dependencies.";
+                    var message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        ClientResources.ProvidedDependenciesWarning,
+                        string.Join(", ", allAssemblies));
 
                     LoggerManager.HandleTestRunMessage(
                         new TestRunMessageEventArgs(TestMessageLevel.Warning, message));

--- a/src/Microsoft.TestPlatform.Client/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.Client/Resources/Resources.Designer.cs
@@ -99,5 +99,16 @@ namespace Microsoft.VisualStudio.TestPlatform.Client.Resources {
                 return ResourceManager.GetString("NoTestHostProviderFound", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies..
+        /// </summary>
+        internal static string ProvidedDependenciesWarning
+        {
+            get
+            {
+                return ResourceManager.GetString("ProvidedDependenciesWarning", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Microsoft.TestPlatform.Client/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.Client/Resources/Resources.resx
@@ -129,4 +129,7 @@
   <data name="WaitForCompletionOperationIsNotAllowedWhenNoTestRunIsActive" xml:space="preserve">
     <value>Wait for completion operation is not allowed when there is no active test run. </value>
   </data>
+  <data name="ProvidedDependenciesWarning" xml:space="preserve">
+    <value>The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</value>
+  </data>
 </root>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Testovací běh nešlo spustit, protože byl neplatný počáteční stav.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvidedDependenciesWarning">
+        <source>The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</source>
+        <target state="new">The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WaitForCompletionOperationIsNotAllowedWhenNoTestRunIsActive">
         <source>Wait for completion operation is not allowed when there is no active test run. </source>
         <target state="translated">V případě, že nejsou aktivní žádné testovací běhy, se operace čekání na dokončení nepovoluje. </target>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Der Testlauf konnte nicht ausgeführt werden, weil der Anfangszustand ungültig war.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvidedDependenciesWarning">
+        <source>The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</source>
+        <target state="new">The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WaitForCompletionOperationIsNotAllowedWhenNoTestRunIsActive">
         <source>Wait for completion operation is not allowed when there is no active test run. </source>
         <target state="translated">Das Warten auf den Fertigstellungsvorgang ist unzulässig, wenn kein aktiver Testlauf vorhanden ist. </target>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">No se pudo ejecutar la serie de pruebas porque el estado inicial no era válido.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvidedDependenciesWarning">
+        <source>The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</source>
+        <target state="new">The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WaitForCompletionOperationIsNotAllowedWhenNoTestRunIsActive">
         <source>Wait for completion operation is not allowed when there is no active test run. </source>
         <target state="translated">La operación “Esperar que termine” no se permite cuando no hay ninguna serie de pruebas activa. </target>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Impossible d'exécuter la série de tests, car l'état initial est non valide.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvidedDependenciesWarning">
+        <source>The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</source>
+        <target state="new">The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WaitForCompletionOperationIsNotAllowedWhenNoTestRunIsActive">
         <source>Wait for completion operation is not allowed when there is no active test run. </source>
         <target state="translated">L'attente de la fin de l'exécution d'une opération n'est pas autorisée quand il n'existe aucune série de tests active. </target>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Non è stato possibile completare l'esecuzione dei test perché lo stato iniziale non era valido.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvidedDependenciesWarning">
+        <source>The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</source>
+        <target state="new">The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WaitForCompletionOperationIsNotAllowedWhenNoTestRunIsActive">
         <source>Wait for completion operation is not allowed when there is no active test run. </source>
         <target state="translated">L'operazione di attesa completamento non è consentita se non sono presenti esecuzioni dei test attive. </target>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">初期状態が無効なため、テストの実行を実行できませんでした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvidedDependenciesWarning">
+        <source>The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</source>
+        <target state="new">The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WaitForCompletionOperationIsNotAllowedWhenNoTestRunIsActive">
         <source>Wait for completion operation is not allowed when there is no active test run. </source>
         <target state="translated">アクティブなテストの実行がない場合、完了の待機操作は許可されません。</target>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">초기 상태가 잘못되어 테스트 실행을 실행할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvidedDependenciesWarning">
+        <source>The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</source>
+        <target state="new">The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WaitForCompletionOperationIsNotAllowedWhenNoTestRunIsActive">
         <source>Wait for completion operation is not allowed when there is no active test run. </source>
         <target state="translated">활성 테스트 실행이 없으면 완료 작업을 대기할 수 없습니다. </target>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nie można wykonać przebiegu testu, ponieważ stan początkowy jest nieprawidłowy.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvidedDependenciesWarning">
+        <source>The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</source>
+        <target state="new">The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WaitForCompletionOperationIsNotAllowedWhenNoTestRunIsActive">
         <source>Wait for completion operation is not allowed when there is no active test run. </source>
         <target state="translated">Oczekiwanie na operację zakończenia nie jest dozwolone, gdy nie ma aktywnego przebiegu testu. </target>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">A execução de teste não pôde ser realizada porque o estado inicial era inválido.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvidedDependenciesWarning">
+        <source>The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</source>
+        <target state="new">The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WaitForCompletionOperationIsNotAllowedWhenNoTestRunIsActive">
         <source>Wait for completion operation is not allowed when there is no active test run. </source>
         <target state="translated">A operação esperar conclusão não é permitida quando não há nenhuma execução de teste ativa. </target>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Не удалось выполнить тестовый запуск из-за недопустимого начального состояния.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvidedDependenciesWarning">
+        <source>The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</source>
+        <target state="new">The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WaitForCompletionOperationIsNotAllowedWhenNoTestRunIsActive">
         <source>Wait for completion operation is not allowed when there is no active test run. </source>
         <target state="translated">Операция "Ожидать завершения" запрещена, если нет активного тестового запуска.</target>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">İlk durum geçersiz olduğundan test çalıştırması yürütülemedi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvidedDependenciesWarning">
+        <source>The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</source>
+        <target state="new">The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WaitForCompletionOperationIsNotAllowedWhenNoTestRunIsActive">
         <source>Wait for completion operation is not allowed when there is no active test run. </source>
         <target state="translated">Etkin bir test çalıştırması olmadığında tamamlanmasını bekleme işlemine izin verilmez. </target>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">由于初始状态无效，无法执行测试运行。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvidedDependenciesWarning">
+        <source>The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</source>
+        <target state="new">The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WaitForCompletionOperationIsNotAllowedWhenNoTestRunIsActive">
         <source>Wait for completion operation is not allowed when there is no active test run. </source>
         <target state="translated">没有活动的测试运行时不允许等待完成操作。</target>

--- a/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.Client/Resources/xlf/Resources.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">因為初始狀態無效，所以無法執行測試回合。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvidedDependenciesWarning">
+        <source>The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</source>
+        <target state="new">The test platform provided the following assemblies to resolve dependencies of test extensions that did not ship their own copy: {0}. Test extensions should ship all their dependencies.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WaitForCompletionOperationIsNotAllowedWhenNoTestRunIsActive">
         <source>Wait for completion operation is not allowed when there is no active test run. </source>
         <target state="translated">沒有使用中的測試回合時，不允許等候完成作業。</target>

--- a/src/Microsoft.TestPlatform.Common/Telemetry/TelemetryDataConstants.cs
+++ b/src/Microsoft.TestPlatform.Common/Telemetry/TelemetryDataConstants.cs
@@ -11,6 +11,10 @@ internal static class TelemetryDataConstants
     // ******************** General ***********************
     public static readonly string DiscoveredExtensions = "VS.TestPlatform.DiscoveredExtensions";
 
+    // Tracks assemblies that vstest provided from its own directory to resolve
+    // extension dependencies. Value is the requesting assembly name.
+    public static readonly string ProvidedAssemblyDependency = "VS.TestPlatform.ProvidedAssemblyDependency";
+
     // ******************** Execution ***********************
     public static readonly string ParallelEnabledDuringExecution = "VS.TestRun.ParallelEnabled";
 

--- a/src/Microsoft.TestPlatform.Common/Telemetry/TelemetryDataConstants.cs
+++ b/src/Microsoft.TestPlatform.Common/Telemetry/TelemetryDataConstants.cs
@@ -11,9 +11,12 @@ internal static class TelemetryDataConstants
     // ******************** General ***********************
     public static readonly string DiscoveredExtensions = "VS.TestPlatform.DiscoveredExtensions";
 
-    // Tracks assemblies that vstest provided from its own directory to resolve
-    // extension dependencies. Value is the requesting assembly name.
-    public static readonly string ProvidedAssemblyDependency = "VS.TestPlatform.ProvidedAssemblyDependency";
+    // Tracks assemblies that vstest provided from its search directories to resolve
+    // extension dependencies. Separated by requester type for privacy.
+    public static readonly string ProvidedDependenciesForUser = "VS.TestPlatform.ProvidedDeps.User";
+    public static readonly string ProvidedDependenciesForUserCount = "VS.TestPlatform.ProvidedDeps.User.Count";
+    public static readonly string ProvidedDependenciesForMicrosoft = "VS.TestPlatform.ProvidedDeps.Microsoft";
+    public static readonly string ProvidedDependenciesForMicrosoftCount = "VS.TestPlatform.ProvidedDeps.Microsoft.Count";
 
     // ******************** Execution ***********************
     public static readonly string ParallelEnabledDuringExecution = "VS.TestRun.ParallelEnabled";

--- a/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs
@@ -9,12 +9,9 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 
-using Microsoft.VisualStudio.TestPlatform.Common.Logging;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-using Microsoft.VisualStudio.TestPlatform.Utilities;
 
 namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities;
 
@@ -47,33 +44,52 @@ internal class AssemblyResolver : IDisposable
     private static readonly string[] SupportedFileExtensions = [".dll", ".exe"];
 
     /// <summary>
-    /// Assemblies that vstest resolved from its own directory on behalf of an extension
-    /// that did not ship its own copy. Key: assembly name, Value: requesting assembly name.
+    /// Tracks all assemblies that vstest resolved from its own search directories on behalf of
+    /// external code. Each entry: assembly name → list of requesting assembly names.
     /// </summary>
-    private static readonly ConcurrentDictionary<string, string> ProvidedDependencies = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly ConcurrentDictionary<string, ConcurrentBag<string>> ProvidedDependencies = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// Known assemblies that extensions should ship themselves.
-    /// When vstest resolves these from its own directory for an external requester,
-    /// we track it in telemetry and optionally warn the user.
+    /// Gets the assemblies that vstest provided from its search directories to resolve
+    /// dependencies of other assemblies.
     /// </summary>
-    private static readonly HashSet<string> TrackedAssemblies = new(StringComparer.OrdinalIgnoreCase)
+    internal static IReadOnlyDictionary<string, ConcurrentBag<string>> GetProvidedDependencies() => ProvidedDependencies;
+
+    /// <summary>
+    /// Builds telemetry-safe summary of provided dependencies.
+    /// Splits into user-requested (count only) and Microsoft/System-requested (names).
+    /// </summary>
+    internal static (string assembliesForUser, int userRequestCount, string assembliesForMicrosoft, int microsoftRequestCount) GetProvidedDependencySummary()
     {
-        "Newtonsoft.Json",
-    };
+        var userAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        int userCount = 0;
+        var msAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        int msCount = 0;
 
-    /// <summary>
-    /// The directory where vstest's own assemblies live.
-    /// </summary>
-    private static readonly string TestPlatformDirectory =
-        Path.GetDirectoryName(typeof(AssemblyResolver).Assembly.GetAssemblyLocation()) ?? string.Empty;
+        foreach (var kvp in ProvidedDependencies)
+        {
+            foreach (var requester in kvp.Value)
+            {
+                if (requester.StartsWith("Microsoft.", StringComparison.OrdinalIgnoreCase)
+                    || requester.StartsWith("System.", StringComparison.OrdinalIgnoreCase))
+                {
+                    msAssemblies.Add(kvp.Key);
+                    msCount++;
+                }
+                else
+                {
+                    userAssemblies.Add(kvp.Key);
+                    userCount++;
+                }
+            }
+        }
 
-    /// <summary>
-    /// Gets the assemblies that vstest provided from its own directory to resolve
-    /// dependencies of extensions that did not ship their own copy.
-    /// Key: assembly name, Value: requesting assembly name.
-    /// </summary>
-    internal static IReadOnlyDictionary<string, string> GetProvidedDependencies() => ProvidedDependencies;
+        return (
+            string.Join("|", userAssemblies),
+            userCount,
+            string.Join("|", msAssemblies),
+            msCount);
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AssemblyResolver"/> class.
@@ -252,54 +268,29 @@ internal class AssemblyResolver : IDisposable
     }
 
     /// <summary>
-    /// When we resolve a tracked assembly (e.g. Newtonsoft.Json) from vstest's own directory
-    /// for an external requester, record it for telemetry and optionally warn the user.
+    /// When we resolve an assembly from vstest's search directories for an external requester,
+    /// record it so telemetry can report which dependencies vstest is providing.
     /// </summary>
-    private static void TrackProvidedDependency(AssemblyName requestedName, string resolvedPath, Assembly? requestingAssembly)
+    private void TrackProvidedDependency(AssemblyName requestedName, string resolvedPath, Assembly? requestingAssembly)
     {
-        if (requestedName.Name is null || !TrackedAssemblies.Contains(requestedName.Name))
+        if (requestedName.Name is null)
         {
             return;
         }
 
-        // Check if we resolved from vstest's own directory (not the extension's directory).
+        // Only track if we resolved from one of OUR search directories.
         var resolvedDir = Path.GetDirectoryName(resolvedPath);
-        if (resolvedDir is null || !resolvedDir.Equals(TestPlatformDirectory, StringComparison.OrdinalIgnoreCase))
+        if (resolvedDir is null || !_searchDirectories.Contains(resolvedDir))
         {
             return;
         }
 
         var requester = requestingAssembly?.GetName().Name ?? "unknown";
+        var bag = ProvidedDependencies.GetOrAdd(requestedName.Name, _ => new ConcurrentBag<string>());
+        bag.Add(requester);
 
-        // Don't track vstest's own assemblies requesting Newtonsoft.Json — that's expected.
-        if (requester.StartsWith("Microsoft.VisualStudio.TestPlatform", StringComparison.OrdinalIgnoreCase)
-            || requester.StartsWith("Microsoft.TestPlatform", StringComparison.OrdinalIgnoreCase))
-        {
-            return;
-        }
-
-        if (!ProvidedDependencies.TryAdd(requestedName.Name, requester))
-        {
-            return;
-        }
-
-        EqtTrace.Info("AssemblyResolver.TrackProvidedDependency: Resolved '{0}' from vstest directory for '{1}'. " +
-            "The extension should ship its own copy.", requestedName.Name, requester);
-
-        // When the feature flag is set, warn the user so they can fix their extension.
-        if (FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_WARN_MISSING_EXTENSIONS_DEPENDENCIES))
-        {
-            var message = $"Assembly '{requestedName.Name}' was resolved from the test platform directory for '{requester}'. "
-                + $"Test extensions should ship their own copy of '{requestedName.Name}'.";
-            try
-            {
-                TestSessionMessageLogger.Instance.SendMessage(TestMessageLevel.Warning, message);
-            }
-            catch
-            {
-                // TestSessionMessageLogger may not be initialized in all contexts.
-            }
-        }
+        EqtTrace.Info("AssemblyResolver.TrackProvidedDependency: Resolved '{0}' from '{1}' for '{2}'.",
+            requestedName.Name, resolvedDir, requester);
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs
@@ -2,15 +2,19 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 
+using Microsoft.VisualStudio.TestPlatform.Common.Logging;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
+using Microsoft.VisualStudio.TestPlatform.Utilities;
 
 namespace Microsoft.VisualStudio.TestPlatform.Common.Utilities;
 
@@ -41,6 +45,35 @@ internal class AssemblyResolver : IDisposable
     private readonly IAssemblyLoadContext _platformAssemblyLoadContext;
 
     private static readonly string[] SupportedFileExtensions = [".dll", ".exe"];
+
+    /// <summary>
+    /// Assemblies that vstest resolved from its own directory on behalf of an extension
+    /// that did not ship its own copy. Key: assembly name, Value: requesting assembly name.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, string> ProvidedDependencies = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Known assemblies that extensions should ship themselves.
+    /// When vstest resolves these from its own directory for an external requester,
+    /// we track it in telemetry and optionally warn the user.
+    /// </summary>
+    private static readonly HashSet<string> TrackedAssemblies = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Newtonsoft.Json",
+    };
+
+    /// <summary>
+    /// The directory where vstest's own assemblies live.
+    /// </summary>
+    private static readonly string TestPlatformDirectory =
+        Path.GetDirectoryName(typeof(AssemblyResolver).Assembly.GetAssemblyLocation()) ?? string.Empty;
+
+    /// <summary>
+    /// Gets the assemblies that vstest provided from its own directory to resolve
+    /// dependencies of extensions that did not ship their own copy.
+    /// Key: assembly name, Value: requesting assembly name.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, string> GetProvidedDependencies() => ProvidedDependencies;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AssemblyResolver"/> class.
@@ -179,6 +212,8 @@ internal class AssemblyResolver : IDisposable
                             assembly = _platformAssemblyLoadContext.LoadAssemblyFromPath(assemblyPath);
                             _resolvedAssemblies[args.Name] = assembly;
 
+                            TrackProvidedDependency(requestedName, assemblyPath, args.RequestingAssembly);
+
                             EqtTrace.Info("AssemblyResolver.OnResolve: Resolved assembly: {0}, from path: {1}", args.Name, assemblyPath);
 
                             return assembly;
@@ -213,6 +248,57 @@ internal class AssemblyResolver : IDisposable
 
             _resolvedAssemblies[args.Name] = null;
             return null;
+        }
+    }
+
+    /// <summary>
+    /// When we resolve a tracked assembly (e.g. Newtonsoft.Json) from vstest's own directory
+    /// for an external requester, record it for telemetry and optionally warn the user.
+    /// </summary>
+    private static void TrackProvidedDependency(AssemblyName requestedName, string resolvedPath, Assembly? requestingAssembly)
+    {
+        if (requestedName.Name is null || !TrackedAssemblies.Contains(requestedName.Name))
+        {
+            return;
+        }
+
+        // Check if we resolved from vstest's own directory (not the extension's directory).
+        var resolvedDir = Path.GetDirectoryName(resolvedPath);
+        if (resolvedDir is null || !resolvedDir.Equals(TestPlatformDirectory, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var requester = requestingAssembly?.GetName().Name ?? "unknown";
+
+        // Don't track vstest's own assemblies requesting Newtonsoft.Json — that's expected.
+        if (requester.StartsWith("Microsoft.VisualStudio.TestPlatform", StringComparison.OrdinalIgnoreCase)
+            || requester.StartsWith("Microsoft.TestPlatform", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        if (!ProvidedDependencies.TryAdd(requestedName.Name, requester))
+        {
+            return;
+        }
+
+        EqtTrace.Info("AssemblyResolver.TrackProvidedDependency: Resolved '{0}' from vstest directory for '{1}'. " +
+            "The extension should ship its own copy.", requestedName.Name, requester);
+
+        // When the feature flag is set, warn the user so they can fix their extension.
+        if (FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_WARN_MISSING_EXTENSIONS_DEPENDENCIES))
+        {
+            var message = $"Assembly '{requestedName.Name}' was resolved from the test platform directory for '{requester}'. "
+                + $"Test extensions should ship their own copy of '{requestedName.Name}'.";
+            try
+            {
+                TestSessionMessageLogger.Instance.SendMessage(TestMessageLevel.Warning, message);
+            }
+            catch
+            {
+                // TestSessionMessageLogger may not be initialized in all contexts.
+            }
         }
     }
 

--- a/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
@@ -80,8 +80,8 @@ internal partial class FeatureFlag : IFeatureFlag
 
     // When set, warns when vstest provides its own copy of a tracked assembly (e.g. Newtonsoft.Json)
     // to resolve a dependency of an extension that did not ship its own copy.
-    // Set VSTEST_WARN_MISSING_EXTENSIONS_DEPENDENCIES=1 to opt into warnings before enforcement.
-    public const string VSTEST_WARN_MISSING_EXTENSIONS_DEPENDENCIES = nameof(VSTEST_WARN_MISSING_EXTENSIONS_DEPENDENCIES);
+    // Set VSTEST_OPTIN_WARN_MISSING_EXTENSIONS_DEPENDENCIES=1 to opt into warnings before enforcement.
+    public const string VSTEST_OPTIN_WARN_MISSING_EXTENSIONS_DEPENDENCIES = nameof(VSTEST_OPTIN_WARN_MISSING_EXTENSIONS_DEPENDENCIES);
 
 
 

--- a/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
@@ -78,6 +78,11 @@ internal partial class FeatureFlag : IFeatureFlag
     // Disable turning dynamic code coverage for native code to OFF by default. Setting this to 1 will skip adding the setting.
     public const string VSTEST_DISABLE_DYNAMICNATIVE_CODECOVERAGE_DEFAULT_SETTING = nameof(VSTEST_DISABLE_DYNAMICNATIVE_CODECOVERAGE_DEFAULT_SETTING);
 
+    // When set, warns when vstest provides its own copy of a tracked assembly (e.g. Newtonsoft.Json)
+    // to resolve a dependency of an extension that did not ship its own copy.
+    // Set VSTEST_WARN_MISSING_EXTENSIONS_DEPENDENCIES=1 to opt into warnings before enforcement.
+    public const string VSTEST_WARN_MISSING_EXTENSIONS_DEPENDENCIES = nameof(VSTEST_WARN_MISSING_EXTENSIONS_DEPENDENCIES);
+
 
 
     [Obsolete("Only use this in tests.")]

--- a/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/FeatureFlag/FeatureFlag.cs
@@ -83,6 +83,9 @@ internal partial class FeatureFlag : IFeatureFlag
     // Set VSTEST_OPTIN_WARN_MISSING_EXTENSIONS_DEPENDENCIES=1 to opt into warnings before enforcement.
     public const string VSTEST_OPTIN_WARN_MISSING_EXTENSIONS_DEPENDENCIES = nameof(VSTEST_OPTIN_WARN_MISSING_EXTENSIONS_DEPENDENCIES);
 
+    // Disables the warning about missing extension dependencies, even after enforcement.
+    public const string VSTEST_DISABLE_WARN_MISSING_EXTENSIONS_DEPENDENCIES = nameof(VSTEST_DISABLE_WARN_MISSING_EXTENSIONS_DEPENDENCIES);
+
 
 
     [Obsolete("Only use this in tests.")]

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/Runtime/IAssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/Runtime/IAssemblyResolver.cs
@@ -46,4 +46,9 @@ public class AssemblyResolveEventArgs : EventArgs
     /// Gets or sets the name of the item to resolve.
     /// </summary>
     public string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the assembly that requested the resolution, if available.
+    /// </summary>
+    public Assembly? RequestingAssembly { get; set; }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces.AssemblyResolveEventArgs.RequestingAssembly.get -> System.Reflection.Assembly?
+Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces.AssemblyResolveEventArgs.RequestingAssembly.set -> void

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net462/Runtime/PlatformAssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net462/Runtime/PlatformAssemblyResolver.cs
@@ -69,7 +69,7 @@ public class PlatformAssemblyResolver : IAssemblyResolver
     /// </returns>
     private Assembly? AssemblyResolverEvent(object sender, object eventArgs)
     {
-        return eventArgs is not ResolveEventArgs args ? null : AssemblyResolve?.Invoke(this, new AssemblyResolveEventArgs(args.Name));
+        return eventArgs is not ResolveEventArgs args ? null : AssemblyResolve?.Invoke(this, new AssemblyResolveEventArgs(args.Name) { RequestingAssembly = args.RequestingAssembly });
     }
 }
 

--- a/test/Microsoft.TestPlatform.Common.UnitTests/RunSettingsManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/RunSettingsManagerTests.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace TestPlatform.Common.UnitTests;
 
 [TestClass]
+[DoNotParallelize]
 public class RunSettingsManagerTests
 {
     [TestCleanup]

--- a/test/TestAssets/NewtonSoftDependencyMissing/NewtonSoftDependencyMissing.csproj
+++ b/test/TestAssets/NewtonSoftDependencyMissing/NewtonSoftDependencyMissing.csproj
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TestProject>true</TestProject>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AssemblyName>NewtonSoftDependencyMissing</AssemblyName>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks)</TargetFrameworks>
+    <OutputType Condition="$(NetCoreAppTargetFramework) == 'true' ">Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestTestAdapterVersion)" />
+    <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestAdapterVersion)" />
+    <!-- Reference Newtonsoft.Json but exclude from output — simulates an extension
+         that depends on Newtonsoft.Json but does not ship its own copy.
+         At runtime, vstest's own copy will be used to resolve this dependency. -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/test/TestAssets/NewtonSoftDependencyMissing/UnitTest1.cs
+++ b/test/TestAssets/NewtonSoftDependencyMissing/UnitTest1.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Newtonsoft.Json;
+
+namespace NewtonSoftDependencyMissing;
+
+public class Account
+{
+    public string Email { get; set; }
+    public bool Active { get; set; }
+}
+
+[TestClass]
+public class UnitTest1
+{
+    [TestMethod]
+    public void TestUsingNewtonsoftWithoutShippingDll()
+    {
+        // This test uses Newtonsoft.Json but the project excludes the runtime asset.
+        // At runtime, Newtonsoft.Json.dll is NOT present next to this assembly,
+        // so vstest's own copy is used. This should be tracked in telemetry.
+        string json = @"{""Email"": ""john@example.com"", ""Active"": true}";
+
+        Account account = JsonConvert.DeserializeObject<Account>(json);
+
+        Assert.IsNotNull(account);
+        Assert.AreEqual("john@example.com", account.Email);
+    }
+}

--- a/test/vstest.console.UnitTests/ExecutorUnitTests.cs
+++ b/test/vstest.console.UnitTests/ExecutorUnitTests.cs
@@ -24,6 +24,8 @@ using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Res
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests;
 
 [TestClass]
+// Because runsettings tests use the instance of RunSettingsManager which is static.
+[DoNotParallelize]
 public class ExecutorUnitTests
 {
     private readonly Mock<ITestPlatformEventSource> _mockTestPlatformEventSource;

--- a/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
@@ -13,6 +13,8 @@ using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Res
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 
 [TestClass]
+// Because runsettings tests use the instance of RunSettingsManager which is static.
+[DoNotParallelize]
 public class EnableLoggersArgumentProcessorTests
 {
     [TestInitialize]

--- a/test/vstest.console.UnitTests/Processors/TestAdapterLoadingStrategyArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestAdapterLoadingStrategyArgumentProcessorTests.cs
@@ -18,6 +18,8 @@ using Moq;
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 
 [TestClass]
+// Because runsettings tests use the instance of RunSettingsManager which is static.
+[DoNotParallelize]
 public class TestAdapterLoadingStrategyArgumentProcessorTests
 {
     private readonly RunSettings _currentActiveSetting;

--- a/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
@@ -20,6 +20,8 @@ using Moq;
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 
 [TestClass]
+// Because runsettings tests use the instance of RunSettingsManager which is static.
+[DoNotParallelize]
 public class TestAdapterPathArgumentProcessorTests
 {
     private readonly RunSettings _currentActiveSetting;


### PR DESCRIPTION
## Problem

Extensions that depend on Newtonsoft.Json but don't ship their own copy silently use vstest's bundled copy. Before we can remove Newtonsoft.Json from vstest, we need to know how many extensions rely on this.

## Solution

**Silent telemetry tracking** — when \AssemblyResolver\ resolves a tracked assembly (e.g. Newtonsoft.Json) from vstest's own directory for an external requester:

1. Record it in a static \ConcurrentDictionary\ (one entry per assembly per process)
2. Report in telemetry as \VS.TestPlatform.ProvidedAssemblyDependency.Newtonsoft.Json=<requester>\
3. Filter out vstest's own internal assemblies (no false positives)
4. No user-visible warnings by default — opt-in via \VSTEST_WARN_MISSING_EXTENSIONS_DEPENDENCIES=1\ feature flag

## Test asset

\NewtonSoftDependencyMissing\ — references Newtonsoft.Json with \<ExcludeAssets>runtime</ExcludeAssets>\. The DLL is NOT in output, so vstest's copy is used at runtime.

## Changes

- \AssemblyResolver.cs\ — track provided dependencies, opt-in warning behind feature flag
- \TelemetryDataConstants.cs\ — new \ProvidedAssemblyDependency\ constant
- \FeatureFlag.cs\ — new \VSTEST_WARN_MISSING_EXTENSIONS_DEPENDENCIES\ flag
- \TestRunRequest.cs\ — report provided dependencies in telemetry at run completion
- \IAssemblyResolver.cs\ — add \RequestingAssembly\ to \AssemblyResolveEventArgs\

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>