### PR TITLE
fix: use WaitForExit() instead of WaitForExitAsync to drain stderr

### DIFF
--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -136,7 +136,6 @@ public partial class ProcessHelper : IProcessHelper
             {
                 process.Exited += async (sender, args) =>
                 {
-                    const int timeout = 500;
 
                     if (sender is Process p)
                     {
@@ -148,15 +147,25 @@ public partial class ProcessHelper : IProcessHelper
                             // See ticket https://github.com/microsoft/vstest/issues/3375 to get the links to all
                             // issues, discussions and documentations.
                             //
-                            // On .NET 5+, we use WaitForExitAsync for a non-blocking, cancellable wait,
-                            // then call the parameterless WaitForExit() to ensure all asynchronous
-                            // output/error readers (ErrorDataReceived, OutputDataReceived) are fully
-                            // drained. Without the second call, the Exited event can fire before the
-                            // final stderr data arrives (e.g. "Stack overflow." from a crashing
-                            // testhost), causing the exit callback to read incomplete stderr.
-                            // See https://github.com/microsoft/vstest/issues/3375 for details.
-                            using var cts = new CancellationTokenSource(timeout);
-#if !NET5_0_OR_GREATER
+                            // On .NET 5+, WaitForExitAsync waits for process exit AND drains all
+                            // asynchronous output/error readers (ErrorDataReceived, OutputDataReceived).
+                            // We run it WITHOUT a CancellationToken so the drain cannot be interrupted
+                            // by threadpool starvation. Instead, we race it against a delay task to
+                            // handle zombie pipes (child process inheriting stdout/stderr handles
+                            // prevents EOF, which would block the drain indefinitely).
+                            //
+                            // For older frameworks, the solution is more tricky but it seems we can get the expected
+                            // behavior using the parameterless 'WaitForExit()' combined with an awaited Task.Run call.
+                            const int zombiePipeTimeout = 2_000;
+#if NET5_0_OR_GREATER
+                            var exitTask = p.WaitForExitAsync(CancellationToken.None);
+                            if (await Task.WhenAny(exitTask, Task.Delay(zombiePipeTimeout)).ConfigureAwait(false) != exitTask)
+                            {
+                                // Timed out — a child process likely holds the stderr/stdout pipe
+                                // handle open (e.g. Selenium WebDriver's Edge Driver). The exitTask
+                                // continues in the background and will complete when the child exits.
+                            }
+#else
                             // NOTE: In case we run on Windows we must call 'WaitForExit(timeout)' instead of calling
                             // the parameterless overload. The reason for this requirement stems from the behavior of
                             // the Selenium WebDriver when debugging a test. If the debugger is detached, the default
@@ -172,10 +181,11 @@ public partial class ProcessHelper : IProcessHelper
                             // the testhost to become a zombie process in the first place.
                             if (_environment.OperatingSystem is PlatformOperatingSystem.Windows)
                             {
-                                p.WaitForExit(timeout);
+                                p.WaitForExit(zombiePipeTimeout);
                             }
                             else
                             {
+                                using var cts = new CancellationTokenSource(zombiePipeTimeout);
                                 cts.Token.Register(() =>
                                 {
                                     try
@@ -194,12 +204,6 @@ public partial class ProcessHelper : IProcessHelper
                                 });
                                 await Task.Run(() => p.WaitForExit(), cts.Token).ConfigureAwait(false);
                             }
-#else
-                            await p.WaitForExitAsync(cts.Token);
-                            // Process has exited; drain async readers. This should be near-instant
-                            // since the process is already dead. If WaitForExitAsync was cancelled
-                            // (zombie/hung process), we skip this via the catch block.
-                            p.WaitForExit();
 #endif
                         }
                         catch

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/System/ProcessHelper.cs
@@ -9,9 +9,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Threading;
-#if !NET5_0_OR_GREATER
 using System.Threading.Tasks;
-#endif
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
 
@@ -150,16 +148,15 @@ public partial class ProcessHelper : IProcessHelper
                             // See ticket https://github.com/microsoft/vstest/issues/3375 to get the links to all
                             // issues, discussions and documentations.
                             //
-                            // On .NET 5 and later, the solution is simple, we can simply use WaitForExitAsync which
-                            // correctly ensure that some time is given to the child process (or any grandchild) to
-                            // flush before exit happens.
-                            //
-                            // For older frameworks, the solution is more tricky but it seems we can get the expected
-                            // behavior using the parameterless 'WaitForExit()' combined with an awaited Task.Run call.
-                            var cts = new CancellationTokenSource(timeout);
-#if NET5_0_OR_GREATER
-                            await p.WaitForExitAsync(cts.Token);
-#else
+                            // On .NET 5+, we use WaitForExitAsync for a non-blocking, cancellable wait,
+                            // then call the parameterless WaitForExit() to ensure all asynchronous
+                            // output/error readers (ErrorDataReceived, OutputDataReceived) are fully
+                            // drained. Without the second call, the Exited event can fire before the
+                            // final stderr data arrives (e.g. "Stack overflow." from a crashing
+                            // testhost), causing the exit callback to read incomplete stderr.
+                            // See https://github.com/microsoft/vstest/issues/3375 for details.
+                            using var cts = new CancellationTokenSource(timeout);
+#if !NET5_0_OR_GREATER
                             // NOTE: In case we run on Windows we must call 'WaitForExit(timeout)' instead of calling
                             // the parameterless overload. The reason for this requirement stems from the behavior of
                             // the Selenium WebDriver when debugging a test. If the debugger is detached, the default
@@ -197,6 +194,12 @@ public partial class ProcessHelper : IProcessHelper
                                 });
                                 await Task.Run(() => p.WaitForExit(), cts.Token).ConfigureAwait(false);
                             }
