### PR TITLE
Forward-port insertion pipeline and System.Memory bump from rel/18.7

### DIFF
--- a/azure-pipelines-insertion.yml
+++ b/azure-pipelines-insertion.yml
@@ -85,14 +85,15 @@ extends:
 
               steps:
 
-              - task: UseDotNet@2
-                displayName: 'Install .NET SDK'
+              - task: PowerShell@2
+                displayName: 'Install .NET SDK from global.json'
                 inputs:
-                  includePreviewVersions: true
-                  useGlobalJson: true
-
-              - script: dotnet tool install Microsoft.RoslynTools --prerelease --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json -g
-                displayName: 'Install roslyn-tools CLI'
+                  targetType: inline
+                  script: |
+                    $globalJson = Get-Content global.json | ConvertFrom-Json
+                    $version = $globalJson.tools.dotnet
+                    Write-Host "Installing .NET SDK version $version from global.json"
+                    & eng/common/dotnet-install.ps1 -version $version -runtime ''
 
               - task: AzureCLI@2
                 displayName: 'Run VS Insertion'
@@ -101,6 +102,9 @@ extends:
                   scriptType: pscore
                   scriptLocation: inlineScript
                   inlineScript: |
+                    # Install Roslyn insertion tools from the dnceng feed, --tools-install as workaround for having to reset the process to add path to dotnet tools
+                    dotnet tool install Microsoft.RoslynTools --prerelease --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json --tool-path . 
+                    
                     # Acquire dnceng AzDO token via WIF service connection
                     $dncengToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
                     if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($dncengToken)) {
@@ -120,10 +124,10 @@ extends:
                       "--component-azdo-uri", "$(ComponentAzdoUri)"
                       "--component-project", "$(ComponentProjectName)"
                       "--build-drop-path", "$(DropPath)"
-                      "--no-insert-corext-packages"
-                      "--no-insert-devdiv-source-files"
+                      "--insert-corext-packages", "false"
+                      "--insert-devdiv-source-files", "false"
                       "--title-prefix", "$(OptionalTitlePrefix)"
-                      "--reviewer-guid", $team
+                      "--reviewer-guid", $team 
                       "--dnceng-azdo-token", $dncengToken
                       "--devdiv-azdo-token", "$(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)"
                       "--ci"
@@ -147,12 +151,9 @@ extends:
                       $insertArgs += "$(CherryPick)"
                     }
 
-                    & roslyn-tools @insertArgs
+                    "Running: ./roslyn-tools.exe $($insertArgs -join ' ')"
+                    ./roslyn-tools.exe @insertArgs
                     if ($LASTEXITCODE -ne 0) {
                       exit $LASTEXITCODE
                     }
 
-              # Avoid warning from subsequent steps.
-              - powershell: |
-                  mkdir artifacts
-                displayName: 'Create artifacts dir'

--- a/azure-pipelines-insertion.yml
+++ b/azure-pipelines-insertion.yml
@@ -90,8 +90,8 @@ extends:
                 inputs:
                   targetType: inline
                   script: |
-                    $globalJson = Get-Content global.json | ConvertFrom-Json
-                    $version = $globalJson.tools.dotnet
+                    $globalJson = Get-Content -Raw global.json | ConvertFrom-Json
+                    $version = $globalJson.sdk.version
                     Write-Host "Installing .NET SDK version $version from global.json"
                     & eng/common/dotnet-install.ps1 -version $version -runtime ''
 
@@ -102,9 +102,10 @@ extends:
                   scriptType: pscore
                   scriptLocation: inlineScript
                   inlineScript: |
-                    # Install Roslyn insertion tools from the dnceng feed, --tools-install as workaround for having to reset the process to add path to dotnet tools
-                    dotnet tool install Microsoft.RoslynTools --prerelease --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json --tool-path . 
-                    
+                    # Install Roslyn insertion tools from the dnceng feed, using --tool-path as a workaround to avoid resetting the process to pick up dotnet tool path changes
+                    $dotnet = "$(Build.SourcesDirectory)\.dotnet\dotnet.exe"
+                    & $dotnet tool install Microsoft.RoslynTools --prerelease --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json --tool-path .
+
                     # Acquire dnceng AzDO token via WIF service connection
                     $dncengToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
                     if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($dncengToken)) {
@@ -127,7 +128,7 @@ extends:
                       "--insert-corext-packages", "false"
                       "--insert-devdiv-source-files", "false"
                       "--title-prefix", "$(OptionalTitlePrefix)"
-                      "--reviewer-guid", $team 
+                      "--reviewer-guid", $team
                       "--dnceng-azdo-token", $dncengToken
                       "--devdiv-azdo-token", "$(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)"
                       "--ci"

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -70,7 +70,7 @@
     <_MicrosoftVSSDKBuildToolsVersion_>17.14.2119</_MicrosoftVSSDKBuildToolsVersion_>
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>
     <NewtonsoftJsonVersion>13.0.4</NewtonsoftJsonVersion>
-    <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
+    <SystemMemoryVersion>4.6.3</SystemMemoryVersion>
     <SystemReflectionMetadataVersion>8.0.0</SystemReflectionMetadataVersion>
     <TestPlatformExternalsVersion>18.2.0-preview-1-11429-120</TestPlatformExternalsVersion>
     <MicrosoftInternalTestPlatformExtensions>18.3.11611.365</MicrosoftInternalTestPlatformExtensions>


### PR DESCRIPTION
Forward port from rel/18.7:

- `azure-pipelines-insertion.yml` — rel/18.7 got several rounds of fixes (#15698, #15700-#15708) to make VS insertion work. Main still has the pre-fix version, next rel/ branched from main would be broken again.
- Bump System.Memory 4.5.5 → 4.6.3 (#15706).