### PR TITLE
Mirror experimental skills from dotnet/skills alongside dotnet-test

### DIFF
--- a/.github/workflows/mirror-dotnet-test-plugin.yml
+++ b/.github/workflows/mirror-dotnet-test-plugin.yml
@@ -21,12 +21,18 @@ jobs:
         with:
           repository: dotnet/skills
           path: dotnet-skills-clone
-          sparse-checkout: plugins/dotnet-test
+          sparse-checkout: |
+            plugins/dotnet-test
+            plugins/dotnet-experimental
 
       - name: Sync dotnet-test skills to .github
         run: |
           mkdir -p .github/skills
           cp -r dotnet-skills-clone/plugins/dotnet-test/skills/. .github/skills
+
+      - name: Sync dotnet-experimental skills to .github
+        run: |
+          cp -r dotnet-skills-clone/plugins/dotnet-experimental/skills/. .github/skills
 
       - name: Sync dotnet-test agents to .github
         run: |


### PR DESCRIPTION
Update the daily mirror workflow to also sparse-checkout and sync `dotnet-experimental` plugin skills from [dotnet/skills](https://github.com/dotnet/skills/tree/main/plugins/dotnet-experimental) into `.github/skills`.

This matches what was done manually in microsoft/testfx#7752 — the next daily mirror run will automatically bring in the experimental test analysis skills (assertion-quality, test-smell-detection, mock-usage-analysis, etc.).

Changes:
- Expanded `sparse-checkout` to include `plugins/dotnet-experimental`
- Added a step to copy experimental skills into `.github/skills`