### PR TITLE
Consolidate test TFMs to latest and simplify compiler conditionals

### DIFF
--- a/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/InvalidManagedNameException.cs
+++ b/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/InvalidManagedNameException.cs
@@ -11,7 +11,7 @@ public class InvalidManagedNameException : Exception, ISerializable
 {
     public InvalidManagedNameException(string? message) : base(message) { }
 
-#if NET8_0_OR_GREATER
+#if NET
     [Obsolete("Serialization constructors are deprecated in .NET8+", DiagnosticId = "SYSLIB0051")]
 #endif
     protected InvalidManagedNameException(SerializationInfo info, StreamingContext context) : base(info, context) { }

--- a/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/ManagedNameHelper.Reflection.cs
+++ b/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/ManagedNameHelper.Reflection.cs
@@ -459,7 +459,7 @@ public static partial class ManagedNameHelper
         if (arity > 0 && methodArity == arity)
         {
             methodBuilder.Append(
-#if NET6_0_OR_GREATER
+#if NET
                 System.Globalization.CultureInfo.InvariantCulture,
 #endif
                 $"`{arity}");

--- a/src/Microsoft.TestPlatform.AdapterUtilities/TestIdProvider.cs
+++ b/src/Microsoft.TestPlatform.AdapterUtilities/TestIdProvider.cs
@@ -103,7 +103,7 @@ public class TestIdProvider
             return _id;
         }
 
-#if NET6_0_OR_GREATER
+#if NET
         var hashSlice = GetHash().AsSpan().Slice(0, 16);
         _id = new Guid(hashSlice);
 #else

--- a/src/Microsoft.TestPlatform.CoreUtilities/Extensions/GuidPolyfill.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Extensions/GuidPolyfill.cs
@@ -9,7 +9,7 @@ internal static class GuidPolyfill
 {
     public static Guid Parse(string s, IFormatProvider? provider)
         => Guid.Parse(s
-#if NET7_0_OR_GREATER
+#if NET
             , System.Globalization.CultureInfo.InvariantCulture
 #endif
             );

--- a/src/Microsoft.TestPlatform.CoreUtilities/Output/OutputExtensions.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Output/OutputExtensions.cs
@@ -116,7 +116,7 @@ public static class OutputExtensions
             return;
         }
 
-#if NET5_0_OR_GREATER
+#if NET
         if (OperatingSystem.IsAndroid() || OperatingSystem.IsIOS() || OperatingSystem.IsBrowser() || OperatingSystem.IsTvOS())
         {
             // Console color not supported on these platforms.

--- a/src/Microsoft.TestPlatform.CoreUtilities/Tracing/EqtTrace.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Tracing/EqtTrace.cs
@@ -52,7 +52,7 @@ public static class EqtTrace
 
 #endif
 
-#if NETSTANDARD || NET || NETCOREAPP3_1
+#if !NETFRAMEWORK
     public static PlatformTraceLevel TraceLevel
     {
         get

--- a/src/Microsoft.TestPlatform.CoreUtilities/Utilities/JobQueue.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Utilities/JobQueue.cs
@@ -290,7 +290,7 @@ public class JobQueue<T> : IDisposable
     /// </summary>
     private void BackgroundJobProcessor(string threadName)
     {
-#if DEBUG && (NETFRAMEWORK || NET || NETSTANDARD2_0_OR_GREATER)
+#if DEBUG
         Thread.CurrentThread.Name = threadName;
 #endif
         bool shutdown = false;

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -407,7 +407,7 @@ internal abstract class BaseRunTests
                 EqtTrace.Verbose("Attaching to default test host.");
 
                 attachedToTestHost = true;
-#if NET5_0_OR_GREATER
+#if NET
                 var pid = Environment.ProcessId;
 #else
                 var pid = Process.GetCurrentProcess().Id;

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/PostProcessing/ArtifactProcessingManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/PostProcessing/ArtifactProcessingManager.cs
@@ -65,7 +65,7 @@ internal class ArtifactProcessingManager : IArtifactProcessingManager
         {
             _testSessionCorrelationId = testSessionCorrelationId;
             _processArtifactFolder = Path.Combine(_fileHelper.GetTempPath(), _testSessionCorrelationId);
-#if NET5_0_OR_GREATER
+#if NET
             var pid = Environment.ProcessId;
 #else
             int pid;

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
@@ -689,7 +689,7 @@ public class TestEngine : ITestEngine
                         stringBuilder.Append(Resources.Resources.SkippingSource).Append(' ');
                     }
                     stringBuilder.AppendLine(
-#if NET6_0_OR_GREATER
+#if NET
                         System.Globalization.CultureInfo.InvariantCulture,
 #endif
                         $"{detail.Source} ({detail.Framework}, {detail.Architecture})");

--- a/src/Microsoft.TestPlatform.Execution.Shared/DebuggerBreakpoint.cs
+++ b/src/Microsoft.TestPlatform.Execution.Shared/DebuggerBreakpoint.cs
@@ -51,7 +51,7 @@ internal static class DebuggerBreakpoint
             else
             {
                 var processId =
-#if NET6_0_OR_GREATER
+#if NET
                     Environment.ProcessId;
 #else
                     Process.GetCurrentProcess().Id;

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/IO/PlatformStream.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/IO/PlatformStream.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETFRAMEWORK || NETCOREAPP || NETSTANDARD2_0
-
 using System.IO;
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
@@ -18,5 +16,3 @@ public class PlatformStream : IStream
         return new BufferedStream(stream, bufferSize);
     }
 }
-
-#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETFRAMEWORK || NETCOREAPP || NETSTANDARD2_0
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Threading;
-#if !NET5_0_OR_GREATER
+#if !NET
 using System.Threading.Tasks;
 #endif
 
@@ -25,7 +23,7 @@ public partial class ProcessHelper : IProcessHelper
     private static readonly string Arm = "arm";
     private readonly Process _currentProcess = Process.GetCurrentProcess();
 
-#if !NET5_0_OR_GREATER
+#if !NET
     private readonly IEnvironment _environment;
 #endif
 
@@ -38,7 +36,7 @@ public partial class ProcessHelper : IProcessHelper
 
     internal ProcessHelper(IEnvironment environment)
     {
-#if !NET5_0_OR_GREATER
+#if !NET
         _environment = environment;
 #endif
     }
@@ -157,7 +155,7 @@ public partial class ProcessHelper : IProcessHelper
                             // For older frameworks, the solution is more tricky but it seems we can get the expected
                             // behavior using the parameterless 'WaitForExit()' combined with an awaited Task.Run call.
                             var cts = new CancellationTokenSource(timeout);
-#if NET5_0_OR_GREATER
+#if NET
                             await p.WaitForExitAsync(cts.Token);
 #else
                             // NOTE: In case we run on Windows we must call 'WaitForExit(timeout)' instead of calling
@@ -329,9 +327,7 @@ public partial class ProcessHelper : IProcessHelper
     private string GetFormattedCurrentProcessArchitecture()
         => GetCurrentProcessArchitecture().ToString()
             .ToLower(
-#if !NETCOREAPP1_0
         CultureInfo.InvariantCulture
-#endif
             );
 
     /// <inheritdoc/>
@@ -343,5 +339,3 @@ public partial class ProcessHelper : IProcessHelper
         }
     }
 }
