### PR TITLE
Centralized Artifact Naming Service

### DIFF
--- a/src/Microsoft.TestPlatform.Common/ArtifactNaming/ArtifactNameProvider.cs
+++ b/src/Microsoft.TestPlatform.Common/ArtifactNaming/ArtifactNameProvider.cs
@@ -1,0 +1,378 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming;
+
+namespace Microsoft.VisualStudio.TestPlatform.Common.ArtifactNaming;
+
+/// <summary>
+/// Default implementation of <see cref="IArtifactNameProvider"/>.
+/// Resolves artifact name templates to concrete, sanitized file paths.
+/// </summary>
+internal sealed class ArtifactNameProvider : IArtifactNameProvider
+{
+    /// <summary>
+    /// Characters that are invalid in file names on Windows (superset of Linux restrictions).
+    /// Manually listed to produce cross-platform-safe file names even when running on Linux.
+    /// </summary>
+    private static readonly HashSet<char> InvalidFileNameChars = new()
+    {
+        '\"', '<', '>', '|', '\0',
+        (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10,
+        (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20,
+        (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30,
+        (char)31, ':', '*', '?', '\\', '/',
+    };
+
+    private static readonly Regex ReservedFileNamesRegex = new(@"(?i:^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9]|CLOCK\$)(\..*)?)$");
+
+    private readonly Func<DateTime> _timeProvider;
+    private readonly Func<string, bool> _fileExists;
+
+    /// <summary>
+    /// Initializes a new instance using the system clock and file system.
+    /// </summary>
+    public ArtifactNameProvider()
+        : this(() => DateTime.UtcNow, File.Exists)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance with injectable time and file-existence providers (for testing).
+    /// </summary>
+    internal ArtifactNameProvider(Func<DateTime> timeProvider, Func<string, bool> fileExists)
+    {
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _fileExists = fileExists ?? throw new ArgumentNullException(nameof(fileExists));
+    }
+
+    /// <inheritdoc />
+    public string Resolve(ArtifactNameRequest request)
+    {
+        _ = request ?? throw new ArgumentNullException(nameof(request));
+
+        // 1. Build the context with auto-populated tokens.
+        IReadOnlyDictionary<string, string> context = EnsureAutoTokens(request.Context);
+
+        // 2. Resolve directory.
+        string directoryTemplate = request.DirectoryTemplate
+            ?? ("{" + ArtifactNameTokens.TestResultsDirectory + "}");
+        string directory = ExpandTemplate(directoryTemplate, context);
+        directory = SanitizePathSegments(directory);
+
+        // 3. Resolve file name.
+        string fileName = ExpandTemplate(request.FileTemplate, context);
+        fileName = SanitizeFileName(fileName);
+
+        // 4. Combine and apply collision behavior.
+        string extension = request.Extension ?? string.Empty;
+        if (extension.Length > 0 && extension[0] != '.')
+        {
+            extension = "." + extension;
+        }
+
+        string basePath = Path.Combine(directory, fileName + extension);
+
+        return request.Collision switch
+        {
+            CollisionBehavior.Overwrite => EnsureDirectory(basePath),
+            CollisionBehavior.Fail => FailIfExists(basePath),
+            CollisionBehavior.AppendCounter => ResolveWithCounter(directory, fileName, extension),
+            CollisionBehavior.AppendTimestamp => ResolveWithTimestamp(directory, fileName, extension),
+            _ => EnsureDirectory(basePath),
+        };
+    }
+
+    /// <inheritdoc />
+    public string ExpandTemplate(string template, IReadOnlyDictionary<string, string> context)
+    {
+        if (StringUtils.IsNullOrEmpty(template))
+        {
+            return string.Empty;
+        }
+
+        var result = new StringBuilder(template.Length * 2);
+        int i = 0;
+
+        while (i < template.Length)
+        {
+            char c = template[i];
+
+            // Escaped braces.
+            if (c == '{' && i + 1 < template.Length && template[i + 1] == '{')
+            {
+                result.Append('{');
+                i += 2;
+                continue;
+            }
+
+            if (c == '}' && i + 1 < template.Length && template[i + 1] == '}')
+            {
+                result.Append('}');
+                i += 2;
+                continue;
+            }
+
+            // Token start.
+            if (c == '{')
+            {
+                int closeBrace = template.IndexOf('}', i + 1);
+                if (closeBrace < 0)
+                {
+                    // No closing brace — keep as literal.
+                    result.Append(c);
+                    i++;
+                    continue;
+                }
+
+                string tokenContent = template.Substring(i + 1, closeBrace - i - 1);
+                string expanded = ExpandToken(tokenContent, context);
+                result.Append(expanded);
+                i = closeBrace + 1;
+                continue;
+            }
+
+            result.Append(c);
+            i++;
+        }
+
+        return result.ToString();
+    }
+
+    /// <summary>
+    /// Expands a single token. Supports <c>TokenName</c>, <c>TokenName:format</c>,
+    /// and <c>TokenName?fallback</c>.
+    /// Unknown/unavailable tokens are kept literally as <c>{TokenName}</c>.
+    /// </summary>
+    private static string ExpandToken(string tokenContent, IReadOnlyDictionary<string, string> context)
+    {
+        // Parse format specifier: {Token:format}
+        string tokenName;
+        string? format = null;
+        string? fallback = null;
+
+        int formatIndex = tokenContent.IndexOf(':');
+        int fallbackIndex = tokenContent.IndexOf('?');
+
+        if (fallbackIndex >= 0)
+        {
+            tokenName = tokenContent.Substring(0, fallbackIndex);
+            fallback = tokenContent.Substring(fallbackIndex + 1);
+        }
+        else if (formatIndex >= 0)
+        {
+            tokenName = tokenContent.Substring(0, formatIndex);
+            format = tokenContent.Substring(formatIndex + 1);
+        }
+        else
+        {
+            tokenName = tokenContent;
+        }
+
+        if (context.TryGetValue(tokenName, out string? value) && value is not null)
+        {
+            // Apply format specifier to Timestamp/Date tokens if the value is a parsable DateTime.
+            if (format is not null
+                && DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTime dt))
+            {
+                return dt.ToString(format, CultureInfo.InvariantCulture);
+            }
+
+            return value;
+        }
+
+        // Token not found — use fallback or keep literal.
+        if (fallback is not null)
+        {
+            return fallback;
+        }
+
+        return "{" + tokenContent + "}";
+    }
+
+    /// <summary>
+    /// Ensures that auto-populated tokens (Timestamp, Date, MachineName, UserName, Pid) are present.
+    /// </summary>
+    private IReadOnlyDictionary<string, string> EnsureAutoTokens(IReadOnlyDictionary<string, string> context)
+    {
+        var now = _timeProvider();
+
+        var merged = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        // Auto tokens — only set if not already provided.
+        merged[ArtifactNameTokens.Timestamp] = now.ToString("yyyyMMdd'T'HHmmss.fff", CultureInfo.InvariantCulture);
+        merged[ArtifactNameTokens.Date] = now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        merged[ArtifactNameTokens.MachineName] = Environment.MachineName;
+        merged[ArtifactNameTokens.UserName] = Environment.UserName;
+#if NET
+        merged[ArtifactNameTokens.Pid] = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+#else
+        merged[ArtifactNameTokens.Pid] = System.Diagnostics.Process.GetCurrentProcess().Id.ToString(CultureInfo.InvariantCulture);
+#endif
+
+        // User-provided context overrides auto tokens.
+        foreach (KeyValuePair<string, string> kvp in context)
+        {
+            merged[kvp.Key] = kvp.Value;
+        }
+
+        return merged;
+    }
+
+    /// <summary>
+    /// Sanitizes a file name segment by replacing invalid characters with underscores.
+    /// </summary>
+    internal static string SanitizeFileName(string fileName)
+    {
+        if (StringUtils.IsNullOrEmpty(fileName))
+        {
+            return fileName;
+        }
+
+        var result = new StringBuilder(fileName.Length);
+        foreach (char c in fileName)
+        {
+            result.Append(InvalidFileNameChars.Contains(c) ? '_' : c);
+        }
+
+        string sanitized = result.ToString().TrimEnd();
+        if (sanitized.Length == 0)
+        {
+            return "_";
+        }
+
+        if (ReservedFileNamesRegex.IsMatch(sanitized))
+        {
+            sanitized = "_" + sanitized;
+        }
+
+        return sanitized;
+    }
+
+    /// <summary>
+    /// Sanitizes path segments in a directory path. Handles both forward and back slashes.
+    /// Each segment is individually sanitized while preserving directory separators.
+    /// </summary>
+    internal static string SanitizePathSegments(string path)
+    {
+        if (StringUtils.IsNullOrEmpty(path))
+        {
+            return path;
+        }
+
+        // Normalize to forward slashes for splitting, then restore platform separator.
+        string normalized = path.Replace('\\', '/');
+        string[] segments = normalized.Split('/');
+
+        var result = new StringBuilder(path.Length);
+        bool first = true;
+
+        foreach (string segment in segments)
+        {
+            if (!first)
+            {
+                result.Append(Path.DirectorySeparatorChar);
+            }
+
+            first = false;
+
+            // Preserve drive letters (e.g., "C:") and empty segments at the start (UNC paths).
+            if (segment.Length == 2 && segment[1] == ':' && char.IsLetter(segment[0]))
+            {
+                result.Append(segment);
+                continue;
+            }
+
+            if (segment.Length == 0)
+            {
+                continue;
+            }
+
+            // Reject ".." traversal.
+            if (segment == "..")
+            {
+                continue;
+            }
+
+            // Keep "." as-is (current directory).
+            if (segment == ".")
+            {
+                result.Append(segment);
+                continue;
+            }
+
+            result.Append(SanitizeFileName(segment));
+        }
+
+        return result.ToString();
+    }
+
+    private string ResolveWithCounter(string directory, string fileName, string extension)
+    {
+        string path = Path.Combine(directory, fileName + extension);
+        path = EnsureDirectory(path);
+
+        if (!_fileExists(path))
+        {
+            return path;
+        }
+
+        for (int i = 2; i < 10000; i++)
+        {
+            string candidate = Path.Combine(directory, fileName + "_" + i.ToString(CultureInfo.InvariantCulture) + extension);
+            if (!_fileExists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        // Extremely unlikely: fall back to GUID suffix.
+        return Path.Combine(directory, fileName + "_" + Guid.NewGuid().ToString("N").Substring(0, 8) + extension);
+    }
+
+    private string ResolveWithTimestamp(string directory, string fileName, string extension)
+    {
+        string timestamp = _timeProvider().ToString("yyyyMMdd'T'HHmmss.fff", CultureInfo.InvariantCulture);
+        string path = Path.Combine(directory, fileName + "_" + timestamp + extension);
+        path = EnsureDirectory(path);
+
+        if (!_fileExists(path))
+        {
+            return path;
+        }
+
+        // If timestamp collision (parallel runs), fall back to counter.
+        return ResolveWithCounter(directory, fileName + "_" + timestamp, extension);
+    }
+
+    private string FailIfExists(string path)
+    {
+        path = EnsureDirectory(path);
+        if (_fileExists(path))
+        {
+            throw new InvalidOperationException(
+                string.Format(CultureInfo.InvariantCulture,
+                    "Artifact path '{0}' already exists and collision behavior is set to Fail.", path));
+        }
+
+        return path;
+    }
+
+    private static string EnsureDirectory(string filePath)
+    {
+        string? directory = Path.GetDirectoryName(filePath);
+        if (!StringUtils.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        return filePath;
+    }
+}

--- a/src/Microsoft.TestPlatform.Common/ArtifactNaming/ArtifactNameProvider.cs
+++ b/src/Microsoft.TestPlatform.Common/ArtifactNaming/ArtifactNameProvider.cs
@@ -19,6 +19,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ArtifactNaming;
 internal sealed class ArtifactNameProvider : IArtifactNameProvider
 {
     /// <summary>
+    /// Name of the marker file created in per-run directories to claim ownership.
+    /// </summary>
+    internal const string MarkerFileName = ".vstest-run";
+
+    /// <summary>
     /// Characters that are invalid in file names on Windows (superset of Linux restrictions).
     /// Manually listed to produce cross-platform-safe file names even when running on Linux.
     /// </summary>
@@ -35,6 +40,9 @@ internal sealed class ArtifactNameProvider : IArtifactNameProvider
 
     private readonly Func<DateTime> _timeProvider;
     private readonly Func<string, bool> _fileExists;
+    private readonly Func<string, bool> _directoryExists;
+    private readonly Action<string> _createDirectory;
+    private readonly Func<string, string, bool> _tryCreateMarkerFile;
 
     /// <summary>
     /// Initializes a new instance using the system clock and file system.
@@ -45,16 +53,24 @@ internal sealed class ArtifactNameProvider : IArtifactNameProvider
     }
 
     /// <summary>
-    /// Initializes a new instance with injectable time and file-existence providers (for testing).
+    /// Initializes a new instance with injectable dependencies (for testing).
     /// </summary>
-    internal ArtifactNameProvider(Func<DateTime> timeProvider, Func<string, bool> fileExists)
+    internal ArtifactNameProvider(
+        Func<DateTime> timeProvider,
+        Func<string, bool> fileExists,
+        Func<string, string, bool>? tryCreateMarkerFile = null,
+        Func<string, bool>? directoryExists = null,
+        Action<string>? createDirectory = null)
     {
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
         _fileExists = fileExists ?? throw new ArgumentNullException(nameof(fileExists));
+        _tryCreateMarkerFile = tryCreateMarkerFile ?? TryCreateMarkerFileOnDisk;
+        _directoryExists = directoryExists ?? Directory.Exists;
+        _createDirectory = createDirectory ?? (path => Directory.CreateDirectory(path));
     }
 
     /// <inheritdoc />
-    public string Resolve(ArtifactNameRequest request)
+    public ArtifactNameResult Resolve(ArtifactNameRequest request)
     {
         _ = request ?? throw new ArgumentNullException(nameof(request));
 
@@ -80,13 +96,17 @@ internal sealed class ArtifactNameProvider : IArtifactNameProvider
 
         string basePath = Path.Combine(directory, fileName + extension);
 
+        // 5. Ensure directory exists and determine ownership.
+        bool isDirectoryOwner = EnsureDirectoryWithOwnership(directory);
+
+        // 6. Resolve collision and detect overwrite.
         return request.Collision switch
         {
-            CollisionBehavior.Overwrite => EnsureDirectory(basePath),
-            CollisionBehavior.Fail => FailIfExists(basePath),
-            CollisionBehavior.AppendCounter => ResolveWithCounter(directory, fileName, extension),
-            CollisionBehavior.AppendTimestamp => ResolveWithTimestamp(directory, fileName, extension),
-            _ => EnsureDirectory(basePath),
+            CollisionBehavior.Overwrite => ResolveOverwrite(basePath, isDirectoryOwner),
+            CollisionBehavior.Fail => ResolveFail(basePath, isDirectoryOwner),
+            CollisionBehavior.AppendCounter => ResolveWithCounter(directory, fileName, extension, isDirectoryOwner),
+            CollisionBehavior.AppendTimestamp => ResolveWithTimestamp(directory, fileName, extension, isDirectoryOwner),
+            _ => ResolveOverwrite(basePath, isDirectoryOwner),
         };
     }
 
@@ -147,8 +167,7 @@ internal sealed class ArtifactNameProvider : IArtifactNameProvider
     }
 
     /// <summary>
-    /// Expands a single token. Supports <c>TokenName</c>, <c>TokenName:format</c>,
-    /// and <c>TokenName?fallback</c>.
+    /// Expands a single token. Supports <c>TokenName</c> and <c>TokenName:format</c>.
     /// Unknown/unavailable tokens are kept literally as <c>{TokenName}</c>.
     /// </summary>
     private static string ExpandToken(string tokenContent, IReadOnlyDictionary<string, string> context)
@@ -156,17 +175,10 @@ internal sealed class ArtifactNameProvider : IArtifactNameProvider
         // Parse format specifier: {Token:format}
         string tokenName;
         string? format = null;
-        string? fallback = null;
 
         int formatIndex = tokenContent.IndexOf(':');
-        int fallbackIndex = tokenContent.IndexOf('?');
 
-        if (fallbackIndex >= 0)
-        {
-            tokenName = tokenContent.Substring(0, fallbackIndex);
-            fallback = tokenContent.Substring(fallbackIndex + 1);
-        }
-        else if (formatIndex >= 0)
+        if (formatIndex >= 0)
         {
             tokenName = tokenContent.Substring(0, formatIndex);
             format = tokenContent.Substring(formatIndex + 1);
@@ -188,12 +200,7 @@ internal sealed class ArtifactNameProvider : IArtifactNameProvider
             return value;
         }
 
-        // Token not found — use fallback or keep literal.
-        if (fallback is not null)
-        {
-            return fallback;
-        }
-
+        // Token not found — keep literal so misconfiguration is obvious.
         return "{" + tokenContent + "}";
     }
 
@@ -314,14 +321,13 @@ internal sealed class ArtifactNameProvider : IArtifactNameProvider
         return result.ToString();
     }
 
-    private string ResolveWithCounter(string directory, string fileName, string extension)
+    private ArtifactNameResult ResolveWithCounter(string directory, string fileName, string extension, bool isDirectoryOwner)
     {
         string path = Path.Combine(directory, fileName + extension);
-        path = EnsureDirectory(path);
 
         if (!_fileExists(path))
         {
-            return path;
+            return new ArtifactNameResult(path, isOverwrite: false, isDirectoryOwner);
         }
 
         for (int i = 2; i < 10000; i++)
@@ -329,32 +335,39 @@ internal sealed class ArtifactNameProvider : IArtifactNameProvider
             string candidate = Path.Combine(directory, fileName + "_" + i.ToString(CultureInfo.InvariantCulture) + extension);
             if (!_fileExists(candidate))
             {
-                return candidate;
+                return new ArtifactNameResult(candidate, isOverwrite: false, isDirectoryOwner);
             }
         }
 
         // Extremely unlikely: fall back to GUID suffix.
-        return Path.Combine(directory, fileName + "_" + Guid.NewGuid().ToString("N").Substring(0, 8) + extension);
+        string fallback = Path.Combine(directory, fileName + "_" + Guid.NewGuid().ToString("N").Substring(0, 8) + extension);
+
+        return new ArtifactNameResult(fallback, isOverwrite: false, isDirectoryOwner);
     }
 
-    private string ResolveWithTimestamp(string directory, string fileName, string extension)
+    private ArtifactNameResult ResolveWithTimestamp(string directory, string fileName, string extension, bool isDirectoryOwner)
     {
         string timestamp = _timeProvider().ToString("yyyyMMdd'T'HHmmss.fff", CultureInfo.InvariantCulture);
         string path = Path.Combine(directory, fileName + "_" + timestamp + extension);
-        path = EnsureDirectory(path);
 
         if (!_fileExists(path))
         {
-            return path;
+            return new ArtifactNameResult(path, isOverwrite: false, isDirectoryOwner);
         }
 
         // If timestamp collision (parallel runs), fall back to counter.
-        return ResolveWithCounter(directory, fileName + "_" + timestamp, extension);
+        return ResolveWithCounter(directory, fileName + "_" + timestamp, extension, isDirectoryOwner);
     }
 
-    private string FailIfExists(string path)
+    private ArtifactNameResult ResolveOverwrite(string path, bool isDirectoryOwner)
     {
-        path = EnsureDirectory(path);
+        bool isOverwrite = _fileExists(path);
+
+        return new ArtifactNameResult(path, isOverwrite, isDirectoryOwner);
+    }
+
+    private ArtifactNameResult ResolveFail(string path, bool isDirectoryOwner)
+    {
         if (_fileExists(path))
         {
             throw new InvalidOperationException(
@@ -362,17 +375,59 @@ internal sealed class ArtifactNameProvider : IArtifactNameProvider
                     "Artifact path '{0}' already exists and collision behavior is set to Fail.", path));
         }
 
-        return path;
+        return new ArtifactNameResult(path, isOverwrite: false, isDirectoryOwner);
     }
 
