### PR TITLE
Report in-flight tests and suggest --blame-crash when testhost crashes

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestRunEventsHandler.cs
@@ -20,6 +20,11 @@ public class TestRunEventsHandler : IInternalTestRunEventsHandler
     private readonly ITestRequestHandler _requestHandler;
 
     /// <summary>
+    /// Gets the underlying request handler for direct message sending.
+    /// </summary>
+    internal ITestRequestHandler RequestHandler => _requestHandler;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="TestRunEventsHandler"/> class.
     /// </summary>
     /// <param name="requestHandler">test request handler</param>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestRunEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/EventHandlers/TestRunEventsHandler.cs
@@ -15,14 +15,9 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.EventHandle
 /// <summary>
 /// The test run events handler.
 /// </summary>
-public class TestRunEventsHandler : IInternalTestRunEventsHandler
+public class TestRunEventsHandler : IInternalTestRunEventsHandler, ITestCaseLifecycleNotifier
 {
     private readonly ITestRequestHandler _requestHandler;
-
-    /// <summary>
-    /// Gets the underlying request handler for direct message sending.
-    /// </summary>
-    internal ITestRequestHandler RequestHandler => _requestHandler;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TestRunEventsHandler"/> class.
@@ -109,4 +104,12 @@ public class TestRunEventsHandler : IInternalTestRunEventsHandler
         EqtTrace.Info("Sending AttachDebuggerToProcess on additional test process with pid: {0}", attachDebuggerInfo.ProcessId);
         return _requestHandler.AttachDebuggerToProcess(attachDebuggerInfo);
     }
+
+    /// <inheritdoc/>
+    void ITestCaseLifecycleNotifier.SendTestCaseStarting(TestCase testCase)
+        => _requestHandler.SendTestCaseStarting(testCase);
+
+    /// <inheritdoc/>
+    void ITestCaseLifecycleNotifier.SendTestCaseFinished(TestCase testCase)
+        => _requestHandler.SendTestCaseFinished(testCase);
 }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/InFlightTestTracker.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/InFlightTestTracker.cs
