### PR TITLE
Simplify HandleRawMessage: reduce competing styles, preserve passthrough semantics

### DIFF
--- a/src/Microsoft.TestPlatform.Client/AttachmentsProcessing/InProcessTestRunAttachmentsProcessingEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.Client/AttachmentsProcessing/InProcessTestRunAttachmentsProcessingEventsHandler.cs
@@ -32,19 +32,12 @@ internal class InProcessTestRunAttachmentsProcessingEventsHandler : ITestRunAtta
         throw new NotImplementedException();
     }
 
+#if !NET
     public void HandleRawMessage(string rawMessage)
     {
         // No-op by design.
-        //
-        // For out-of-process vstest.console, raw messages are passed to the translation layer but
-        // they are never read and don't get passed to the actual events handler in TW. If they
-        // were (as it happens for in-process vstest.console since there is no more translation
-        // layer) a NotImplemented exception would be raised as per the time this of writing this
-        // note.
-        //
-        // Consider changing this logic in the future if TW changes the handling logic for raw
-        // messages.
     }
+#endif
 
     public void HandleTestRunAttachmentsProcessingComplete(
         TestRunAttachmentsProcessingCompleteEventArgs attachmentsProcessingCompleteEventArgs,

--- a/src/Microsoft.TestPlatform.Client/AttachmentsProcessing/TestRunAttachmentsProcessingEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.Client/AttachmentsProcessing/TestRunAttachmentsProcessingEventsHandler.cs
@@ -66,9 +66,11 @@ public class TestRunAttachmentsProcessingEventsHandler : ITestRunAttachmentsProc
         _communicationManager.SendMessage(MessageType.TestMessage, testMessagePayload);
     }
 
+#if !NET
     /// <inheritdoc/>
     public void HandleRawMessage(string rawMessage)
     {
         // No-Op
     }
+#endif
 }

--- a/src/Microsoft.TestPlatform.Client/TestSession/InProcessTestSessionEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.Client/TestSession/InProcessTestSessionEventsHandler.cs
@@ -26,19 +26,12 @@ internal class InProcessTestSessionEventsHandler : ITestSessionEventsHandler
         _testSessionEventsHandler.HandleLogMessage(level, message);
     }
 
+#if !NET
     public void HandleRawMessage(string rawMessage)
     {
         // No-op by design.
-        //
-        // For out-of-process vstest.console, raw messages are passed to the translation layer but
-        // they are never read and don't get passed to the actual events handler in TW. If they
-        // were (as it happens for in-process vstest.console since there is no more translation
-        // layer) a NotImplemented exception would be raised as per the time this of writing this
-        // note.
-        //
-        // Consider changing this logic in the future if TW changes the handling logic for raw
-        // messages.
     }
+#endif
 
     public void HandleStartTestSessionComplete(StartTestSessionCompleteEventArgs? eventArgs)
     {

--- a/src/Microsoft.TestPlatform.Client/TestSession/TestSessionEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.Client/TestSession/TestSessionEventsHandler.cs
@@ -62,9 +62,11 @@ internal class TestSessionEventsHandler : ITestSessionEventsHandler
         _communicationManager.SendMessage(MessageType.TestMessage, messagePayload);
     }
 
+#if !NET
     /// <inheritdoc />
     public void HandleRawMessage(string rawMessage)
     {
         // No-op.
     }
+#endif
 }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestDiscoveryEventHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestDiscoveryEventHandler.cs
@@ -77,9 +77,11 @@ public class TestDiscoveryEventHandler : ITestDiscoveryEventsHandler2
         _requestHandler.SendLog(level, message);
     }
 
+#if !NET
     public void HandleRawMessage(string rawMessage)
     {
         // No-Op
         // TestHost at this point has no functionality where it requires rawmessage
     }
+#endif
 }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestInitializeEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestInitializeEventsHandler.cs