-    private static string EnsureDirectory(string filePath)
+    /// <summary>
+    /// Ensures the directory exists and attempts to claim ownership via a marker file.
+    /// Returns <see langword="true"/> if this process created the directory (owns it).
+    /// </summary>
+    private bool EnsureDirectoryWithOwnership(string directory)
     {
-        string? directory = Path.GetDirectoryName(filePath);
-        if (!StringUtils.IsNullOrEmpty(directory))
+        if (StringUtils.IsNullOrEmpty(directory))
         {
-            Directory.CreateDirectory(directory);
+            return false;
         }
 
-        return filePath;
+        bool directoryExisted = _directoryExists(directory);
+        _createDirectory(directory);
+
+        if (directoryExisted)
+        {
+            // Directory already existed — we're not the owner.
+            return false;
+        }
+
+        // New directory — claim ownership with an atomic marker file.
+        string markerPath = Path.Combine(directory, MarkerFileName);
+#if NET
+        string markerContent = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+#else
+        string markerContent = System.Diagnostics.Process.GetCurrentProcess().Id.ToString(CultureInfo.InvariantCulture);
+#endif
+
+        return _tryCreateMarkerFile(markerPath, markerContent);
+    }
+
+    /// <summary>
+    /// Atomically creates a marker file using <see cref="FileMode.CreateNew"/>.
+    /// Returns <see langword="true"/> if this call created the file, <see langword="false"/> if it already existed.
+    /// </summary>
+    private static bool TryCreateMarkerFileOnDisk(string path, string content)
+    {
+        try
+        {
+            // FileMode.CreateNew fails atomically if the file already exists.
+            using FileStream fs = new(path, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+            byte[] bytes = Encoding.UTF8.GetBytes(content);
+            fs.Write(bytes, 0, bytes.Length);
+
+            return true;
+        }
+        catch (IOException)
+        {
+            // File already exists — another process claimed ownership.
+            return false;
+        }
     }
 }

--- a/src/Microsoft.TestPlatform.Common/ArtifactNaming/ArtifactNameProvider.cs
+++ b/src/Microsoft.TestPlatform.Common/ArtifactNaming/ArtifactNameProvider.cs
@@ -249,7 +249,7 @@ internal sealed class ArtifactNameProvider : IArtifactNameProvider
             result.Append(InvalidFileNameChars.Contains(c) ? '_' : c);
         }
 
-        string sanitized = result.ToString().TrimEnd();
+        string sanitized = result.ToString().TrimEnd(' ', '.');
         if (sanitized.Length == 0)
         {
             return "_";

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/TestLoggerManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/TestLoggerManager.cs
@@ -58,6 +58,16 @@ internal class TestLoggerManager : ITestLoggerManager
     private bool _treatNoTestsAsError;
 
     /// <summary>
+    /// Target architecture (e.g. "x64", "x86", "ARM64").
+    /// </summary>
+    private string? _targetArchitecture;
+
+    /// <summary>
+    /// Shared test run timestamp for artifact naming.
+    /// </summary>
+    private string? _testRunTimestamp;
+
+    /// <summary>
     /// Test Logger Events instance which will be passed to loggers when they are initialized.
     /// </summary>
     private readonly InternalTestLoggerEvents _loggerEvents;
@@ -83,12 +93,17 @@ internal class TestLoggerManager : ITestLoggerManager
     private readonly IAssemblyLoadContext _assemblyLoadContext;
 
     /// <summary>
+    /// Time provider for generating timestamps. Injected for testability.
+    /// </summary>
+    private readonly Func<DateTime> _timeProvider;
+
+    /// <summary>
     /// Test logger manager.
     /// </summary>
     /// <param name="requestData">Request Data for Providing Common Services/Data for Discovery and Execution.</param>
     /// <param name="messageLogger">Message Logger.</param>
     /// <param name="loggerEvents">Logger events.</param>
-    public TestLoggerManager(IRequestData requestData, IMessageLogger messageLogger, InternalTestLoggerEvents loggerEvents) : this(requestData, messageLogger, loggerEvents, new PlatformAssemblyLoadContext())
+    public TestLoggerManager(IRequestData requestData, IMessageLogger messageLogger, InternalTestLoggerEvents loggerEvents) : this(requestData, messageLogger, loggerEvents, new PlatformAssemblyLoadContext(), () => DateTime.UtcNow)
     {
     }
 
@@ -99,14 +114,17 @@ internal class TestLoggerManager : ITestLoggerManager
     /// <param name="messageLogger"></param>
     /// <param name="loggerEvents"></param>
     /// <param name="assemblyLoadContext"></param>
+    /// <param name="timeProvider">Provides current UTC time. Injected for testability.</param>
     internal TestLoggerManager(IRequestData requestData, IMessageLogger messageLogger,
-        InternalTestLoggerEvents loggerEvents, IAssemblyLoadContext assemblyLoadContext)
+        InternalTestLoggerEvents loggerEvents, IAssemblyLoadContext assemblyLoadContext,
+        Func<DateTime> timeProvider)
     {
         _requestData = requestData;
         _messageLogger = messageLogger;
         _testLoggerExtensionManager = null;
         _loggerEvents = loggerEvents;
         _assemblyLoadContext = assemblyLoadContext;
+        _timeProvider = timeProvider;
     }
 
     /// <summary>
@@ -135,6 +153,8 @@ internal class TestLoggerManager : ITestLoggerManager
         // Store test run directory. This runsettings is the final runsettings merging CLI args and runsettings.
         _testRunDirectory = GetResultsDirectory(runSettings);
         _targetFramework = GetTargetFramework(runSettings)?.Name;
+        _targetArchitecture = GetTargetArchitecture(runSettings);
+        _testRunTimestamp = GetOrGenerateTestRunTimestamp(runSettings);
         _treatNoTestsAsError = GetTreatNoTestsAsError(runSettings);
 
         var loggers = XmlRunSettingsUtilities.GetLoggerRunSettings(runSettings);
@@ -479,6 +499,67 @@ internal class TestLoggerManager : ITestLoggerManager
     }
 
     /// <summary>
