### PR TITLE
Mark PathConverter tests as Windows-only

### DIFF
--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/EventHandlers/PathConverterDiscoveryCriteriaRegressionTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/EventHandlers/PathConverterDiscoveryCriteriaRegressionTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.UnitTests.EventHan
 /// Regression tests for PathConverter DiscoveryCriteria and TestRunCriteria handling.
 /// </summary>
 [TestClass]
+[TestCategory("Windows")]
 public class PathConverterDiscoveryCriteriaRegressionTests
 {
     private readonly PathConverter _pathConverter;

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/EventHandlers/PathConverterRegressionTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/EventHandlers/PathConverterRegressionTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.UnitTests.EventHan
 /// Regression tests for PathConverter — path conversion for UWP deployment.
 /// </summary>
 [TestClass]
+[TestCategory("Windows")]
 public class PathConverterRegressionTests
 {
     private readonly PathConverter _pathConverter;


### PR DESCRIPTION
## Problem

PathConverter regression tests fail on Linux because they use hardcoded Windows backslash paths (\C:\Remote\TestDir\). On Linux, \Path.DirectorySeparatorChar\ is \/\ and \GetFullPath\ doesn't normalize Windows-style paths, so the path replacement never matches.

## Fix

Add \[TestCategory("Windows")]\ to both \PathConverterRegressionTests\ and \PathConverterDiscoveryCriteriaRegressionTests\. PathConverter is a UWP deployment feature that only applies on Windows.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>