+#else
+                            await p.WaitForExitAsync(cts.Token);
+                            // Process has exited; drain async readers. This should be near-instant
+                            // since the process is already dead. If WaitForExitAsync was cancelled
+                            // (zombie/hung process), we skip this via the catch block.
+                            p.WaitForExit();
 #endif
                         }
                         catch

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
@@ -156,6 +156,39 @@ public class ExecutionTests : AcceptanceTestBase
         StdOutputDoesNotContains("Total tests: 6");
     }
 
+    /// <summary>
+    /// Verifies that aborting a hanging test run via TestSessionTimeout completes quickly.
+    /// After the timeout fires, vstest.console should kill the testhost and exit without
+    /// significant delay. This guards against regressions in ProcessHelper's Exited handler
+    /// where the async reader drain wait could slow down the abort path.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Windows-Review")]
+    [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
+    public void AbortOnTimeoutShouldCompleteQuickly(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var assemblyPaths = GetAssetFullPath("SimpleTestProject3.dll");
+        var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
+        arguments = string.Concat(arguments, " /TestCaseFilter:TestSessionTimeoutTest");
+
+        // 3 second session timeout — the first test sleeps 3s so this fires quickly.
+        arguments = string.Concat(arguments, " -- RunConfiguration.TestSessionTimeout=3000");
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        InvokeVsTest(arguments);
+        stopwatch.Stop();
+
+        ExitCodeEquals(1);
+
+        // The session timeout is 3s. After abort, vstest.console should tear down testhost
+        // and exit quickly. Allow generous overhead for CI, but catch egregious delays
+        // (e.g., a 30s hang from a broken drain wait).
+        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(30),
+            "vstest.console should complete abort within a reasonable time after session timeout");
+    }
+
     [TestMethod]
     [NetFullTargetFrameworkDataSource(inIsolation: true, inProcess: true)]
     [NetCoreTargetFrameworkDataSource]

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
@@ -173,6 +173,61 @@ public class ExecutionTests : AcceptanceTestBase
         ExitCodeEquals(0);
     }
 
