### PR TITLE
Fix insertion pipeline to install .NET SDK from global.json

### DIFF
--- a/azure-pipelines-insertion.yml
+++ b/azure-pipelines-insertion.yml
@@ -88,8 +88,12 @@ extends:
               - task: PowerShell@2
                 displayName: 'Install .NET SDK from global.json'
                 inputs:
-                  filePath: eng/common/dotnet-install.ps1
-                  arguments: -runtime '' -version 'Latest'
+                  targetType: inline
+                  script: |
+                    $globalJson = Get-Content global.json | ConvertFrom-Json
+                    $version = $globalJson.tools.dotnet
+                    Write-Host "Installing .NET SDK version $version from global.json"
+                    & eng/common/dotnet-install.ps1 -version $version
 
               - script: dotnet tool install Microsoft.RoslynTools --prerelease --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json -g
                 displayName: 'Install roslyn-tools CLI'


### PR DESCRIPTION
The insertion pipeline was using `-version 'Latest'` which installs the latest stable public SDK (e.g. .NET 10), not the .NET 11 preview pinned in `global.json`.

This changes the step to read `tools.dotnet` from `global.json` and pass that specific version to `dotnet-install.ps1`, ensuring the correct .NET 11 preview SDK is installed.

Build: https://dnceng.visualstudio.com/internal/_build/results?buildId=2955568&view=results