@@ -1,0 +1,183 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
+
+namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
+
+/// <summary>
+/// Tracks a set of in-flight test executions that share the same <see cref="Guid"/>.
+/// Uses inline slots to avoid queue allocation in the common case (unique Guid per test).
+/// </summary>
+internal sealed class InFlightTest
+{
+    public TestCaseStartingPayload Slot0;
+    public DateTimeOffset StartTime0;
+    public TestCaseStartingPayload? Slot1;
+    public DateTimeOffset StartTime1;
+    public TestCaseStartingPayload? Slot2;
+    public DateTimeOffset StartTime2;
+    public TestCaseStartingPayload? Slot3;
+    public DateTimeOffset StartTime3;
+    public Queue<(TestCaseStartingPayload Payload, DateTimeOffset StartTime)>? Overflow;
+
+    public InFlightTest(TestCaseStartingPayload payload, DateTimeOffset startTime)
+    {
+        Slot0 = payload;
+        StartTime0 = startTime;
+    }
+
+    /// <summary>
+    /// Adds another in-flight execution for the same Guid. Returns false if this should not happen (defensive).
+    /// </summary>
+    public void Add(TestCaseStartingPayload payload, DateTimeOffset startTime)
+    {
+        if (Slot1 is null)
+        {
+            Slot1 = payload;
+            StartTime1 = startTime;
+        }
+        else if (Slot2 is null)
+        {
+            Slot2 = payload;
+            StartTime2 = startTime;
+        }
+        else if (Slot3 is null)
+        {
+            Slot3 = payload;
+            StartTime3 = startTime;
+        }
+        else
+        {
+            Overflow ??= new Queue<(TestCaseStartingPayload, DateTimeOffset)>();
+            Overflow.Enqueue((payload, startTime));
+        }
+    }
+
+    /// <summary>
+    /// Removes the oldest in-flight execution (FIFO). Returns true if there are still entries remaining.
+    /// </summary>
+    public bool RemoveOldest()
+    {
+        // Shift slots down
+        if (Slot1 is not null)
+        {
+            Slot0 = Slot1;
+            StartTime0 = StartTime1;
+            Slot1 = Slot2;
+            StartTime1 = StartTime2;
+            Slot2 = Slot3;
+            StartTime2 = StartTime3;
+            Slot3 = null;
+            StartTime3 = default;
+
+            // Refill Slot3 from overflow if available
+            if (Overflow is { Count: > 0 })
+            {
+                var (payload, startTime) = Overflow.Dequeue();
+                Slot3 = payload;
+                StartTime3 = startTime;
+            }
+
+            return true;
+        }
+
+        // Slot0 was the only entry
+        return false;
+    }
+
+    /// <summary>
+    /// Enumerates all in-flight entries with their display name and start time.
+    /// </summary>
+    public IEnumerable<(string? DisplayName, DateTimeOffset StartTime)> GetAll()
+    {
+        yield return (Slot0.DisplayName, StartTime0);
+
+        if (Slot1 is not null)
+        {
+            yield return (Slot1.DisplayName, StartTime1);
+        }
+
+        if (Slot2 is not null)
+        {
+            yield return (Slot2.DisplayName, StartTime2);
+        }
+
+        if (Slot3 is not null)
+        {
+            yield return (Slot3.DisplayName, StartTime3);
+        }
+
+        if (Overflow is not null)
+        {
+            foreach (var (payload, startTime) in Overflow)
+            {
+                yield return (payload.DisplayName, startTime);
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Thread-safe tracker for tests currently executing in a testhost.
+/// Used by vstest.console to report which tests were running when a testhost crashes.
+/// </summary>
+internal sealed class InFlightTestTracker
+{
+    private readonly ConcurrentDictionary<Guid, InFlightTest> _tests = new();
+
+    /// <summary>
+    /// Records that a test has started executing.
+    /// </summary>
+    public void TestStarting(TestCaseStartingPayload payload, DateTimeOffset startTime)
+    {
+        _tests.AddOrUpdate(
+            payload.Id,
+            _ => new InFlightTest(payload, startTime),
+            (_, existing) =>
+            {
+                existing.Add(payload, startTime);
+                return existing;
+            });
+    }
+
+    /// <summary>
+    /// Records that a test has finished executing. Removes the oldest execution for the given Guid.
+    /// </summary>
+    public void TestFinished(Guid testId)
+    {
+        if (_tests.TryGetValue(testId, out var inFlight))
+        {
+            if (!inFlight.RemoveOldest())
+            {
+                _tests.TryRemove(testId, out _);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets all tests that are currently in-flight. Used when testhost crashes to report what was running.
+    /// </summary>
+    public IReadOnlyList<(string? DisplayName, DateTimeOffset StartTime)> GetInFlightTests()
+    {
+        var result = new List<(string?, DateTimeOffset)>();
+        foreach (var kvp in _tests)
+        {
+            foreach (var entry in kvp.Value.GetAll())
+            {
+                result.Add(entry);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Returns true if there are any in-flight tests being tracked.
+    /// </summary>
+    public bool HasInFlightTests => !_tests.IsEmpty;
+}

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/InFlightTestTracker.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/InFlightTestTracker.cs
@@ -12,9 +12,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 /// <summary>
 /// Tracks a set of in-flight test executions that share the same <see cref="Guid"/>.
 /// Uses inline slots to avoid queue allocation in the common case (unique Guid per test).
+/// All mutation and enumeration is guarded by a lock because the message-receive thread
+/// updates slots while the abort thread may read them concurrently via <see cref="GetAll"/>.
 /// </summary>
 internal sealed class InFlightTest
 {
+    private readonly object _lock = new();
     public TestCaseStartingPayload Slot0;
     public DateTimeOffset StartTime0;
     public TestCaseStartingPayload? Slot1;
@@ -32,29 +35,32 @@ internal sealed class InFlightTest
     }
 
     /// <summary>
-    /// Adds another in-flight execution for the same Guid. Returns false if this should not happen (defensive).
+    /// Adds another in-flight execution for the same Guid.
     /// </summary>
     public void Add(TestCaseStartingPayload payload, DateTimeOffset startTime)
     {
-        if (Slot1 is null)
+        lock (_lock)
         {
-            Slot1 = payload;
-            StartTime1 = startTime;
-        }
-        else if (Slot2 is null)
-        {
-            Slot2 = payload;
-            StartTime2 = startTime;
-        }
-        else if (Slot3 is null)
-        {
-            Slot3 = payload;
-            StartTime3 = startTime;
-        }
-        else
-        {
-            Overflow ??= new Queue<(TestCaseStartingPayload, DateTimeOffset)>();
-            Overflow.Enqueue((payload, startTime));
+            if (Slot1 is null)
+            {
+                Slot1 = payload;
+                StartTime1 = startTime;
+            }
+            else if (Slot2 is null)
+            {
+                Slot2 = payload;
+                StartTime2 = startTime;
+            }
+            else if (Slot3 is null)
+            {
+                Slot3 = payload;
+                StartTime3 = startTime;
+            }
+            else
+            {
+                Overflow ??= new Queue<(TestCaseStartingPayload, DateTimeOffset)>();
+                Overflow.Enqueue((payload, startTime));
+            }
         }
     }
 
@@ -63,61 +69,70 @@ internal sealed class InFlightTest
     /// </summary>
     public bool RemoveOldest()
     {
-        // Shift slots down
-        if (Slot1 is not null)
+        lock (_lock)
         {
-            Slot0 = Slot1;
-            StartTime0 = StartTime1;
-            Slot1 = Slot2;
-            StartTime1 = StartTime2;
-            Slot2 = Slot3;
-            StartTime2 = StartTime3;
-            Slot3 = null;
-            StartTime3 = default;
-
-            // Refill Slot3 from overflow if available
-            if (Overflow is { Count: > 0 })
+            // Shift slots down
+            if (Slot1 is not null)
             {
-                var (payload, startTime) = Overflow.Dequeue();
-                Slot3 = payload;
-                StartTime3 = startTime;
+                Slot0 = Slot1;
+                StartTime0 = StartTime1;
+                Slot1 = Slot2;
+                StartTime1 = StartTime2;
+                Slot2 = Slot3;
+                StartTime2 = StartTime3;
+                Slot3 = null;
+                StartTime3 = default;
+
+                // Refill Slot3 from overflow if available
+                if (Overflow is { Count: > 0 })
+                {
+                    var (payload, startTime) = Overflow.Dequeue();
+                    Slot3 = payload;
+                    StartTime3 = startTime;
+                }
+
+                return true;
             }
 
-            return true;
+            // Slot0 was the only entry
+            return false;
         }
-
-        // Slot0 was the only entry
-        return false;
     }
 
     /// <summary>
-    /// Enumerates all in-flight entries with their display name and start time.
+    /// Returns a snapshot of all in-flight entries with their display name and start time.
     /// </summary>
-    public IEnumerable<(string? DisplayName, DateTimeOffset StartTime)> GetAll()
+    public IReadOnlyList<(string? DisplayName, DateTimeOffset StartTime)> GetAll()
     {
-        yield return (Slot0.DisplayName, StartTime0);
-
-        if (Slot1 is not null)
+        lock (_lock)
         {
-            yield return (Slot1.DisplayName, StartTime1);
-        }
+            var result = new List<(string?, DateTimeOffset)>();
+            result.Add((Slot0.DisplayName, StartTime0));
 
-        if (Slot2 is not null)
-        {
-            yield return (Slot2.DisplayName, StartTime2);
-        }
-
-        if (Slot3 is not null)
-        {
-            yield return (Slot3.DisplayName, StartTime3);
-        }
-
-        if (Overflow is not null)
-        {
-            foreach (var (payload, startTime) in Overflow)
+            if (Slot1 is not null)
             {
-                yield return (payload.DisplayName, startTime);
+                result.Add((Slot1.DisplayName, StartTime1));
             }
+
+            if (Slot2 is not null)
+            {
+                result.Add((Slot2.DisplayName, StartTime2));
+            }
+
+            if (Slot3 is not null)
+            {
+                result.Add((Slot3.DisplayName, StartTime3));
+            }
+
+            if (Overflow is not null)
+            {
+                foreach (var (payload, startTime) in Overflow)
+                {
+                    result.Add((payload.DisplayName, startTime));
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/ITestCaseLifecycleNotifier.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/ITestCaseLifecycleNotifier.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
+
+/// <summary>
+/// Provides lightweight test case lifecycle notifications for real-time in-flight tracking.
+/// Implemented by event handlers that can relay start/finish signals to the console.
+/// </summary>
+internal interface ITestCaseLifecycleNotifier
+{
+    void SendTestCaseStarting(TestCase testCase);
+
+    void SendTestCaseFinished(TestCase testCase);
+}

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/ITestRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Interfaces/ITestRequestHandler.cs
@@ -94,4 +94,18 @@ public interface ITestRequestHandler : IDisposable
     /// <param name="attachDebuggerInfo">Process ID and tfm of the process to which the debugger should be attached.</param>
     /// <returns><see langword="true"/> if the debugger was successfully attached to the requested process, <see langword="false"/> otherwise.</returns>
     bool AttachDebuggerToProcess(AttachDebuggerInfo attachDebuggerInfo);
+
+    /// <summary>
+    /// Sends a lightweight notification that a test case has started executing.
+    /// Used for real-time in-flight test tracking on the console side.
+    /// </summary>
+    /// <param name="testCase">The test case that started.</param>
+    void SendTestCaseStarting(TestCase testCase);
+
+    /// <summary>
+    /// Sends a lightweight notification that a test case has finished executing.
+    /// Used for real-time in-flight test tracking on the console side.
+    /// </summary>
+    /// <param name="testCase">The test case that finished.</param>
+    void SendTestCaseFinished(TestCase testCase);
 }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Messages/MessageType.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Messages/MessageType.cs
@@ -112,6 +112,18 @@ public static class MessageType
     public const string TestRunStatsChange = "TestExecution.StatsChange";
 
     /// <summary>
+    /// Lightweight notification that a test case has started executing.
+    /// Sent unbatched from testhost to console for real-time in-flight test tracking.
+    /// </summary>
+    public const string TestCaseStarting = "TestExecution.TestCaseStarting";
+
+    /// <summary>
+    /// Lightweight notification that a test case has finished executing.
+    /// Sent unbatched from testhost to console for real-time in-flight test tracking.
+    /// </summary>
+    public const string TestCaseFinished = "TestExecution.TestCaseFinished";
+
+    /// <summary>
     /// The execution complete.
     /// </summary>
     public const string ExecutionComplete = "TestExecution.Completed";

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Messages/TestCaseFinishedPayload.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Messages/TestCaseFinishedPayload.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
+
+/// <summary>
+/// Payload for the TestCaseFinished message, sent from testhost to console when a test completes execution.
+/// </summary>
+[DataContract]
+public class TestCaseFinishedPayload
+{
+    /// <summary>
+    /// Gets or sets the test case ID.
+    /// </summary>
+    [DataMember]
+    public Guid Id { get; set; }
+}

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Messages/TestCaseStartingPayload.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Messages/TestCaseStartingPayload.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
+
+/// <summary>
+/// Payload for the TestCaseStarting message, sent from testhost to console when a test begins execution.
+/// </summary>
+[DataContract]
+public class TestCaseStartingPayload
+{
+    /// <summary>
+    /// Gets or sets the test case ID.
+    /// </summary>
+    [DataMember]
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the display name of the test case.
+    /// </summary>
+    [DataMember]
+    public string? DisplayName { get; set; }
+}

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,5 +1,19 @@
 #nullable enable
 const Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel.MessageType.TelemetryEventMessage = "TestPlatform.TelemetryEvent" -> string!
+const Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel.MessageType.TestCaseFinished = "TestExecution.TestCaseFinished" -> string!
+const Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel.MessageType.TestCaseStarting = "TestExecution.TestCaseStarting" -> string!
+Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces.ITestRequestHandler.SendTestCaseFinished(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase! testCase) -> void
+Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces.ITestRequestHandler.SendTestCaseStarting(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase! testCase) -> void
+Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel.TestCaseFinishedPayload
+Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel.TestCaseFinishedPayload.Id.get -> System.Guid
+Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel.TestCaseFinishedPayload.Id.set -> void
+Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel.TestCaseFinishedPayload.TestCaseFinishedPayload() -> void
+Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel.TestCaseStartingPayload
+Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel.TestCaseStartingPayload.DisplayName.get -> string?
+Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel.TestCaseStartingPayload.DisplayName.set -> void
+Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel.TestCaseStartingPayload.Id.get -> System.Guid
+Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel.TestCaseStartingPayload.Id.set -> void
+Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel.TestCaseStartingPayload.TestCaseStartingPayload() -> void
 ~static Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources.Resources.ConnectionTimeoutProcessDidNotStartErrorMessage.get -> string
 ~static Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources.Resources.ConnectionTimeoutProcessExitedErrorMessage.get -> string
 ~static Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Resources.Resources.ConnectionTimeoutWithDetailsErrorMessage.get -> string

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -50,6 +50,7 @@ public class TestRequestSender : ITestRequestSender
     // that implies host is using version 1.
     private int _protocolVersion = 1;
     private bool _isDiscoveryAborted;
+    private readonly InFlightTestTracker _inFlightTests = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TestRequestSender"/> class.
@@ -593,6 +594,24 @@ public class TestRequestSender : ITestRequestSender
                     _channel.Send(resultMessage);
 
                     break;
+
+                case MessageType.TestCaseStarting:
+                    var testCaseStarting = _dataSerializer.DeserializePayload<TestCaseStartingPayload>(message);
+                    if (testCaseStarting is not null)
+                    {
+                        EqtTrace.Info("TestRequestSender.OnExecutionMessageReceived: TestCaseStarting received for: {0}", testCaseStarting.DisplayName);
+                        _inFlightTests.TestStarting(testCaseStarting, DateTimeOffset.UtcNow);
+                    }
+                    break;
+
+                case MessageType.TestCaseFinished:
+                    var testCaseFinished = _dataSerializer.DeserializePayload<TestCaseFinishedPayload>(message);
+                    if (testCaseFinished is not null)
+                    {
+                        EqtTrace.Info("TestRequestSender.OnExecutionMessageReceived: TestCaseFinished received for: {0}", testCaseFinished.Id);
+                        _inFlightTests.TestFinished(testCaseFinished.Id);
+                    }
+                    break;
             }
         }
         catch (Exception exception)
@@ -748,6 +767,14 @@ public class TestRequestSender : ITestRequestSender
         // TODO: this timeout is 10 seconds, make it also configurable like the other famous timeout that is 100ms
         if (_clientExited.Wait(_clientExitedWaitTime))
         {
+            // Give a brief moment for any in-flight protocol messages (like TestCaseStarting)
+            // to be processed before we build the error. The message receive loop runs on a
+            // separate thread and may still be draining buffered messages.
+            if (!_inFlightTests.HasInFlightTests)
+            {
+                Thread.Sleep(50);
+            }
+
             // Set a default message of test host process exited and additionally specify the error if we were able to get it
             // from error output of the process
             EqtTrace.Info("TestRequestSender.GetAbortErrorMessage: Received test host error message.");
@@ -757,14 +784,46 @@ public class TestRequestSender : ITestRequestSender
                 reason = $"{reason} : {_clientExitErrorMessage}";
             }
 
+            reason = AppendInFlightTestsInfo(reason);
+
             return reason;
         }
         else
         {
             EqtTrace.Info("TestRequestSender.GetAbortErrorMessage: Timed out waiting for test host error message.");
-            return CommonResources.UnableToCommunicateToTestHost;
+            return AppendInFlightTestsInfo(CommonResources.UnableToCommunicateToTestHost);
         }
     }
+
+    private string AppendInFlightTestsInfo(string reason)
+    {
+        var sb = new System.Text.StringBuilder(reason);
+
+        if (_inFlightTests.HasInFlightTests)
+        {
+            var inFlight = _inFlightTests.GetInFlightTests();
+            var now = DateTimeOffset.UtcNow;
+            sb.AppendLine();
+            sb.AppendLine("Tests that were executing when the crash occurred:");
+            foreach (var (displayName, startTime) in inFlight)
+            {
+                var elapsed = now - startTime;
+                sb.AppendLine($"  {displayName ?? "<unknown>"} (running for {FormatElapsed(elapsed)})");
+            }
+        }
+
+        sb.AppendLine();
+        sb.Append("Consider using --blame-crash to collect a crash dump for further diagnosis.");
+
+        return sb.ToString();
+    }
+
+    private static string FormatElapsed(TimeSpan elapsed) => elapsed.TotalSeconds switch
+    {
+        < 1 => $"{elapsed.Milliseconds}ms",
+        < 60 => $"{elapsed.TotalSeconds:F0}s",
+        _ => $"{elapsed.TotalMinutes:F0}m {elapsed.Seconds}s",
+    };
 
     private void LogErrorMessage(string message)
     {

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -772,7 +772,7 @@ public class TestRequestSender : ITestRequestSender
             // separate thread and may still be draining buffered messages.
             if (!_inFlightTests.HasInFlightTests)
             {
-                Thread.Sleep(50);
+                SpinWait.SpinUntil(() => _inFlightTests.HasInFlightTests, millisecondsTimeout: 50);
             }
 
             // Set a default message of test host process exited and additionally specify the error if we were able to get it
@@ -822,7 +822,7 @@ public class TestRequestSender : ITestRequestSender
     {
         < 1 => $"{elapsed.Milliseconds}ms",
         < 60 => $"{elapsed.TotalSeconds:F0}s",
-        _ => $"{elapsed.TotalMinutes:F0}m {elapsed.Seconds}s",
+        _ => $"{(int)elapsed.TotalMinutes}m {elapsed.Seconds}s",
     };
 
     private void LogErrorMessage(string message)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Adapter/FrameworkHandle.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Adapter/FrameworkHandle.cs
@@ -45,9 +45,12 @@ internal class FrameworkHandle : TestExecutionRecorder, IFrameworkHandle2, IDisp
     /// <param name="testRunCache"> The test run cache. </param>
     /// <param name="testExecutionContext"> The test execution context. </param>
     /// <param name="testRunEventsHandler">TestRun Events Handler</param>
+    /// <param name="onTestCaseStarting">Optional callback for real-time in-flight test tracking.</param>
+    /// <param name="onTestCaseFinished">Optional callback for real-time in-flight test tracking.</param>
     public FrameworkHandle(ITestCaseEventsHandler? testCaseEventsHandler, ITestRunCache testRunCache,
-        TestExecutionContext testExecutionContext, IInternalTestRunEventsHandler testRunEventsHandler)
-        : base(testCaseEventsHandler, testRunCache)
+        TestExecutionContext testExecutionContext, IInternalTestRunEventsHandler testRunEventsHandler,
+        Action<TestCase>? onTestCaseStarting = null, Action<TestCase>? onTestCaseFinished = null)
+        : base(testCaseEventsHandler, testRunCache, onTestCaseStarting, onTestCaseFinished)
     {
         _testExecutionContext = testExecutionContext;
         _testRunEventsHandler = testRunEventsHandler;

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Adapter/TestExecutionRecorder.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Adapter/TestExecutionRecorder.cs
@@ -21,6 +21,8 @@ internal class TestExecutionRecorder : TestSessionMessageLogger, ITestExecutionR
     private readonly List<AttachmentSet> _attachmentSets;
     private readonly ITestRunCache _testRunCache;
     private readonly ITestCaseEventsHandler? _testCaseEventsHandler;
+    private readonly Action<TestCase>? _onTestCaseStarting;
+    private readonly Action<TestCase>? _onTestCaseFinished;
 
     /// <summary>
     /// Contains TestCase Ids for test cases that are in progress
@@ -35,10 +37,18 @@ internal class TestExecutionRecorder : TestSessionMessageLogger, ITestExecutionR
     /// </summary>
     /// <param name="testCaseEventsHandler"> The test Case Events Handler. </param>
     /// <param name="testRunCache"> The test run cache.  </param>
-    public TestExecutionRecorder(ITestCaseEventsHandler? testCaseEventsHandler, ITestRunCache testRunCache)
+    /// <param name="onTestCaseStarting"> Optional callback invoked when a test case starts, for real-time in-flight tracking. </param>
+    /// <param name="onTestCaseFinished"> Optional callback invoked when a test case finishes, for real-time in-flight tracking. </param>
+    public TestExecutionRecorder(
+        ITestCaseEventsHandler? testCaseEventsHandler,
+        ITestRunCache testRunCache,
+        Action<TestCase>? onTestCaseStarting = null,
+        Action<TestCase>? onTestCaseFinished = null)
     {
         _testRunCache = testRunCache;
         _testCaseEventsHandler = testCaseEventsHandler;
+        _onTestCaseStarting = onTestCaseStarting;
+        _onTestCaseFinished = onTestCaseFinished;
         _attachmentSets = new List<AttachmentSet>();
 
         // As a framework guideline, we should get events in this order:
@@ -70,6 +80,7 @@ internal class TestExecutionRecorder : TestSessionMessageLogger, ITestExecutionR
     {
         EqtTrace.Verbose("TestExecutionRecorder.RecordStart: Starting test: {0}.", testCase.FullyQualifiedName);
         _testRunCache.OnTestStarted(testCase);
+        _onTestCaseStarting?.Invoke(testCase);
 
         if (_testCaseEventsHandler != null)
         {
@@ -115,6 +126,7 @@ internal class TestExecutionRecorder : TestSessionMessageLogger, ITestExecutionR
     {
         EqtTrace.Verbose("TestExecutionRecorder.RecordEnd: test: {0} execution completed.", testCase.FullyQualifiedName);
         _testRunCache.OnTestCompletion(testCase);
+        _onTestCaseFinished?.Invoke(testCase);
         SendTestCaseEnd(testCase, outcome);
     }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
@@ -613,4 +613,21 @@ public class TestRequestHandler : ITestRequestHandler, IDeploymentAwareTestReque
         EqtTrace.Verbose("TestRequestHandler.SendData: sending data from testhost: {0}", data);
         _channel?.Send(data);
     }
+
+    /// <inheritdoc />
+    public void SendTestCaseStarting(TestCase testCase)
+    {
+        EqtTrace.Info("TestRequestHandler.SendTestCaseStarting: Sending test case starting for: {0}", testCase.DisplayName);
+        var payload = new TestCaseStartingPayload { Id = testCase.Id, DisplayName = testCase.DisplayName };
+        var data = _dataSerializer.SerializePayload(MessageType.TestCaseStarting, payload, _protocolVersion);
+        SendData(data);
+    }
+
+    /// <inheritdoc />
+    public void SendTestCaseFinished(TestCase testCase)
+    {
+        var payload = new TestCaseFinishedPayload { Id = testCase.Id };
+        var data = _dataSerializer.SerializePayload(MessageType.TestCaseFinished, payload, _protocolVersion);
+        SendData(data);
+    }
 }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -18,6 +18,7 @@ using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.Common.Telemetry;
 using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.EventHandlers;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Tracing.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Adapter;
@@ -156,11 +157,14 @@ internal abstract class BaseRunTests
         RunContext.SolutionDirectory = RunSettingsUtilities.GetSolutionDirectory(runConfig);
         _runConfiguration = runConfig;
 
+        var requestHandler = (testRunEventsHandler as TestRunEventsHandler)?.RequestHandler;
         FrameworkHandle = new FrameworkHandle(
             _testCaseEventsHandler,
             TestRunCache,
             TestExecutionContext,
-            TestRunEventsHandler);
+            TestRunEventsHandler,
+            onTestCaseStarting: requestHandler is not null ? tc => requestHandler.SendTestCaseStarting(tc) : null,
+            onTestCaseFinished: requestHandler is not null ? tc => requestHandler.SendTestCaseFinished(tc) : null);
         FrameworkHandle.TestRunMessage += OnTestRunMessage;
 
         ExecutorUrisThatRanTests = new List<string>();

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -18,7 +18,6 @@ using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.Common.Telemetry;
 using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
-using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.EventHandlers;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Tracing.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Adapter;
@@ -157,14 +156,14 @@ internal abstract class BaseRunTests
         RunContext.SolutionDirectory = RunSettingsUtilities.GetSolutionDirectory(runConfig);
         _runConfiguration = runConfig;
 
-        var requestHandler = (testRunEventsHandler as TestRunEventsHandler)?.RequestHandler;
+        var notifier = testRunEventsHandler as ITestCaseLifecycleNotifier;
         FrameworkHandle = new FrameworkHandle(
             _testCaseEventsHandler,
             TestRunCache,
             TestExecutionContext,
             TestRunEventsHandler,
-            onTestCaseStarting: requestHandler is not null ? tc => requestHandler.SendTestCaseStarting(tc) : null,
-            onTestCaseFinished: requestHandler is not null ? tc => requestHandler.SendTestCaseFinished(tc) : null);
+            onTestCaseStarting: notifier is not null ? tc => notifier.SendTestCaseStarting(tc) : null,
+            onTestCaseFinished: notifier is not null ? tc => notifier.SendTestCaseFinished(tc) : null);
         FrameworkHandle.TestRunMessage += OnTestRunMessage;
 
         ExecutorUrisThatRanTests = new List<string>();

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.TestRequestHandler.SendTestCaseFinished(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase! testCase) -> void
+Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.TestRequestHandler.SendTestCaseStarting(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase! testCase) -> void

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
@@ -229,6 +229,59 @@ public class ExecutionTests : AcceptanceTestBase
     }
 
     [TestMethod]
+    [NetCoreTargetFrameworkDataSource]
+    public void WhenTestHostCrashesTheErrorSuggestsUsingBlameCrash(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var assemblyPaths = GetAssetFullPath("SimpleTestProject3.dll");
+        var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
+        arguments = string.Concat(arguments, " /testcasefilter:ExitwithUnhandleException");
+
+        InvokeVsTest(arguments);
+
+        ExitCodeEquals(1);
+        // The error message should suggest using --blame-crash for further diagnosis.
+        StdErrorContains("--blame-crash");
+    }
+
+    [TestMethod]
+    [NetCoreTargetFrameworkDataSource]
+    public void WhenTestHostCrashesWithUnhandledExceptionTheErrorShowsInFlightTest(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var assemblyPaths = GetAssetFullPath("SimpleTestProject3.dll");
+        var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
+        arguments = string.Concat(arguments, " /testcasefilter:ExitwithUnhandleException");
+
+        InvokeVsTest(arguments);
+
+        ExitCodeEquals(1);
+        StdErrorContains("Tests that were executing when the crash occurred:");
+        StdErrorContains("ExitwithUnhandleException");
+    }
+
+    [TestMethod]
+    [NetCoreTargetFrameworkDataSource]
+    public void WhenTestHostCrashesWithStackOverflowTheErrorShowsInFlightTest(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var assemblyPaths = GetAssetFullPath("SimpleTestProject3.dll");
+        var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
+        arguments = string.Concat(arguments, " /testcasefilter:ExitWithStackoverFlow");
+
+        InvokeVsTest(arguments);
+
+        ExitCodeEquals(1);
+        // Even for stack overflow, the error should suggest --blame-crash.
+        StdErrorContains("--blame-crash");
+        // The test name should appear if the message was sent before the crash.
+        // Stack overflow may kill the process before the message arrives, so we only check blame-crash suggestion.
+    }
+
+    [TestMethod]
     [TestCategory("Windows-Review")]
     [NetFullTargetFrameworkDataSource]
     public void IncompatibleSourcesWarningShouldBeDisplayedInTheConsoleWhenGivenIncompatibleX86andX64Dll(RunnerInfo runnerInfo)

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
@@ -212,7 +212,7 @@ public class TestRequestSenderTests
 
         var expectedErrorMessage = "Reason: Test host process crashed";
         RaiseClientDisconnectedEvent();
-        _mockDiscoveryEventsHandler.Verify(eh => eh.HandleLogMessage(TestMessageLevel.Error, It.Is<string>(s => s.EndsWith(expectedErrorMessage))), Times.Once);
+        _mockDiscoveryEventsHandler.Verify(eh => eh.HandleLogMessage(TestMessageLevel.Error, It.Is<string>(s => s.Contains(expectedErrorMessage))), Times.Once);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Problem

When testhost crashes, users get an unhelpful `Test host process crashed` message with no indication of which test was running or how to diagnose. This is the most upvoted open issue (#2952, 26 thumbs up).

## Solution

Always-on blame lite: lightweight real-time test tracking without requiring `--blame`.

New protocol messages `TestCaseStarting`/`TestCaseFinished` sent unbatched from testhost (~280 bytes per test). Console tracks in-flight tests in `InFlightTestTracker` with inline-slot optimization.

On crash, users now see:

```
Test host process crashed : <crash details>
Tests that were executing when the crash occurred:
  MyTest.CrashingMethod (running for 2s)
Consider using --blame-crash to collect a crash dump for further diagnosis.
```

## Testing

3 new integration tests (6 variants), all existing tests pass.

## Backward compatibility

Older testhosts: console shows old behavior plus `--blame-crash` suggestion. Older consoles: unknown messages silently ignored.

Fixes #2952