+    /// <summary>
+    /// Verifies that vstest.console does not hang when testhost starts a child process
+    /// that inherits the stderr pipe handle and outlives testhost. This simulates the
+    /// Selenium WebDriver scenario where Edge Driver (child) keeps the pipe handle open
+    /// after testhost exits.
+    ///
+    /// The protection is the 500ms timeout in ProcessHelper.cs's Exited handler.
+    /// Without it, the parameterless WaitForExit() would block forever waiting for pipe EOF.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Windows-Review")]
+    [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
+    public void VsTestShouldNotHangWhenChildProcessHoldsPipeOpen(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var assemblyPaths = GetAssetFullPath("zombie-child-process.dll");
+        var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        InvokeVsTest(arguments);
+        stopwatch.Stop();
+
+        // The test should pass (the test method itself passes immediately).
+        ValidateSummaryStatus(1, 0, 0);
+        ExitCodeEquals(0);
+
+        // vstest.console should complete well within 60 seconds.
+        // The child process sleeps for 30s, so if vstest.console waits for the pipe EOF
+        // it would take at least 30s. A healthy run completes in a few seconds.
+        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(60),
+            "vstest.console should not hang waiting for pipe EOF from the child process");
+
+        // Clean up the sleeping-child process if it's still running.
+        var stderrOutput = StdErr;
+        var pidMatch = System.Text.RegularExpressions.Regex.Match(stderrOutput, @"ZOMBIE_CHILD_PID=(\d+)");
+        if (pidMatch.Success && int.TryParse(pidMatch.Groups[1].Value, out int childPid))
+        {
+            try
+            {
+                var childProcess = System.Diagnostics.Process.GetProcessById(childPid);
+                childProcess.Kill();
+                childProcess.WaitForExit(5000);
+            }
+            catch (ArgumentException)
+            {
+                // Process already exited
+            }
+            catch (InvalidOperationException)
+            {
+                // Process already exited
+            }
+        }
+    }
+
     [TestMethod]
     [NetFullTargetFrameworkDataSource]
     [NetCoreTargetFrameworkDataSource]

--- a/test/TestAssets/TestAssets.slnx
+++ b/test/TestAssets/TestAssets.slnx
@@ -72,8 +72,10 @@
   <Project Path="SimpleTestProjectARM64/SimpleTestProjectARM64.csproj" />
   <Project Path="SimpleTestProjectMessedUpTargetFramework/SimpleTestProjectMessedUpTargetFramework.csproj" />
   <Project Path="SimpleTestProjectx86/SimpleTestProjectx86.csproj" />
+  <Project Path="sleeping-child/sleeping-child.csproj" />
   <Project Path="TerminalLoggerTestProject/TerminalLoggerTestProject.csproj" />
   <Project Path="timeout/timeout.csproj" />
   <Project Path="Tools/Tools.csproj" />
   <Project Path="XUTestProject/XUTestProject.csproj" />
+  <Project Path="zombie-child-process/zombie-child-process.csproj" />
 </Solution>

--- a/test/TestAssets/sleeping-child/Program.cs
+++ b/test/TestAssets/sleeping-child/Program.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// A minimal process that sleeps for a configurable time.
+// Used by zombie-child-process test to simulate a child process (e.g., Selenium WebDriver's
+// Edge Driver) that outlives testhost while holding inherited pipe handles open.
+
+using System.Globalization;
+using System.Threading;
+
+int sleepMs = args.Length > 0 ? int.Parse(args[0], CultureInfo.InvariantCulture) : 30_000;
+Thread.Sleep(sleepMs);

