### PR TITLE
Claim TestHost net462 dependencies

### DIFF
--- a/src/package/Microsoft.TestPlatform.TestHost/Microsoft.TestPlatform.TestHost.nuspec
+++ b/src/package/Microsoft.TestPlatform.TestHost/Microsoft.TestPlatform.TestHost.nuspec
@@ -10,7 +10,10 @@
         <dependency id="Newtonsoft.Json" version="$NewtonsoftJsonVersion$"/>
       </group>
 
-      <group targetFramework="net462"></group>
+      <group targetFramework="net462">
+        <dependency id="Microsoft.TestPlatform.ObjectModel" version="$Version$"/>
+        <dependency id="Newtonsoft.Json" version="$NewtonsoftJsonVersion$"/>
+      </group>
     </dependencies>
   </metadata>
 


### PR DESCRIPTION
## Description

Add the missing Microsoft.TestPlatform.ObjectModel and Newtonsoft.Json dependency declarations to the 
et462 group of Microsoft.TestPlatform.TestHost.

The 
et8.0 group already claimed these dependencies; the gap was only in the .NET Framework group.

## Related issue

Fixes #15642