@@ -54,9 +54,11 @@ public class TestInitializeEventsHandler : ITestMessageEventHandler
         _requestHandler.SendLog(level, message);
     }
 
+#if !NET
     public void HandleRawMessage(string rawMessage)
     {
         // No-Op
         // TestHost at this point has no functionality where it requires rawmessage
     }
+#endif
 }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestRunEventsHandler.cs
@@ -80,11 +80,13 @@ public class TestRunEventsHandler : IInternalTestRunEventsHandler
         _requestHandler.SendLog(level, message);
     }
 
+#if !NET
     public void HandleRawMessage(string rawMessage)
     {
         // No-Op
         // TestHost at this point has no functionality where it requires rawmessage
     }
+#endif
 
     /// <summary>
     /// Launches a process with a given process info under debugger

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
@@ -311,6 +311,8 @@ public class ProxyDiscoveryManager : IProxyDiscoveryManager, IBaseProxy, ITestDi
             _discoveryDataAggregator.MarkSourcesWithStatus(new[] { _previousSource }, DiscoveryStatus.FullyDiscovered);
             _previousSource = null;
         }
+
+        Close();
         _baseTestDiscoveryEventsHandler?.HandleDiscoveryComplete(discoveryCompleteEventArgs, lastChunk);
     }
 
@@ -324,12 +326,6 @@ public class ProxyDiscoveryManager : IProxyDiscoveryManager, IBaseProxy, ITestDi
     /// <inheritdoc/>
     public void HandleRawMessage(string rawMessage)
     {
-        var message = _dataSerializer.DeserializeMessage(rawMessage);
-        if (string.Equals(message.MessageType, MessageType.DiscoveryComplete))
-        {
-            Close();
-        }
-
         _baseTestDiscoveryEventsHandler?.HandleRawMessage(rawMessage);
     }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -419,6 +419,7 @@ internal class ProxyExecutionManager : IProxyExecutionManager, IBaseProxy, IInte
     /// <inheritdoc/>
     public void HandleTestRunComplete(TestRunCompleteEventArgs testRunCompleteArgs, TestRunChangedEventArgs? lastChunkArgs, ICollection<AttachmentSet>? runContextAttachments, ICollection<string>? executorUris)
     {
+        Close();
         _baseTestRunEventsHandler?.HandleTestRunComplete(testRunCompleteArgs, lastChunkArgs, runContextAttachments, executorUris);
     }
 
@@ -431,16 +432,6 @@ internal class ProxyExecutionManager : IProxyExecutionManager, IBaseProxy, IInte
     /// <inheritdoc/>
     public void HandleRawMessage(string rawMessage)
     {
-        // TODO: PERF: - why do we have to deserialize the messages here only to read that this is
-        // execution complete? Why can't we act on it somewhere else where the result of deserialization is not
-        // thrown away?
-        var message = _dataSerializer.DeserializeMessage(rawMessage);
-
-        if (string.Equals(message.MessageType, MessageType.ExecutionComplete))
-        {
-            Close();
-        }
-
         _baseTestRunEventsHandler?.HandleRawMessage(rawMessage);
     }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/PostProcessing/PostProcessingTestRunAttachmentsProcessingEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/PostProcessing/PostProcessingTestRunAttachmentsProcessingEventsHandler.cs
@@ -27,8 +27,10 @@ internal class PostProcessingTestRunAttachmentsProcessingEventsHandler : ITestRu
     public void HandleLogMessage(TestMessageLevel level, string? message)
     { }
 
+#if !NET
     public void HandleRawMessage(string rawMessage)
     { }
+#endif
 
     public void HandleTestRunAttachmentsProcessingProgress(TestRunAttachmentsProcessingProgressEventArgs attachmentsProcessingProgressEventArgs)
     { }

--- a/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestRunEventsHandler.cs
@@ -45,7 +45,11 @@ public interface ITestMessageEventHandler
     /// Raw Message from the host directly
     /// </summary>
     /// <param name="rawMessage">raw message args from host</param>
