### PR TITLE
Add ARM64 msdia140.dll support to test platform packages

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -75,7 +75,7 @@
     <SystemReflectionMetadataVersion>8.0.0</SystemReflectionMetadataVersion>
     <TestPlatformExternalsVersion>18.0.0-preview-1-10911-061</TestPlatformExternalsVersion>
     <MicrosoftInternalTestPlatformExtensions>18.3.11611.365</MicrosoftInternalTestPlatformExtensions>
-    <TestPlatformMSDiaVersion>18.0.11024.295</TestPlatformMSDiaVersion>
+    <TestPlatformMSDiaVersion>18.7.0-preview-1-11715-406</TestPlatformMSDiaVersion>
     <SystemDiagnosticsDiagnosticSourceVersion>8.0.1</SystemDiagnosticsDiagnosticSourceVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>6.1.0</SystemRuntimeCompilerServicesUnsafeVersion>

--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -19,7 +19,7 @@ function Verify-Nuget-Packages {
     $expectedNumOfFiles = @{
         "Microsoft.CodeCoverage"                      = 76
         "Microsoft.NET.Test.Sdk"                      = 26
-        "Microsoft.TestPlatform"                      = 545
+        "Microsoft.TestPlatform"                      = 551
         "Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI" = 390
         "Microsoft.TestPlatform.Build"                = 21
         "Microsoft.TestPlatform.CLI"                  = 485

--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -20,14 +20,14 @@ function Verify-Nuget-Packages {
         "Microsoft.CodeCoverage"                      = 76
         "Microsoft.NET.Test.Sdk"                      = 26
         "Microsoft.TestPlatform"                      = 545
-        "Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI" = 388
+        "Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI" = 390
         "Microsoft.TestPlatform.Build"                = 21
-        "Microsoft.TestPlatform.CLI"                  = 483
+        "Microsoft.TestPlatform.CLI"                  = 485
         "Microsoft.TestPlatform.Extensions.TrxLogger" = 35
         "Microsoft.TestPlatform.ObjectModel"          = 93
         "Microsoft.TestPlatform.AdapterUtilities"     = 62
-        "Microsoft.TestPlatform.Portable"             = 609
-        "Microsoft.TestPlatform.TestHost"             = 64
+        "Microsoft.TestPlatform.Portable"             = 611
+        "Microsoft.TestPlatform.TestHost"             = 65
         "Microsoft.TestPlatform.TranslationLayer"     = 175
         "Microsoft.TestPlatform.Internal.Uwp"         = 39
     }

--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -19,7 +19,7 @@ function Verify-Nuget-Packages {
     $expectedNumOfFiles = @{
         "Microsoft.CodeCoverage"                      = 76
         "Microsoft.NET.Test.Sdk"                      = 26
-        "Microsoft.TestPlatform"                      = 551
+        "Microsoft.TestPlatform"                      = 550
         "Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI" = 390
         "Microsoft.TestPlatform.Build"                = 21
         "Microsoft.TestPlatform.CLI"                  = 485

--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.nuspec
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.nuspec
@@ -77,6 +77,8 @@
     <file src="net48\Microsoft.Internal.Dia\x64\msdia140.dll.manifest" target="contentFiles\any\net10.0\TestHostNetFramework\x64" />
     <file src="net48\Microsoft.Internal.Dia\x86\msdia140.dll"          target="contentFiles\any\net10.0\TestHostNetFramework\x86" />
     <file src="net48\Microsoft.Internal.Dia\x86\msdia140.dll.manifest" target="contentFiles\any\net10.0\TestHostNetFramework\x86" />
+    <file src="net48\Microsoft.Internal.Dia\arm64\msdia140.dll"          target="contentFiles\any\net10.0\TestHostNetFramework\arm64" />
+    <file src="net48\Microsoft.Internal.Dia\arm64\msdia140.dll.manifest" target="contentFiles\any\net10.0\TestHostNetFramework\arm64" />
 
     <file src="net48\datacollector.exe" target="contentFiles\any\net10.0\TestHostNetFramework" />
     <file src="net48\datacollector.exe.config" target="contentFiles\any\net10.0\TestHostNetFramework" />

--- a/src/package/Microsoft.TestPlatform.Portable/Microsoft.TestPlatform.Portable.nuspec
+++ b/src/package/Microsoft.TestPlatform.Portable/Microsoft.TestPlatform.Portable.nuspec
@@ -605,6 +605,8 @@
     <file src="net8.0\Microsoft.Internal.Dia\x64\msdia140.dll.manifest"	target="tools\net8.0\TestHostNetFramework\x64\msdia140.dll.manifest" />
     <file src="net8.0\Microsoft.Internal.Dia\x86\msdia140.dll"	target="tools\net8.0\TestHostNetFramework\x86\msdia140.dll" />
     <file src="net8.0\Microsoft.Internal.Dia\x86\msdia140.dll.manifest"	target="tools\net8.0\TestHostNetFramework\x86\msdia140.dll.manifest" />
+    <file src="net8.0\Microsoft.Internal.Dia\arm64\msdia140.dll"	target="tools\net8.0\TestHostNetFramework\arm64\msdia140.dll" />
+    <file src="net8.0\Microsoft.Internal.Dia\arm64\msdia140.dll.manifest"	target="tools\net8.0\TestHostNetFramework\arm64\msdia140.dll.manifest" />
 
     <file src="net8.0\zh-Hans\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"	target="tools\net8.0\TestHostNetFramework\zh-Hans\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" />
     <file src="net8.0\zh-Hans\Microsoft.TestPlatform.CoreUtilities.resources.dll"	target="tools\net8.0\TestHostNetFramework\zh-Hans\Microsoft.TestPlatform.CoreUtilities.resources.dll" />

--- a/src/package/Microsoft.TestPlatform.TestHost/Microsoft.TestPlatform.TestHost.csproj
+++ b/src/package/Microsoft.TestPlatform.TestHost/Microsoft.TestPlatform.TestHost.csproj
@@ -42,9 +42,11 @@
     <ItemGroup>
       <DiaFilesX86 Include="$(PkgMicrosoft_Internal_Dia)\tools\net451\x86\*"></DiaFilesX86>
       <DiaFilesX64 Include="$(PkgMicrosoft_Internal_Dia)\tools\net451\x64\*"></DiaFilesX64>
+      <DiaFilesArm64 Include="$(PkgMicrosoft_Internal_Dia)\tools\net451\arm64\*"></DiaFilesArm64>
     </ItemGroup>
     <Copy SourceFiles="@(DiaFilesX86)" DestinationFolder="$(OutDir)\x86" />
     <Copy SourceFiles="@(DiaFilesX64)" DestinationFolder="$(OutDir)\x64" />
+    <Copy SourceFiles="@(DiaFilesArm64)" DestinationFolder="$(OutDir)\arm64" />
   </Target>
 
   <ItemGroup>

--- a/src/package/Microsoft.TestPlatform.TestHost/Microsoft.TestPlatform.TestHost.nuspec
+++ b/src/package/Microsoft.TestPlatform.TestHost/Microsoft.TestPlatform.TestHost.nuspec
@@ -33,6 +33,7 @@
 
     <file src="net8.0\x86\msdia140.dll" target="lib\net8.0\x86\" />
     <file src="net8.0\x64\msdia140.dll" target="lib\net8.0\x64\" />
+    <file src="net8.0\arm64\msdia140.dll" target="lib\net8.0\arm64\" />
 
     <!--
           We move AnyCPU version of testhost.dll, at the moment we don't have native code that needs particular architecture inside testhost.dll.

--- a/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.nuspec
+++ b/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.nuspec
@@ -230,10 +230,14 @@
     <file src="net48\Microsoft.Internal.Dia\x64\msdia140.dll.manifest" target="tools\net462\Common7\IDE\Extensions\TestPlatform\Extensions\TestImpact\ComComponents\x64\msdia140.dll.manifest" />
     <file src="net48\Microsoft.Internal.Dia\x86\msdia140.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\Extensions\TestImpact\ComComponents\x86\msdia140.dll" />
     <file src="net48\Microsoft.Internal.Dia\x86\msdia140.dll.manifest" target="tools\net462\Common7\IDE\Extensions\TestPlatform\Extensions\TestImpact\ComComponents\x86\msdia140.dll.manifest" />
+    <file src="net48\Microsoft.Internal.Dia\arm64\msdia140.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\Extensions\TestImpact\ComComponents\arm64\msdia140.dll" />
+    <file src="net48\Microsoft.Internal.Dia\arm64\msdia140.dll.manifest" target="tools\net462\Common7\IDE\Extensions\TestPlatform\Extensions\TestImpact\ComComponents\arm64\msdia140.dll.manifest" />
     <file src="net48\Microsoft.Internal.Dia\x64\msdia140.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\Extensions\V1\TestImpact\ComComponents\x64\msdia140.dll" />
     <file src="net48\Microsoft.Internal.Dia\x64\msdia140.dll.manifest" target="tools\net462\Common7\IDE\Extensions\TestPlatform\Extensions\V1\TestImpact\ComComponents\x64\msdia140.dll.manifest" />
     <file src="net48\Microsoft.Internal.Dia\x86\msdia140.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\Extensions\V1\TestImpact\ComComponents\x86\msdia140.dll" />
     <file src="net48\Microsoft.Internal.Dia\x86\msdia140.dll.manifest" target="tools\net462\Common7\IDE\Extensions\TestPlatform\Extensions\V1\TestImpact\ComComponents\x86\msdia140.dll.manifest" />
+    <file src="net48\Microsoft.Internal.Dia\arm64\msdia140.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\Extensions\V1\TestImpact\ComComponents\arm64\msdia140.dll" />
+    <file src="net48\Microsoft.Internal.Dia\arm64\msdia140.dll.manifest" target="tools\net462\Common7\IDE\Extensions\TestPlatform\Extensions\V1\TestImpact\ComComponents\arm64\msdia140.dll.manifest" />
     <file src="net48\fr\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\fr\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" />
     <file src="net48\fr\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\fr\Microsoft.TestPlatform.CoreUtilities.resources.dll" />
     <file src="net48\fr\Microsoft.TestPlatform.CrossPlatEngine.resources.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\fr\Microsoft.TestPlatform.CrossPlatEngine.resources.dll" />
@@ -342,6 +346,8 @@
     <file src="net48\Microsoft.Internal.Dia\x64\msdia140.dll.manifest" target="tools\net462\Common7\IDE\Extensions\TestPlatform\x64\msdia140.dll.manifest" />
     <file src="net48\Microsoft.Internal.Dia\x86\msdia140.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\x86\msdia140.dll" />
     <file src="net48\Microsoft.Internal.Dia\x86\msdia140.dll.manifest" target="tools\net462\Common7\IDE\Extensions\TestPlatform\x86\msdia140.dll.manifest" />
+    <file src="net48\Microsoft.Internal.Dia\arm64\msdia140.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\arm64\msdia140.dll" />
+    <file src="net48\Microsoft.Internal.Dia\arm64\msdia140.dll.manifest" target="tools\net462\Common7\IDE\Extensions\TestPlatform\arm64\msdia140.dll.manifest" />
     <file src="net48\zh-Hans\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\zh-Hans\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" />
     <file src="net48\zh-Hans\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\zh-Hans\Microsoft.TestPlatform.CoreUtilities.resources.dll" />
     <file src="net48\zh-Hans\Microsoft.TestPlatform.CrossPlatEngine.resources.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\zh-Hans\Microsoft.TestPlatform.CrossPlatEngine.resources.dll" />

--- a/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.nuspec
+++ b/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.nuspec
@@ -346,7 +346,7 @@
     <file src="net48\Microsoft.Internal.Dia\x64\msdia140.dll.manifest" target="tools\net462\Common7\IDE\Extensions\TestPlatform\x64\msdia140.dll.manifest" />
     <file src="net48\Microsoft.Internal.Dia\x86\msdia140.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\x86\msdia140.dll" />
     <file src="net48\Microsoft.Internal.Dia\x86\msdia140.dll.manifest" target="tools\net462\Common7\IDE\Extensions\TestPlatform\x86\msdia140.dll.manifest" />
-    <file src="net48\Microsoft.Internal.Dia\arm64\msdia140.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\arm64\msdia140.dll" />
+    <!-- arm64\msdia140.dll is already included via the Microsoft.Internal.CodeCoverage wildcard above -->
     <file src="net48\Microsoft.Internal.Dia\arm64\msdia140.dll.manifest" target="tools\net462\Common7\IDE\Extensions\TestPlatform\arm64\msdia140.dll.manifest" />
     <file src="net48\zh-Hans\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\zh-Hans\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" />
     <file src="net48\zh-Hans\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="tools\net462\Common7\IDE\Extensions\TestPlatform\zh-Hans\Microsoft.TestPlatform.CoreUtilities.resources.dll" />

--- a/src/package/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI.csproj
+++ b/src/package/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI.csproj
@@ -205,6 +205,9 @@
       <VsixSourceItem Include="$(MsDiaFolder)x86\*">
         <VSIXSubPath>x86</VSIXSubPath>
       </VsixSourceItem>
+      <VsixSourceItem Include="$(MsDiaFolder)arm64\*">
+        <VSIXSubPath>arm64</VSIXSubPath>
+      </VsixSourceItem>
     </ItemGroup>
 
     <!-- Code Coverage -->


### PR DESCRIPTION
Adds ARM64 support for `msdia140.dll` across the test platform packaging, enabling ARM64 test hosts to use the DIA SDK for symbol resolution and crash dump analysis (#15327)

## Changes

| File | Change |
|------|--------|
| `eng/Versions.props` | Bump `TestPlatformMSDiaVersion` to `18.7.0-preview-1-11715-406` |
| `TestHost.csproj` | Add `DiaFilesArm64` item group + copy in `CopyDiaFiles` target |
| `TestHost.nuspec` | Add `arm64/msdia140.dll` to `lib/net8.0/arm64/` |
| `CLI.nuspec` | Add `arm64/msdia140.dll` + manifest to `TestHostNetFramework/arm64/` |

## Context

The `Microsoft.Internal.Dia` package version `18.7.0-preview-1-11715-406` now includes ARM64 binaries alongside existing x86 and x64. The test platform packaging only referenced x86 and x64 — this PR wires ARM64 through the build and nuspec layout.

## Validation

- ARM64 DLL confirmed present in the updated package (`tools/net451/arm64/msdia140.dll`)
- PDB resolves on the Microsoft public symbol server for all three architectures (x86, x64, arm64) via `dotnet-symbol`
- CLI.csproj already uses wildcard globs (`**/*`) for Dia file copy — no change needed there