### PR TITLE
Update Microsoft.Internal.TestPlatform.Extensions to 18.3.11611.365

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -74,7 +74,7 @@
     <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
     <SystemReflectionMetadataVersion>8.0.0</SystemReflectionMetadataVersion>
     <TestPlatformExternalsVersion>18.0.0-preview-1-10911-061</TestPlatformExternalsVersion>
-    <MicrosoftInternalTestPlatformExtensions>18.0.0-preview-1-10911-061</MicrosoftInternalTestPlatformExtensions>
+    <MicrosoftInternalTestPlatformExtensions>18.3.11611.365</MicrosoftInternalTestPlatformExtensions>
     <TestPlatformMSDiaVersion>18.0.11024.295</TestPlatformMSDiaVersion>
     <SystemDiagnosticsDiagnosticSourceVersion>8.0.1</SystemDiagnosticsDiagnosticSourceVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>


### PR DESCRIPTION
Fixes symbol resolution issues.

\\\
18.0.0-preview-1-10911-061 → 18.3.11611.365
\\\

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>