+#if NET
+    void HandleRawMessage(string rawMessage) { }
+#else
     void HandleRawMessage(string rawMessage);
+#endif
 
     /// <summary>
     /// Handle a IMessageLogger message event from Adapter

--- a/src/vstest.console/HandlerToEventsRegistrarAdapter.cs
+++ b/src/vstest.console/HandlerToEventsRegistrarAdapter.cs
@@ -15,7 +15,6 @@ internal class DiscoveryHandlerToEventsRegistrarAdapter : ITestDiscoveryEventsRe
     private readonly EventHandler<DiscoveredTestsEventArgs> _handleDiscoveredTests;
     private readonly EventHandler<TestRunMessageEventArgs> _handleLogMessage;
     private readonly EventHandler<DiscoveryCompleteEventArgs> _handleDiscoveryComplete;
-    private readonly EventHandler<string> _handleRawMessage;
 
     public DiscoveryHandlerToEventsRegistrarAdapter(ITestDiscoveryEventsHandler2 handler)
     {
@@ -23,19 +22,6 @@ internal class DiscoveryHandlerToEventsRegistrarAdapter : ITestDiscoveryEventsRe
         _handleDiscoveredTests += (_, e) => _handler.HandleDiscoveredTests(e.DiscoveredTestCases);
         _handleLogMessage += (_, e) => _handler.HandleLogMessage(e.Level, e.Message);
         _handleDiscoveryComplete += (_, e) => _handler.HandleDiscoveryComplete(e, null);
-        _handleRawMessage += (_, e) =>
-        {
-            // No-op by design.
-            //
-            // For out-of-process vstest.console, raw messages are passed to the translation layer but
-            // they are never read and don't get passed to the actual events handler in TW. If they
-            // were (as it happens for in-process vstest.console since there is no more translation
-            // layer) a NotImplemented exception would be raised as per the time this of writing this
-            // note.
-            //
-            // Consider changing this logic in the future if TW changes the handling logic for raw
-            // messages.
-        };
     }
 
     public void LogWarning(string message)
@@ -48,7 +34,6 @@ internal class DiscoveryHandlerToEventsRegistrarAdapter : ITestDiscoveryEventsRe
         discoveryRequest.OnDiscoveredTests += _handleDiscoveredTests;
         discoveryRequest.OnDiscoveryMessage += _handleLogMessage;
         discoveryRequest.OnDiscoveryComplete += _handleDiscoveryComplete;
-        discoveryRequest.OnRawMessageReceived += _handleRawMessage;
     }
 
     public void UnregisterDiscoveryEvents(IDiscoveryRequest discoveryRequest)
@@ -56,7 +41,6 @@ internal class DiscoveryHandlerToEventsRegistrarAdapter : ITestDiscoveryEventsRe
         discoveryRequest.OnDiscoveredTests -= _handleDiscoveredTests;
         discoveryRequest.OnDiscoveryMessage -= _handleLogMessage;
         discoveryRequest.OnDiscoveryComplete -= _handleDiscoveryComplete;
-        discoveryRequest.OnRawMessageReceived -= _handleRawMessage;
     }
 }
 
