### PR TITLE
[rel/18.7] Add dual-mode CI validation for nupkg counts and assembly binding redirects

### DIFF
--- a/eng/expected-nupkg-file-counts.json
+++ b/eng/expected-nupkg-file-counts.json
@@ -1,0 +1,15 @@
+{
+  "Microsoft.CodeCoverage": 76,
+  "Microsoft.NET.Test.Sdk": 26,
+  "Microsoft.TestPlatform": 550,
+  "Microsoft.TestPlatform.AdapterUtilities": 62,
+  "Microsoft.TestPlatform.Build": 21,
+  "Microsoft.TestPlatform.CLI": 485,
+  "Microsoft.TestPlatform.Extensions.TrxLogger": 35,
+  "Microsoft.TestPlatform.Internal.Uwp": 39,
+  "Microsoft.TestPlatform.ObjectModel": 93,
+  "Microsoft.TestPlatform.Portable": 611,
+  "Microsoft.TestPlatform.TestHost": 65,
+  "Microsoft.TestPlatform.TranslationLayer": 175,
+  "Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI": 390
+}

--- a/eng/verify-binding-redirects.ps1
+++ b/eng/verify-binding-redirects.ps1
@@ -1,0 +1,211 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$script:isCI = $env:TF_BUILD -eq 'true' -or $env:CI -eq 'true'
+
+# Verifies that binding redirects in source app.config files match the actual
+# assembly versions of the DLLs shipped in the extracted nupkg packages.
+#
+# In CI: validates and fails with instructions to run locally.
+# Locally: auto-fixes the source app.config files with the correct versions.
+
+# Each source app.config maps to a specific exe that ships in the packages.
+$script:AppConfigs = @(
+    @{ Config = "src/vstest.console/app.config";  ExeName = "vstest.console.exe" }
+    @{ Config = "src/testhost.x86/app.config";    ExeName = "testhost.x86.exe" }
+    @{ Config = "src/datacollector/app.config";    ExeName = "datacollector.exe" }
+)
+
+function Find-ExeInPackages {
+    param(
+        [string] $ExeName,
+        [string[]] $PackageDirs
+    )
+
+    foreach ($dir in $PackageDirs) {
+        $found = Get-ChildItem $dir -Recurse -Filter $ExeName -File -ErrorAction SilentlyContinue
+        if ($found) {
+            # Prefer the one closest to a net462 or root layout (not nested in TestHostNetFramework).
+            $preferred = $found | Where-Object { $_.FullName -notlike "*TestHostNetFramework*" } | Select-Object -First 1
+            if ($preferred) { return $preferred.DirectoryName }
+            return $found[0].DirectoryName
+        }
+    }
+
+    return $null
+}
+
+function Get-ManagedAssemblyVersion {
+    param([string] $DllPath)
+
+    try {
+        return [System.Reflection.AssemblyName]::GetAssemblyName($DllPath).Version.ToString()
+    }
+    catch {
+        return $null
+    }
+}
+
+function Verify-BindingRedirects {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$PackageDirs,
+
+        [Parameter(Mandatory)]
+        [ValidateSet("Debug", "Release")]
+        [string]$Configuration
+    )
+
+    $repoRoot = Resolve-Path "$PSScriptRoot/.."
+    $errors = @()
+    $configsToFix = @{}
+
+    foreach ($entry in $script:AppConfigs) {
+        $configPath = Join-Path $repoRoot $entry.Config
+        if (-not (Test-Path $configPath)) {
+            Write-Host "Skipping $($entry.ExeName): config '$configPath' not found."
+            continue
+        }
+
+        $deployDir = Find-ExeInPackages -ExeName $entry.ExeName -PackageDirs $PackageDirs
+        if (-not $deployDir) {
+            Write-Host "Skipping $($entry.ExeName): not found in any extracted package."
+            continue
+        }
+
+        Write-Host "Checking assembly redirects for $($entry.ExeName) (from '$deployDir')..."
+
+        [xml]$xml = Get-Content $configPath -Raw
+        $nsMgr = New-Object System.Xml.XmlNamespaceManager($xml.NameTable)
+        $nsMgr.AddNamespace("asm", "urn:schemas-microsoft-com:asm.v1")
+
+        # Build search directories from probing paths in the config.
+        $searchDirs = @($deployDir)
+        $probingNodes = $xml.SelectNodes("//asm:probing", $nsMgr)
+        foreach ($probing in $probingNodes) {
+            $privatePath = $probing.GetAttribute("privatePath")
+            if ($privatePath) {
+                foreach ($subPath in $privatePath -split ";") {
+                    $probingDir = Join-Path $deployDir $subPath.Trim()
+                    if (Test-Path $probingDir) { $searchDirs += $probingDir }
+                }
+            }
+        }
+
+        $dependentAssemblies = $xml.SelectNodes("//asm:dependentAssembly", $nsMgr)
+        foreach ($dep in $dependentAssemblies) {
+            $identity = $dep.SelectSingleNode("asm:assemblyIdentity", $nsMgr)
+            $redirect = $dep.SelectSingleNode("asm:bindingRedirect", $nsMgr)
+            if (-not $identity -or -not $redirect) { continue }
+
+            $assemblyName = $identity.GetAttribute("name")
+            $currentNewVersion = $redirect.GetAttribute("newVersion")
+            $currentOldVersion = $redirect.GetAttribute("oldVersion")
+
+            # Look for the assembly DLL in each search directory.
+            $dllPath = $null
+            foreach ($dir in $searchDirs) {
+                $candidate = Join-Path $dir "$assemblyName.dll"
+                if (Test-Path $candidate) { $dllPath = $candidate; break }
+            }
+
+            if (-not $dllPath) {
+                Write-Host "  $assemblyName - not found in package layout, skipping."
+                continue
+            }
+
+            $actualVersion = Get-ManagedAssemblyVersion -DllPath $dllPath
+            if (-not $actualVersion) {
+                Write-Host "  $assemblyName - could not read version (native or corrupt?), skipping."
+                continue
+            }
+
+            if ($currentNewVersion -eq $actualVersion) {
+                Write-Host "  $assemblyName - OK ($actualVersion)"
+                continue
+            }
+
+            # newVersion needs updating, and the upper bound of oldVersion range too.
+            $newOldVersion = $currentOldVersion
+            if ($currentOldVersion -match '^(.*)-(.*)$') {
+                $newOldVersion = "$($Matches[1])-$actualVersion"
+            }
+
+            $errors += "$($entry.ExeName): $assemblyName redirect newVersion is '$currentNewVersion' but actual assembly version is '$actualVersion'"
+
+            if (-not $configsToFix.ContainsKey($configPath)) {
+                $configsToFix[$configPath] = @()
+            }
+
+            $configsToFix[$configPath] += @{
+                AssemblyName  = $assemblyName
+                OldNewVersion = $currentNewVersion
+                NewNewVersion = $actualVersion
+                OldOldVersion = $currentOldVersion
+                NewOldVersion = $newOldVersion
+            }
+
+            if ($script:isCI) {
+                Write-Host "  $assemblyName - MISMATCH: expected $actualVersion, found $currentNewVersion" -ForegroundColor Red
+            }
+            else {
+                Write-Host "  $assemblyName - FIXING: $currentNewVersion -> $actualVersion (oldVersion: $currentOldVersion -> $newOldVersion)" -ForegroundColor Yellow
+            }
+        }
+    }
+
+    # Apply fixes using XML DOM with whitespace preservation.
+    if (-not $script:isCI) {
+        foreach ($configPath in $configsToFix.Keys) {
+            $xmlDoc = New-Object System.Xml.XmlDocument
+            $xmlDoc.PreserveWhitespace = $true
+            $xmlDoc.Load($configPath)
+
+            $nsMgr = New-Object System.Xml.XmlNamespaceManager($xmlDoc.NameTable)
+            $nsMgr.AddNamespace("asm", "urn:schemas-microsoft-com:asm.v1")
+
+            foreach ($fix in $configsToFix[$configPath]) {
+                $nodes = $xmlDoc.SelectNodes("//asm:dependentAssembly[asm:assemblyIdentity[@name='$($fix.AssemblyName)']]/asm:bindingRedirect", $nsMgr)
+                $applied = $false
+                foreach ($node in $nodes) {
+                    if ($node.GetAttribute("newVersion") -eq $fix.OldNewVersion) {
+                        $node.SetAttribute("oldVersion", $fix.NewOldVersion)
+                        $node.SetAttribute("newVersion", $fix.NewNewVersion)
+                        $applied = $true
+                    }
+                }
+
+                if (-not $applied) {
+                    Write-Error "Failed to apply binding redirect fix for '$($fix.AssemblyName)' in '$configPath'. The expected redirect node was not found."
+                }
+            }
+
+            # Preserve the original BOM if present.
+            $bom = [System.IO.File]::ReadAllBytes($configPath)
+            $hasBom = $bom.Length -ge 3 -and $bom[0] -eq 0xEF -and $bom[1] -eq 0xBB -and $bom[2] -eq 0xBF
+            $encoding = if ($hasBom) { New-Object System.Text.UTF8Encoding($true) } else { New-Object System.Text.UTF8Encoding($false) }
+            $writer = New-Object System.IO.StreamWriter($configPath, $false, $encoding)
+            $xmlDoc.Save($writer)
+            $writer.Dispose()
+            Write-Host "Updated '$configPath'." -ForegroundColor Green
+        }
+    }
+
+    if ($errors) {
+        if ($script:isCI) {
+            $message = "Assembly binding redirect mismatches detected:`n"
+            $message += ($errors -join "`n")
+            $message += "`n`nTo fix this, run the following command locally after building and packing:`n"
+            $message += "  .\build.cmd -c $Configuration`n"
+            $message += "This will rebuild, pack, and auto-update the app.config files with the correct versions.`n"
+            $message += "Then commit the updated app.config files."
+            Write-Error $message
+        }
+        else {
+            Write-Host "`nFixed $($errors.Count) binding redirect(s). Please commit the updated app.config files." -ForegroundColor Green
+        }
+    }
+    else {
+        Write-Host "All binding redirects match their DLL versions."
+    }
+}

