### PR TITLE
Fix mutex cleanup crash on macOS/Linux

### DIFF
--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
@@ -182,7 +182,7 @@ public class IntegrationTestBuild : IntegrationTestBase
                 // AssemblyCleanup may run on a different thread than AssemblyInitialize.
                 // On macOS/Linux the runtime throws InvalidOperationException for
                 // cross-thread release; on Windows it throws ApplicationException.
-                try { s_sessionMutex.ReleaseMutex(); } catch (Exception) { }
+                try { s_sessionMutex.ReleaseMutex(); } catch (Exception ex) when (ex is ApplicationException or InvalidOperationException) { }
             }
             s_sessionMutex.Dispose();
             s_sessionMutex = null;

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
@@ -179,7 +179,10 @@ public class IntegrationTestBuild : IntegrationTestBase
         {
             if (s_isSessionMutexOwner)
             {
-                try { s_sessionMutex.ReleaseMutex(); } catch (ApplicationException) { }
+                // AssemblyCleanup may run on a different thread than AssemblyInitialize.
+                // On macOS/Linux the runtime throws InvalidOperationException for
+                // cross-thread release; on Windows it throws ApplicationException.
+                try { s_sessionMutex.ReleaseMutex(); } catch (Exception) { }
             }
             s_sessionMutex.Dispose();
             s_sessionMutex = null;


### PR DESCRIPTION
AssemblyCleanup may run on a different thread than AssemblyInitialize. On macOS/Linux the .NET runtime throws InvalidOperationException (not ApplicationException) when ReleaseMutex() is called from a non-owning thread. This widens the catch to handle both platforms.