### PR TITLE
Fix typos and add comments to empty catch blocks

### DIFF
--- a/src/Microsoft.TestPlatform.Common/Filtering/FilterExpressionWrapper.cs
+++ b/src/Microsoft.TestPlatform.Common/Filtering/FilterExpressionWrapper.cs
@@ -51,7 +51,7 @@ public class FilterExpressionWrapper
                 // Property value regex is only supported for fast filter,
                 // so we ignore it if no fast filter is constructed.
 
-                // TODO: surface an error message to suer.
+                // TODO: surface an error message to user.
                 var regexString = options?.FilterRegEx;
                 if (!regexString.IsNullOrEmpty())
                 {

--- a/src/Microsoft.TestPlatform.Execution.Shared/UILanguageOverride.cs
+++ b/src/Microsoft.TestPlatform.Execution.Shared/UILanguageOverride.cs
@@ -55,7 +55,7 @@ internal class UiLanguageOverride
             {
                 return new CultureInfo(dotnetCliLanguage);
             }
-            catch (CultureNotFoundException) { }
+            catch (CultureNotFoundException) { /* Culture not available on this system — fall back to default. */ }
         }
 
         // VSLANG=<lcid> is set by VS and we respect that as well so that we will respect the VS
@@ -67,8 +67,8 @@ internal class UiLanguageOverride
             {
                 return new CultureInfo(vsLcid);
             }
-            catch (ArgumentOutOfRangeException) { }
-            catch (CultureNotFoundException) { }
+            catch (ArgumentOutOfRangeException) { /* Invalid culture value — fall back to default. */ }
+            catch (CultureNotFoundException) { /* Culture not available on this system — fall back to default. */ }
         }
 
         return null;

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameCollector.cs
@@ -318,6 +318,7 @@ public class BlameCollector : DataCollector, ITestExecutionEnvironmentSpecifier
             }
             catch (InvalidOperationException)
             {
+                // Process may have already exited — safe to ignore.
             }
         }
         catch (Exception ex)

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -266,6 +266,7 @@ public partial class ProcessHelper : IProcessHelper
         }
         catch (InvalidOperationException)
         {
+            // Process may have already exited — exit code unavailable.
         }
 
         exitCode = 0;
@@ -301,6 +302,7 @@ public partial class ProcessHelper : IProcessHelper
         }
         catch (InvalidOperationException)
         {
+            // Process may have already exited — exit code unavailable.
         }
     }
 


### PR DESCRIPTION
## Summary
Fix minor code quality issues:

1. **Fix typo** in `FilterExpressionWrapper.cs`: \`suer\` → \`user\`
2. **Add comments to empty catch blocks** in:
   - `BlameCollector.cs` — `InvalidOperationException` (process may have exited)
   - `UILanguageOverride.cs` — `CultureNotFoundException` and `ArgumentOutOfRangeException` (culture fallback)
   - `ProcessHelper.cs` — `InvalidOperationException` (process may have exited)

These are comment-only changes with no behavior impact.