+    /// Gets the target architecture (e.g. "x64", "x86", "ARM64") from RunSettings.
+    /// </summary>
+    /// <param name="runSettings">Test run settings.</param>
+    /// <returns>Architecture string, or null if not available.</returns>
+    internal static string? GetTargetArchitecture(string? runSettings)
+    {
+        if (runSettings != null)
+        {
+            try
+            {
+                RunConfiguration runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(runSettings);
+
+                // Only propagate architecture when explicitly set in RunSettings.
+                // Default is the OS architecture, but we don't want to surface that
+                // unless the user or engine has explicitly configured it.
+                if (runConfiguration.TargetPlatformSet)
+                {
+                    return runConfiguration.TargetPlatform.ToString().ToLowerInvariant();
+                }
+            }
+            catch (SettingsException se)
+            {
+                EqtTrace.Error("TestLoggerManager.GetTargetArchitecture: Unable to get the target architecture: Error {0}", se);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Gets the shared test run timestamp from RunSettings, or generates a new one.
+    /// The timestamp is in ISO 8601 compact format: yyyyMMddTHHmmss.fff
+    /// If <c>&lt;ArtifactRunTimestamp&gt;</c> is already set in RunSettings (e.g. by the
+    /// orchestrator for cross-process synchronization), that value is used.
+    /// Otherwise a new timestamp is generated from the current UTC time.
+    /// </summary>
+    /// <param name="runSettings">Test run settings.</param>
+    /// <returns>Timestamp string.</returns>
+    internal string GetOrGenerateTestRunTimestamp(string? runSettings)
+    {
+        if (runSettings != null)
+        {
+            try
+            {
+                RunConfiguration runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(runSettings);
+                string? existingTimestamp = runConfiguration.ArtifactRunTimestamp;
+                if (!StringUtils.IsNullOrEmpty(existingTimestamp))
+                {
+                    return existingTimestamp;
+                }
+            }
+            catch (SettingsException se)
+            {
+                EqtTrace.Error("TestLoggerManager.GetOrGenerateTestRunTimestamp: Unable to read ArtifactRunTimestamp: Error {0}", se);
+            }
+        }
+
+        return _timeProvider().ToUniversalTime().ToString("yyyyMMdd'T'HHmmss.fff", CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
     /// Enables sending of events to the loggers which are registered.
     /// </summary>
     /// <remarks>
@@ -636,6 +717,8 @@ internal class TestLoggerManager : ITestLoggerManager
         // Add default logger parameters...
         loggerParams[DefaultLoggerParameterNames.TestRunDirectory] = _testRunDirectory;
         loggerParams[DefaultLoggerParameterNames.TargetFramework] = _targetFramework;
+        loggerParams[DefaultLoggerParameterNames.TargetArchitecture] = _targetArchitecture;
+        loggerParams[DefaultLoggerParameterNames.TestRunTimestamp] = _testRunTimestamp;
 
         // Add custom logger parameters
         if (_treatNoTestsAsError)

--- a/src/Microsoft.TestPlatform.ObjectModel/ArtifactNaming/ArtifactNameRequest.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/ArtifactNaming/ArtifactNameRequest.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming;
+
+/// <summary>
+/// Describes a request to resolve an artifact file name from a template.
+/// </summary>
+public sealed class ArtifactNameRequest
+{
+    /// <summary>
+    /// Gets or sets the file name template (without directory, without extension).
+    /// Uses <c>{TokenName}</c> placeholders for token expansion.
+    /// </summary>
+    /// <example><c>{AssemblyName}_{Tfm}_{Architecture}</c></example>
+    public string FileTemplate { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the file extension including the leading dot.
+    /// </summary>
+    /// <example><c>.trx</c>, <c>.xml</c>, <c>.coverage</c></example>
+    public string Extension { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the token values available for template expansion.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Context { get; set; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Gets or sets the collision behavior when the resolved path already exists.
+    /// Defaults to <see cref="CollisionBehavior.AppendCounter"/>.
+    /// </summary>
+    public CollisionBehavior Collision { get; set; } = CollisionBehavior.AppendCounter;
+
+    /// <summary>
+    /// Gets or sets the optional directory template. When <see langword="null"/>, the value of
+    /// <see cref="ArtifactNameTokens.TestResultsDirectory"/> from <see cref="Context"/> is used.
+    /// </summary>
+    public string? DirectoryTemplate { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional artifact kind tag for diagnostics (e.g., "trx", "coverage", "blame").
+    /// </summary>
+    public string? ArtifactKind { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional producer name for diagnostics (e.g., "TrxLogger", "BlameCollector").
+    /// </summary>
+    public string? ProducerName { get; set; }
+}

--- a/src/Microsoft.TestPlatform.ObjectModel/ArtifactNaming/ArtifactNameResult.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/ArtifactNaming/ArtifactNameResult.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming;
+
+/// <summary>
+/// Result of resolving an artifact name. Contains the resolved path and metadata
+/// about the resolution process (e.g., whether an existing file was detected).
+/// </summary>
+public sealed class ArtifactNameResult
+{
+    /// <summary>
+    /// Gets the fully resolved, sanitized file path.
+    /// </summary>
+    public string FilePath { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the resolved path already existed before resolution.
+    /// When <see langword="true"/> with <see cref="CollisionBehavior.Overwrite"/>, the caller
+    /// should log a warning before writing.
+    /// </summary>
+    public bool IsOverwrite { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this process created (and therefore owns) the
+    /// output directory. When <see langword="false"/>, the directory was already present
+    /// (possibly created by another test host in the same run, or a previous run).
+    /// </summary>
+    public bool IsDirectoryOwner { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArtifactNameResult"/> class.
+    /// </summary>
+    public ArtifactNameResult(string filePath, bool isOverwrite, bool isDirectoryOwner)
+    {
+        FilePath = filePath;
+        IsOverwrite = isOverwrite;
+        IsDirectoryOwner = isDirectoryOwner;
+    }
+
+    /// <summary>
+    /// Returns the resolved file path.
+    /// </summary>
+    public override string ToString() => FilePath;
+}

--- a/src/Microsoft.TestPlatform.ObjectModel/ArtifactNaming/ArtifactNameTokens.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/ArtifactNaming/ArtifactNameTokens.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming;
+
+/// <summary>
+/// Well-known token names for artifact name templates.
+/// </summary>
+public static class ArtifactNameTokens
+{
+    /// <summary>The test results output directory.</summary>
+    public const string TestResultsDirectory = "TestResultsDirectory";
+
+    /// <summary>The target framework short name (e.g., "net8.0").</summary>
+    public const string Tfm = "Tfm";
+
+    /// <summary>UTC timestamp in sortable ISO 8601 compact format with milliseconds: 20260415T105100.123</summary>
+    public const string Timestamp = "Timestamp";
+
+    /// <summary>UTC date only: 2026-04-15</summary>
+    public const string Date = "Date";
+
+    /// <summary>The machine name.</summary>
+    public const string MachineName = "MachineName";
+
+    /// <summary>The current user name.</summary>
+    public const string UserName = "UserName";
+
+    /// <summary>The current process ID.</summary>
+    public const string Pid = "Pid";
+
+    /// <summary>Short 8-character hex prefix of the test run ID.</summary>
+    public const string RunId = "RunId";
+
+    /// <summary>Full test session GUID.</summary>
+    public const string SessionId = "SessionId";
+
+    /// <summary>The test assembly file name without extension.</summary>
+    public const string AssemblyName = "AssemblyName";
+
+    /// <summary>The runtime architecture (e.g., "x64", "x86", "arm64").</summary>
+    public const string Architecture = "Architecture";
+
+    /// <summary>The build configuration (e.g., "Debug", "Release").</summary>
+    public const string Configuration = "Configuration";
+
+    /// <summary>The project name.</summary>
+    public const string ProjectName = "ProjectName";
+
+    /// <summary>The test host index in parallel execution.</summary>
+    public const string HostId = "HostId";
+}

--- a/src/Microsoft.TestPlatform.ObjectModel/ArtifactNaming/ArtifactNamingPresets.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/ArtifactNaming/ArtifactNamingPresets.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming;
+
+/// <summary>
+/// Built-in artifact naming presets that define directory and file template pairs.
+/// </summary>
+public static class ArtifactNamingPresets
+{
+    /// <summary>CI preset: flat output folder, deterministic names, overwrite on rerun.</summary>
+    public const string CI = "ci";
+
+    /// <summary>Local preset: per-run timestamped subfolder, deterministic file names.</summary>
+    public const string Local = "local";
+
+    /// <summary>Detailed preset: per-run folder with run ID in file names.</summary>
+    public const string Detailed = "detailed";
+
+    /// <summary>Flat preset: minimal file names, one per assembly.</summary>
+    public const string Flat = "flat";
+
+    /// <summary>
+    /// Gets the directory and file templates for a named preset.
+    /// </summary>
+    /// <param name="presetName">The preset name (case-insensitive).</param>
+    /// <param name="directoryTemplate">The directory template for the preset.</param>
+    /// <param name="fileTemplate">The file template for the preset.</param>
+    /// <param name="collision">The collision behavior for the preset.</param>
+    /// <returns><see langword="true"/> if the preset was found; otherwise <see langword="false"/>.</returns>
+    public static bool TryGetPreset(
+        string presetName,
+        out string directoryTemplate,
+        out string fileTemplate,
+        out CollisionBehavior collision)
+    {
+        switch (presetName.ToLowerInvariant())
+        {
+            case CI:
+                directoryTemplate = "{" + ArtifactNameTokens.TestResultsDirectory + "}";
+                fileTemplate = "{" + ArtifactNameTokens.AssemblyName + "}_{" + ArtifactNameTokens.Tfm + "}_{" + ArtifactNameTokens.Architecture + "}";
+                collision = CollisionBehavior.Overwrite;
+                return true;
+
+            case Local:
+                directoryTemplate = "{" + ArtifactNameTokens.TestResultsDirectory + "}/{" + ArtifactNameTokens.Timestamp + "}";
+                fileTemplate = "{" + ArtifactNameTokens.AssemblyName + "}_{" + ArtifactNameTokens.Tfm + "}_{" + ArtifactNameTokens.Architecture + "}";
+                collision = CollisionBehavior.AppendCounter;
+                return true;
+
+            case Detailed:
+                directoryTemplate = "{" + ArtifactNameTokens.TestResultsDirectory + "}/{" + ArtifactNameTokens.Timestamp + "}";
+                fileTemplate = "{" + ArtifactNameTokens.AssemblyName + "}_{" + ArtifactNameTokens.Tfm + "}_{" + ArtifactNameTokens.Architecture + "}_{" + ArtifactNameTokens.RunId + "}";
+                collision = CollisionBehavior.AppendCounter;
+                return true;
+
+            case Flat:
+                directoryTemplate = "{" + ArtifactNameTokens.TestResultsDirectory + "}";
+                fileTemplate = "{" + ArtifactNameTokens.AssemblyName + "}";
+                collision = CollisionBehavior.AppendCounter;
+                return true;
+
+            default:
+                directoryTemplate = string.Empty;
+                fileTemplate = string.Empty;
+                collision = CollisionBehavior.AppendCounter;
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Gets all known preset names.
+    /// </summary>
+    public static IReadOnlyList<string> All { get; } = new[] { CI, Local, Detailed, Flat };
+}

--- a/src/Microsoft.TestPlatform.ObjectModel/ArtifactNaming/CollisionBehavior.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/ArtifactNaming/CollisionBehavior.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming;
+
+/// <summary>
+/// Defines how to handle file name collisions when the resolved artifact path already exists.
+/// </summary>
+public enum CollisionBehavior
+{
+    /// <summary>
+    /// Append an incrementing counter suffix: file_2.trx, file_3.trx, etc.
+    /// </summary>
+    AppendCounter,
+
+    /// <summary>
+    /// Overwrite the existing file.
+    /// </summary>
+    Overwrite,
+
+    /// <summary>
+    /// Fail with an error if the path already exists.
+    /// </summary>
+    Fail,
+
+    /// <summary>
+    /// Append a timestamp suffix to make the name unique.
+    /// </summary>
+    AppendTimestamp,
+}

--- a/src/Microsoft.TestPlatform.ObjectModel/ArtifactNaming/IArtifactNameProvider.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/ArtifactNaming/IArtifactNameProvider.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming;
+
+/// <summary>
+/// Resolves artifact name templates to concrete, sanitized file paths.
+/// All artifacts are files.
+/// </summary>
+public interface IArtifactNameProvider
+{
+    /// <summary>
+    /// Resolves a template to a concrete, sanitized, collision-safe file path.
+    /// </summary>
+    /// <param name="request">The artifact name request containing template, extension, context, and collision behavior.</param>
+    /// <returns>The fully resolved file path.</returns>
+    string Resolve(ArtifactNameRequest request);
+
+    /// <summary>
+    /// Expands a template string by replacing <c>{TokenName}</c> placeholders with values
+    /// from the provided context. Does not perform sanitization or collision handling.
+    /// </summary>
+    /// <param name="template">The template string with <c>{TokenName}</c> placeholders.</param>
+    /// <param name="context">Token name-value pairs for expansion.</param>
+    /// <returns>The expanded string. Unknown tokens are kept literally (e.g., <c>{Unknown}</c>).</returns>
+    string ExpandTemplate(string template, IReadOnlyDictionary<string, string> context);
+}

--- a/src/Microsoft.TestPlatform.ObjectModel/ArtifactNaming/IArtifactNameProvider.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/ArtifactNaming/IArtifactNameProvider.cs
@@ -13,10 +13,12 @@ public interface IArtifactNameProvider
 {
     /// <summary>
     /// Resolves a template to a concrete, sanitized, collision-safe file path.
+    /// The result includes metadata about whether the file already existed (overwrite)
+    /// and whether this process owns the output directory.
     /// </summary>
     /// <param name="request">The artifact name request containing template, extension, context, and collision behavior.</param>
-    /// <returns>The fully resolved file path.</returns>
-    string Resolve(ArtifactNameRequest request);
+    /// <returns>The resolution result containing the file path and ownership metadata.</returns>
+    ArtifactNameResult Resolve(ArtifactNameRequest request);
 
     /// <summary>
     /// Expands a template string by replacing <c>{TokenName}</c> placeholders with values

--- a/src/Microsoft.TestPlatform.ObjectModel/Constants.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/Constants.cs
@@ -251,10 +251,27 @@ public static class Constants
 /// </summary>
 public static class DefaultLoggerParameterNames
 {
-    // Denotes target location for test run results
-    // For ex. TrxLogger saves test run results at this target
+    /// <summary>
+    /// Denotes target location for test run results.
+    /// For ex. TrxLogger saves test run results at this target.
+    /// </summary>
     public const string TestRunDirectory = "TestRunDirectory";
 
-    // Denotes target framework for the tests.
+    /// <summary>
+    /// Denotes target framework for the tests.
+    /// </summary>
     public const string TargetFramework = "TargetFramework";
+
+    /// <summary>
+    /// Target platform architecture (e.g. "x64", "x86", "ARM64").
+    /// Extracted from RunConfiguration.TargetPlatform.
+    /// </summary>
+    public const string TargetArchitecture = "TargetArchitecture";
+
+    /// <summary>
+    /// Shared timestamp for the current test run in ISO 8601 compact format
+    /// (e.g. "20260415T105100.123"). Generated once per run and propagated
+    /// to all loggers so that artifacts from the same run share a folder.
+    /// </summary>
+    public const string TestRunTimestamp = "TestRunTimestamp";
 }

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Unshipped.txt
@@ -10,3 +10,49 @@ Microsoft.VisualStudio.TestPlatform.ObjectModel.TelemetryEvent.Name.get -> strin
 Microsoft.VisualStudio.TestPlatform.ObjectModel.TelemetryEvent.Properties.get -> System.Collections.Generic.IDictionary<string!, object!>!
 Microsoft.VisualStudio.TestPlatform.ObjectModel.TelemetryEvent.TelemetryEvent(string! name, System.Collections.Generic.IDictionary<string!, object!>! properties) -> void
 Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.CreateNoNewWindow.get -> bool
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest.ArtifactKind.get -> string?
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest.ArtifactKind.set -> void
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest.ArtifactNameRequest() -> void
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest.Collision.get -> Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.CollisionBehavior
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest.Collision.set -> void
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest.Context.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest.Context.set -> void
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest.DirectoryTemplate.get -> string?
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest.DirectoryTemplate.set -> void
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest.Extension.get -> string!
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest.Extension.set -> void
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest.FileTemplate.get -> string!
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest.FileTemplate.set -> void
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest.ProducerName.get -> string?
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest.ProducerName.set -> void
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameTokens
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameTokens.Architecture = "Architecture" -> string!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameTokens.AssemblyName = "AssemblyName" -> string!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameTokens.Configuration = "Configuration" -> string!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameTokens.Date = "Date" -> string!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameTokens.HostId = "HostId" -> string!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameTokens.MachineName = "MachineName" -> string!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameTokens.Pid = "Pid" -> string!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameTokens.ProjectName = "ProjectName" -> string!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameTokens.RunId = "RunId" -> string!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameTokens.SessionId = "SessionId" -> string!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameTokens.TestResultsDirectory = "TestResultsDirectory" -> string!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameTokens.Tfm = "Tfm" -> string!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameTokens.Timestamp = "Timestamp" -> string!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameTokens.UserName = "UserName" -> string!
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNamingPresets
+static Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNamingPresets.All.get -> System.Collections.Generic.IReadOnlyList<string!>!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNamingPresets.CI = "ci" -> string!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNamingPresets.Detailed = "detailed" -> string!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNamingPresets.Flat = "flat" -> string!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNamingPresets.Local = "local" -> string!
+static Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNamingPresets.TryGetPreset(string! presetName, out string! directoryTemplate, out string! fileTemplate, out Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.CollisionBehavior collision) -> bool
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.CollisionBehavior
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.CollisionBehavior.AppendCounter = 0 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.CollisionBehavior
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.CollisionBehavior.AppendTimestamp = 3 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.CollisionBehavior
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.CollisionBehavior.Fail = 2 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.CollisionBehavior
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.CollisionBehavior.Overwrite = 1 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.CollisionBehavior
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.IArtifactNameProvider
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.IArtifactNameProvider.ExpandTemplate(string! template, System.Collections.Generic.IReadOnlyDictionary<string!, string!>! context) -> string!
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.IArtifactNameProvider.Resolve(Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest! request) -> string!

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Unshipped.txt
@@ -53,6 +53,12 @@ Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.CollisionBehavior
 Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.CollisionBehavior.AppendTimestamp = 3 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.CollisionBehavior
 Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.CollisionBehavior.Fail = 2 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.CollisionBehavior
 Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.CollisionBehavior.Overwrite = 1 -> Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.CollisionBehavior
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameResult
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameResult.ArtifactNameResult(string! filePath, bool isOverwrite, bool isDirectoryOwner) -> void
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameResult.FilePath.get -> string!
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameResult.IsDirectoryOwner.get -> bool
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameResult.IsOverwrite.get -> bool
+override Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameResult.ToString() -> string!
 Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.IArtifactNameProvider
 Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.IArtifactNameProvider.ExpandTemplate(string! template, System.Collections.Generic.IReadOnlyDictionary<string!, string!>! context) -> string!
-Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.IArtifactNameProvider.Resolve(Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest! request) -> string!
+Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.IArtifactNameProvider.Resolve(Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest! request) -> Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameResult!

--- a/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.ObjectModel/PublicAPI/PublicAPI.Unshipped.txt
@@ -62,3 +62,6 @@ override Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.Artifact
 Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.IArtifactNameProvider
 Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.IArtifactNameProvider.ExpandTemplate(string! template, System.Collections.Generic.IReadOnlyDictionary<string!, string!>! context) -> string!
 Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.IArtifactNameProvider.Resolve(Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameRequest! request) -> Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming.ArtifactNameResult!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.DefaultLoggerParameterNames.TargetArchitecture = "TargetArchitecture" -> string!
+const Microsoft.VisualStudio.TestPlatform.ObjectModel.DefaultLoggerParameterNames.TestRunTimestamp = "TestRunTimestamp" -> string!
+Microsoft.VisualStudio.TestPlatform.ObjectModel.RunConfiguration.ArtifactRunTimestamp.get -> string?

--- a/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
@@ -474,6 +474,13 @@ public class RunConfiguration : TestRunSettings
     /// </summary>
     public bool SkipDefaultAdapters { get; private set; }
 
+    /// <summary>
+    /// Shared timestamp for artifact naming, in ISO 8601 compact format (e.g. "20260415T105100.123").
+    /// When set by the orchestrator, all child processes use this same value so artifacts from
+    /// the same run share a directory. When not set, each process generates its own timestamp.
+    /// </summary>
+    public string? ArtifactRunTimestamp { get; private set; }
+
     /// <inheritdoc/>
     public override XmlElement ToXml()
     {
@@ -608,6 +615,13 @@ public class RunConfiguration : TestRunSettings
         XmlElement skipDefaultAdapters = doc.CreateElement(nameof(SkipDefaultAdapters));
         skipDefaultAdapters.InnerXml = SkipDefaultAdapters.ToString();
         root.AppendChild(skipDefaultAdapters);
+
+        if (ArtifactRunTimestamp is not null)
+        {
+            XmlElement artifactRunTimestamp = doc.CreateElement(nameof(ArtifactRunTimestamp));
+            artifactRunTimestamp.InnerXml = ArtifactRunTimestamp;
+            root.AppendChild(artifactRunTimestamp);
+        }
 
         return root;
     }
@@ -1040,6 +1054,14 @@ public class RunConfiguration : TestRunSettings
                             }
 
                             runConfiguration.SkipDefaultAdapters = boolValue;
+                            break;
+                        }
+
+                    case nameof(ArtifactRunTimestamp):
+                        {
+                            XmlRunSettingsUtilities.ThrowOnHasAttributes(reader);
+                            string element = reader.ReadElementContentAsString();
+                            runConfiguration.ArtifactRunTimestamp = element;
                             break;
                         }
 

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ArtifactNaming/ArtifactNameProviderTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ArtifactNaming/ArtifactNameProviderTests.cs
@@ -46,37 +46,56 @@ public sealed class ArtifactNameProviderTests
         return ctx;
     }
 
-    private static ArtifactNameProvider CreateProvider(HashSet<string>? existingFiles = null)
+    private static ArtifactNameProvider CreateProvider(
+        HashSet<string>? existingFiles = null,
+        HashSet<string>? existingMarkers = null,
+        HashSet<string>? existingDirectories = null)
     {
         existingFiles ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        existingMarkers ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        existingDirectories ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         return new ArtifactNameProvider(
             () => FixedTime,
-            path => existingFiles.Contains(Path.GetFullPath(path)));
+            path => existingFiles.Contains(Path.GetFullPath(path)),
+            tryCreateMarkerFile: (path, _) =>
+            {
+                if (existingMarkers.Contains(Path.GetFullPath(path)))
+                {
+                    return false;
+                }
+
+                existingMarkers.Add(Path.GetFullPath(path));
+                return true;
+            },
+            directoryExists: path => existingDirectories.Contains(Path.GetFullPath(path)),
+            createDirectory: path => existingDirectories.Add(Path.GetFullPath(path)));
     }
 
     [TestMethod]
     public void Resolve_BasicTemplate_ProducesExpectedPath()
     {
-        var provider = CreateProvider();
-        var context = CreateContext(testResultsDir: "TestResults");
+        ArtifactNameProvider provider = CreateProvider();
+        Dictionary<string, string> context = CreateContext(testResultsDir: "TestResults");
 
-        string result = provider.Resolve(new ArtifactNameRequest
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
         {
             FileTemplate = "{AssemblyName}_{Tfm}_{Architecture}",
             Extension = ".trx",
             Context = context,
         });
 
-        Assert.IsTrue(result.EndsWith("MyTests_net8.0_x64.trx", StringComparison.Ordinal), $"Actual: {result}");
+        Assert.IsTrue(result.FilePath.EndsWith("MyTests_net8.0_x64.trx", StringComparison.Ordinal), $"Actual: {result.FilePath}");
+        Assert.IsFalse(result.IsOverwrite);
     }
 
     [TestMethod]
     public void Resolve_WithDirectoryTemplate_CreatesSubdirectory()
     {
-        var provider = CreateProvider();
-        var context = CreateContext(testResultsDir: "TestResults");
+        ArtifactNameProvider provider = CreateProvider();
+        Dictionary<string, string> context = CreateContext(testResultsDir: "TestResults");
 
-        string result = provider.Resolve(new ArtifactNameRequest
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
         {
             FileTemplate = "{AssemblyName}_{Tfm}",
             Extension = ".trx",
@@ -84,19 +103,18 @@ public sealed class ArtifactNameProviderTests
             DirectoryTemplate = "{TestResultsDirectory}/{Tfm}",
         });
 
-        // Should contain the TFM as a directory segment.
-        Assert.Contains(Path.Combine("TestResults", "net8.0"), result);
-        Assert.IsTrue(result.EndsWith("MyTests_net8.0.trx", StringComparison.Ordinal), $"Actual: {result}");
+        Assert.Contains(Path.Combine("TestResults", "net8.0"), result.FilePath);
+        Assert.IsTrue(result.FilePath.EndsWith("MyTests_net8.0.trx", StringComparison.Ordinal), $"Actual: {result.FilePath}");
     }
 
     [TestMethod]
     public void Resolve_Overwrite_ReturnsSamePathEvenIfExists()
     {
         string expectedPath = Path.GetFullPath(Path.Combine("TestResults", "MyTests_net8.0_x64.trx"));
-        var provider = CreateProvider(new HashSet<string> { expectedPath });
-        var context = CreateContext(testResultsDir: "TestResults");
+        ArtifactNameProvider provider = CreateProvider(existingFiles: new HashSet<string> { expectedPath });
+        Dictionary<string, string> context = CreateContext(testResultsDir: "TestResults");
 
-        string result = provider.Resolve(new ArtifactNameRequest
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
         {
             FileTemplate = "{AssemblyName}_{Tfm}_{Architecture}",
             Extension = ".trx",
@@ -104,17 +122,35 @@ public sealed class ArtifactNameProviderTests
             Collision = CollisionBehavior.Overwrite,
         });
 
-        Assert.AreEqual(expectedPath, Path.GetFullPath(result));
+        Assert.AreEqual(expectedPath, Path.GetFullPath(result.FilePath));
+        Assert.IsTrue(result.IsOverwrite, "Should detect that file already exists.");
+    }
+
+    [TestMethod]
+    public void Resolve_Overwrite_NoOverwriteWhenFileDoesNotExist()
+    {
+        ArtifactNameProvider provider = CreateProvider();
+        Dictionary<string, string> context = CreateContext(testResultsDir: "TestResults");
+
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}_{Tfm}_{Architecture}",
+            Extension = ".trx",
+            Context = context,
+            Collision = CollisionBehavior.Overwrite,
+        });
+
+        Assert.IsFalse(result.IsOverwrite);
     }
 
     [TestMethod]
     public void Resolve_AppendCounter_AppendsSuffixWhenFileExists()
     {
         string basePath = Path.GetFullPath(Path.Combine("TestResults", "MyTests_net8.0_x64.trx"));
-        var provider = CreateProvider(new HashSet<string> { basePath });
-        var context = CreateContext(testResultsDir: "TestResults");
+        ArtifactNameProvider provider = CreateProvider(existingFiles: new HashSet<string> { basePath });
+        Dictionary<string, string> context = CreateContext(testResultsDir: "TestResults");
 
-        string result = provider.Resolve(new ArtifactNameRequest
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
         {
             FileTemplate = "{AssemblyName}_{Tfm}_{Architecture}",
             Extension = ".trx",
@@ -123,7 +159,8 @@ public sealed class ArtifactNameProviderTests
         });
 
         string expected = Path.GetFullPath(Path.Combine("TestResults", "MyTests_net8.0_x64_2.trx"));
-        Assert.AreEqual(expected, Path.GetFullPath(result));
+        Assert.AreEqual(expected, Path.GetFullPath(result.FilePath));
+        Assert.IsFalse(result.IsOverwrite);
     }
 
     [TestMethod]
@@ -132,10 +169,10 @@ public sealed class ArtifactNameProviderTests
         string basePath = Path.GetFullPath(Path.Combine("TestResults", "MyTests_net8.0_x64.trx"));
         string counter2 = Path.GetFullPath(Path.Combine("TestResults", "MyTests_net8.0_x64_2.trx"));
         string counter3 = Path.GetFullPath(Path.Combine("TestResults", "MyTests_net8.0_x64_3.trx"));
-        var provider = CreateProvider(new HashSet<string> { basePath, counter2, counter3 });
-        var context = CreateContext(testResultsDir: "TestResults");
+        ArtifactNameProvider provider = CreateProvider(existingFiles: new HashSet<string> { basePath, counter2, counter3 });
+        Dictionary<string, string> context = CreateContext(testResultsDir: "TestResults");
 
-        string result = provider.Resolve(new ArtifactNameRequest
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
         {
             FileTemplate = "{AssemblyName}_{Tfm}_{Architecture}",
             Extension = ".trx",
@@ -144,15 +181,15 @@ public sealed class ArtifactNameProviderTests
         });
 
         string expected = Path.GetFullPath(Path.Combine("TestResults", "MyTests_net8.0_x64_4.trx"));
-        Assert.AreEqual(expected, Path.GetFullPath(result));
+        Assert.AreEqual(expected, Path.GetFullPath(result.FilePath));
     }
 
     [TestMethod]
     public void Resolve_Fail_ThrowsWhenFileExists()
     {
         string basePath = Path.GetFullPath(Path.Combine("TestResults", "MyTests.trx"));
-        var provider = CreateProvider(new HashSet<string> { basePath });
-        var context = CreateContext(testResultsDir: "TestResults");
+        ArtifactNameProvider provider = CreateProvider(existingFiles: new HashSet<string> { basePath });
+        Dictionary<string, string> context = CreateContext(testResultsDir: "TestResults");
 
         Assert.ThrowsExactly<InvalidOperationException>(() => provider.Resolve(new ArtifactNameRequest
         {
@@ -167,10 +204,10 @@ public sealed class ArtifactNameProviderTests
     public void Resolve_AppendTimestamp_AddsTimestampSuffix()
     {
         string basePath = Path.GetFullPath(Path.Combine("TestResults", "MyTests_net8.0_x64.trx"));
-        var provider = CreateProvider(new HashSet<string> { basePath });
-        var context = CreateContext(testResultsDir: "TestResults");
+        ArtifactNameProvider provider = CreateProvider(existingFiles: new HashSet<string> { basePath });
+        Dictionary<string, string> context = CreateContext(testResultsDir: "TestResults");
 
-        string result = provider.Resolve(new ArtifactNameRequest
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
         {
             FileTemplate = "{AssemblyName}_{Tfm}_{Architecture}",
             Extension = ".trx",
@@ -178,40 +215,40 @@ public sealed class ArtifactNameProviderTests
             Collision = CollisionBehavior.AppendTimestamp,
         });
 
-        Assert.Contains("20260415T105100.123", result);
+        Assert.Contains("20260415T105100.123", result.FilePath);
     }
 
     [TestMethod]
     public void Resolve_AutoTokens_TimestampAndMachineNamePopulated()
     {
-        var provider = CreateProvider();
+        ArtifactNameProvider provider = CreateProvider();
         var context = new Dictionary<string, string>
         {
             [ArtifactNameTokens.TestResultsDirectory] = "TestResults",
         };
 
-        string result = provider.Resolve(new ArtifactNameRequest
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
         {
             FileTemplate = "{Timestamp}_{MachineName}",
             Extension = ".trx",
             Context = context,
         });
 
-        Assert.Contains("20260415T105100.123", result);
-        Assert.Contains(Environment.MachineName, result);
+        Assert.Contains("20260415T105100.123", result.FilePath);
+        Assert.Contains(Environment.MachineName, result.FilePath);
     }
 
     [TestMethod]
     public void Resolve_MissingToken_KeptLiterallyInOutput()
     {
-        var provider = CreateProvider();
+        ArtifactNameProvider provider = CreateProvider();
         var context = new Dictionary<string, string>
         {
             [ArtifactNameTokens.TestResultsDirectory] = "TestResults",
             [ArtifactNameTokens.Tfm] = "net8.0",
         };
 
-        string result = provider.Resolve(new ArtifactNameRequest
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
         {
             FileTemplate = "{AssemblyName}_{Tfm}",
             Extension = ".trx",
@@ -220,24 +257,24 @@ public sealed class ArtifactNameProviderTests
 
         // AssemblyName not in context → kept as {AssemblyName}
         // {} are NOT in our invalid chars list (we discussed this!)
-        Assert.Contains("{AssemblyName}", result);
-        Assert.Contains("net8.0", result);
+        Assert.Contains("{AssemblyName}", result.FilePath);
+        Assert.Contains("net8.0", result.FilePath);
     }
 
     [TestMethod]
     public void Resolve_ExtensionWithoutDot_DotIsAdded()
     {
-        var provider = CreateProvider();
-        var context = CreateContext(testResultsDir: "TestResults");
+        ArtifactNameProvider provider = CreateProvider();
+        Dictionary<string, string> context = CreateContext(testResultsDir: "TestResults");
 
-        string result = provider.Resolve(new ArtifactNameRequest
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
         {
             FileTemplate = "{AssemblyName}",
             Extension = "trx",
             Context = context,
         });
 
-        Assert.IsTrue(result.EndsWith(".trx", StringComparison.Ordinal), $"Actual: {result}");
+        Assert.IsTrue(result.FilePath.EndsWith(".trx", StringComparison.Ordinal), $"Actual: {result.FilePath}");
     }
 
     [TestMethod]
@@ -245,10 +282,10 @@ public sealed class ArtifactNameProviderTests
     {
         Assert.IsTrue(ArtifactNamingPresets.TryGetPreset("ci", out string dirTemplate, out string fileTemplate, out CollisionBehavior collision));
 
-        var provider = CreateProvider();
-        var context = CreateContext(testResultsDir: "TestResults");
+        ArtifactNameProvider provider = CreateProvider();
+        Dictionary<string, string> context = CreateContext(testResultsDir: "TestResults");
 
-        string result = provider.Resolve(new ArtifactNameRequest
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
         {
             FileTemplate = fileTemplate,
             Extension = ".trx",
@@ -257,7 +294,7 @@ public sealed class ArtifactNameProviderTests
             Collision = collision,
         });
 
-        Assert.IsTrue(result.EndsWith("MyTests_net8.0_x64.trx", StringComparison.Ordinal), $"Actual: {result}");
+        Assert.IsTrue(result.FilePath.EndsWith("MyTests_net8.0_x64.trx", StringComparison.Ordinal), $"Actual: {result.FilePath}");
         Assert.AreEqual(CollisionBehavior.Overwrite, collision);
     }
 
@@ -266,10 +303,10 @@ public sealed class ArtifactNameProviderTests
     {
         Assert.IsTrue(ArtifactNamingPresets.TryGetPreset("local", out string dirTemplate, out string fileTemplate, out CollisionBehavior collision));
 
-        var provider = CreateProvider();
-        var context = CreateContext(testResultsDir: "TestResults");
+        ArtifactNameProvider provider = CreateProvider();
+        Dictionary<string, string> context = CreateContext(testResultsDir: "TestResults");
 
-        string result = provider.Resolve(new ArtifactNameRequest
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
         {
             FileTemplate = fileTemplate,
             Extension = ".trx",
@@ -278,7 +315,7 @@ public sealed class ArtifactNameProviderTests
             Collision = collision,
         });
 
-        Assert.Contains("20260415T105100.123", result);
+        Assert.Contains("20260415T105100.123", result.FilePath);
     }
 
     [TestMethod]
@@ -325,18 +362,18 @@ public sealed class ArtifactNameProviderTests
     [TestMethod]
     public void Resolve_NullRequest_ThrowsArgumentNullException()
     {
-        var provider = CreateProvider();
+        ArtifactNameProvider provider = CreateProvider();
         Assert.ThrowsExactly<ArgumentNullException>(() => provider.Resolve(null!));
     }
 
     [TestMethod]
     public void Resolve_MultipleFilesPerProducer_BlameScenario()
     {
-        var provider = CreateProvider();
-        var context = CreateContext(testResultsDir: "TestResults");
+        ArtifactNameProvider provider = CreateProvider();
+        Dictionary<string, string> context = CreateContext(testResultsDir: "TestResults");
         context[ArtifactNameTokens.Pid] = "12345";
 
-        string seqPath = provider.Resolve(new ArtifactNameRequest
+        ArtifactNameResult seqResult = provider.Resolve(new ArtifactNameRequest
         {
             FileTemplate = "{AssemblyName}_{Tfm}_{Architecture}_blame-sequence",
             Extension = ".xml",
@@ -344,7 +381,7 @@ public sealed class ArtifactNameProviderTests
             ArtifactKind = "blame-sequence",
         });
 
-        string dumpPath = provider.Resolve(new ArtifactNameRequest
+        ArtifactNameResult dumpResult = provider.Resolve(new ArtifactNameRequest
         {
             FileTemplate = "{AssemblyName}_{Tfm}_{Architecture}_crashdump_{Pid}",
             Extension = ".dmp",
@@ -352,8 +389,60 @@ public sealed class ArtifactNameProviderTests
             ArtifactKind = "blame-crashdump",
         });
 
-        Assert.IsTrue(seqPath.EndsWith("blame-sequence.xml", StringComparison.Ordinal), $"Actual: {seqPath}");
-        Assert.IsTrue(dumpPath.EndsWith("crashdump_12345.dmp", StringComparison.Ordinal), $"Actual: {dumpPath}");
-        Assert.AreNotEqual(seqPath, dumpPath);
+        Assert.IsTrue(seqResult.FilePath.EndsWith("blame-sequence.xml", StringComparison.Ordinal), $"Actual: {seqResult.FilePath}");
+        Assert.IsTrue(dumpResult.FilePath.EndsWith("crashdump_12345.dmp", StringComparison.Ordinal), $"Actual: {dumpResult.FilePath}");
+        Assert.AreNotEqual(seqResult.FilePath, dumpResult.FilePath);
+    }
+
+    [TestMethod]
+    public void Resolve_DirectoryOwnership_FirstCallOwnsDirectory()
+    {
+        ArtifactNameProvider provider = CreateProvider();
+        Dictionary<string, string> context = CreateContext(testResultsDir: "TestResults");
+
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}_{Tfm}_{Architecture}",
+            Extension = ".trx",
+            Context = context,
+            DirectoryTemplate = "{TestResultsDirectory}/{Timestamp}",
+        });
+
+        Assert.IsTrue(result.IsDirectoryOwner, "First call should own the directory.");
+    }
+
+    [TestMethod]
+    public void Resolve_DirectoryOwnership_SecondCallDoesNotOwnDirectory()
+    {
+        // Simulate directory already existing (created by another process).
+        string dir = Path.GetFullPath(Path.Combine("TestResults", "20260415T105100.123"));
+        ArtifactNameProvider provider = CreateProvider(existingDirectories: new HashSet<string> { dir });
+        Dictionary<string, string> context = CreateContext(testResultsDir: "TestResults");
+
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}_{Tfm}_{Architecture}",
+            Extension = ".trx",
+            Context = context,
+            DirectoryTemplate = "{TestResultsDirectory}/{Timestamp}",
+        });
+
+        Assert.IsFalse(result.IsDirectoryOwner, "Should not own directory that already existed.");
+    }
+
+    [TestMethod]
+    public void Resolve_ResultToString_ReturnsFilePath()
+    {
+        ArtifactNameProvider provider = CreateProvider();
+        Dictionary<string, string> context = CreateContext(testResultsDir: "TestResults");
+
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}",
+            Extension = ".trx",
+            Context = context,
+        });
+
+        Assert.AreEqual(result.FilePath, result.ToString());
     }
 }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ArtifactNaming/ArtifactNameProviderTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ArtifactNaming/ArtifactNameProviderTests.cs
@@ -445,4 +445,213 @@ public sealed class ArtifactNameProviderTests
 
         Assert.AreEqual(result.FilePath, result.ToString());
     }
+
+    [TestMethod]
+    public void SanitizeFileName_TrailingDot_IsStripped()
+    {
+        string result = ArtifactNameProvider.SanitizeFileName("file.");
+
+        Assert.AreEqual("file", result);
+    }
+
+    [TestMethod]
+    public void SanitizeFileName_TrailingSpace_IsStripped()
+    {
+        string result = ArtifactNameProvider.SanitizeFileName("file ");
+
+        Assert.AreEqual("file", result);
+    }
+
+    [TestMethod]
+    public void SanitizeFileName_TrailingDotsAndSpaces_AreStripped()
+    {
+        string result = ArtifactNameProvider.SanitizeFileName("file . .");
+
+        Assert.AreEqual("file", result);
+    }
+
+    [TestMethod]
+    public void SanitizeFileName_AllInvalidChars_ReturnsUnderscore()
+    {
+        string result = ArtifactNameProvider.SanitizeFileName("***");
+
+        Assert.AreEqual("___", result);
+    }
+
+    [TestMethod]
+    public void SanitizeFileName_ReservedNameCaseInsensitive_PrefixedWithUnderscore()
+    {
+        string result = ArtifactNameProvider.SanitizeFileName("con");
+
+        Assert.AreEqual("_con", result);
+    }
+
+    [TestMethod]
+    public void SanitizePathSegments_ReservedNameInDirectorySegment_PrefixedWithUnderscore()
+    {
+        string result = ArtifactNameProvider.SanitizePathSegments("TestResults/CON/output");
+
+        Assert.Contains("_CON", result);
+        Assert.DoesNotContain(Path.DirectorySeparatorChar + "CON" + Path.DirectorySeparatorChar, result);
+    }
+
+    [TestMethod]
+    public void Resolve_NullExtension_ProducesPathWithoutExtension()
+    {
+        ArtifactNameProvider provider = CreateProvider();
+        Dictionary<string, string> context = CreateContext(testResultsDir: "TestResults");
+
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}",
+            Extension = null!,
+            Context = context,
+        });
+
+        Assert.IsTrue(result.FilePath.EndsWith("MyTests", StringComparison.Ordinal), $"Actual: {result.FilePath}");
+    }
+
+    [TestMethod]
+    public void Resolve_EmptyExtension_ProducesPathWithoutExtension()
+    {
+        ArtifactNameProvider provider = CreateProvider();
+        Dictionary<string, string> context = CreateContext(testResultsDir: "TestResults");
+
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}",
+            Extension = "",
+            Context = context,
+        });
+
+        Assert.IsTrue(result.FilePath.EndsWith("MyTests", StringComparison.Ordinal), $"Actual: {result.FilePath}");
+    }
+
+    [TestMethod]
+    public void Resolve_ContextOverridesAutoTimestamp()
+    {
+        ArtifactNameProvider provider = CreateProvider();
+        var context = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [ArtifactNameTokens.TestResultsDirectory] = "TestResults",
+            [ArtifactNameTokens.Timestamp] = "CUSTOM_STAMP",
+        };
+
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{Timestamp}",
+            Extension = ".trx",
+            Context = context,
+        });
+
+        Assert.Contains("CUSTOM_STAMP", result.FilePath);
+        Assert.DoesNotContain("20260415", result.FilePath);
+    }
+
+    [TestMethod]
+    public void Resolve_ContextCaseInsensitive_OverridesAutoTokens()
+    {
+        ArtifactNameProvider provider = CreateProvider();
+        var context = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [ArtifactNameTokens.TestResultsDirectory] = "TestResults",
+            ["timestamp"] = "custom_lower",
+        };
+
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{Timestamp}",
+            Extension = ".trx",
+            Context = context,
+        });
+
+        // lowercase "timestamp" should override auto-populated "Timestamp" because
+        // the merged dictionary is case-insensitive.
+        Assert.Contains("custom_lower", result.FilePath);
+    }
+
+    [TestMethod]
+    public void SanitizePathSegments_DotDotMixed_AllTraversalStripped()
+    {
+        string result = ArtifactNameProvider.SanitizePathSegments("a/../b/../../c");
+
+        Assert.DoesNotContain("..", result);
+        Assert.Contains("a", result);
+        Assert.Contains("b", result);
+        Assert.Contains("c", result);
+    }
+
+    [TestMethod]
+    public void SanitizePathSegments_RootedUnixPath_HandledSafely()
+    {
+        string result = ArtifactNameProvider.SanitizePathSegments("/tmp/foo");
+
+        // Should not crash. The leading / creates an empty segment which is skipped.
+        Assert.Contains("tmp", result);
+        Assert.Contains("foo", result);
+    }
+
+    [TestMethod]
+    public void Resolve_Fail_DoesNotThrowWhenFileDoesNotExist()
+    {
+        ArtifactNameProvider provider = CreateProvider();
+        Dictionary<string, string> context = CreateContext(testResultsDir: "TestResults");
+
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}_{Tfm}_{Architecture}",
+            Extension = ".trx",
+            Context = context,
+            Collision = CollisionBehavior.Fail,
+        });
+
+        Assert.IsFalse(result.IsOverwrite);
+        Assert.IsTrue(result.FilePath.EndsWith("MyTests_net8.0_x64.trx", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void Resolve_AppendTimestamp_WithTimestampCollision_FallsBackToCounter()
+    {
+        // Both the base path and the timestamped path exist.
+        string basePath = Path.GetFullPath(Path.Combine("TestResults", "MyTests.trx"));
+        string timestamped = Path.GetFullPath(Path.Combine("TestResults", "MyTests_20260415T105100.123.trx"));
+        ArtifactNameProvider provider = CreateProvider(existingFiles: new HashSet<string> { basePath, timestamped });
+        var context = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [ArtifactNameTokens.TestResultsDirectory] = "TestResults",
+            [ArtifactNameTokens.AssemblyName] = "MyTests",
+        };
+
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}",
+            Extension = ".trx",
+            Context = context,
+            Collision = CollisionBehavior.AppendTimestamp,
+        });
+
+        // Should fall back to counter: MyTests_20260415T105100.123_2.trx
+        Assert.Contains("20260415T105100.123_2", result.FilePath);
+    }
+
+    [TestMethod]
+    public void Resolve_NoTestResultsDirectory_UsesLiteralToken()
+    {
+        ArtifactNameProvider provider = CreateProvider();
+        var context = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [ArtifactNameTokens.AssemblyName] = "MyTests",
+        };
+
+        // No TestResultsDirectory in context and no DirectoryTemplate → defaults to {TestResultsDirectory}
+        // which is missing → kept literally.
+        ArtifactNameResult result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}",
+            Extension = ".trx",
+            Context = context,
+        });
+
+        Assert.Contains("{TestResultsDirectory}", result.FilePath);
+    }
 }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ArtifactNaming/ArtifactNameProviderTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ArtifactNaming/ArtifactNameProviderTests.cs