--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -14,22 +14,18 @@ Param(
 $ErrorActionPreference = 'Stop'
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 
+$isCI = $env:TF_BUILD -eq 'true' -or $env:CI -eq 'true'
+$expectedCountsFile = Join-Path $PSScriptRoot "expected-nupkg-file-counts.json"
+
+# Import binding redirect verification.
+. "$PSScriptRoot/verify-binding-redirects.ps1"
+
 function Verify-Nuget-Packages {
     Write-Host "Starting Verify-Nuget-Packages."
-    $expectedNumOfFiles = @{
-        "Microsoft.CodeCoverage"                      = 76
-        "Microsoft.NET.Test.Sdk"                      = 26
-        "Microsoft.TestPlatform"                      = 550
-        "Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI" = 390
-        "Microsoft.TestPlatform.Build"                = 21
-        "Microsoft.TestPlatform.CLI"                  = 485
-        "Microsoft.TestPlatform.Extensions.TrxLogger" = 35
-        "Microsoft.TestPlatform.ObjectModel"          = 93
-        "Microsoft.TestPlatform.AdapterUtilities"     = 62
-        "Microsoft.TestPlatform.Portable"             = 611
-        "Microsoft.TestPlatform.TestHost"             = 65
-        "Microsoft.TestPlatform.TranslationLayer"     = 175
-        "Microsoft.TestPlatform.Internal.Uwp"         = 39
+    $expectedNumOfFiles = @{}
+    $json = Get-Content $expectedCountsFile -Raw | ConvertFrom-Json
+    foreach ($property in $json.PSObject.Properties) {
+        $expectedNumOfFiles[$property.Name] = [int]$property.Value
     }
 
     $packageDirectory = Resolve-Path "$PSScriptRoot/../artifacts/packages/$configuration"
@@ -91,6 +87,8 @@ function Verify-Nuget-Packages {
 
     Write-Host "Verify NuGet packages files."
     $errors = @()
+    $actualCounts = @{}
+    $hasCountMismatch = $false
     foreach ($unzipNugetPackageDir in $unzipNugetPackageDirs) {
         # Directory is named after the package file (e.g. "Microsoft.TestPlatform.18.6.0-dev.nupkg"),
         # so strip the extension to get the base name for key derivation.
@@ -99,12 +97,16 @@ function Verify-Nuget-Packages {
         Write-Host "Verifying package '$packageBaseName'."
 
         $actualNumOfFiles = (Get-ChildItem -Recurse -File -Path $unzipNugetPackageDir | Where-Object { $_.Name -ne '.signature.p7s' }).Count
+        $actualCounts[$packageKey] = $actualNumOfFiles
+
         if (-not $expectedNumOfFiles.ContainsKey($packageKey)) {
-            $errors += "Package '$packageKey' is not present in file expectedNumOfFiles table. Is that package known?"
+            $errors += "Package '$packageKey' is not present in '$expectedCountsFile'. Add it to the expected counts file."
+            $hasCountMismatch = $true
             continue
         }
         if ($expectedNumOfFiles[$packageKey] -ne $actualNumOfFiles) {
             $errors += "Number of files are not equal for '$packageBaseName', expected: $($expectedNumOfFiles[$packageKey]) actual: $actualNumOfFiles"
+            $hasCountMismatch = $true
         }
 
         if ($packageKey -eq "Microsoft.TestPlatform") {
@@ -112,7 +114,46 @@ function Verify-Nuget-Packages {
         }
     }
 
-    if ($errors) {
+    if ($hasCountMismatch) {
+        if ($isCI) {
+            $errors += ""
+            $errors += "To fix this, run the following command locally after building and packing:"
+            $errors += "  .\build.cmd -c $configuration"
+            $errors += "This will rebuild, pack, and auto-update '$expectedCountsFile' with the correct values."
+            $errors += "Then commit the updated file."
+            Write-Error "There are file count mismatches:`n$($errors -join "`n")"
+        }
+        else {
+            Write-Host ""
+            Write-Host "File count mismatches detected. Updating '$expectedCountsFile'." -ForegroundColor Yellow
+            foreach ($err in $errors) {
+                Write-Host "  $err" -ForegroundColor Yellow
+            }
+
+            # Build the updated counts: start from expected, overlay with actual
+            $updatedCounts = [ordered]@{}
+            foreach ($key in ($expectedNumOfFiles.Keys + $actualCounts.Keys) | Sort-Object -Unique) {
+                if ($actualCounts.ContainsKey($key)) {
+                    $updatedCounts[$key] = $actualCounts[$key]
+                }
+                else {
+                    $updatedCounts[$key] = $expectedNumOfFiles[$key]
+                }
+            }
+
+            # Write clean JSON (2-space indent, no BOM, no trailing spaces).
+            $lines = @("{")
+            $keys = @($updatedCounts.Keys)
+            for ($i = 0; $i -lt $keys.Count; $i++) {
+                $comma = if ($i -lt $keys.Count - 1) { "," } else { "" }
+                $lines += "  ""$($keys[$i])"": $($updatedCounts[$keys[$i]])$comma"
+            }
+            $lines += "}"
+            [System.IO.File]::WriteAllText($expectedCountsFile, ($lines -join "`n") + "`n", [System.Text.UTF8Encoding]::new($false))
+            Write-Host "Updated '$expectedCountsFile'. Please commit the changes." -ForegroundColor Green
+        }
+    }
+    elseif ($errors) {
         Write-Error "There are $($errors.Count) errors:`n$($errors -join "`n")"
     }
 
@@ -316,3 +357,6 @@ Start-sleep -Seconds 10
 # skipped, it is hard to find the right dumpbin.exe and corflags tools on server
 # Verify-NugetPackageExe -configuration $configuration -UnzipNugetPackages $unzipNugetPackages
 Verify-NugetPackageVersion -configuration $configuration -UnzipNugetPackages $unzipNugetPackages
+
+Write-Host "`nVerifying binding redirects..."
+Verify-BindingRedirects -PackageDirs $unzipNugetPackages -Configuration $configuration


### PR DESCRIPTION
Backport of #15691 to rel/18.7.

Adds dual-mode CI validation scripts:
- **CI mode**: Validates nupkg file counts and binding redirects, fails with instructions to fix locally
- **Local mode**: Auto-fixes \xpected-nupkg-file-counts.json\ and \pp.config\ binding redirects

Files changed:
- \ng/expected-nupkg-file-counts.json\ (new) - expected nupkg file counts for rel/18.7
- \ng/verify-binding-redirects.ps1\ (new) - binding redirect validation against extracted packages
- \ng/verify-nupkgs.ps1\ (modified) - reads counts from JSON, dual-mode, calls binding redirect check