### PR TITLE
Expand unit test coverage for key reliability gaps

### DIFF
--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FilterExpressionTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FilterExpressionTests.cs
@@ -99,4 +99,39 @@ public class FilterExpressionTests
         Assert.AreEqual(@"|", tokens[3]);
         Assert.AreEqual(@"T2\)", tokens[4]);
     }
+
+    [TestMethod]
+    public void TokenizeFilterShouldHandleEmptyString()
+    {
+        var conditionString = string.Empty;
+
+        var tokens = FilterExpression.TokenizeFilterExpressionString(conditionString).ToArray();
+
+        Assert.IsEmpty(tokens);
+    }
+
+    [TestMethod]
+    public void TokenizeFilterShouldHandleOnlyWhitespace()
+    {
+        var conditionString = "   ";
+
+        var tokens = FilterExpression.TokenizeFilterExpressionString(conditionString).ToArray();
+
+        Assert.HasCount(1, tokens);
+        Assert.AreEqual("   ", tokens[0]);
+    }
+
+    [TestMethod]
+    public void TokenizeFilterShouldHandleMultipleConsecutivePipes()
+    {
+        var conditionString = "A||B";
+
+        var tokens = FilterExpression.TokenizeFilterExpressionString(conditionString).ToArray();
+
+        Assert.HasCount(4, tokens);
+        Assert.AreEqual("A", tokens[0]);
+        Assert.AreEqual("|", tokens[1]);
+        Assert.AreEqual("|", tokens[2]);
+        Assert.AreEqual("B", tokens[3]);
+    }
 }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FilterExpressionWrapperRegressionTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FilterExpressionWrapperRegressionTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestPlatform.Common.Filtering;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.TestPlatform.Common.UnitTests.Filtering;
+
+/// <summary>
+/// Regression tests for FilterExpressionWrapper behavior and edge cases.
+/// </summary>
+[TestClass]
+public class FilterExpressionWrapperRegressionTests
+{
+    [TestMethod]
+    public void FilterExpressionWrapper_NullFilter_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() => new FilterExpressionWrapper(null!, null));
+    }
+
+    [TestMethod]
+    public void FilterExpressionWrapper_EmptyFilter_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() => new FilterExpressionWrapper(string.Empty, null));
+    }
+
+    [TestMethod]
+    public void FilterExpressionWrapper_ValidFilter_ParseErrorShouldBeNull()
+    {
+        var wrapper = new FilterExpressionWrapper("FullyQualifiedName=Test1");
+
+        Assert.IsTrue(string.IsNullOrEmpty(wrapper.ParseError),
+            "A valid filter should not produce a parse error.");
+    }
+
+    [TestMethod]
+    public void FilterExpressionWrapper_InvalidFilter_ParseErrorShouldNotBeNull()
+    {
+        var wrapper = new FilterExpressionWrapper("((Invalid)");
+
+        Assert.IsFalse(string.IsNullOrEmpty(wrapper.ParseError),
+            "An invalid filter should produce a parse error.");
+    }
+
+    [TestMethod]
+    public void FilterExpressionWrapper_EvaluateShouldMatchCaseInsensitively()
+    {
+        var wrapper = new FilterExpressionWrapper("FullyQualifiedName=testmethod");
+
+        // "TESTMETHOD" should match "testmethod" due to case-insensitive comparison.
+        bool result = wrapper.Evaluate(s => s == "FullyQualifiedName" ? "TESTMETHOD" : null);
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void ValidForPropertiesShouldReturnInvalidPropertyNames()
+    {
+        var wrapper = new FilterExpressionWrapper("UnknownProp=Value1|AnotherBadProp=Value2");
+
+        var invalidProperties = wrapper.ValidForProperties(
+            new List<string> { "FullyQualifiedName", "TestCategory" }, s => null);
+
+        Assert.IsNotNull(invalidProperties);
+        Assert.HasCount(2, invalidProperties);
+    }
+}

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/TestCaseFilterExpressionTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/TestCaseFilterExpressionTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -25,6 +26,44 @@ public class TestCaseFilterExpressionTests
 
         TestCase dummyTestCase = new();
         bool result = testCaseFilterExpression.MatchTestCase(dummyTestCase, s => "unused");
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void ValidForPropertiesShouldReturnNullWhenAllPropertiesAreKnown()
+    {
+        var filterExpressionWrapper = new FilterExpressionWrapper("FullyQualifiedName=Ns.Class.Method");
+        var testCaseFilterExpression = new TestCaseFilterExpression(filterExpressionWrapper);
+
+        var invalidProperties = testCaseFilterExpression.ValidForProperties(
+            new List<string> { "FullyQualifiedName", "TestCategory" }, s => null);
+
+        Assert.IsNull(invalidProperties, "No invalid properties expected when all filter properties are known.");
+    }
+
+    [TestMethod]
+    public void MatchTestCaseShouldReturnFalseWhenPropertyValueDoesNotMatch()
+    {
+        var filterExpressionWrapper = new FilterExpressionWrapper("FullyQualifiedName=Ns.Class.Method1");
+        var testCaseFilterExpression = new TestCaseFilterExpression(filterExpressionWrapper);
+
+        TestCase testCase = new("Ns.Class.Method2", new System.Uri("executor://test"), "test.dll");
+        bool result = testCaseFilterExpression.MatchTestCase(testCase,
+            s => s == "FullyQualifiedName" ? testCase.FullyQualifiedName : null);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void MatchTestCaseShouldReturnTrueWhenPropertyValueMatches()
+    {
+        var filterExpressionWrapper = new FilterExpressionWrapper("FullyQualifiedName=Ns.Class.Method1");
+        var testCaseFilterExpression = new TestCaseFilterExpression(filterExpressionWrapper);
+
+        TestCase testCase = new("Ns.Class.Method1", new System.Uri("executor://test"), "test.dll");
+        bool result = testCaseFilterExpression.MatchTestCase(testCase,
+            s => s == "FullyQualifiedName" ? testCase.FullyQualifiedName : null);
 
         Assert.IsTrue(result);
     }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Telemetry/MetricsCollectionTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Telemetry/MetricsCollectionTests.cs
@@ -85,4 +85,25 @@ public class MetricsCollectionTests
 
         Assert.IsGreaterThan(0, _metricsCollection.Metrics.Count);
     }
