### PR TITLE
Update Microsoft.VisualStudio.QualityTools to version with symbols

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -73,7 +73,7 @@
     <SystemCollectionsImmutableVersion>9.0.11</SystemCollectionsImmutableVersion>
     <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
     <SystemReflectionMetadataVersion>8.0.0</SystemReflectionMetadataVersion>
-    <TestPlatformExternalsVersion>18.0.0-preview-1-10911-061</TestPlatformExternalsVersion>
+    <TestPlatformExternalsVersion>18.2.0-preview-1-11429-120</TestPlatformExternalsVersion>
     <MicrosoftInternalTestPlatformExtensions>18.3.11611.365</MicrosoftInternalTestPlatformExtensions>
     <TestPlatformMSDiaVersion>18.0.11024.295</TestPlatformMSDiaVersion>
     <SystemDiagnosticsDiagnosticSourceVersion>8.0.1</SystemDiagnosticsDiagnosticSourceVersion>


### PR DESCRIPTION
Bump `TestPlatformExternalsVersion` from `18.0.0-preview-1-10911-061` to `18.2.0-preview-1-11429-120`, which is the newest version that has symbols archived on the Microsoft symbol server.

This enables debuggers to download PDBs for `Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll` on demand, resolving the missing symbols issue for C++ / native test debugging.