### PR TITLE
Add copilot-setup-steps.yml

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,27 @@
+name: "Copilot Setup Steps"
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Build the repository
+        run: |
+          chmod +x build.sh eng/build.sh eng/common/build.sh eng/common/tools.sh
+          ./build.sh


### PR DESCRIPTION
Closes #15582

Adds \.github/copilot-setup-steps.yml\ so GitHub Copilot coding agents can restore and build the project when assigned issues. The repo uses Arcade which auto-installs the SDK from global.json into \.dotnet/\ on first build.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>