+
+    [TestMethod]
+    public void ClearShouldRemoveAllMetrics()
+    {
+        _metricsCollection.Add("Key1", "Value1");
+        _metricsCollection.Add("Key2", "Value2");
+        _metricsCollection.Add("Key3", 42);
+
+        _metricsCollection.Clear();
+
+        Assert.IsEmpty(_metricsCollection.Metrics);
+    }
+
+    [TestMethod]
+    public void ClearShouldNotThrowWhenCollectionIsEmpty()
+    {
+        // Collection is empty after construction; clearing should be a no-op.
+        _metricsCollection.Clear();
+
+        Assert.IsEmpty(_metricsCollection.Metrics);
+    }
 }

--- a/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/FeatureFlag/FeatureFlagTests.cs
+++ b/test/Microsoft.TestPlatform.CoreUtilities.UnitTests/FeatureFlag/FeatureFlagTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 using Microsoft.VisualStudio.TestPlatform.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -13,5 +15,80 @@ public class FeatureFlagTests
     public void SingletonAlwaysReturnsTheSameInstance()
     {
         Assert.IsTrue(ReferenceEquals(FeatureFlag.Instance, FeatureFlag.Instance));
+    }
+
+    [TestMethod]
+    public void IsSetShouldReturnFalseWhenEnvVarIsSetToZero()
+    {
+        // Use a unique name that has never been seen by this singleton instance.
+        const string flagName = "TEST_FEATUREFLAG_ISSET_ZERO_9A1B2C";
+        Environment.SetEnvironmentVariable(flagName, "0");
+        try
+        {
+            Assert.IsFalse(FeatureFlag.Instance.IsSet(flagName));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(flagName, null);
+        }
+    }
+
+    [TestMethod]
+    public void IsSetShouldReturnFalseWhenEnvVarIsNotSet()
+    {
+        const string flagName = "TEST_FEATUREFLAG_ISSET_NULL_9A1B2C";
+        Environment.SetEnvironmentVariable(flagName, null);
+        Assert.IsFalse(FeatureFlag.Instance.IsSet(flagName));
+    }
+
+    [TestMethod]
+    public void IsSetShouldReturnTrueWhenEnvVarIsSetToOne()
+    {
+        const string flagName = "TEST_FEATUREFLAG_ISSET_ONE_9A1B2C";
+        Environment.SetEnvironmentVariable(flagName, "1");
+        try
+        {
+            Assert.IsTrue(FeatureFlag.Instance.IsSet(flagName));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(flagName, null);
+        }
+    }
+
+    [TestMethod]
+    public void IsSetShouldReturnTrueWhenEnvVarIsAnyNonZeroString()
+    {
+        const string flagName = "TEST_FEATUREFLAG_ISSET_NONZERO_9A1B2C";
+        Environment.SetEnvironmentVariable(flagName, "true");
+        try
+        {
+            Assert.IsTrue(FeatureFlag.Instance.IsSet(flagName));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(flagName, null);
+        }
+    }
+
+    [TestMethod]
+    public void IsSetShouldCacheResultSoSubsequentEnvVarChangesAreIgnored()
+    {
+        const string flagName = "TEST_FEATUREFLAG_ISSET_CACHE_9A1B2C";
+        Environment.SetEnvironmentVariable(flagName, "1");
+        try
+        {
+            bool firstCheck = FeatureFlag.Instance.IsSet(flagName);
+            // Clear the env var after the first call; the cached value should persist.
+            Environment.SetEnvironmentVariable(flagName, null);
+            bool secondCheck = FeatureFlag.Instance.IsSet(flagName);
+
+            Assert.IsTrue(firstCheck);
+            Assert.IsTrue(secondCheck, "IsSet should return the cached value, not re-read the env var.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(flagName, null);
+        }
     }
 }

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Client/TestRunStatisticsTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/Client/TestRunStatisticsTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.TestPlatform.ObjectModel.UnitTests.Client;
+
+[TestClass]
+public class TestRunStatisticsTests
+{
+    [TestMethod]
+    public void IndexerShouldReturnZeroWhenStatsIsNull()
+    {
+        var stats = new TestRunStatistics(null);
+
+        Assert.AreEqual(0L, stats[TestOutcome.Passed]);
+        Assert.AreEqual(0L, stats[TestOutcome.Failed]);
+        Assert.AreEqual(0L, stats[TestOutcome.Skipped]);
+    }
+
+    [TestMethod]
+    public void IndexerShouldReturnZeroWhenOutcomeNotInStats()
+    {
+        var statsDict = new Dictionary<TestOutcome, long>
+        {
+            { TestOutcome.Passed, 10 }
+        };
+        var stats = new TestRunStatistics(statsDict);
+
+        Assert.AreEqual(0L, stats[TestOutcome.Failed]);
+        Assert.AreEqual(0L, stats[TestOutcome.Skipped]);
+    }
+
+    [TestMethod]
+    public void IndexerShouldReturnCountWhenOutcomeIsInStats()
+    {
+        var statsDict = new Dictionary<TestOutcome, long>
+        {
+            { TestOutcome.Passed, 5 },
+            { TestOutcome.Failed, 3 },
+            { TestOutcome.Skipped, 1 }
+        };
+        var stats = new TestRunStatistics(statsDict);
+
+        Assert.AreEqual(5L, stats[TestOutcome.Passed]);
+        Assert.AreEqual(3L, stats[TestOutcome.Failed]);
+        Assert.AreEqual(1L, stats[TestOutcome.Skipped]);
+    }
+
+    [TestMethod]
+    public void ExecutedTestsShouldBeSettableAndGettable()
+    {
+        var stats = new TestRunStatistics(executedTests: 42, stats: null);
+
+        Assert.AreEqual(42L, stats.ExecutedTests);
+    }
+}


### PR DESCRIPTION
This PR adds 23 new unit tests across six areas that had sparse or no coverage.

## Changes

**FeatureFlagTests.cs** — 5 new tests:
- IsSet returns false when env var is \