@@ -64,7 +48,6 @@ internal class RunHandlerToEventsRegistrarAdapter : ITestRunEventsRegistrar
 {
     private readonly ITestRunEventsHandler _handler;
     private readonly EventHandler<TestRunMessageEventArgs> _handleLogMessage;
-    private readonly EventHandler<string> _handleRawMessage;
     private readonly EventHandler<TestRunChangedEventArgs> _handleTestRunStatsChange;
     private readonly EventHandler<TestRunCompleteEventArgs> _handleTestRunComplete;
 
@@ -72,19 +55,6 @@ internal class RunHandlerToEventsRegistrarAdapter : ITestRunEventsRegistrar
     {
         _handler = handler;
         _handleLogMessage = (_, e) => _handler.HandleLogMessage(e.Level, e.Message);
-        _handleRawMessage = (_, e) =>
-        {
-            // No-op by design.
-            //
-            // For out-of-process vstest.console, raw messages are passed to the translation layer but
-            // they are never read and don't get passed to the actual events handler in TW. If they
-            // were (as it happens for in-process vstest.console since there is no more translation
-            // layer) a NotImplemented exception would be raised as per the time this of writing this
-            // note.
-            //
-            // Consider changing this logic in the future if TW changes the handling logic for raw
-            // messages.
-        };
         _handleTestRunComplete = (_, e) => _handler.HandleTestRunComplete(e, null, null, null);
         _handleTestRunStatsChange = (_, e) => _handler.HandleTestRunStatsChange(e);
     }
@@ -97,7 +67,6 @@ internal class RunHandlerToEventsRegistrarAdapter : ITestRunEventsRegistrar
     public void RegisterTestRunEvents(ITestRunRequest testRunRequest)
     {
         testRunRequest.TestRunMessage += _handleLogMessage;
-        testRunRequest.OnRawMessageReceived += _handleRawMessage;
         testRunRequest.OnRunStatsChange += _handleTestRunStatsChange;
         testRunRequest.OnRunCompletion += _handleTestRunComplete;
     }
@@ -105,7 +74,6 @@ internal class RunHandlerToEventsRegistrarAdapter : ITestRunEventsRegistrar
     public void UnregisterTestRunEvents(ITestRunRequest testRunRequest)
     {
         testRunRequest.TestRunMessage -= _handleLogMessage;
-        testRunRequest.OnRawMessageReceived -= _handleRawMessage;
         testRunRequest.OnRunStatsChange -= _handleTestRunStatsChange;
         testRunRequest.OnRunCompletion -= _handleTestRunComplete;
     }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyDiscoveryManagerTests.cs
@@ -385,23 +385,12 @@ public class ProxyDiscoveryManagerTests : ProxyBaseManagerTests
     }
 
     [TestMethod]
-    public void DiscoverTestsCloseTestHostIfRawMessageIsOfTypeDiscoveryComplete()
+    public void DiscoverTestsClosesTestHostWhenHandleDiscoveryCompleteIsCalled()
     {
         Mock<ITestDiscoveryEventsHandler2> mockTestDiscoveryEventsHandler = new();
 
         _mockDataSerializer.Setup(ds => ds.SerializePayload(MessageType.TestMessage, It.IsAny<TestMessagePayload>())).Returns(MessageType.TestMessage);
         _mockDataSerializer.Setup(ds => ds.SerializePayload(MessageType.DiscoveryComplete, It.IsAny<DiscoveryCompletePayload>())).Returns(MessageType.DiscoveryComplete);
-
-        _mockDataSerializer.Setup(mds => mds.DeserializeMessage(It.IsAny<string>())).Returns((string rawMessage) =>
-        {
-            var messageType = rawMessage.Contains(MessageType.DiscoveryComplete) ? MessageType.DiscoveryComplete : MessageType.TestMessage;
-            var message = new Message
-            {
-                MessageType = messageType
-            };
-
-            return message;
-        });
 
         // Act.
         _discoveryManager.DiscoverTests(_discoveryCriteria, mockTestDiscoveryEventsHandler.Object);
@@ -411,25 +400,59 @@ public class ProxyDiscoveryManagerTests : ProxyBaseManagerTests
     }
 
     [TestMethod]