@@ -1,0 +1,359 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using Microsoft.VisualStudio.TestPlatform.Common.ArtifactNaming;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TestPlatform.Common.UnitTests.ArtifactNaming;
+
+[TestClass]
+public sealed class ArtifactNameProviderTests
+{
+    private static readonly DateTime FixedTime = new(2026, 4, 15, 10, 51, 0, 123, DateTimeKind.Utc);
+
+    private static Dictionary<string, string> CreateContext(
+        string? assemblyName = "MyTests",
+        string? tfm = "net8.0",
+        string? architecture = "x64",
+        string? testResultsDir = null)
+    {
+        var ctx = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (assemblyName is not null)
+        {
+            ctx[ArtifactNameTokens.AssemblyName] = assemblyName;
+        }
+
+        if (tfm is not null)
+        {
+            ctx[ArtifactNameTokens.Tfm] = tfm;
+        }
+
+        if (architecture is not null)
+        {
+            ctx[ArtifactNameTokens.Architecture] = architecture;
+        }
+
+        if (testResultsDir is not null)
+        {
+            ctx[ArtifactNameTokens.TestResultsDirectory] = testResultsDir;
+        }
+
+        return ctx;
+    }
+
+    private static ArtifactNameProvider CreateProvider(HashSet<string>? existingFiles = null)
+    {
+        existingFiles ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        return new ArtifactNameProvider(
+            () => FixedTime,
+            path => existingFiles.Contains(Path.GetFullPath(path)));
+    }
+
+    [TestMethod]
+    public void Resolve_BasicTemplate_ProducesExpectedPath()
+    {
+        var provider = CreateProvider();
+        var context = CreateContext(testResultsDir: "TestResults");
+
+        string result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}_{Tfm}_{Architecture}",
+            Extension = ".trx",
+            Context = context,
+        });
+
+        Assert.IsTrue(result.EndsWith("MyTests_net8.0_x64.trx", StringComparison.Ordinal), $"Actual: {result}");
+    }
+
+    [TestMethod]
+    public void Resolve_WithDirectoryTemplate_CreatesSubdirectory()
+    {
+        var provider = CreateProvider();
+        var context = CreateContext(testResultsDir: "TestResults");
+
+        string result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}_{Tfm}",
+            Extension = ".trx",
+            Context = context,
+            DirectoryTemplate = "{TestResultsDirectory}/{Tfm}",
+        });
+
+        // Should contain the TFM as a directory segment.
+        Assert.Contains(Path.Combine("TestResults", "net8.0"), result);
+        Assert.IsTrue(result.EndsWith("MyTests_net8.0.trx", StringComparison.Ordinal), $"Actual: {result}");
+    }
+
+    [TestMethod]
+    public void Resolve_Overwrite_ReturnsSamePathEvenIfExists()
+    {
+        string expectedPath = Path.GetFullPath(Path.Combine("TestResults", "MyTests_net8.0_x64.trx"));
+        var provider = CreateProvider(new HashSet<string> { expectedPath });
+        var context = CreateContext(testResultsDir: "TestResults");
+
+        string result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}_{Tfm}_{Architecture}",
+            Extension = ".trx",
+            Context = context,
+            Collision = CollisionBehavior.Overwrite,
+        });
+
+        Assert.AreEqual(expectedPath, Path.GetFullPath(result));
+    }
+
+    [TestMethod]
+    public void Resolve_AppendCounter_AppendsSuffixWhenFileExists()
+    {
+        string basePath = Path.GetFullPath(Path.Combine("TestResults", "MyTests_net8.0_x64.trx"));
+        var provider = CreateProvider(new HashSet<string> { basePath });
+        var context = CreateContext(testResultsDir: "TestResults");
+
+        string result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}_{Tfm}_{Architecture}",
+            Extension = ".trx",
+            Context = context,
+            Collision = CollisionBehavior.AppendCounter,
+        });
+
+        string expected = Path.GetFullPath(Path.Combine("TestResults", "MyTests_net8.0_x64_2.trx"));
+        Assert.AreEqual(expected, Path.GetFullPath(result));
+    }
+
+    [TestMethod]
+    public void Resolve_AppendCounter_SkipsExistingCounters()
+    {
+        string basePath = Path.GetFullPath(Path.Combine("TestResults", "MyTests_net8.0_x64.trx"));
+        string counter2 = Path.GetFullPath(Path.Combine("TestResults", "MyTests_net8.0_x64_2.trx"));
+        string counter3 = Path.GetFullPath(Path.Combine("TestResults", "MyTests_net8.0_x64_3.trx"));
+        var provider = CreateProvider(new HashSet<string> { basePath, counter2, counter3 });
+        var context = CreateContext(testResultsDir: "TestResults");
+
+        string result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}_{Tfm}_{Architecture}",
+            Extension = ".trx",
+            Context = context,
+            Collision = CollisionBehavior.AppendCounter,
+        });
+
+        string expected = Path.GetFullPath(Path.Combine("TestResults", "MyTests_net8.0_x64_4.trx"));
+        Assert.AreEqual(expected, Path.GetFullPath(result));
+    }
+
+    [TestMethod]
+    public void Resolve_Fail_ThrowsWhenFileExists()
+    {
+        string basePath = Path.GetFullPath(Path.Combine("TestResults", "MyTests.trx"));
+        var provider = CreateProvider(new HashSet<string> { basePath });
+        var context = CreateContext(testResultsDir: "TestResults");
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}",
+            Extension = ".trx",
+            Context = context,
+            Collision = CollisionBehavior.Fail,
+        }));
+    }
+
+    [TestMethod]
+    public void Resolve_AppendTimestamp_AddsTimestampSuffix()
+    {
+        string basePath = Path.GetFullPath(Path.Combine("TestResults", "MyTests_net8.0_x64.trx"));
+        var provider = CreateProvider(new HashSet<string> { basePath });
+        var context = CreateContext(testResultsDir: "TestResults");
+
+        string result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}_{Tfm}_{Architecture}",
+            Extension = ".trx",
+            Context = context,
+            Collision = CollisionBehavior.AppendTimestamp,
+        });
+
+        Assert.Contains("20260415T105100.123", result);
+    }
+
+    [TestMethod]
+    public void Resolve_AutoTokens_TimestampAndMachineNamePopulated()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string>
+        {
+            [ArtifactNameTokens.TestResultsDirectory] = "TestResults",
+        };
+
+        string result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{Timestamp}_{MachineName}",
+            Extension = ".trx",
+            Context = context,
+        });
+
+        Assert.Contains("20260415T105100.123", result);
+        Assert.Contains(Environment.MachineName, result);
+    }
+
+    [TestMethod]
+    public void Resolve_MissingToken_KeptLiterallyInOutput()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string>
+        {
+            [ArtifactNameTokens.TestResultsDirectory] = "TestResults",
+            [ArtifactNameTokens.Tfm] = "net8.0",
+        };
+
+        string result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}_{Tfm}",
+            Extension = ".trx",
+            Context = context,
+        });
+
+        // AssemblyName not in context → kept as {AssemblyName}
+        // {} are NOT in our invalid chars list (we discussed this!)
+        Assert.Contains("{AssemblyName}", result);
+        Assert.Contains("net8.0", result);
+    }
+
+    [TestMethod]
+    public void Resolve_ExtensionWithoutDot_DotIsAdded()
+    {
+        var provider = CreateProvider();
+        var context = CreateContext(testResultsDir: "TestResults");
+
+        string result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}",
+            Extension = "trx",
+            Context = context,
+        });
+
+        Assert.IsTrue(result.EndsWith(".trx", StringComparison.Ordinal), $"Actual: {result}");
+    }
+
+    [TestMethod]
+    public void Resolve_CIPreset_ProducesFlatDeterministicPath()
+    {
+        Assert.IsTrue(ArtifactNamingPresets.TryGetPreset("ci", out string dirTemplate, out string fileTemplate, out CollisionBehavior collision));
+
+        var provider = CreateProvider();
+        var context = CreateContext(testResultsDir: "TestResults");
+
+        string result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = fileTemplate,
+            Extension = ".trx",
+            Context = context,
+            DirectoryTemplate = dirTemplate,
+            Collision = collision,
+        });
+
+        Assert.IsTrue(result.EndsWith("MyTests_net8.0_x64.trx", StringComparison.Ordinal), $"Actual: {result}");
+        Assert.AreEqual(CollisionBehavior.Overwrite, collision);
+    }
+
+    [TestMethod]
+    public void Resolve_LocalPreset_CreatesTimestampedSubdirectory()
+    {
+        Assert.IsTrue(ArtifactNamingPresets.TryGetPreset("local", out string dirTemplate, out string fileTemplate, out CollisionBehavior collision));
+
+        var provider = CreateProvider();
+        var context = CreateContext(testResultsDir: "TestResults");
+
+        string result = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = fileTemplate,
+            Extension = ".trx",
+            Context = context,
+            DirectoryTemplate = dirTemplate,
+            Collision = collision,
+        });
+
+        Assert.Contains("20260415T105100.123", result);
+    }
+
+    [TestMethod]
+    public void SanitizeFileName_InvalidChars_ReplacedWithUnderscore()
+    {
+        string result = ArtifactNameProvider.SanitizeFileName("test<file>name");
+
+        Assert.AreEqual("test_file_name", result);
+    }
+
+    [TestMethod]
+    public void SanitizeFileName_ReservedName_PrefixedWithUnderscore()
+    {
+        string result = ArtifactNameProvider.SanitizeFileName("CON");
+
+        Assert.AreEqual("_CON", result);
+    }
+
+    [TestMethod]
+    public void SanitizeFileName_ReservedNameWithExtension_PrefixedWithUnderscore()
+    {
+        string result = ArtifactNameProvider.SanitizeFileName("NUL.txt");
+
+        Assert.AreEqual("_NUL.txt", result);
+    }
+
+    [TestMethod]
+    public void SanitizePathSegments_DotDotTraversal_IsStripped()
+    {
+        string result = ArtifactNameProvider.SanitizePathSegments("TestResults/../etc/passwd");
+
+        Assert.DoesNotContain("..", result);
+        Assert.Contains("etc", result);
+    }
+
+    [TestMethod]
+    public void SanitizePathSegments_DriveLetterPreserved()
+    {
+        string result = ArtifactNameProvider.SanitizePathSegments("C:/TestResults/output");
+
+        Assert.IsTrue(result.StartsWith("C:", StringComparison.Ordinal), $"Actual: {result}");
+    }
+
+    [TestMethod]
+    public void Resolve_NullRequest_ThrowsArgumentNullException()
+    {
+        var provider = CreateProvider();
+        Assert.ThrowsExactly<ArgumentNullException>(() => provider.Resolve(null!));
+    }
+
+    [TestMethod]
+    public void Resolve_MultipleFilesPerProducer_BlameScenario()
+    {
+        var provider = CreateProvider();
+        var context = CreateContext(testResultsDir: "TestResults");
+        context[ArtifactNameTokens.Pid] = "12345";
+
+        string seqPath = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}_{Tfm}_{Architecture}_blame-sequence",
+            Extension = ".xml",
+            Context = context,
+            ArtifactKind = "blame-sequence",
+        });
+
+        string dumpPath = provider.Resolve(new ArtifactNameRequest
+        {
+            FileTemplate = "{AssemblyName}_{Tfm}_{Architecture}_crashdump_{Pid}",
+            Extension = ".dmp",
+            Context = context,
+            ArtifactKind = "blame-crashdump",
+        });
+
+        Assert.IsTrue(seqPath.EndsWith("blame-sequence.xml", StringComparison.Ordinal), $"Actual: {seqPath}");
+        Assert.IsTrue(dumpPath.EndsWith("crashdump_12345.dmp", StringComparison.Ordinal), $"Actual: {dumpPath}");
+        Assert.AreNotEqual(seqPath, dumpPath);
+    }
+}

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ArtifactNaming/ArtifactNameTemplateTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ArtifactNaming/ArtifactNameTemplateTests.cs
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using Microsoft.VisualStudio.TestPlatform.Common.ArtifactNaming;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.ArtifactNaming;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TestPlatform.Common.UnitTests.ArtifactNaming;
+
+[TestClass]
+public sealed class ArtifactNameTemplateTests
+{
+    private static readonly DateTime FixedTime = new(2026, 4, 15, 10, 51, 0, 123, DateTimeKind.Utc);
+
+    private static ArtifactNameProvider CreateProvider(Func<string, bool>? fileExists = null)
+        => new(() => FixedTime, fileExists ?? (_ => false));
+
+    [TestMethod]
+    public void ExpandTemplate_SimpleToken_IsReplaced()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string> { ["Name"] = "MyTests" };
+
+        string result = provider.ExpandTemplate("{Name}", context);
+
+        Assert.AreEqual("MyTests", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_MultipleTokens_AreReplaced()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string>
+        {
+            ["AssemblyName"] = "MyTests",
+            ["Tfm"] = "net8.0",
+            ["Architecture"] = "x64",
+        };
+
+        string result = provider.ExpandTemplate("{AssemblyName}_{Tfm}_{Architecture}", context);
+
+        Assert.AreEqual("MyTests_net8.0_x64", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_UnknownToken_IsKeptLiterally()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string>();
+
+        string result = provider.ExpandTemplate("{Unknown}", context);
+
+        Assert.AreEqual("{Unknown}", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_MixOfKnownAndUnknown_ExpandsCorrectly()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string> { ["Tfm"] = "net8.0" };
+
+        string result = provider.ExpandTemplate("{AssemblyName}_{Tfm}", context);
+
+        Assert.AreEqual("{AssemblyName}_net8.0", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_EscapedBraces_ProduceLiteralBraces()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string>();
+
+        string result = provider.ExpandTemplate("{{literal}}", context);
+
+        Assert.AreEqual("{literal}", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_FallbackSyntax_UsesFallbackWhenTokenMissing()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string>();
+
+        string result = provider.ExpandTemplate("{AssemblyName?default}", context);
+
+        Assert.AreEqual("default", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_FallbackSyntax_UsesValueWhenTokenPresent()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string> { ["AssemblyName"] = "MyTests" };
+
+        string result = provider.ExpandTemplate("{AssemblyName?default}", context);
+
+        Assert.AreEqual("MyTests", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_FormatSyntax_FormatsTimestamp()
+    {
+        var provider = CreateProvider();
+        string isoTimestamp = FixedTime.ToString("o", System.Globalization.CultureInfo.InvariantCulture);
+        var context = new Dictionary<string, string> { ["Timestamp"] = isoTimestamp };
+
+        string result = provider.ExpandTemplate("{Timestamp:yyyyMMdd}", context);
+
+        Assert.AreEqual("20260415", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_EmptyTemplate_ReturnsEmpty()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string>();
+
+        string result = provider.ExpandTemplate("", context);
+
+        Assert.AreEqual("", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_NoTokens_ReturnsLiteral()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string>();
+
+        string result = provider.ExpandTemplate("plain_text", context);
+
+        Assert.AreEqual("plain_text", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_UnclosedBrace_KeptAsLiteral()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string>();
+
+        string result = provider.ExpandTemplate("{unclosed", context);
+
+        Assert.AreEqual("{unclosed", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_AdjacentTokens_ExpandCorrectly()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string>
+        {
+            ["A"] = "hello",
+            ["B"] = "world",
+        };
+
+        string result = provider.ExpandTemplate("{A}{B}", context);
+
+        Assert.AreEqual("helloworld", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_TokenInDirectoryPath_ExpandsCorrectly()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string>
+        {
+            ["TestResultsDirectory"] = "TestResults",
+            ["Timestamp"] = "20260415T105100.123",
+        };
+
+        string result = provider.ExpandTemplate("{TestResultsDirectory}/{Timestamp}", context);
+
+        Assert.AreEqual("TestResults/20260415T105100.123", result);
+    }
+}

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ArtifactNaming/ArtifactNameTemplateTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ArtifactNaming/ArtifactNameTemplateTests.cs
@@ -80,25 +80,15 @@ public sealed class ArtifactNameTemplateTests
     }
 
     [TestMethod]
-    public void ExpandTemplate_FallbackSyntax_UsesFallbackWhenTokenMissing()
+    public void ExpandTemplate_QuestionMarkInToken_KeptLiterally()
     {
         var provider = CreateProvider();
         var context = new Dictionary<string, string>();
 
+        // ? is not a valid path char — kept literally to show misconfiguration.
         string result = provider.ExpandTemplate("{AssemblyName?default}", context);
 
-        Assert.AreEqual("default", result);
-    }
-
-    [TestMethod]
-    public void ExpandTemplate_FallbackSyntax_UsesValueWhenTokenPresent()
-    {
-        var provider = CreateProvider();
-        var context = new Dictionary<string, string> { ["AssemblyName"] = "MyTests" };
-
-        string result = provider.ExpandTemplate("{AssemblyName?default}", context);
-
-        Assert.AreEqual("MyTests", result);
+        Assert.AreEqual("{AssemblyName?default}", result);
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ArtifactNaming/ArtifactNameTemplateTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ArtifactNaming/ArtifactNameTemplateTests.cs
@@ -165,4 +165,102 @@ public sealed class ArtifactNameTemplateTests
 
         Assert.AreEqual("TestResults/20260415T105100.123", result);
     }
+
+    [TestMethod]
+    public void ExpandTemplate_EmptyToken_KeptLiterally()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string>();
+
+        string result = provider.ExpandTemplate("{}", context);
+
+        Assert.AreEqual("{}", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_LoneBrace_KeptLiterally()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string>();
+
+        string result = provider.ExpandTemplate("a}b", context);
+
+        Assert.AreEqual("a}b", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_WhitespaceToken_KeptLiterally()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string>();
+
+        string result = provider.ExpandTemplate("{ Token }", context);
+
+        Assert.AreEqual("{ Token }", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_UnknownTokenWithFormat_KeptLiterally()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string>();
+
+        string result = provider.ExpandTemplate("{Missing:yyyy}", context);
+
+        Assert.AreEqual("{Missing:yyyy}", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_MultipleColons_FirstColonIsFormatSeparator()
+    {
+        var provider = CreateProvider();
+        string isoTimestamp = FixedTime.ToString("o", System.Globalization.CultureInfo.InvariantCulture);
+        var context = new Dictionary<string, string> { ["Timestamp"] = isoTimestamp };
+
+        // Format "HH:mm:ss" contains colons — only the first colon separates token from format.
+        string result = provider.ExpandTemplate("{Timestamp:HH:mm:ss}", context);
+
+        Assert.AreEqual("10:51:00", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_FormatOnNonDateTimeValue_FormatIgnored()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string> { ["BuildId"] = "12345" };
+
+        // "12345" is not a DateTime — format is silently ignored, raw value returned.
+        string result = provider.ExpandTemplate("{BuildId:D4}", context);
+
+        Assert.AreEqual("12345", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_TripleBraces_EscapedBracePlusToken()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string> { ["X"] = "val" };
+
+        // {{{ → escaped { + start of token, but there's no inner token name that matches.
+        // Actually: {{ → literal {, then {X} → "val"
+        string result = provider.ExpandTemplate("{{{X}}}", context);
+
+        // {{ → {, {X} → val, }} → }
+        Assert.AreEqual("{val}", result);
+    }
+
+    [TestMethod]
+    public void ExpandTemplate_CaseInsensitiveTokenLookup()
+    {
+        var provider = CreateProvider();
+        var context = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["assemblyname"] = "MyTests",
+        };
+
+        // Template uses PascalCase, context has lowercase — should still match.
+        string result = provider.ExpandTemplate("{AssemblyName}", context);
+
+        Assert.AreEqual("MyTests", result);
+    }
 }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestLoggerManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestLoggerManagerTests.cs
@@ -1033,7 +1033,7 @@ public class TestLoggerManagerTests
         testLoggerManager.Initialize(settingsXml);
 
         Assert.AreEqual(1, ValidLoggerWithParameters.Counter);
-        Assert.HasCount(4, ValidLoggerWithParameters.Parameters!); // Two additional because of testRunDirectory and targetFramework
+        Assert.HasCount(6, ValidLoggerWithParameters.Parameters!); // Four additional because of testRunDirectory, targetFramework, targetArchitecture and testRunTimestamp
         Assert.AreEqual("Value1", ValidLoggerWithParameters.Parameters!["Key1"]);
         Assert.AreEqual("Value2", ValidLoggerWithParameters.Parameters!["Key2"]);
 
@@ -1073,7 +1073,7 @@ public class TestLoggerManagerTests
         testLoggerManager.Initialize(settingsXml);
 
         Assert.AreEqual(1, ValidLoggerWithParameters.Counter);
-        Assert.HasCount(3, ValidLoggerWithParameters.Parameters!); // Two additional because of testRunDirectory and targetFramework
+        Assert.HasCount(5, ValidLoggerWithParameters.Parameters!); // Four additional because of testRunDirectory, targetFramework, targetArchitecture and testRunTimestamp
         Assert.IsFalse(ValidLoggerWithParameters.Parameters!.TryGetValue("Key1", out var key1Value));
         Assert.AreEqual("Value2", ValidLoggerWithParameters.Parameters!["Key2"]);
 
@@ -1114,7 +1114,7 @@ public class TestLoggerManagerTests
         testLoggerManager.Initialize(settingsXml);
 
         Assert.AreEqual(1, ValidLoggerWithParameters.Counter);
-        Assert.HasCount(4, ValidLoggerWithParameters.Parameters!); // Two additional because of testRunDirectory and targetFramework
+        Assert.HasCount(6, ValidLoggerWithParameters.Parameters!); // Four additional because of testRunDirectory, targetFramework, targetArchitecture and testRunTimestamp
         Assert.AreEqual("Value3", ValidLoggerWithParameters.Parameters!["Key1"]);
         Assert.AreEqual("Value2", ValidLoggerWithParameters.Parameters!["Key2"]);
 
@@ -1185,7 +1185,7 @@ public class TestLoggerManagerTests
         testLoggerManager.Initialize(settingsXml);
 
         Assert.AreEqual(1, ValidLoggerWithParameters.Counter);
-        Assert.HasCount(4, ValidLoggerWithParameters.Parameters!); // Two additional because of testRunDirectory and targetFramework
+        Assert.HasCount(6, ValidLoggerWithParameters.Parameters!); // Four additional because of testRunDirectory, targetFramework, targetArchitecture and testRunTimestamp
         Assert.AreEqual("Value1", ValidLoggerWithParameters.Parameters!["Key1"]);
         Assert.AreEqual("Value2", ValidLoggerWithParameters.Parameters!["Key2"]);
         mockMetricsCollection.Verify(
@@ -1223,7 +1223,7 @@ public class TestLoggerManagerTests
         testLoggerManager.Initialize(settingsXml);
 
         Assert.AreEqual(1, ValidLoggerWithParameters.Counter);
-        Assert.HasCount(4, ValidLoggerWithParameters.Parameters!); // Two additional because of testRunDirectory and targetFramework
+        Assert.HasCount(6, ValidLoggerWithParameters.Parameters!); // Four additional because of testRunDirectory, targetFramework, targetArchitecture and testRunTimestamp
         Assert.AreEqual("Value1", ValidLoggerWithParameters.Parameters!["Key1"]);
         Assert.AreEqual("Value2", ValidLoggerWithParameters.Parameters!["Key2"]);
         mockMetricsCollection.Verify(
@@ -1261,7 +1261,7 @@ public class TestLoggerManagerTests
         testLoggerManager.Initialize(settingsXml);
 
         Assert.AreEqual(1, ValidLoggerWithParameters.Counter);
-        Assert.HasCount(4, ValidLoggerWithParameters.Parameters!); // Two additional because of testRunDirectory and targetFramework
+        Assert.HasCount(6, ValidLoggerWithParameters.Parameters!); // Four additional because of testRunDirectory, targetFramework, targetArchitecture and testRunTimestamp
         Assert.AreEqual("Value1", ValidLoggerWithParameters.Parameters!["Key1"]);
         Assert.AreEqual("Value2", ValidLoggerWithParameters.Parameters!["Key2"]);
         mockMetricsCollection.Verify(
@@ -1299,7 +1299,7 @@ public class TestLoggerManagerTests
         testLoggerManager.Initialize(settingsXml);
 
         Assert.AreEqual(1, ValidLoggerWithParameters.Counter);
-        Assert.HasCount(4, ValidLoggerWithParameters.Parameters!); // Two additional because of testRunDirectory and targetFramework
+        Assert.HasCount(6, ValidLoggerWithParameters.Parameters!); // Four additional because of testRunDirectory, targetFramework, targetArchitecture and testRunTimestamp
         Assert.AreEqual("Value1", ValidLoggerWithParameters.Parameters!["Key1"]);
         Assert.AreEqual("Value2", ValidLoggerWithParameters.Parameters!["Key2"]);
         mockMetricsCollection.Verify(
@@ -1343,7 +1343,7 @@ public class TestLoggerManagerTests
         testLoggerManager.Initialize(settingsXml);
 
         Assert.AreEqual(1, ValidLoggerWithParameters.Counter);
-        Assert.HasCount(4, ValidLoggerWithParameters.Parameters!); // Two additional because of testRunDirectory and targetFramework
+        Assert.HasCount(6, ValidLoggerWithParameters.Parameters!); // Four additional because of testRunDirectory, targetFramework, targetArchitecture and testRunTimestamp
         Assert.AreEqual("Value1", ValidLoggerWithParameters.Parameters!["Key1"]);
         Assert.AreEqual("DummyTestResultsFolder", ValidLoggerWithParameters.Parameters!["testRunDirectory"]);
         Assert.AreEqual("Value2", ValidLoggerWithParameters.Parameters!["Key2"]);
@@ -1387,7 +1387,7 @@ public class TestLoggerManagerTests
         testLoggerManager.Initialize(settingsXml);
 
         Assert.AreEqual(1, ValidLoggerWithParameters.Counter);
-        Assert.HasCount(4, ValidLoggerWithParameters.Parameters!); // Two additional because of testRunDirectory and targetFramework
+        Assert.HasCount(6, ValidLoggerWithParameters.Parameters!); // Four additional because of testRunDirectory, targetFramework, targetArchitecture and testRunTimestamp
         Assert.AreEqual("Value1", ValidLoggerWithParameters.Parameters!["Key1"]);
         Assert.AreEqual(Constants.DefaultResultsDirectory, ValidLoggerWithParameters.Parameters!["testRunDirectory"]);
         Assert.AreEqual("Value2", ValidLoggerWithParameters.Parameters!["Key2"]);
@@ -1662,4 +1662,195 @@ public class TestLoggerManagerTests
 
         }
     }
+
+    #region GetTargetArchitecture Tests
+
+    [TestMethod]
+    public void GetTargetArchitectureShouldReturnNullForNullRunSettings()
+    {
+        Assert.IsNull(TestLoggerManager.GetTargetArchitecture(null));
+    }
+
+    [TestMethod]
+    public void GetTargetArchitectureShouldReturnNullForDefaultArchitecture()
+    {
+        string settingsXml = @"
+            <RunSettings>
+              <RunConfiguration>
+              </RunConfiguration>
+            </RunSettings>";
+
+        // Default architecture is Architecture.Default which should return null.
+        Assert.IsNull(TestLoggerManager.GetTargetArchitecture(settingsXml));
+    }
+
+    [TestMethod]
+    public void GetTargetArchitectureShouldReturnX64WhenSet()
+    {
+        string settingsXml = @"
+            <RunSettings>
+              <RunConfiguration>
+                <TargetPlatform>x64</TargetPlatform>
+              </RunConfiguration>
+            </RunSettings>";
+
+        Assert.AreEqual("x64", TestLoggerManager.GetTargetArchitecture(settingsXml));
+    }
+
+    [TestMethod]
+    public void GetTargetArchitectureShouldReturnX86WhenSet()
+    {
+        string settingsXml = @"
+            <RunSettings>
+              <RunConfiguration>
+                <TargetPlatform>x86</TargetPlatform>
+              </RunConfiguration>
+            </RunSettings>";
+
+        Assert.AreEqual("x86", TestLoggerManager.GetTargetArchitecture(settingsXml));
+    }
+
+    [TestMethod]
+    public void GetTargetArchitectureShouldReturnArm64WhenSet()
+    {
+        string settingsXml = @"
+            <RunSettings>
+              <RunConfiguration>
+                <TargetPlatform>ARM64</TargetPlatform>
+              </RunConfiguration>
+            </RunSettings>";
+
+        Assert.AreEqual("arm64", TestLoggerManager.GetTargetArchitecture(settingsXml));
+    }
+
+    #endregion
+
+    #region GetOrGenerateTestRunTimestamp Tests
+
+    [TestMethod]
+    public void GetOrGenerateTestRunTimestampShouldUseExistingTimestampFromRunSettings()
+    {
+        string settingsXml = @"
+            <RunSettings>
+              <RunConfiguration>
+                <ArtifactRunTimestamp>20260415T105100.123</ArtifactRunTimestamp>
+              </RunConfiguration>
+            </RunSettings>";
+
+        var manager = new DummyTestLoggerManager();
+        string timestamp = manager.GetOrGenerateTestRunTimestamp(settingsXml);
+
+        Assert.AreEqual("20260415T105100.123", timestamp);
+    }
+
+    [TestMethod]
+    public void GetOrGenerateTestRunTimestampShouldGenerateNewTimestampWhenNotInRunSettings()
+    {
+        string settingsXml = @"
+            <RunSettings>
+              <RunConfiguration>
+              </RunConfiguration>
+            </RunSettings>";
+
+        var manager = new DummyTestLoggerManager();
+        string timestamp = manager.GetOrGenerateTestRunTimestamp(settingsXml);
+
+        // Verify it matches the ISO 8601 compact format: yyyyMMddTHHmmss.fff
+        Assert.IsNotNull(timestamp);
+        Assert.AreEqual(19, timestamp.Length, $"Timestamp '{timestamp}' should be in yyyyMMddTHHmmss.fff format (19 chars)");
+        Assert.Contains("T", timestamp, $"Timestamp '{timestamp}' should contain 'T' separator");
+        Assert.Contains(".", timestamp, $"Timestamp '{timestamp}' should contain '.' for milliseconds");
+    }
+
+    [TestMethod]
+    public void GetOrGenerateTestRunTimestampShouldGenerateTimestampForNullRunSettings()
+    {
+        var manager = new DummyTestLoggerManager();
+        string timestamp = manager.GetOrGenerateTestRunTimestamp(null);
+
+        Assert.IsNotNull(timestamp);
+        Assert.AreEqual(19, timestamp.Length, $"Timestamp '{timestamp}' should be 19 chars");
+    }
+
+    #endregion
+
+    #region Context Propagation Integration Tests
+
+    [TestMethod]
+    public void InitializeShouldPassArchitectureAndTimestampToLoggers()
+    {
+        ValidLoggerWithParameters.Reset();
+        var mockRequestData = new Mock<IRequestData>();
+        var mockMetricsCollection = new Mock<IMetricsCollection>();
+        mockRequestData.Setup(rd => rd.MetricsCollection).Returns(mockMetricsCollection.Object);
+
+        string codeBase = typeof(TestLoggerManagerTests).Assembly.Location;
+
+        string settingsXml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <RunSettings>
+                  <RunConfiguration>
+                    <TargetPlatform>x64</TargetPlatform>
+                    <TargetFrameworkVersion>Framework45</TargetFrameworkVersion>
+                  </RunConfiguration>
+                  <LoggerRunSettings>
+                    <Loggers>
+                      <Logger friendlyName=""TestLoggerWithParameterExtension"" uri=""invalid://invalid"" assemblyQualifiedName=""invalidAssembly"" codeBase=""" + codeBase + @""">
+                        <Configuration>
+                          <Key1>Value1</Key1>
+                        </Configuration>
+                      </Logger>
+                    </Loggers>
+                  </LoggerRunSettings>
+                </RunSettings>";
+
+        var testLoggerManager = new DummyTestLoggerManager(mockRequestData.Object);
+        testLoggerManager.Initialize(settingsXml);
+
+        Assert.AreEqual(1, ValidLoggerWithParameters.Counter);
+        Assert.IsNotNull(ValidLoggerWithParameters.Parameters);
+
+        // Verify new parameters are present
+        Assert.IsTrue(ValidLoggerWithParameters.Parameters!.ContainsKey(DefaultLoggerParameterNames.TargetArchitecture));
+        Assert.AreEqual("x64", ValidLoggerWithParameters.Parameters![DefaultLoggerParameterNames.TargetArchitecture]);
+
+        Assert.IsTrue(ValidLoggerWithParameters.Parameters!.ContainsKey(DefaultLoggerParameterNames.TestRunTimestamp));
+        string? timestamp = ValidLoggerWithParameters.Parameters![DefaultLoggerParameterNames.TestRunTimestamp];
+        Assert.IsNotNull(timestamp);
+        Assert.Contains("T", timestamp!, $"Timestamp should be in ISO 8601 compact format, got: {timestamp}");
+    }
+
+    [TestMethod]
+    public void InitializeShouldUseArtifactRunTimestampFromRunSettingsIfPresent()
+    {
+        ValidLoggerWithParameters.Reset();
+        var mockRequestData = new Mock<IRequestData>();
+        var mockMetricsCollection = new Mock<IMetricsCollection>();
+        mockRequestData.Setup(rd => rd.MetricsCollection).Returns(mockMetricsCollection.Object);
+
+        string codeBase = typeof(TestLoggerManagerTests).Assembly.Location;
+
+        string settingsXml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <RunSettings>
+                  <RunConfiguration>
+                    <ArtifactRunTimestamp>20260415T105100.123</ArtifactRunTimestamp>
+                  </RunConfiguration>
+                  <LoggerRunSettings>
+                    <Loggers>
+                      <Logger friendlyName=""TestLoggerWithParameterExtension"" uri=""invalid://invalid"" assemblyQualifiedName=""invalidAssembly"" codeBase=""" + codeBase + @""">
+                        <Configuration>
+                          <Key1>Value1</Key1>
+                        </Configuration>
+                      </Logger>
+                    </Loggers>
+                  </LoggerRunSettings>
+                </RunSettings>";
+
+        var testLoggerManager = new DummyTestLoggerManager(mockRequestData.Object);
+        testLoggerManager.Initialize(settingsXml);
+
+        Assert.AreEqual(1, ValidLoggerWithParameters.Counter);
+        Assert.AreEqual("20260415T105100.123", ValidLoggerWithParameters.Parameters![DefaultLoggerParameterNames.TestRunTimestamp]);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
# Centralized Artifact Naming Service

## TL;DR

A centralized naming service that gives every vstest extension (TrxLogger, BlameCollector,
coverage, etc.) deterministic, collision-free output file paths. Users get predictable
`TestResults/` layouts without post-processing scripts, glob hacks, or silent data loss.

Resolves #2378 #15673 #3026 #1603 #2113

---

## The Problem Today

When you run `dotnet test`, each extension names its output files independently.
There is no shared naming convention — each extension has its own ad-hoc logic with
its own bugs:

| What Happens | Impact | Issues |
|---|---|---|
| **TRX files overwrite each other** in multi-TFM/multi-project solutions | Test results lost silently — CI reports 100% pass on partial data | #15673, #3026, #1603, #2113 |
| **Data collectors use GUID directories** | `TestResults/a3f7b2c1-4d5e-.../coverage.xml` — unpredictable paths force glob patterns in CI | #2378 (76 👍) |
| **Local dev gets machine-name spam** | `jajares@DESKTOP-ABC 2026-04-15 10_04_49.trx` — useless info, no per-run grouping | — |
| **Race conditions between parallel hosts** | Two test hosts can pick the same filename and one overwrites the other | — |

### Root Cause

No shared naming service. Each extension re-invents file naming:

- **TrxLogger** builds its own path in `GetTrxFilePath()` / `SetDefaultTrxFilePath()`
- **HtmlLogger** copies TrxLogger's logic with slightly different defaults
- **BlameCollector** uses `Sequence_{Guid}.xml`
- **DataCollectionAttachmentManager** appends GUIDs at lines 108, 115 — the root of #2378
- **EventLogCollector** uses `Event Log.xml` with a counter

Each has its own collision handling (or none), its own sanitization (or none), and its own
assumptions about directory structure.

---

## Before & After

### Multi-TFM CI (data loss → everything preserved)

```bash
dotnet test MySolution.sln --logger "trx;LogFileName=Results.trx"
```

**Before:**
```
TestResults/
└── Results.trx    ← Only the LAST project's results survive.
                     Other projects' results were silently overwritten.
```

**After:**
```
TestResults/
├── MyProject.Tests_net8.0_x64.trx
├── MyProject.Tests_net10.0_x64.trx
├── OtherProject.Tests_net8.0_x64.trx
└── OtherProject.Tests_net10.0_x64.trx
```

Each file is unique by construction: `{AssemblyName}_{Tfm}_{Architecture}`.

### Coverage GUID directories → deterministic paths

**Before:**
```
TestResults/
└── a3f7b2c1-4d5e-6f78-9a0b-c1d2e3f4a5b6/
    └── coverage.cobertura.xml
```

CI pipelines need `**/coverage.cobertura.xml` glob patterns. Andrew Arnott (AArnott)
has a PowerShell post-processing script in his `Library.Template` to recursively find files.

**After:**
```
TestResults/
├── MyProject.Tests_net8.0_x64.trx
└── MyProject.Tests_net8.0_x64.cobertura.xml
```

```yaml
# CI pipeline — deterministic path, no globs
- publish: 'TestResults/*.cobertura.xml'
```

### Local dev (machine-name spam → per-run folders)

**Before:**
```
TestResults/
├── jajares@DESKTOP-ABC 2026-04-15 10_04_49.trx
├── jajares@DESKTOP-ABC 2026-04-15 10_12_33.trx
├── jajares@DESKTOP-ABC 2026-04-15 10_04_49_net8.0.trx
└── jajares@DESKTOP-ABC 2026-04-15 10_12_33_net8.0.trx
```

**After (`local` preset):**
```
TestResults/
├── 20260415T100449.123/
│   ├── MyProject.Tests_net8.0_x64.trx
│   └── MyProject.Tests_net10.0_x64.trx
└── 20260415T101233.456/
    ├── MyProject.Tests_net8.0_x64.trx
    └── MyProject.Tests_net10.0_x64.trx
```

Each run = one folder. Delete one run: `rm -rf TestResults/20260415T100449.123/`.
Latest = last alphabetically (ISO 8601 sorts chronologically).

---

## How It Works

### Template System

Extensions request a file path by providing a **template** with `{Token}` placeholders:

```
{AssemblyName}_{Tfm}_{Architecture}
```

The service expands tokens from context (RunSettings, environment), sanitizes the
result for the file system, handles collisions, and returns a ready-to-use path.

### Available Tokens

| Token | Example | Source |
|---|---|---|
| `{TestResultsDirectory}` | `TestResults` | RunSettings |
| `{AssemblyName}` | `MyProject.Tests` | Test source path |
| `{Tfm}` | `net8.0` | RunSettings → logger params |
| `{Architecture}` | `x64` | RunSettings → logger params |
| `{Timestamp}` | `20260415T105100.123` | Shared per-run timestamp |
| `{MachineName}` | `BUILD-01` | `Environment.MachineName` |
| `{UserName}` | `dev` | `Environment.UserName` |
| `{Pid}` | `12345` | Process ID |
| `{RunId}` | `a1b2c3d4` | Short 8-char hex unique ID |
| `{Date}` | `2026-04-15` | Date only |

Tokens can have format specifiers: `{Timestamp:yyyyMMdd}` → `20260415`.

Unknown tokens stay literal in the output (e.g., `{Unknown}` → `{Unknown}`), making
misconfiguration immediately obvious.

### Built-in Presets

| Preset | Directory | File Template | Collision | Use Case |
|---|---|---|---|---|
| `ci` | `TestResults/` | `{AssemblyName}_{Tfm}_{Architecture}` | Overwrite | Flat, deterministic CI |
| `local` | `TestResults/{Timestamp}/` | `{AssemblyName}_{Tfm}_{Architecture}` | AppendCounter | Per-run folders |
| `detailed` | `TestResults/{Timestamp}/` | `{AssemblyName}_{Tfm}_{Architecture}_{RunId}` | AppendCounter | Rich + unique |
| `flat` | `TestResults/` | `{AssemblyName}` | AppendCounter | Minimal |

### Configuration

**RunSettings** (for the whole solution):
```xml
<RunSettings>
  <RunConfiguration>
    <ArtifactNamingPreset>ci</ArtifactNamingPreset>
    <!-- OR custom templates -->
    <ArtifactDirectoryTemplate>{TestResultsDirectory}</ArtifactDirectoryTemplate>
    <ArtifactFileTemplate>{AssemblyName}_{Tfm}_{Architecture}</ArtifactFileTemplate>
  </RunConfiguration>
</RunSettings>
```

**CLI** (per-logger override):
```bash
dotnet test --logger "trx;ArtifactName={AssemblyName}_{Tfm}"
```

Priority: CLI param > RunSettings template > RunSettings preset > extension default.

---

## Safety Features

### Path Sanitization
- Invalid filename chars → `_`
- Reserved Windows names (`CON`, `PRN`, `NUL`, ...) → `_CON`, `_PRN`
- Trailing dots/spaces stripped (Windows normalizes these)
- No `..` path traversal allowed — output stays under results directory

### Overwrite Detection
- `FileMode.CreateNew` used to detect when a file already exists
- `Resolve()` returns `ArtifactNameResult` with `IsOverwrite` flag
- Callers can log a warning instead of silently losing data

### Atomic Directory Ownership
- Per-run timestamped directories get a `.vstest-run` marker file
- Created atomically with `FileMode.CreateNew` + PID content
- Prevents two concurrent runs from accidentally sharing a directory

### Collision Behaviors
| Behavior | What Happens |
|---|---|
| `AppendCounter` | `file.trx` → `file_2.trx` → `file_3.trx` |
| `Overwrite` | Replace existing (with `IsOverwrite` warning) |
| `Fail` | Throw on collision (strict CI mode) |
| `AppendTimestamp` | Append millisecond timestamp to disambiguate |

---

## Cross-Process Timestamp Synchronization

When `dotnet test MySolution.sln` runs, MSBuild spawns a separate `dotnet test` per project.
For the `local` preset, all projects should share the **same** timestamped folder.

**Solution**: The orchestrator injects `<ArtifactRunTimestamp>` into RunSettings before
spawning child processes. Each child reads this shared value instead of generating its own.

```xml
<RunConfiguration>
  <ArtifactRunTimestamp>20260415T105100.123</ArtifactRunTimestamp>
</RunConfiguration>
```

This uses the same RunSettings propagation mechanism that already works for
`ResultsDirectory`, `TargetPlatform`, and `TargetFramework`.

---

## Changes in This PR

### New files (ObjectModel — public API)

| File | Purpose |
|---|---|
| `ArtifactNaming/IArtifactNameProvider.cs` | Public interface: `Resolve()` → `ArtifactNameResult` |
| `ArtifactNaming/ArtifactNameRequest.cs` | Request: template, extension, context, collision behavior |
| `ArtifactNaming/ArtifactNameResult.cs` | Result: `FilePath`, `IsOverwrite`, `IsDirectoryOwner` |
| `ArtifactNaming/ArtifactNameTokens.cs` | Well-known token constants |
| `ArtifactNaming/ArtifactNamingPresets.cs` | Built-in preset definitions |
| `ArtifactNaming/CollisionBehavior.cs` | Collision behavior enum |

### New files (Common — implementation)

| File | Purpose |
|---|---|
| `ArtifactNaming/ArtifactNameProvider.cs` | Template parser, sanitization, collision handling, atomic ownership |

### Modified files

| File | Change |
|---|---|
| `Constants.cs` | Added `DefaultLoggerParameterNames.TargetArchitecture`, `TestRunTimestamp` |
| `RunConfiguration.cs` | Added `ArtifactRunTimestamp` property with XML round-trip |
| `TestLoggerManager.cs` | Extracts architecture + timestamp from RunSettings, passes to all loggers |
| `PublicAPI.Unshipped.txt` | All new public API surface |

### Test coverage

| Test File | Tests | Coverage |
|---|---|---|
| `ArtifactNameTemplateTests.cs` | 20 | Template expansion, escaping, format specifiers, parser edge cases |
| `ArtifactNameProviderTests.cs` | 38 | Collision behaviors, presets, sanitization, atomic ownership, edge cases |
| `TestLoggerManagerTests.cs` | +10 (71 total) | Architecture extraction, timestamp generation, end-to-end propagation |

All **129 tests** pass on both `net11.0` and `net481`.

---

## What We Don't Do

- **No breaking changes** — current defaults produce same output until opt-in flip
- **No MSBuild properties** — configuration is RunSettings + CLI only
- **No MTP integration** — vstest only for now
- **No custom token injection** — shell expansion (`$BUILD_NUMBER`) already covers this

## Backward Compatibility

The service ships with templates that reproduce today's behavior exactly. Extensions
adopt the service with zero visible change. The improved defaults
(`{AssemblyName}_{Tfm}_{Architecture}`) are a separate opt-in step announced in
release notes. Users can pin the old format via `<ArtifactFileTemplate>` in RunSettings.

## Next Steps (follow-up PRs)

1. **TrxLogger integration** — wire `IArtifactNameProvider` into TrxLogger
2. **Other extensions** — HtmlLogger, BlameCollector, DataCollectionAttachmentManager
3. **RunSettings integration** — parse `<ArtifactNamingPreset>` / `<ArtifactFileTemplate>` from RunConfiguration