-
-#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/PlatformEqtTrace.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/PlatformEqtTrace.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETFRAMEWORK || NETCOREAPP || NETSTANDARD2_0
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -446,5 +444,3 @@ public partial class PlatformEqtTrace : IPlatformEqtTrace
         Source.Switch.Level = SourceLevels.Off;
     }
 }
-
-#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/RollingFileTraceListener.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/RollingFileTraceListener.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETFRAMEWORK || NETCOREAPP || NETSTANDARD2_0
-
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -480,5 +478,3 @@ public class RollingFileTraceListener : TextWriterTraceListener
         }
     }
 }
-
-#endif

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net462/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net462/System/ProcessHelper.cs
@@ -51,7 +51,7 @@ public partial class ProcessHelper : IProcessHelper
 
     public PlatformArchitecture GetProcessArchitecture(int processId)
     {
-#if NETCOREAPP || NETSTANDARD2_0_OR_GREATER
+#if !NETFRAMEWORK
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             // No implementation for this for cross platform, and we cannot move this to platform specific file.

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/Runtime/PlatformAssemblyExtensions.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/Runtime/PlatformAssemblyExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETCOREAPP
+#if NET
 
 using System.Reflection;
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/Runtime/PlatformAssemblyLoadContext.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/Runtime/PlatformAssemblyLoadContext.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETCOREAPP
+#if NET
 
 using System.Reflection;
 using System.Runtime.Loader;

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/Runtime/PlatformAssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/Runtime/PlatformAssemblyResolver.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETCOREAPP
+#if NET
 
 using System;
 using System.Reflection;

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformEnvironment.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformEnvironment.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETCOREAPP
+#if NET
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformThread.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/PlatformThread.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETCOREAPP
+#if NET
 
 using System;
 using System.Runtime.ExceptionServices;

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessHelper.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETCOREAPP
+#if NET
 
 using System;
 using System.Diagnostics;

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessStartInfoExtensions.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/System/ProcessStartInfoExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETCOREAPP
+#if NET
 
 using System.Diagnostics;
 

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleWrapper.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-#if !NET5_0_OR_GREATER
+#if !NET
 using System.Diagnostics;
 #endif
 using System.Globalization;
@@ -169,7 +169,7 @@ public class VsTestConsoleWrapper : IVsTestConsoleWrapper
         if (port > 0)
         {
             // Fill the parameters
-#if NET5_0_OR_GREATER
+#if NET
             _consoleParameters.ParentProcessId = Environment.ProcessId;
 #else
             using (var process = Process.GetCurrentProcess())
@@ -682,7 +682,7 @@ public class VsTestConsoleWrapper : IVsTestConsoleWrapper
         if (port > 0)
         {
             // Fill the parameters
-#if NET5_0_OR_GREATER
+#if NET
             _consoleParameters.ParentProcessId = Environment.ProcessId;
 #else
             using (var process = Process.GetCurrentProcess())

--- a/src/testhost.x86/DefaultEngineInvoker.cs
+++ b/src/testhost.x86/DefaultEngineInvoker.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-#if NETCOREAPP2_0_OR_GREATER || NETFRAMEWORK
+#if NET || NETFRAMEWORK
 using System.IO;
 #endif
 using System.Net;
@@ -109,7 +109,7 @@ internal class DefaultEngineInvoker :
                 .Assembly
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
             EqtTrace.Verbose($"Version: {version} Current process architecture: {_processHelper.GetCurrentProcessArchitecture()}");
-#if NETCOREAPP2_0_OR_GREATER || NETFRAMEWORK
+#if NET || NETFRAMEWORK
             // https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.location?view=net-6.0#remarks
             // In .NET 5 and later versions, for bundled assemblies, the value returned is an empty string.
             string objectTypeLocation = typeof(object).Assembly.Location;
@@ -131,7 +131,7 @@ internal class DefaultEngineInvoker :
 #endif
         }
 
-#if NETCOREAPP
+#if NET
         TestHostTraceListener.Setup();
 #endif
 

--- a/src/testhost.x86/TestHostTraceListener.cs
+++ b/src/testhost.x86/TestHostTraceListener.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETCOREAPP
+#if NET
 
 using System;
 using System.Diagnostics;

--- a/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs
+++ b/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs
@@ -60,7 +60,7 @@ internal class AssemblyMetadataProvider : IAssemblyMetadataProvider
             var assemblyName = AssemblyName.GetAssemblyName(assemblyPath);
 
             var processorArchitecture =
-#if NET7_0_OR_GREATER
+#if NET
                 // AssemblyName doesn't include ProcessorArchitecture in net7.
                 // It will always be ProcessorArchitecture.None.
                 ProcessorArchitecture.None;

--- a/src/vstest.console/InProcessVsTestConsoleWrapper.cs
+++ b/src/vstest.console/InProcessVsTestConsoleWrapper.cs
@@ -93,7 +93,7 @@ internal class InProcessVsTestConsoleWrapper : IVsTestConsoleWrapper
 
         // Fill the parameters.
         consoleParameters.ParentProcessId =
-#if NET6_0_OR_GREATER
+#if NET
             Environment.ProcessId;
 #else
             System.Diagnostics.Process.GetCurrentProcess().Id;

--- a/test/Intent.Primitives/Intent.Primitives.csproj
+++ b/test/Intent.Primitives/Intent.Primitives.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net11.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/Intent/Intent.csproj
+++ b/test/Intent/Intent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net11.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Microsoft.TestPlatform.Acceptance.IntegrationTests.csproj
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/Microsoft.TestPlatform.Acceptance.IntegrationTests.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="BannedSymbols.txt" />

--- a/test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/Microsoft.TestPlatform.AdapterUtilities.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.AdapterUtilities.UnitTests/Microsoft.TestPlatform.AdapterUtilities.UnitTests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>Microsoft.TestPlatform.AdapterUtilities.UnitTests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/test/Microsoft.TestPlatform.Build.UnitTests/Microsoft.TestPlatform.Build.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/Microsoft.TestPlatform.Build.UnitTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>Microsoft.TestPlatform.Build.UnitTests</AssemblyName>
   </PropertyGroup>

--- a/test/Microsoft.TestPlatform.Client.UnitTests/Microsoft.TestPlatform.Client.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.Client.UnitTests/Microsoft.TestPlatform.Client.UnitTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>Microsoft.TestPlatform.Client.UnitTests</AssemblyName>
   </PropertyGroup>

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Microsoft.TestPlatform.Common.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Microsoft.TestPlatform.Common.UnitTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>Microsoft.TestPlatform.Common.UnitTests</AssemblyName>
   </PropertyGroup>

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>Microsoft.TestPlatform.CommunicationUtilities.PlatformTests</AssemblyName>
   </PropertyGroup>

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/Microsoft.TestPlatform.CommunicationUtilities.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/Microsoft.TestPlatform.CommunicationUtilities.UnitTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>Microsoft.TestPlatform.CommunicationUtilities.UnitTests</AssemblyName>
   </PropertyGroup>

--- a/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Microsoft.TestPlatform.CoreUtilities.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Microsoft.TestPlatform.CoreUtilities.UnitTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>Microsoft.TestPlatform.CoreUtilities.UnitTests</AssemblyName>
   </PropertyGroup>

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Microsoft.TestPlatform.CrossPlatEngine.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Microsoft.TestPlatform.CrossPlatEngine.UnitTests.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <AssemblyName>Microsoft.TestPlatform.CrossPlatEngine.UnitTests</AssemblyName>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests/Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests.csproj
@@ -19,7 +19,7 @@
     <RootNamespace>Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests</RootNamespace>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>Microsoft.TestPlatform.Extensions.BlameDataCollector.UnitTests</AssemblyName>
   </PropertyGroup>

--- a/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests</AssemblyName>
   </PropertyGroup>

--- a/test/Microsoft.TestPlatform.Library.IntegrationTests/Microsoft.TestPlatform.Library.IntegrationTests.csproj
+++ b/test/Microsoft.TestPlatform.Library.IntegrationTests/Microsoft.TestPlatform.Library.IntegrationTests.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net10.0;net481</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="TestAssets\**" />

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Microsoft.TestPlatform.ObjectModel.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Microsoft.TestPlatform.ObjectModel.UnitTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>Microsoft.TestPlatform.ObjectModel.UnitTests</AssemblyName>
   </PropertyGroup>

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Microsoft.TestPlatform.TestHostProvider.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Microsoft.TestPlatform.TestHostProvider.UnitTests.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <AssemblyName>Microsoft.TestPlatform.TestHostProvider.UnitTests</AssemblyName>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/test/Microsoft.TestPlatform.TestUtilities/Microsoft.TestPlatform.TestUtilities.csproj
+++ b/test/Microsoft.TestPlatform.TestUtilities/Microsoft.TestPlatform.TestUtilities.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <AssemblyName>Microsoft.TestPlatform.TestUtilities</AssemblyName>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net10.0;net481</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
     <UseBannedApiAnalyzers>true</UseBannedApiAnalyzers>
   </PropertyGroup>

--- a/test/Microsoft.TestPlatform.Utilities.UnitTests/Microsoft.TestPlatform.Utilities.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.Utilities.UnitTests/Microsoft.TestPlatform.Utilities.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>Microsoft.TestPlatform.Utilities.UnitTests</AssemblyName>
   </PropertyGroup>

--- a/test/TranslationLayer.UnitTests/TranslationLayer.UnitTests.csproj
+++ b/test/TranslationLayer.UnitTests/TranslationLayer.UnitTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>TranslationLayer.UnitTests</AssemblyName>
   </PropertyGroup>

--- a/test/coverlet.collector/coverlet.collector.csproj
+++ b/test/coverlet.collector/coverlet.collector.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
     <!-- Don't change the version from 9.9.9.9 it is used in tests to recognize this "mock" library. -->
     <AssemblyVersion>9.9.9.9</AssemblyVersion>

--- a/test/datacollector.PlatformTests/datacollector.PlatformTests.csproj
+++ b/test/datacollector.PlatformTests/datacollector.PlatformTests.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Microsoft.VisualStudio.TestPlatform.DataCollector.PlatformTests</RootNamespace>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <OutputType Condition=" $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '$(NetCoreAppMinimum)')) ">Exe</OutputType>
     <AssemblyName>datacollector.PlatformTests</AssemblyName>
   </PropertyGroup>

--- a/test/datacollector.UnitTests/datacollector.UnitTests.csproj
+++ b/test/datacollector.UnitTests/datacollector.UnitTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <AssemblyName>datacollector.UnitTests</AssemblyName>
   </PropertyGroup>
   <ItemGroup>

--- a/test/testhost.UnitTests/testhost.UnitTests.csproj
+++ b/test/testhost.UnitTests/testhost.UnitTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>testhost.UnitTests</AssemblyName>
     <PlatformTarget Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '$(NetFrameworkMinimum)'))">x64</PlatformTarget>

