### PR TITLE
Report child process info on connection timeout

### DIFF
--- a/playground/TestPlatform.Playground/Environment.cs
+++ b/playground/TestPlatform.Playground/Environment.cs
@@ -9,7 +9,7 @@ internal class EnvironmentVariables
 {
     public static readonly Dictionary<string, string?> Variables = new()
     {
-        ["VSTEST_CONNECTION_TIMEOUT"] = "999",
+        ["VSTEST_CONNECTION_TIMEOUT"] = "0.1",
         ["VSTEST_DEBUG_NOBP"] = "1",
         ["VSTEST_RUNNER_DEBUG_ATTACHVS"] = "0",
         ["VSTEST_HOST_DEBUG_ATTACHVS"] = "0",

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
 const Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel.MessageType.TelemetryEventMessage = "TestPlatform.TelemetryEvent" -> string!
+~static Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources.Resources.ConnectionTimeoutWithErrorMessage.get -> string

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
 const Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel.MessageType.TelemetryEventMessage = "TestPlatform.TelemetryEvent" -> string!
-~static Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources.Resources.ConnectionTimeoutWithErrorMessage.get -> string
+~static Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources.Resources.ConnectionTimeoutProcessDidNotStartErrorMessage.get -> string
+~static Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources.Resources.ConnectionTimeoutProcessExitedErrorMessage.get -> string
+~static Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources.Resources.ConnectionTimeoutWithDetailsErrorMessage.get -> string

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.Designer.cs
@@ -116,6 +116,15 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}.
+        /// </summary>
+        public static string ConnectionTimeoutWithErrorMessage {
+            get {
+                return ResourceManager.GetString("ConnectionTimeoutWithErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Test host process crashed.
         /// </summary>
         public static string TestHostProcessCrashed {

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -20,7 +19,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -40,7 +39,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources {
         public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources.Resources", typeof(Resources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -116,11 +115,29 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}.
+        ///   Looks up a localized string similar to {0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting..
         /// </summary>
-        public static string ConnectionTimeoutWithErrorMessage {
+        public static string ConnectionTimeoutProcessDidNotStartErrorMessage {
             get {
-                return ResourceManager.GetString("ConnectionTimeoutWithErrorMessage", resourceCulture);
+                return ResourceManager.GetString("ConnectionTimeoutProcessDidNotStartErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}.
+        /// </summary>
+        public static string ConnectionTimeoutProcessExitedErrorMessage {
+            get {
+                return ResourceManager.GetString("ConnectionTimeoutProcessExitedErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout..
+        /// </summary>
+        public static string ConnectionTimeoutWithDetailsErrorMessage {
+            get {
+                return ResourceManager.GetString("ConnectionTimeoutWithDetailsErrorMessage", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.resx
@@ -141,8 +141,8 @@
   <data name="ConnectionTimeoutErrorMessage" xml:space="preserve">
     <value>{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</value>
   </data>
-  <data name="ConnectionTimeoutWithErrorMessage" xml:space="preserve">
-    <value>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</value>
+  <data name="ConnectionTimeoutProcessExitedErrorMessage" xml:space="preserve">
+    <value>{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</value>
   </data>
   <data name="TestHostProcessCrashed" xml:space="preserve">
     <value>Test host process crashed</value>
@@ -152,5 +152,11 @@
   </data>
   <data name="AbortedTestDiscoveryWithReason" xml:space="preserve">
     <value>The active test discovery was aborted. Reason: {0}</value>
+  </data>
+  <data name="ConnectionTimeoutProcessDidNotStartErrorMessage" xml:space="preserve">
+    <value>{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</value>
+  </data>
+  <data name="ConnectionTimeoutWithDetailsErrorMessage" xml:space="preserve">
+    <value>{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</value>
   </data>
 </root>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/Resources.resx
@@ -141,6 +141,9 @@
   <data name="ConnectionTimeoutErrorMessage" xml:space="preserve">
     <value>{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</value>
   </data>
+  <data name="ConnectionTimeoutWithErrorMessage" xml:space="preserve">
+    <value>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</value>
+  </data>
   <data name="TestHostProcessCrashed" xml:space="preserve">
     <value>Test host process crashed</value>
   </data>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.cs.xlf
@@ -47,7 +47,11 @@
         <target state="translated">Procesu {0} se nepovedlo připojit k procesu {1} ani po {2} s. Důvodem může být pomalý počítač. Nastavením proměnné prostředí {3} prosím časový limit prodlužte.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessCrashed">
+            <trans-unit id="ConnectionTimeoutWithErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
+        <note />
+      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Proces testovacího hostitele se chybově ukončil.</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.cs.xlf
@@ -22,6 +22,21 @@
         <target state="translated">Aktivní zjišťování testu se přerušilo. Důvod: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessDidNotStartErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessExitedErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutWithDetailsErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
         <source>Unable to communicate with test host process.</source>
         <target state="translated">Nepovedlo se navázat komunikaci s procesem hostitele testu.</target>
@@ -44,14 +59,10 @@
       </trans-unit>
       <trans-unit id="ConnectionTimeoutErrorMessage">
         <source>{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</source>
-        <target state="translated">Procesu {0} se nepovedlo připojit k procesu {1} ani po {2} s. Důvodem může být pomalý počítač. Nastavením proměnné prostředí {3} prosím časový limit prodlužte.</target>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</target>
         <note />
       </trans-unit>
-            <trans-unit id="ConnectionTimeoutWithErrorMessage">
-        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
-        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
-        <note />
-      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Proces testovacího hostitele se chybově ukončil.</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.de.xlf
@@ -47,7 +47,11 @@
         <target state="translated">Fehler beim Herstellen einer Verbindung des Prozesses "{0}" mit dem Prozess "{1}" nach {2} Sekunden. Möglicherweise ist der Computer langsam. Legen Sie die Umgebungsvariable "{3}" fest, um den Timeoutwert zu erhöhen.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessCrashed">
+            <trans-unit id="ConnectionTimeoutWithErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
+        <note />
+      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Der Testhostprozess ist abgestürzt.</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.de.xlf
@@ -22,6 +22,21 @@
         <target state="translated">Die aktive Testermittlung wurde abgebrochen. Grund: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessDidNotStartErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessExitedErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutWithDetailsErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
         <source>Unable to communicate with test host process.</source>
         <target state="translated">Die Kommunikation mit dem Testhostprozess ist nicht möglich.</target>
@@ -44,14 +59,10 @@
       </trans-unit>
       <trans-unit id="ConnectionTimeoutErrorMessage">
         <source>{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</source>
-        <target state="translated">Fehler beim Herstellen einer Verbindung des Prozesses "{0}" mit dem Prozess "{1}" nach {2} Sekunden. Möglicherweise ist der Computer langsam. Legen Sie die Umgebungsvariable "{3}" fest, um den Timeoutwert zu erhöhen.</target>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</target>
         <note />
       </trans-unit>
-            <trans-unit id="ConnectionTimeoutWithErrorMessage">
-        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
-        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
-        <note />
-      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Der Testhostprozess ist abgestürzt.</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.es.xlf
@@ -47,7 +47,11 @@
         <target state="translated">El proceso {0} no pudo conectar con el proceso {1} después de {2} segundos. Esto puede deberse a la lentitud de la máquina, configure la variable de entorno {3} para aumentar el tiempo de espera.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessCrashed">
+            <trans-unit id="ConnectionTimeoutWithErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
+        <note />
+      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Proceso de host de pruebas bloqueado</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.es.xlf
@@ -22,6 +22,21 @@
         <target state="translated">Se ha anulado la detección de pruebas activa. Motivo: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessDidNotStartErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessExitedErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutWithDetailsErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
         <source>Unable to communicate with test host process.</source>
         <target state="translated">No se puede establecer comunicación con el proceso del host de pruebas.</target>
@@ -44,14 +59,10 @@
       </trans-unit>
       <trans-unit id="ConnectionTimeoutErrorMessage">
         <source>{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</source>
-        <target state="translated">El proceso {0} no pudo conectar con el proceso {1} después de {2} segundos. Esto puede deberse a la lentitud de la máquina, configure la variable de entorno {3} para aumentar el tiempo de espera.</target>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</target>
         <note />
       </trans-unit>
-            <trans-unit id="ConnectionTimeoutWithErrorMessage">
-        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
-        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
-        <note />
-      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Proceso de host de pruebas bloqueado</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.fr.xlf
@@ -47,7 +47,11 @@
         <target state="translated">Le processus {0} n’a pas réussi à se connecter au processus {1} après {2} secondes. Cette situation peut se produire à cause de la lenteur de la machine. Définissez la variable d’environnement {3} de sorte à augmenter le délai d’expiration.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessCrashed">
+            <trans-unit id="ConnectionTimeoutWithErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
+        <note />
+      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Plantage du processus hôte de test</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.fr.xlf
@@ -22,6 +22,21 @@
         <target state="translated">La découverte de tests active a été abandonnée. Raison : {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessDidNotStartErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessExitedErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutWithDetailsErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
         <source>Unable to communicate with test host process.</source>
         <target state="translated">Impossible de communiquer avec le processus hôte du test.</target>
@@ -44,14 +59,10 @@
       </trans-unit>
       <trans-unit id="ConnectionTimeoutErrorMessage">
         <source>{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</source>
-        <target state="translated">Le processus {0} n’a pas réussi à se connecter au processus {1} après {2} secondes. Cette situation peut se produire à cause de la lenteur de la machine. Définissez la variable d’environnement {3} de sorte à augmenter le délai d’expiration.</target>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</target>
         <note />
       </trans-unit>
-            <trans-unit id="ConnectionTimeoutWithErrorMessage">
-        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
-        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
-        <note />
-      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Plantage du processus hôte de test</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.it.xlf
@@ -22,6 +22,21 @@
         <target state="translated">L'individuazione dei test attivi è stata interrotta. Motivo: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessDidNotStartErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessExitedErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutWithDetailsErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
         <source>Unable to communicate with test host process.</source>
         <target state="translated">Non è possibile comunicare con il processo host dei test.</target>
@@ -44,14 +59,10 @@
       </trans-unit>
       <trans-unit id="ConnectionTimeoutErrorMessage">
         <source>{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</source>
-        <target state="translated">Il processo {0} non è riuscito a connettersi al processo {1} dopo {2} secondi. Questo problema può verificarsi a causa della lentezza del computer. Impostare la variabile di ambiente {3} in modo da incrementare il timeout.</target>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</target>
         <note />
       </trans-unit>
-            <trans-unit id="ConnectionTimeoutWithErrorMessage">
-        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
-        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
-        <note />
-      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Arresto anomalo del processo host di test</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.it.xlf
@@ -47,7 +47,11 @@
         <target state="translated">Il processo {0} non è riuscito a connettersi al processo {1} dopo {2} secondi. Questo problema può verificarsi a causa della lentezza del computer. Impostare la variabile di ambiente {3} in modo da incrementare il timeout.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessCrashed">
+            <trans-unit id="ConnectionTimeoutWithErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
+        <note />
+      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Arresto anomalo del processo host di test</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ja.xlf
@@ -22,6 +22,21 @@
         <target state="translated">アクティブなテスト探索が中止されました。理由: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessDidNotStartErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessExitedErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutWithDetailsErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
         <source>Unable to communicate with test host process.</source>
         <target state="translated">テスト ホスト プロセスと通信できません。</target>
@@ -44,14 +59,10 @@
       </trans-unit>
       <trans-unit id="ConnectionTimeoutErrorMessage">
         <source>{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</source>
-        <target state="translated">{0} プロセスでは、{2} 秒後に {1} プロセスへ接続できませんでした。これは、マシンの遅さが原因で発生する可能性があるため、環境変数 {3} を設定してタイムアウト時間を増やしてください。</target>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</target>
         <note />
       </trans-unit>
-            <trans-unit id="ConnectionTimeoutWithErrorMessage">
-        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
-        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
-        <note />
-      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">テストのホスト プロセスがクラッシュしました</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ja.xlf
@@ -47,7 +47,11 @@
         <target state="translated">{0} プロセスでは、{2} 秒後に {1} プロセスへ接続できませんでした。これは、マシンの遅さが原因で発生する可能性があるため、環境変数 {3} を設定してタイムアウト時間を増やしてください。</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessCrashed">
+            <trans-unit id="ConnectionTimeoutWithErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
+        <note />
+      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">テストのホスト プロセスがクラッシュしました</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ko.xlf
@@ -22,6 +22,21 @@
         <target state="translated">활성 테스트 검색이 중단되었습니다. 이유: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessDidNotStartErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessExitedErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutWithDetailsErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
         <source>Unable to communicate with test host process.</source>
         <target state="translated">테스트 호스트 프로세스와 통신할 수 없습니다.</target>
@@ -44,14 +59,10 @@
       </trans-unit>
       <trans-unit id="ConnectionTimeoutErrorMessage">
         <source>{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</source>
-        <target state="translated">{0} 프로세스가 {2}초 후 {1} 프로세스에 연결하지 못했습니다. 이런 오류는 컴퓨터가 느려서 발생할 수 있습니다. 환경 변수 {3}을(를) 설정하여 시간 제한을 늘리세요.</target>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</target>
         <note />
       </trans-unit>
-            <trans-unit id="ConnectionTimeoutWithErrorMessage">
-        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
-        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
-        <note />
-      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">테스트 호스트 프로세스 작동이 중단됨</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ko.xlf
@@ -47,7 +47,11 @@
         <target state="translated">{0} 프로세스가 {2}초 후 {1} 프로세스에 연결하지 못했습니다. 이런 오류는 컴퓨터가 느려서 발생할 수 있습니다. 환경 변수 {3}을(를) 설정하여 시간 제한을 늘리세요.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessCrashed">
+            <trans-unit id="ConnectionTimeoutWithErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
+        <note />
+      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">테스트 호스트 프로세스 작동이 중단됨</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pl.xlf
@@ -22,6 +22,21 @@
         <target state="translated">Aktywny proces wykrywania testu został przerwany. Przyczyna: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessDidNotStartErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessExitedErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutWithDetailsErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
         <source>Unable to communicate with test host process.</source>
         <target state="translated">Nie można nawiązać komunikacji z procesem hosta.</target>
@@ -44,14 +59,10 @@
       </trans-unit>
       <trans-unit id="ConnectionTimeoutErrorMessage">
         <source>{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</source>
-        <target state="translated">Proces {0} nie mógł połączyć się z procesem {1} w ciągu {2} sekund. Przyczyną może być wolne działanie maszyny. Zwiększ limit czasu, ustawiając zmienną środowiskową {3}.</target>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</target>
         <note />
       </trans-unit>
-            <trans-unit id="ConnectionTimeoutWithErrorMessage">
-        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
-        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
-        <note />
-      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Wystąpiła awaria procesu hosta testu</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pl.xlf
@@ -47,7 +47,11 @@
         <target state="translated">Proces {0} nie mógł połączyć się z procesem {1} w ciągu {2} sekund. Przyczyną może być wolne działanie maszyny. Zwiększ limit czasu, ustawiając zmienną środowiskową {3}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessCrashed">
+            <trans-unit id="ConnectionTimeoutWithErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
+        <note />
+      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Wystąpiła awaria procesu hosta testu</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pt-BR.xlf
@@ -22,6 +22,21 @@
         <target state="translated">A descoberta de teste ativa foi anulada. Motivo: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessDidNotStartErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessExitedErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutWithDetailsErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
         <source>Unable to communicate with test host process.</source>
         <target state="translated">Não é possível se comunicar com o processo de host de teste.</target>
@@ -44,14 +59,10 @@
       </trans-unit>
       <trans-unit id="ConnectionTimeoutErrorMessage">
         <source>{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</source>
-        <target state="translated">O processo {0} falha ao se conectar ao processo {1} após {2} segundos. Isso pode ocorrer devido à lentidão do computador. Defina a variável de ambiente {3} para aumentar o tempo limite.</target>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</target>
         <note />
       </trans-unit>
-            <trans-unit id="ConnectionTimeoutWithErrorMessage">
-        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
-        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
-        <note />
-      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Falha no processo do host de teste</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.pt-BR.xlf
@@ -47,7 +47,11 @@
         <target state="translated">O processo {0} falha ao se conectar ao processo {1} após {2} segundos. Isso pode ocorrer devido à lentidão do computador. Defina a variável de ambiente {3} para aumentar o tempo limite.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessCrashed">
+            <trans-unit id="ConnectionTimeoutWithErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
+        <note />
+      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Falha no processo do host de teste</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ru.xlf
@@ -47,7 +47,11 @@
         <target state="translated">Процесс {0} не смог подключиться к процессу {1} по прошествии {2} с. Это может происходить из-за медленной работы компьютера. Увеличьте время ожидания в переменной среды {3}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessCrashed">
+            <trans-unit id="ConnectionTimeoutWithErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
+        <note />
+      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Сбой хост-процесса теста</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.ru.xlf
@@ -22,6 +22,21 @@
         <target state="translated">Активное обнаружение тестов прервано. Причина: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessDidNotStartErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessExitedErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutWithDetailsErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
         <source>Unable to communicate with test host process.</source>
         <target state="translated">Не удалось связаться с хост-процессом теста.</target>
@@ -44,14 +59,10 @@
       </trans-unit>
       <trans-unit id="ConnectionTimeoutErrorMessage">
         <source>{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</source>
-        <target state="translated">Процесс {0} не смог подключиться к процессу {1} по прошествии {2} с. Это может происходить из-за медленной работы компьютера. Увеличьте время ожидания в переменной среды {3}.</target>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</target>
         <note />
       </trans-unit>
-            <trans-unit id="ConnectionTimeoutWithErrorMessage">
-        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
-        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
-        <note />
-      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Сбой хост-процесса теста</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.tr.xlf
@@ -47,7 +47,11 @@
         <target state="translated">{0} işlemi, {2} saniye sonra {1} işlemine bağlanamadı. Bu durum makinenin yavaşlığından kaynaklanıyor olabilir, zaman aşımı süresini artırmak için lütfen ortam değişkenini {3} olarak ayarlayın.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessCrashed">
+            <trans-unit id="ConnectionTimeoutWithErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
+        <note />
+      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Test ana işlemi kilitlendi</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.tr.xlf
@@ -22,6 +22,21 @@
         <target state="translated">Etkin test bulma iptal edildi. Nedeni: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessDidNotStartErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessExitedErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutWithDetailsErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
         <source>Unable to communicate with test host process.</source>
         <target state="translated">Test ana bilgisayarı işlemi ile iletişim kurulamıyor.</target>
@@ -44,14 +59,10 @@
       </trans-unit>
       <trans-unit id="ConnectionTimeoutErrorMessage">
         <source>{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</source>
-        <target state="translated">{0} işlemi, {2} saniye sonra {1} işlemine bağlanamadı. Bu durum makinenin yavaşlığından kaynaklanıyor olabilir, zaman aşımı süresini artırmak için lütfen ortam değişkenini {3} olarak ayarlayın.</target>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</target>
         <note />
       </trans-unit>
-            <trans-unit id="ConnectionTimeoutWithErrorMessage">
-        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
-        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
-        <note />
-      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">Test ana işlemi kilitlendi</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.xlf
@@ -42,6 +42,11 @@
         <target state="new">{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConnectionTimeoutWithErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="new">Test host process crashed</target>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hans.xlf
@@ -22,6 +22,21 @@
         <target state="translated">活动的测试发现已中止。原因: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessDidNotStartErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessExitedErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutWithDetailsErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
         <source>Unable to communicate with test host process.</source>
         <target state="translated">无法与测试宿主进程通信。</target>
@@ -44,14 +59,10 @@
       </trans-unit>
       <trans-unit id="ConnectionTimeoutErrorMessage">
         <source>{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</source>
-        <target state="translated">{0} 进程未能在 {2} 秒后连接到 {1} 进程。出现此问题可能是因为计算机性能较低，请设置环境变量 {3}，增加超时时间值。</target>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</target>
         <note />
       </trans-unit>
-            <trans-unit id="ConnectionTimeoutWithErrorMessage">
-        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
-        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
-        <note />
-      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">测试主机进程崩溃</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hans.xlf
@@ -47,7 +47,11 @@
         <target state="translated">{0} 进程未能在 {2} 秒后连接到 {1} 进程。出现此问题可能是因为计算机性能较低，请设置环境变量 {3}，增加超时时间值。</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessCrashed">
+            <trans-unit id="ConnectionTimeoutWithErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
+        <note />
+      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">测试主机进程崩溃</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hant.xlf
@@ -47,7 +47,11 @@
         <target state="translated">在 {2} 秒後，{0} 處理序無法連線到 {1} 處理序。原因可能是電腦太慢，請設定環境變數 {3}，加長逾時。</target>
         <note />
       </trans-unit>
-      <trans-unit id="TestHostProcessCrashed">
+            <trans-unit id="ConnectionTimeoutWithErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
+        <note />
+      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">測試主機處理序當機</target>
         <note />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Resources/xlf/Resources.zh-Hant.xlf
@@ -22,6 +22,21 @@
         <target state="translated">使用中的測試探索已中止。原因: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessDidNotStartErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process failed to start, this might happen because of  antivirus preventing it from starting.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutProcessExitedErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process {3} - {4}, exited with exitCode {5}, and error output: \n{6}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConnectionTimeoutWithDetailsErrorMessage">
+        <source>{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</source>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. When the timeout happened, the process {3} -{4} was still running. This most often happens because of machine slowness, please set environment variable {5} to increase timeout.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToCommunicateToTestHost">
         <source>Unable to communicate with test host process.</source>
         <target state="translated">無法與測試主機處理序通訊。</target>
@@ -44,14 +59,10 @@
       </trans-unit>
       <trans-unit id="ConnectionTimeoutErrorMessage">
         <source>{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</source>
-        <target state="translated">在 {2} 秒後，{0} 處理序無法連線到 {1} 處理序。原因可能是電腦太慢，請設定環境變數 {3}，加長逾時。</target>
+        <target state="new">{0} process failed to connect to {1} process after {2} seconds. This may occur due to machine slowness, please set environment variable {3} to increase timeout.</target>
         <note />
       </trans-unit>
-            <trans-unit id="ConnectionTimeoutWithErrorMessage">
-        <source>{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</source>
-        <target state="new">{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: \n{5}</target>
-        <note />
-      </trans-unit>      <trans-unit id="TestHostProcessCrashed">
+      <trans-unit id="TestHostProcessCrashed">
         <source>Test host process crashed</source>
         <target state="translated">測試主機處理序當機</target>
         <note />

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -540,6 +540,15 @@ public class ProxyOperationManager
                 CoreUtilitiesConstants.TesthostProcessName,
                 connTimeout,
                 EnvironmentHelper.VstestConnectionTimeout);
+
+            // Add process ID info if available so the user knows which process is stuck.
+            if (_testHostProcessId > 0)
+            {
+                errorMsg += string.Format(
+                    CultureInfo.CurrentCulture,
+                    " The process with id {0} was still running when this message was reported.",
+                    _testHostProcessId);
+            }
         }
 
         // After testhost process launched failed with error.

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IProcessManager.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IProcessManager.cs
@@ -34,15 +34,20 @@ internal interface IProcessManager
     /// <summary>
     /// Process that we manage, or managed, useful for reporting to correlate log messages when the process no longer lives.
     /// </summary>
-    int ProcessId { get; }
+    string? ProcessName { get; }
+
+    /// <summary>
+    /// Process that we manage, or managed, useful for reporting to correlate log messages when the process no longer lives.
+    /// </summary>
+    int? ProcessId { get; }
 
     /// <summary>
     /// Error output of the process. Cleared on new process start.
     /// </summary>
-    string ErrorOutput { get; }
+    string? ErrorOutput { get; }
 
     /// <summary>
     /// Exit code of the process. Cleared on new process start.
     /// </summary>
-    int ExitCode { get; }
+    int? ExitCode { get; }
 }

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IProcessManager.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IProcessManager.cs
@@ -35,4 +35,14 @@ internal interface IProcessManager
     /// Process that we manage, or managed, useful for reporting to correlate log messages when the process no longer lives.
     /// </summary>
     int ProcessId { get; }
+
+    /// <summary>
+    /// Error output of the process. Cleared on new process start.
+    /// </summary>
+    string ErrorOutput { get; }
+
+    /// <summary>
+    /// Exit code of the process. Cleared on new process start.
+    /// </summary>
+    int ExitCode { get; }
 }

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Text;
 using System.Threading;
 
 using Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces;
@@ -53,6 +54,7 @@ internal sealed class VsTestConsoleProcessManager : IProcessManager, IDisposable
     private readonly bool _isNetCoreRunner;
     private readonly string? _dotnetExePath;
     private readonly ManualResetEvent _processExitedEvent = new(false);
+    private readonly StringBuilder _vstestConsoleError = new();
     private Process? _process;
 
     private bool _vstestConsoleStarted;
@@ -63,6 +65,12 @@ internal sealed class VsTestConsoleProcessManager : IProcessManager, IDisposable
 
     /// <inheritdoc/>
     public int ProcessId { get; set; }
+
+    /// <inheritdoc/>
+    public string ErrorOutput => _vstestConsoleError.ToString();
+
+    /// <inheritdoc/>
+    public int ExitCode { get; private set; } = -1;
 
     /// <inheritdoc/>
     public event EventHandler? ProcessExited;
@@ -113,6 +121,10 @@ internal sealed class VsTestConsoleProcessManager : IProcessManager, IDisposable
         {
             throw new FileNotFoundException(string.Format(CultureInfo.CurrentCulture, InternalResources.CannotFindConsoleRunner, consoleRunnerPath), consoleRunnerPath);
         }
+
+        ProcessId = -1;
+        ExitCode = -1;
+        _vstestConsoleError.Clear();
 
         var arguments = string.Join(" ", BuildArguments(consoleParameters));
         var info = new ProcessStartInfo(consoleRunnerPath, arguments)
@@ -221,6 +233,7 @@ internal sealed class VsTestConsoleProcessManager : IProcessManager, IDisposable
         {
             _processExitedEvent.Set();
             _vstestConsoleExited = true;
+            ExitCode = ((Process)sender!).ExitCode;
             ProcessExited?.Invoke(sender, e);
         }
     }
@@ -230,6 +243,7 @@ internal sealed class VsTestConsoleProcessManager : IProcessManager, IDisposable
         if (e.Data != null)
         {
             EqtTrace.Error(e.Data);
+            _vstestConsoleError.AppendLine(e.Data);
         }
     }
 

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
@@ -64,13 +64,16 @@ internal sealed class VsTestConsoleProcessManager : IProcessManager, IDisposable
     internal IFileHelper FileHelper { get; set; }
 
     /// <inheritdoc/>
-    public int ProcessId { get; set; }
+    public string? ProcessName { get; set; }
 
     /// <inheritdoc/>
-    public string ErrorOutput => _vstestConsoleError.ToString();
+    public int? ProcessId { get; set; }
 
     /// <inheritdoc/>
-    public int ExitCode { get; private set; } = -1;
+    public string? ErrorOutput => _vstestConsoleError.ToString();
+
+    /// <inheritdoc/>
+    public int? ExitCode { get; private set; } = -1;
 
     /// <inheritdoc/>
     public event EventHandler? ProcessExited;
@@ -122,8 +125,9 @@ internal sealed class VsTestConsoleProcessManager : IProcessManager, IDisposable
             throw new FileNotFoundException(string.Format(CultureInfo.CurrentCulture, InternalResources.CannotFindConsoleRunner, consoleRunnerPath), consoleRunnerPath);
         }
 
-        ProcessId = -1;
-        ExitCode = -1;
+        ProcessName = null;
+        ProcessId = null;
+        ExitCode = null;
         _vstestConsoleError.Clear();
 
         var arguments = string.Join(" ", BuildArguments(consoleParameters));
@@ -162,6 +166,7 @@ internal sealed class VsTestConsoleProcessManager : IProcessManager, IDisposable
         {
             _process = Process.Start(info);
             ProcessId = _process!.Id;
+            ProcessName = _process.ProcessName;
             EqtTrace.Info($"VsTestConsoleProcessManager.StartProcess: Started process id:{_process.Id}"); // Not normally needed, but if you run multiple instances of wrapper it helps to also add {Environment.StackTrace}
         }
         catch (Win32Exception ex)
@@ -191,10 +196,10 @@ internal sealed class VsTestConsoleProcessManager : IProcessManager, IDisposable
     public void ShutdownProcess()
     {
         // Ideally process should die by itself
-        EqtTrace.Info($"VsTestConsoleProcessManager.ShutDownProcess : Will terminate vstest.console process id:{ProcessId}, waiting {Endsessiontimeout} milliseconds for it to exit.");
+        EqtTrace.Info($"VsTestConsoleProcessManager.ShutDownProcess : Will terminate vstest.console process: {ProcessId}-{ProcessName}, waiting {Endsessiontimeout} milliseconds for it to exit.");
         if (!_processExitedEvent.WaitOne(Endsessiontimeout) && IsProcessInitialized())
         {
-            EqtTrace.Info($"VsTestConsoleProcessManager.ShutDownProcess : Terminating vstest.console process id:{ProcessId} after waiting for {Endsessiontimeout} milliseconds.");
+            EqtTrace.Info($"VsTestConsoleProcessManager.ShutDownProcess : Terminating vstest.console process: {ProcessId}-{ProcessName} after waiting for {Endsessiontimeout} milliseconds.");
             _vstestConsoleExited = true;
             if (_process is not null)
             {
@@ -204,11 +209,11 @@ internal sealed class VsTestConsoleProcessManager : IProcessManager, IDisposable
                 _process.Dispose();
                 _process = null;
             }
-            EqtTrace.Info($"VsTestConsoleProcessManager.ShutDownProcess : Terminated vstest.console process id:{ProcessId}.");
+            EqtTrace.Info($"VsTestConsoleProcessManager.ShutDownProcess : Terminated vstest.console process: {ProcessId}-{ProcessName}.");
         }
         else
         {
-            EqtTrace.Verbose($"VsTestConsoleProcessManager.ShutDownProcess : Process id:{ProcessId} already exited, doing nothing.");
+            EqtTrace.Verbose($"VsTestConsoleProcessManager.ShutDownProcess : Process: {ProcessId}-{ProcessName} already exited, doing nothing.");
         }
     }
 

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
@@ -1218,15 +1218,21 @@ public class VsTestConsoleWrapper : IVsTestConsoleWrapper
         var timeout = EnvironmentHelper.GetConnectionTimeout();
         if (!_requestSender.WaitForRequestHandlerConnection(timeout * 1000))
         {
-            var processName = _processHelper.GetCurrentProcessFileName();
+            var currentProcessName = _processHelper.GetCurrentProcessFileName();
+            var childProcessId = _vstestConsoleProcessManager.ProcessId;
+            var childProcessExitCode = _vstestConsoleProcessManager.ExitCode;
+            var childProcessErrorOutput = _vstestConsoleProcessManager.ErrorOutput;
+
             throw new TransationLayerException(
                 string.Format(
                     CultureInfo.CurrentCulture,
-                    CommunicationUtilitiesResources.ConnectionTimeoutErrorMessage,
-                    processName,
+                    CommunicationUtilitiesResources.ConnectionTimeoutWithErrorMessage,
+                    currentProcessName,
                     CoreUtilitiesConstants.VstestConsoleProcessName,
                     timeout,
-                    EnvironmentHelper.VstestConnectionTimeout)
+                    childProcessId,
+                    childProcessExitCode,
+                    childProcessErrorOutput)
             );
         }
 

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
@@ -1260,6 +1260,7 @@ public class VsTestConsoleWrapper : IVsTestConsoleWrapper
                         CoreUtilitiesConstants.VstestConsoleProcessName,
                         timeout,
                         childProcessId,
+                        childProcessName,
                         childProcessExitCode,
                         childProcessErrorOutput)
                 );

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
@@ -1219,21 +1219,51 @@ public class VsTestConsoleWrapper : IVsTestConsoleWrapper
         if (!_requestSender.WaitForRequestHandlerConnection(timeout * 1000))
         {
             var currentProcessName = _processHelper.GetCurrentProcessFileName();
+            var childProcessName = _vstestConsoleProcessManager.ProcessName;
             var childProcessId = _vstestConsoleProcessManager.ProcessId;
             var childProcessExitCode = _vstestConsoleProcessManager.ExitCode;
             var childProcessErrorOutput = _vstestConsoleProcessManager.ErrorOutput;
 
-            throw new TransationLayerException(
-                string.Format(
-                    CultureInfo.CurrentCulture,
-                    CommunicationUtilitiesResources.ConnectionTimeoutWithErrorMessage,
-                    currentProcessName,
-                    CoreUtilitiesConstants.VstestConsoleProcessName,
-                    timeout,
-                    childProcessId,
-                    childProcessExitCode,
-                    childProcessErrorOutput)
-            );
+            if (childProcessId == null)
+            {
+                // Process failed to start, likely due to antivirus or other startup issues. Recommend checking machine for issues that may prevent process from starting.
+                throw new TransationLayerException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        CommunicationUtilitiesResources.ConnectionTimeoutProcessDidNotStartErrorMessage,
+                        currentProcessName,
+                        CoreUtilitiesConstants.VstestConsoleProcessName,
+                        timeout));
+            }
+            else if (childProcessExitCode == null)
+            {
+                // Process is still alive but failed to connect within the timeout, likely due to machine slowness. Recommend increasing timeout.
+                throw new TransationLayerException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        CommunicationUtilitiesResources.ConnectionTimeoutWithDetailsErrorMessage,
+                        currentProcessName,
+                        CoreUtilitiesConstants.VstestConsoleProcessName,
+                        timeout,
+                        childProcessId,
+                        childProcessName,
+                        EnvironmentHelper.VstestConnectionTimeout));
+            }
+            else
+            {
+                // Process started and exited within the timeout, likely due to startup issues or incompatible environment. Recommend checking the error output for more details.
+                throw new TransationLayerException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        CommunicationUtilitiesResources.ConnectionTimeoutProcessExitedErrorMessage,
+                        currentProcessName,
+                        CoreUtilitiesConstants.VstestConsoleProcessName,
+                        timeout,
+                        childProcessId,
+                        childProcessExitCode,
+                        childProcessErrorOutput)
+                );
+            }
         }
 
         _testPlatformEventSource.TranslationLayerInitializeStop();

--- a/test/TranslationLayer.UnitTests/VsTestConsoleWrapperTests.cs
+++ b/test/TranslationLayer.UnitTests/VsTestConsoleWrapperTests.cs
@@ -271,6 +271,9 @@ public class VsTestConsoleWrapperTests
     {
         _mockProcessHelper.Setup(x => x.GetCurrentProcessFileName()).Returns("DummyProcess");
         _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
+        _mockProcessManager.Setup(pm => pm.ProcessId).Returns(0);
+        _mockProcessManager.Setup(pm => pm.ExitCode).Returns(0);
+        _mockProcessManager.Setup(pm => pm.ErrorOutput).Returns("");
 
         var exception = Assert.ThrowsExactly<TransationLayerException>(() => _consoleWrapper.InitializeExtensions(new List<string> { "Hello", "World" }));
         Assert.AreEqual("DummyProcess process failed to connect to vstest.console process after 90 seconds. The process with id 0, exited with exitCode 0, and error output: \\n", exception.Message);
@@ -329,6 +332,9 @@ public class VsTestConsoleWrapperTests
     {
         _mockProcessHelper.Setup(x => x.GetCurrentProcessFileName()).Returns("DummyProcess");
         _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
+        _mockProcessManager.Setup(pm => pm.ProcessId).Returns(0);
+        _mockProcessManager.Setup(pm => pm.ExitCode).Returns(0);
+        _mockProcessManager.Setup(pm => pm.ErrorOutput).Returns("");
 
         var exception = Assert.ThrowsExactly<TransationLayerException>(() => _consoleWrapper.DiscoverTests(new List<string> { "Hello", "World" }, null, null, new Mock<ITestDiscoveryEventsHandler2>().Object));
         Assert.AreEqual("DummyProcess process failed to connect to vstest.console process after 90 seconds. The process with id 0, exited with exitCode 0, and error output: \\n", exception.Message);
@@ -697,5 +703,53 @@ public class VsTestConsoleWrapperTests
         _mockRequestSender.Verify(rs => rs.EndSession(), Times.Once);
         _mockRequestSender.Verify(rs => rs.Close(), Times.Once);
         _mockProcessManager.Verify(x => x.ShutdownProcess(), Times.Once);
+    }
+
+    [TestMethod]
+    public void StartSessionShouldReportProcessCrashDetailsOnTimeout()
+    {
+        _mockRequestSender.Setup(rs => rs.InitializeCommunication()).Returns(100);
+        _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
+        _mockProcessManager.Setup(pm => pm.ProcessId).Returns(5432);
+        _mockProcessManager.Setup(pm => pm.ExitCode).Returns(1);
+        _mockProcessManager.Setup(pm => pm.ErrorOutput).Returns("Unhandled exception: System.OutOfMemoryException");
+        _mockProcessHelper.Setup(x => x.GetCurrentProcessFileName()).Returns("TestRunner");
+
+        var ex = Assert.ThrowsExactly<TransationLayerException>(() => _consoleWrapper.InitializeExtensions(new[] { "path" }));
+
+        Assert.Contains("5432", ex.Message);
+        Assert.Contains("exitCode 1", ex.Message);
+        Assert.Contains("OutOfMemoryException", ex.Message);
+    }
+
+    [TestMethod]
+    public void StartSessionShouldReportHangingProcessDetailsOnTimeout()
+    {
+        _mockRequestSender.Setup(rs => rs.InitializeCommunication()).Returns(100);
+        _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
+        _mockProcessManager.Setup(pm => pm.ProcessId).Returns(5432);
+        _mockProcessManager.Setup(pm => pm.ExitCode).Returns(-1);
+        _mockProcessManager.Setup(pm => pm.ErrorOutput).Returns("");
+        _mockProcessHelper.Setup(x => x.GetCurrentProcessFileName()).Returns("TestRunner");
+
+        var ex = Assert.ThrowsExactly<TransationLayerException>(() => _consoleWrapper.InitializeExtensions(new[] { "path" }));
+
+        Assert.Contains("5432", ex.Message);
+        Assert.Contains("exitCode -1", ex.Message);
+    }
+
+    [TestMethod]
+    public void StartSessionShouldReportNotStartedProcessOnTimeout()
+    {
+        _mockRequestSender.Setup(rs => rs.InitializeCommunication()).Returns(100);
+        _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
+        _mockProcessManager.Setup(pm => pm.ProcessId).Returns(-1);
+        _mockProcessManager.Setup(pm => pm.ExitCode).Returns(-1);
+        _mockProcessManager.Setup(pm => pm.ErrorOutput).Returns("");
+        _mockProcessHelper.Setup(x => x.GetCurrentProcessFileName()).Returns("TestRunner");
+
+        var ex = Assert.ThrowsExactly<TransationLayerException>(() => _consoleWrapper.InitializeExtensions(new[] { "path" }));
+
+        Assert.Contains("-1", ex.Message);
     }
 }

--- a/test/TranslationLayer.UnitTests/VsTestConsoleWrapperTests.cs
+++ b/test/TranslationLayer.UnitTests/VsTestConsoleWrapperTests.cs
@@ -273,7 +273,7 @@ public class VsTestConsoleWrapperTests
         _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
 
         var exception = Assert.ThrowsExactly<TransationLayerException>(() => _consoleWrapper.InitializeExtensions(new List<string> { "Hello", "World" }));
-        Assert.AreEqual("DummyProcess process failed to connect to vstest.console process after 90 seconds. This may occur due to machine slowness, please set environment variable VSTEST_CONNECTION_TIMEOUT to increase timeout.", exception.Message);
+        Assert.AreEqual("DummyProcess process failed to connect to vstest.console process after 90 seconds. The process with id 0, exited with exitCode 0, and error output: \\n", exception.Message);
         _mockRequestSender.Verify(rs => rs.InitializeExtensions(It.IsAny<IEnumerable<string>>()), Times.Never);
     }
 
@@ -331,7 +331,7 @@ public class VsTestConsoleWrapperTests
         _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
 
         var exception = Assert.ThrowsExactly<TransationLayerException>(() => _consoleWrapper.DiscoverTests(new List<string> { "Hello", "World" }, null, null, new Mock<ITestDiscoveryEventsHandler2>().Object));
-        Assert.AreEqual("DummyProcess process failed to connect to vstest.console process after 90 seconds. This may occur due to machine slowness, please set environment variable VSTEST_CONNECTION_TIMEOUT to increase timeout.", exception.Message);
+        Assert.AreEqual("DummyProcess process failed to connect to vstest.console process after 90 seconds. The process with id 0, exited with exitCode 0, and error output: \\n", exception.Message);
         _mockRequestSender.Verify(rs => rs.DiscoverTests(It.IsAny<IEnumerable<string>>(), It.IsAny<string>(), null, null, It.IsAny<ITestDiscoveryEventsHandler2>()), Times.Never);
     }
 

--- a/test/TranslationLayer.UnitTests/VsTestConsoleWrapperTests.cs
+++ b/test/TranslationLayer.UnitTests/VsTestConsoleWrapperTests.cs
@@ -271,12 +271,15 @@ public class VsTestConsoleWrapperTests
     {
         _mockProcessHelper.Setup(x => x.GetCurrentProcessFileName()).Returns("DummyProcess");
         _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
-        _mockProcessManager.Setup(pm => pm.ProcessId).Returns(0);
-        _mockProcessManager.Setup(pm => pm.ExitCode).Returns(0);
-        _mockProcessManager.Setup(pm => pm.ErrorOutput).Returns("");
+        _mockProcessManager.Setup(pm => pm.ProcessId).Returns(1234);
+        _mockProcessManager.Setup(pm => pm.ProcessName).Returns("vstest.console");
+        _mockProcessManager.Setup(pm => pm.ExitCode).Returns(1);
+        _mockProcessManager.Setup(pm => pm.ErrorOutput).Returns("some error");
 
         var exception = Assert.ThrowsExactly<TransationLayerException>(() => _consoleWrapper.InitializeExtensions(new List<string> { "Hello", "World" }));
-        Assert.AreEqual("DummyProcess process failed to connect to vstest.console process after 90 seconds. The process with id 0, exited with exitCode 0, and error output: \\n", exception.Message);
+        Assert.Contains("1234", exception.Message);
+        Assert.Contains("exitCode 1", exception.Message);
+        Assert.Contains("some error", exception.Message);
         _mockRequestSender.Verify(rs => rs.InitializeExtensions(It.IsAny<IEnumerable<string>>()), Times.Never);
     }
 
@@ -332,12 +335,14 @@ public class VsTestConsoleWrapperTests
     {
         _mockProcessHelper.Setup(x => x.GetCurrentProcessFileName()).Returns("DummyProcess");
         _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
-        _mockProcessManager.Setup(pm => pm.ProcessId).Returns(0);
-        _mockProcessManager.Setup(pm => pm.ExitCode).Returns(0);
+        _mockProcessManager.Setup(pm => pm.ProcessId).Returns((int?)0);
+        _mockProcessManager.Setup(pm => pm.ProcessName).Returns("vstest.console");
+        _mockProcessManager.Setup(pm => pm.ExitCode).Returns((int?)0);
         _mockProcessManager.Setup(pm => pm.ErrorOutput).Returns("");
 
         var exception = Assert.ThrowsExactly<TransationLayerException>(() => _consoleWrapper.DiscoverTests(new List<string> { "Hello", "World" }, null, null, new Mock<ITestDiscoveryEventsHandler2>().Object));
-        Assert.AreEqual("DummyProcess process failed to connect to vstest.console process after 90 seconds. The process with id 0, exited with exitCode 0, and error output: \\n", exception.Message);
+        Assert.Contains("DummyProcess", exception.Message);
+        Assert.Contains("exitCode 0", exception.Message);
         _mockRequestSender.Verify(rs => rs.DiscoverTests(It.IsAny<IEnumerable<string>>(), It.IsAny<string>(), null, null, It.IsAny<ITestDiscoveryEventsHandler2>()), Times.Never);
     }
 
@@ -710,8 +715,9 @@ public class VsTestConsoleWrapperTests
     {
         _mockRequestSender.Setup(rs => rs.InitializeCommunication()).Returns(100);
         _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
-        _mockProcessManager.Setup(pm => pm.ProcessId).Returns(5432);
-        _mockProcessManager.Setup(pm => pm.ExitCode).Returns(1);
+        _mockProcessManager.Setup(pm => pm.ProcessId).Returns((int?)5432);
+        _mockProcessManager.Setup(pm => pm.ProcessName).Returns("vstest.console");
+        _mockProcessManager.Setup(pm => pm.ExitCode).Returns((int?)1);
         _mockProcessManager.Setup(pm => pm.ErrorOutput).Returns("Unhandled exception: System.OutOfMemoryException");
         _mockProcessHelper.Setup(x => x.GetCurrentProcessFileName()).Returns("TestRunner");
 
@@ -727,15 +733,16 @@ public class VsTestConsoleWrapperTests
     {
         _mockRequestSender.Setup(rs => rs.InitializeCommunication()).Returns(100);
         _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
-        _mockProcessManager.Setup(pm => pm.ProcessId).Returns(5432);
-        _mockProcessManager.Setup(pm => pm.ExitCode).Returns(-1);
+        _mockProcessManager.Setup(pm => pm.ProcessId).Returns((int?)5432);
+        _mockProcessManager.Setup(pm => pm.ProcessName).Returns("vstest.console");
+        _mockProcessManager.Setup(pm => pm.ExitCode).Returns((int?)null);
         _mockProcessManager.Setup(pm => pm.ErrorOutput).Returns("");
         _mockProcessHelper.Setup(x => x.GetCurrentProcessFileName()).Returns("TestRunner");
 
         var ex = Assert.ThrowsExactly<TransationLayerException>(() => _consoleWrapper.InitializeExtensions(new[] { "path" }));
 
         Assert.Contains("5432", ex.Message);
-        Assert.Contains("exitCode -1", ex.Message);
+        Assert.Contains("still running", ex.Message);
     }
 
     [TestMethod]
@@ -743,13 +750,14 @@ public class VsTestConsoleWrapperTests
     {
         _mockRequestSender.Setup(rs => rs.InitializeCommunication()).Returns(100);
         _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>())).Returns(false);
-        _mockProcessManager.Setup(pm => pm.ProcessId).Returns(-1);
-        _mockProcessManager.Setup(pm => pm.ExitCode).Returns(-1);
-        _mockProcessManager.Setup(pm => pm.ErrorOutput).Returns("");
+        _mockProcessManager.Setup(pm => pm.ProcessId).Returns((int?)null);
+        _mockProcessManager.Setup(pm => pm.ProcessName).Returns((string?)null);
+        _mockProcessManager.Setup(pm => pm.ExitCode).Returns((int?)null);
+        _mockProcessManager.Setup(pm => pm.ErrorOutput).Returns((string?)null);
         _mockProcessHelper.Setup(x => x.GetCurrentProcessFileName()).Returns("TestRunner");
 
         var ex = Assert.ThrowsExactly<TransationLayerException>(() => _consoleWrapper.InitializeExtensions(new[] { "path" }));
 
-        Assert.Contains("-1", ex.Message);
+        Assert.Contains("failed to start", ex.Message);
     }
 }


### PR DESCRIPTION
Closes #15569

## Problem

When vstest times out waiting for a child process to connect, the error message only says 'increase timeout' — no info about what happened to the child process.

## Solution

Include child process details in the timeout error message:
- **Process ID** and **exit code** (if exited)
- **Error output** (stderr)
- **'Process was still running'** message with PID (if timeout, not crash)

### TranslationLayer → vstest.console
- \VsTestConsoleProcessManager\: captures stderr (\StringBuilder\) and exit code in callbacks
- \IProcessManager\: adds \ErrorOutput\ and \ExitCode\ properties
- \VsTestConsoleWrapper\: uses \ConnectionTimeoutWithErrorMessage\ with full details

### vstest.console → testhost
- \ProxyOperationManager.ThrowExceptionOnConnectionFailure()\: appends process ID when testhost is still running

## New resource
\ConnectionTimeoutWithErrorMessage\: \{0} process failed to connect to {1} process after {2} seconds. The process with id {3}, exited with exitCode {4}, and error output: {5}\

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>