### PR TITLE
Update System.Memory from 4.5.5 to 4.6.3

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -71,7 +71,7 @@
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <SystemCollectionsImmutableVersion>9.0.11</SystemCollectionsImmutableVersion>
-    <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
+    <SystemMemoryVersion>4.6.3</SystemMemoryVersion>
     <SystemReflectionMetadataVersion>8.0.0</SystemReflectionMetadataVersion>
     <TestPlatformExternalsVersion>18.0.0-preview-1-10911-061</TestPlatformExternalsVersion>
     <MicrosoftInternalTestPlatformExtensions>18.3.11611.365</MicrosoftInternalTestPlatformExtensions>


### PR DESCRIPTION
Update System.Memory to the latest version (4.6.3).

The assembly version remains 4.0.1.2, so no binding redirect changes are needed.

Build and smoke tests verified locally.