-    public void DiscoverTestsShouldNotCloseTestHostIfRawMessageIsNotOfTypeDiscoveryComplete()
+    public void HandleRawMessageShouldNotDeserializeAndShouldForwardToBaseHandler()
     {
         Mock<ITestDiscoveryEventsHandler2> mockTestDiscoveryEventsHandler = new();
 
-        _mockDataSerializer.Setup(mds => mds.DeserializeMessage(It.IsAny<string>())).Returns(() =>
-        {
-            var message = new Message
-            {
-                MessageType = MessageType.DiscoveryInitialize
-            };
-
-            return message;
-        });
-
-        // Act.
+        // Arrange - register the handler so the proxy has somewhere to forward.
         _discoveryManager.DiscoverTests(_discoveryCriteria, mockTestDiscoveryEventsHandler.Object);
 
-        // Verify
-        _mockTestHostManager.Verify(mthm => mthm.CleanTestHostAsync(It.IsAny<CancellationToken>()), Times.Never);
+        // Act - HandleRawMessage should be a pure passthrough.
+        _discoveryManager.HandleRawMessage("some raw message");
+
+        // Verify - raw message is forwarded, no deserialization happens.
+        _mockDataSerializer.Verify(ds => ds.DeserializeMessage("some raw message"), Times.Never);
+    }
+
+    [TestMethod]
+    public void HandleRawMessageShouldForwardToBaseHandlerWhenHandlerIsRegistered()
+    {
+        // Arrange: register handler via DiscoverTests.
+        Mock<ITestDiscoveryEventsHandler2> mockTestDiscoveryEventsHandler = new();
+        _discoveryManager.DiscoverTests(_discoveryCriteria, mockTestDiscoveryEventsHandler.Object);
+
+        // Clear invocations from the error-handling path so we only track the direct call.
+        mockTestDiscoveryEventsHandler.Invocations.Clear();
+        _mockDataSerializer.Invocations.Clear();
+
+        // Act
+        _discoveryManager.HandleRawMessage("any-raw-message");
+
+        // Assert - message forwarded as-is, no DeserializeMessage call.
+        mockTestDiscoveryEventsHandler.Verify(h => h.HandleRawMessage("any-raw-message"), Times.Once);
+        _mockDataSerializer.Verify(ds => ds.DeserializeMessage(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public void HandleDiscoveryCompleteShouldCloseProxy()
+    {
+        // Arrange: register handler via DiscoverTests.
+        Mock<ITestDiscoveryEventsHandler2> mockTestDiscoveryEventsHandler = new();
+        _mockDataSerializer.Setup(ds => ds.SerializePayload(MessageType.TestMessage, It.IsAny<TestMessagePayload>())).Returns(MessageType.TestMessage);
+        _mockDataSerializer.Setup(ds => ds.SerializePayload(MessageType.DiscoveryComplete, It.IsAny<DiscoveryCompletePayload>())).Returns(MessageType.DiscoveryComplete);
+        _discoveryManager.DiscoverTests(_discoveryCriteria, mockTestDiscoveryEventsHandler.Object);
+
+        // Clear invocations from the error-handling path.
+        _mockTestHostManager.Invocations.Clear();
+        mockTestDiscoveryEventsHandler.Invocations.Clear();
+
+        // Act: directly call HandleDiscoveryComplete.
+        var completeArgs = new DiscoveryCompleteEventArgs(-1, false);
+        _discoveryManager.HandleDiscoveryComplete(completeArgs, null);
+
+        // Assert: Close() was called which triggers CleanTestHostAsync.
+        _mockTestHostManager.Verify(mthm => mthm.CleanTestHostAsync(It.IsAny<CancellationToken>()), Times.Once);
+        mockTestDiscoveryEventsHandler.Verify(h => h.HandleDiscoveryComplete(completeArgs, null), Times.Once);
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyExecutionManagerTests.cs
@@ -567,7 +567,7 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
     }
 
     [TestMethod]
-    public void ExecuteTestsCloseTestHostIfRawMessageIfOfTypeExecutionComplete()
+    public void ExecuteTestsClosesTestHostWhenHandleTestRunCompleteIsCalled()
     {
         Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
 
@@ -575,17 +575,6 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
 
         _mockDataSerializer.Setup(ds => ds.SerializePayload(MessageType.TestMessage, It.IsAny<TestMessagePayload>())).Returns(MessageType.TestMessage);
         _mockDataSerializer.Setup(ds => ds.SerializePayload(MessageType.ExecutionComplete, It.IsAny<TestRunCompletePayload>())).Returns(MessageType.ExecutionComplete);
-
-        _mockDataSerializer.Setup(mds => mds.DeserializeMessage(It.IsAny<string>())).Returns((string rawMessage) =>
-        {
-            var messageType = rawMessage.Contains(MessageType.ExecutionComplete) ? MessageType.ExecutionComplete : MessageType.TestMessage;
-            var message = new Message
-            {
-                MessageType = messageType
-            };
-
-            return message;
-        });
 
         // Act.
         _testExecutionManager.StartTestRun(_mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
@@ -595,26 +584,60 @@ public class ProxyExecutionManagerTests : ProxyBaseManagerTests
     }
 
     [TestMethod]
-    public void ExecuteTestsShouldNotCloseTestHostIfRawMessageIsNotOfTypeExecutionComplete()
+    public void HandleRawMessageShouldNotDeserializeAndShouldForwardToBaseHandler()
     {
         Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
+
+        // Act - HandleRawMessage should be a pure passthrough.
+        _testExecutionManager.HandleRawMessage("some raw message");
+
+        // Verify - raw message is forwarded, no deserialization happens.
+        _mockDataSerializer.Verify(ds => ds.DeserializeMessage(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public void HandleRawMessageShouldForwardToBaseHandlerWhenHandlerIsRegistered()
+    {
+        // Arrange: register handler via StartTestRun (connection fails, but handler gets registered).
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
         _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
-
-        _mockDataSerializer.Setup(mds => mds.DeserializeMessage(It.IsAny<string>())).Returns(() =>
-        {
-            var message = new Message
-            {
-                MessageType = MessageType.ExecutionInitialize
-            };
-
-            return message;
-        });
-
-        // Act.
+        _mockDataSerializer.Setup(ds => ds.SerializePayload(MessageType.TestMessage, It.IsAny<TestMessagePayload>())).Returns("test-message-payload");
+        _mockDataSerializer.Setup(ds => ds.SerializePayload(MessageType.ExecutionComplete, It.IsAny<TestRunCompletePayload>())).Returns("execution-complete-payload");
         _testExecutionManager.StartTestRun(_mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
 
-        // Verify
-        _mockTestHostManager.Verify(mthm => mthm.CleanTestHostAsync(It.IsAny<CancellationToken>()), Times.Never);
+        // Clear invocations from the error-handling path so we only track the direct call.
+        mockTestRunEventsHandler.Invocations.Clear();
+        _mockDataSerializer.Invocations.Clear();
+
+        // Act
+        _testExecutionManager.HandleRawMessage("any-raw-message");
+
+        // Assert - message forwarded as-is, no DeserializeMessage call.
+        mockTestRunEventsHandler.Verify(h => h.HandleRawMessage("any-raw-message"), Times.Once);
+        _mockDataSerializer.Verify(ds => ds.DeserializeMessage(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public void HandleTestRunCompleteShouldCloseProxy()
+    {
+        // Arrange: register handler via StartTestRun to initialize the proxy.
+        Mock<IInternalTestRunEventsHandler> mockTestRunEventsHandler = new();
+        _mockRequestSender.Setup(s => s.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
+        _mockDataSerializer.Setup(ds => ds.SerializePayload(MessageType.TestMessage, It.IsAny<TestMessagePayload>())).Returns("test-message-payload");
+        _mockDataSerializer.Setup(ds => ds.SerializePayload(MessageType.ExecutionComplete, It.IsAny<TestRunCompletePayload>())).Returns("execution-complete-payload");
+        _testExecutionManager.StartTestRun(_mockTestRunCriteria.Object, mockTestRunEventsHandler.Object);
+
+        // Clear invocations from the error-handling path.
+        _mockTestHostManager.Invocations.Clear();
+        mockTestRunEventsHandler.Invocations.Clear();
+
+        // Act: directly call HandleTestRunComplete.
+        var completeArgs = new TestRunCompleteEventArgs(null, false, false, null, new System.Collections.ObjectModel.Collection<AttachmentSet>(), new System.Collections.ObjectModel.Collection<InvokedDataCollector>(), TimeSpan.Zero);
+        _testExecutionManager.HandleTestRunComplete(completeArgs, null, null, null);
+
+        // Assert: Close() was called which triggers CleanTestHostAsync.
+        _mockTestHostManager.Verify(mthm => mthm.CleanTestHostAsync(It.IsAny<CancellationToken>()), Times.Once);
+        mockTestRunEventsHandler.Verify(h => h.HandleTestRunComplete(completeArgs, null, null, null), Times.Once);
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/DataCollectionTestRunEventsHandlerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/DataCollection/DataCollectionTestRunEventsHandlerTests.cs
@@ -52,6 +52,18 @@ public class DataCollectionTestRunEventsHandlerTests
     }
 
     [TestMethod]
+    public void HandleRawMessageShouldNotCallAfterTestRunEndForNonCompleteMessages()
+    {
+        _mockDataSerializer.Setup(x => x.DeserializeMessage(It.IsAny<string>())).Returns(new Message() { MessageType = MessageType.TestMessage });
+        _testRunEventHandler.HandleRawMessage("non-complete-message");
+
+        _baseTestRunEventsHandler.Verify(th => th.HandleRawMessage("non-complete-message"), Times.Once);
+        _proxyDataCollectionManager.Verify(
+            dcm => dcm.AfterTestRunEnd(It.IsAny<bool>(), It.IsAny<IInternalTestRunEventsHandler>()),
+            Times.Never);
+    }
+
+    [TestMethod]
     public void HandleRawMessageShouldGetDataCollectorAttachments()
     {
         var testRunCompleteEventArgs = new TestRunCompleteEventArgs(null, false, false, null, new Collection<AttachmentSet>(), new Collection<InvokedDataCollector>(), new TimeSpan());


### PR DESCRIPTION
## Summary

Reduces the number of competing communication styles used internally around `HandleRawMessage` while preserving raw protocol passthrough semantics and public API compatibility.

## Changes

### Core refactoring
- **ProxyExecutionManager / ProxyDiscoveryManager** — `HandleRawMessage` is now a pure passthrough (no deserialization). `Close()` moved to the typed completion handlers (`HandleTestRunComplete` / `HandleDiscoveryComplete`) where it belongs, resolving a long-standing TODO about unnecessary deserialization.
- **HandlerToEventsRegistrarAdapter** — Removed 32 lines of dead no-op `OnRawMessageReceived` subscriptions that obscured intent.

### Default interface method
- **ITestMessageEventHandler.HandleRawMessage** — Added a default no-op body on .NET 5+ (DIM). The 8 existing no-op stub implementations are now compiled only for `net462`/`netstandard2.0` via `#if !NET`.

### Test coverage
- Updated 4 existing tests to match the new Close()-via-typed-handler behavior.
- Added 5 new regression tests covering: passthrough forwarding without deserialization, proxy close via typed completion handlers, and data collection non-complete message passthrough.

## What stays the same
- Public API surface — no changes to `ITestMessageEventHandler`, `ITestRunEventsHandler`, or `ITestDiscoveryEventsHandler` signatures.
- Raw message flow to IDE/translation layer via `OnRawMessageReceived` event.
- Parallel handler aggregation logic (block complete, forward everything else).
- Data collection enrichment of `ExecutionComplete` messages.
- `TestRunRequest` / `DiscoveryRequest` conditional deserialization for telemetry/loggers.

## Validation
- Full build: 0 warnings, 0 errors
- All 6 affected unit test assemblies pass (1664+ tests)