--- a/test/vstest.ProgrammerTests/vstest.ProgrammerTests.csproj
+++ b/test/vstest.ProgrammerTests/vstest.ProgrammerTests.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net11.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/test/vstest.console.UnitTests/vstest.console.UnitTests.csproj
+++ b/test/vstest.console.UnitTests/vstest.console.UnitTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <TargetFrameworks>net11.0;net481</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>vstest.console.UnitTests</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
## Changes

### Test project TFM updates
- All unit test projects: **net9.0;net48 → net11.0;net481** (latest .NET + latest .NET Framework)
- Single-TFM test projects (Intent, ProgrammerTests): **net8.0 → net11.0**
- CommunicationUtilities.UnitTests: **net10.0;net9.0;net48 → net11.0;net481** (drop redundant net9.0)
- Integration tests (Acceptance, Library): **net9.0 → net10.0** (net11.0 hits a preview runtime NamedMutex bug on Linux/macOS)
- TestUtilities: **net9.0;net48 → net11.0;net10.0;net481** (net10.0 needed by integration tests)
- net48-only projects (EventLogCollector, SettingsMigrator): unchanged

### Compiler conditional consolidation

Since `NetCoreAppMinimum` is `net8.0`, all versioned conditionals are equivalent to `#if NET`:

- `NET5_0_OR_GREATER`, `NET6_0_OR_GREATER`, `NET7_0_OR_GREATER`, `NET8_0_OR_GREATER` → `NET`
- `NETCOREAPP`, `NETCOREAPP2_0_OR_GREATER` → `NET`
- `NETSTANDARD || NET || NETCOREAPP3_1` → `!NETFRAMEWORK`
- `NETCOREAPP || NETSTANDARD2_0_OR_GREATER` → `!NETFRAMEWORK`
- `DEBUG && (NETFRAMEWORK || NET || NETSTANDARD2_0_OR_GREATER)` → `DEBUG` (all TFMs covered)
- Removed dead `!NETCOREAPP1_0` guard
- Removed always-true `#if NETFRAMEWORK || NET || NETSTANDARD2_0` whole-file guards in PlatformAbstractions (project only builds those 3 TFMs)

### Validation
- Build: 0 warnings, 0 errors
- All unit tests pass locally
- CI: all checks green (Windows, Ubuntu, macOS, Source-Build)