--- a/test/TestAssets/sleeping-child/sleeping-child.csproj
+++ b/test/TestAssets/sleeping-child/sleeping-child.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>$(NetCoreAppTargetFrameworks)</TargetFrameworks>
+    <RootNamespace>sleeping_child</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/test/TestAssets/zombie-child-process/UnitTest1.cs
+++ b/test/TestAssets/zombie-child-process/UnitTest1.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace zombie_child_process;
+
+/// <summary>
+/// This test simulates the Selenium WebDriver scenario where testhost starts a child process
+/// (e.g., Edge Driver) that outlives testhost. The child inherits testhost's stderr pipe handle
+/// (UseShellExecute=false on .NET Core). After testhost exits, vstest.console's parameterless
+/// WaitForExit() would block indefinitely waiting for the pipe EOF that never comes because the
+/// child still holds the handle.
+///
+/// The ProcessHelper's WaitForExitAsync(cts) timeout protects against this hang.
+/// This test exists to verify that protection does not regress.
+/// </summary>
+[TestClass]
+public class UnitTest1
+{
+    [TestMethod]
+    public void TestPassesWhileChildHoldsStderrPipe()
+    {
+        // Resolve path to sleeping-child exe using the same output structure.
+        // Our DLL: artifacts/bin/TestAssets/zombie-child-process/{config}/{tfm}/zombie-child-process.dll
+        // Child:   artifacts/bin/TestAssets/sleeping-child/{config}/{tfm}/sleeping-child{.exe}
+        var assemblyDir = Path.GetDirectoryName(typeof(UnitTest1).Assembly.Location)!;
+        var testAssetsDir = Path.GetFullPath(Path.Combine(assemblyDir, "..", "..", ".."));
+        var configDir = new DirectoryInfo(assemblyDir).Parent!.Name;
+        var tfmDir = new DirectoryInfo(assemblyDir).Name;
+
+        var childName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "sleeping-child.exe"
+            : "sleeping-child";
+        var childPath = Path.Combine(testAssetsDir, "sleeping-child", configDir, tfmDir, childName);
+
+        if (!File.Exists(childPath))
+        {
+            Assert.Inconclusive($"sleeping-child not found at: {childPath}");
+        }
+
+        // Start the child process with UseShellExecute=false so it INHERITS testhost's
+        // stdio pipe handles (the default on .NET Core). This is the key mechanism that
+        // causes the "zombie pipe" issue — the child holds the stderr pipe handle open
+        // even after testhost exits.
+        var psi = new ProcessStartInfo
+        {
+            FileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? childPath
+                : "dotnet",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            psi.Arguments = $"{childPath} 30000";
+        }
+        else
+        {
+            psi.Arguments = "30000";
+        }
+
+        var child = Process.Start(psi);
+        Assert.IsNotNull(child, "Failed to start sleeping-child process.");
+
+        // Write the child PID to stderr so the integration test can verify it was started
+        // and clean it up afterward.
+        Console.Error.WriteLine($"ZOMBIE_CHILD_PID={child.Id}");
+
+        // Pass immediately — do NOT wait for the child.
+        // This simulates a Selenium test that starts Edge Driver and returns.
+        // Testhost will exit, but the child keeps running, holding the pipe.
+    }
+}

--- a/test/TestAssets/zombie-child-process/zombie-child-process.csproj
+++ b/test/TestAssets/zombie-child-process/zombie-child-process.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TestProject>true</TestProject>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFrameworks>$(NetCoreAppTargetFrameworks)</TargetFrameworks>
+    <RootNamespace>zombie_child_process</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(PackageVersion)" />
+    <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestTestAdapterVersion)" />
+    <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestFrameworkVersion)" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Problem

When testhost crashes with a stack overflow, vstest sometimes reports just \Test host process crashed\ instead of \Test host process crashed : Stack overflow.\. The stderr output from the crash is intermittently lost.

## Root Cause

Race condition in \ProcessHelper.cs\ Exited event handler:

1. Testhost crashes → \Process.Exited\ event fires
2. Handler calls \WaitForExitAsync(cts.Token)\
3. Handler calls \xitCallBack\ → \TestHostManagerCallbacks.ExitCallBack\ reads \	estHostProcessStdError\
4. **But \ErrorDataReceived\ may not have delivered the final stderr data yet**

\WaitForExitAsync\ does NOT guarantee that all asynchronous readers (\ErrorDataReceived\, \OutputDataReceived\) have reached EOF before returning. The parameterless \WaitForExit()\ does.

## Fix

Replace \WaitForExitAsync(cts.Token)\ with \wait Task.Run(() => p.WaitForExit(), cts.Token)\ on .NET 5+.

- **\WaitForExit()\** waits for both process exit AND async reader EOF — no race
- **\Task.Run\** keeps it non-blocking in the event handler
- **\CancellationTokenSource(500ms)\** handles zombie processes (e.g. Selenium WebDriver detach)
- Matches the pattern already used in the pre-.NET 5 Unix code path

## Repro

Reproduced with a stress test (50-200 iterations of crashing a child process and capturing stderr):
- \WaitForExitAsync\: 49/50 captured (1 missed) under load
- \WaitForExit()\: 50/50 captured ✅

The race is load/timing dependent — consistent with flaky CI.

## Flaky Test Fixed

\TheRunTestsShouldThrowOnStackOverflowException\ in \TranslationLayerTests/RunTests.cs\

Relates to https://github.com/microsoft/vstest/issues/3375