### PR TITLE
Add support for filtering uncategorized tests with TestCategory=None

### DIFF
--- a/src/Microsoft.TestPlatform.Filter.Source/Condition.cs
+++ b/src/Microsoft.TestPlatform.Filter.Source/Condition.cs
@@ -71,6 +71,11 @@ internal sealed class Condition
     /// </summary>
     public const Operation DefaultOperation = Operation.Contains;
 
+    /// <summary>
+    /// Reserved filter value that matches tests with no value for a given property (uncategorized).
+    /// </summary>
+    internal const string NoneFilterValue = "None";
+
 #if !IS_VSTEST_REPO
     private const string TestCaseFilterFormatException = "Incorrect format for TestCaseFilter {0}. Specify the correct format and try again. Note that the incorrect format can lead to no test getting executed.";
 
@@ -103,10 +108,9 @@ internal sealed class Condition
 
     private bool EvaluateEqualOperation(string[]? multiValue)
     {
-        // Special case: empty string filter value matches null/empty property (uncategorized tests).
-        // For non-null arrays, fall through to the normal equality check so that arrays containing
-        // empty-string elements (e.g. from [TestCategory("")]) also match, consistent with FastFilter.
-        if (Value.Length == 0 && multiValue is null or { Length: 0 })
+        // Reserved keyword: "None" matches tests with no value for this property (uncategorized).
+        if (multiValue is null or { Length: 0 }
+            && string.Equals(Value, NoneFilterValue, StringComparison.OrdinalIgnoreCase))
         {
             return true;
         }
@@ -128,15 +132,6 @@ internal sealed class Condition
 
     private bool EvaluateContainsOperation(string[]? multiValue)
     {
-        // Special case: empty string filter value matches null/empty property (uncategorized tests).
-        // We must not fall through to the normal Contains check because every string "contains" the
-        // empty string (IndexOf("") == 0), which would match ALL tests rather than just uncategorized ones.
-        // Also treat arrays where all elements are empty as uncategorized.
-        if (Value.Length == 0)
-        {
-            return multiValue is null || Array.TrueForAll(multiValue, static v => v.Length == 0);
-        }
-
         if (multiValue != null)
         {
             foreach (string propertyValue in multiValue)
@@ -201,32 +196,23 @@ internal sealed class Condition
             return new Condition(DefaultPropertyName, DefaultOperation, FilterHelper.Unescape(conditionString!.Trim()));
         }
 
-        if (parts.Length == 2)
-        {
-            // Two parts means property name and operator with no value (e.g. "TestCategory=").
-            // Treat the value as empty string to support filtering for uncategorized tests.
-            parts = new[] { parts[0], parts[1], string.Empty };
-        }
-
         if (parts.Length != 3)
         {
             ThrownFormatExceptionForInvalidCondition(conditionString);
         }
 
-        // Property name (parts[0]) and operator (parts[1]) must not be empty.
-        // parts[2] (value) can be empty to support filtering for uncategorized tests.
-#if IS_VSTEST_REPO
-        if (parts[0].IsNullOrWhiteSpace() || parts[1].IsNullOrWhiteSpace())
-#else
-        if (string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
-#endif
+        for (int index = 0; index < 3; index++)
         {
-            ThrownFormatExceptionForInvalidCondition(conditionString);
+#if IS_VSTEST_REPO
+            if (parts[index].IsNullOrWhiteSpace())
+#else
+            if (string.IsNullOrWhiteSpace(parts[index]))
+#endif
+            {
+                ThrownFormatExceptionForInvalidCondition(conditionString);
+            }
+            parts[index] = parts[index].Trim();
         }
-
-        parts[0] = parts[0].Trim();
-        parts[1] = parts[1].Trim();
-        parts[2] = parts[2].Trim();
 
         Operation operation = GetOperator(parts[1]);
         Condition condition = new(parts[0], operation, FilterHelper.Unescape(parts[2]));

--- a/src/Microsoft.TestPlatform.Filter.Source/Condition.cs
+++ b/src/Microsoft.TestPlatform.Filter.Source/Condition.cs
@@ -104,9 +104,11 @@ internal sealed class Condition
     private bool EvaluateEqualOperation(string[]? multiValue)
     {
         // Special case: empty string filter value matches null/empty property (uncategorized tests).
-        if (Value.Length == 0)
+        // For non-null arrays, fall through to the normal equality check so that arrays containing
+        // empty-string elements (e.g. from [TestCategory("")]) also match, consistent with FastFilter.
+        if (Value.Length == 0 && multiValue is null or { Length: 0 })
         {
-            return multiValue is null or { Length: 0 };
+            return true;
         }
 
         // if any value in multi-valued property matches 'this.Value', for Equal to evaluate true.
@@ -127,9 +129,12 @@ internal sealed class Condition
     private bool EvaluateContainsOperation(string[]? multiValue)
     {
         // Special case: empty string filter value matches null/empty property (uncategorized tests).
+        // We must not fall through to the normal Contains check because every string "contains" the
+        // empty string (IndexOf("") == 0), which would match ALL tests rather than just uncategorized ones.
+        // Also treat arrays where all elements are empty as uncategorized.
         if (Value.Length == 0)
         {
-            return multiValue is null or { Length: 0 };
+            return multiValue is null || Array.TrueForAll(multiValue, static v => v.Length == 0);
         }
 
         if (multiValue != null)

--- a/src/Microsoft.TestPlatform.Filter.Source/Condition.cs
+++ b/src/Microsoft.TestPlatform.Filter.Source/Condition.cs
@@ -103,6 +103,12 @@ internal sealed class Condition
 
     private bool EvaluateEqualOperation(string[]? multiValue)
     {
+        // Special case: empty string filter value matches null/empty property (uncategorized tests).
+        if (Value.Length == 0)
+        {
+            return multiValue is null or { Length: 0 };
+        }
+
         // if any value in multi-valued property matches 'this.Value', for Equal to evaluate true.
         if (multiValue != null)
         {
@@ -120,6 +126,12 @@ internal sealed class Condition
 
     private bool EvaluateContainsOperation(string[]? multiValue)
     {
+        // Special case: empty string filter value matches null/empty property (uncategorized tests).
+        if (Value.Length == 0)
+        {
+            return multiValue is null or { Length: 0 };
+        }
+
         if (multiValue != null)
         {
             foreach (string propertyValue in multiValue)
@@ -184,23 +196,32 @@ internal sealed class Condition
             return new Condition(DefaultPropertyName, DefaultOperation, FilterHelper.Unescape(conditionString!.Trim()));
         }
 
+        if (parts.Length == 2)
+        {
+            // Two parts means property name and operator with no value (e.g. "TestCategory=").
+            // Treat the value as empty string to support filtering for uncategorized tests.
+            parts = new[] { parts[0], parts[1], string.Empty };
+        }
+
         if (parts.Length != 3)
         {
             ThrownFormatExceptionForInvalidCondition(conditionString);
         }
 
-        for (int index = 0; index < 3; index++)
-        {
+        // Property name (parts[0]) and operator (parts[1]) must not be empty.
+        // parts[2] (value) can be empty to support filtering for uncategorized tests.
 #if IS_VSTEST_REPO
-            if (parts[index].IsNullOrWhiteSpace())
+        if (parts[0].IsNullOrWhiteSpace() || parts[1].IsNullOrWhiteSpace())
 #else
-            if (string.IsNullOrWhiteSpace(parts[index]))
+        if (string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
 #endif
-            {
-                ThrownFormatExceptionForInvalidCondition(conditionString);
-            }
-            parts[index] = parts[index].Trim();
+        {
+            ThrownFormatExceptionForInvalidCondition(conditionString);
         }
+
+        parts[0] = parts[0].Trim();
+        parts[1] = parts[1].Trim();
+        parts[2] = parts[2].Trim();
 
         Operation operation = GetOperator(parts[1]);
         Condition condition = new(parts[0], operation, FilterHelper.Unescape(parts[2]));

--- a/src/Microsoft.TestPlatform.Filter.Source/FastFilter.cs
+++ b/src/Microsoft.TestPlatform.Filter.Source/FastFilter.cs
@@ -82,9 +82,18 @@ internal sealed class FastFilter
         bool matched = false;
         foreach (var name in FilterProperties.Keys)
         {
-            // If there is no value corresponding to given name, treat it as unmatched.
+            // Special case: if filter contains empty string, check if property is null/empty (uncategorized).
+            bool hasEmptyStringFilter = FilterProperties[name].Contains(string.Empty);
+
+            // If there is no value corresponding to given name, treat it as unmatched unless filtering for empty string.
             if (!TryGetPropertyValue(name, propertyValueProvider, out var singleValue, out var multiValues))
             {
+                if (hasEmptyStringFilter)
+                {
+                    matched = true;
+                    break;
+                }
+
                 continue;
             }
 
@@ -93,10 +102,15 @@ internal sealed class FastFilter
                 var value = PropertyValueRegex == null ? singleValue : ApplyRegex(singleValue);
                 matched = value != null && FilterProperties[name].Contains(value);
             }
-            else
+            else if (multiValues is { Length: > 0 })
             {
                 var values = PropertyValueRegex == null ? multiValues : multiValues?.Select(value => ApplyRegex(value));
                 matched = values?.Any(result => result != null && FilterProperties[name].Contains(result)) == true;
+            }
+            else if (hasEmptyStringFilter)
+            {
+                // Empty array matches empty string filter.
+                matched = true;
             }
 
             if (matched)

--- a/src/Microsoft.TestPlatform.Filter.Source/FastFilter.cs
+++ b/src/Microsoft.TestPlatform.Filter.Source/FastFilter.cs
@@ -82,13 +82,13 @@ internal sealed class FastFilter
         bool matched = false;
         foreach (var name in FilterProperties.Keys)
         {
-            // Special case: if filter contains empty string, check if property is null/empty (uncategorized).
-            bool hasEmptyStringFilter = FilterProperties[name].Contains(string.Empty);
+            // Reserved keyword: "None" matches tests with no value for this property (uncategorized).
+            bool hasNoneFilter = FilterProperties[name].Contains(Condition.NoneFilterValue);
 
-            // If there is no value corresponding to given name, treat it as unmatched unless filtering for empty string.
+            // If there is no value corresponding to given name, treat it as unmatched unless filtering for "None".
             if (!TryGetPropertyValue(name, propertyValueProvider, out var singleValue, out var multiValues))
             {
-                if (hasEmptyStringFilter)
+                if (hasNoneFilter)
                 {
                     matched = true;
                     break;
@@ -107,9 +107,9 @@ internal sealed class FastFilter
                 var values = PropertyValueRegex == null ? multiValues : multiValues?.Select(value => ApplyRegex(value));
                 matched = values?.Any(result => result != null && FilterProperties[name].Contains(result)) == true;
             }
-            else if (hasEmptyStringFilter)
+            else if (hasNoneFilter)
             {
-                // Empty array matches empty string filter.
+                // Empty array matches "None" filter (uncategorized).
                 matched = true;
             }
 

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TestCaseFilterTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TestCaseFilterTests.cs
@@ -178,4 +178,43 @@ public class TestCaseFilterTests : AcceptanceTestBase
         ValidateTestsNotDiscovered(listOfNotDiscoveredTests);
     }
 
+    [TestMethod]
+    [NetFullTargetFrameworkDataSourceAttribute(inIsolation: true, inProcess: true)]
+    [NetCoreTargetFrameworkDataSource]
+    public void RunSelectedTestsWithEmptyTestCategoryFilterMatchesUncategorizedTests(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var arguments = PrepareArguments(
+            GetSampleTestAssembly(),
+            GetTestAdapterPath(),
+            string.Empty, FrameworkArgValue,
+            runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
+        // Empty TestCategory value should match tests without any TestCategory attribute.
+        // In SimpleTestProject: PassingTest (no category) and SkippingTest (no category, ignored).
+        // FailingTest has TestCategory("CategoryA") and should NOT be matched.
+        arguments = string.Concat(arguments, " /TestCaseFilter:\"TestCategory=\"");
+        InvokeVsTest(arguments);
+        ValidateSummaryStatus(1, 0, 1);
+    }
+
+    [TestMethod]
+    [NetFullTargetFrameworkDataSourceAttribute(inIsolation: true, inProcess: true)]
+    [NetCoreTargetFrameworkDataSource]
+    public void RunSelectedTestsWithEmptyTestCategoryNotEqualFilterMatchesCategorizedTests(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var arguments = PrepareArguments(
+            GetSampleTestAssembly(),
+            GetTestAdapterPath(),
+            string.Empty, FrameworkArgValue,
+            runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
+        // NotEqual to empty TestCategory should match tests WITH categories.
+        // In SimpleTestProject: only FailingTest has TestCategory("CategoryA").
+        arguments = string.Concat(arguments, " /TestCaseFilter:\"TestCategory!=\"");
+        InvokeVsTest(arguments);
+        ValidateSummaryStatus(0, 1, 0);
+    }
+
 }

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TestCaseFilterTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TestCaseFilterTests.cs
@@ -181,7 +181,7 @@ public class TestCaseFilterTests : AcceptanceTestBase
     [TestMethod]
     [NetFullTargetFrameworkDataSourceAttribute(inIsolation: true, inProcess: true)]
     [NetCoreTargetFrameworkDataSource]
-    public void RunSelectedTestsWithEmptyTestCategoryFilterMatchesUncategorizedTests(RunnerInfo runnerInfo)
+    public void RunSelectedTestsWithNoneTestCategoryFilterMatchesUncategorizedTests(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
@@ -190,10 +190,10 @@ public class TestCaseFilterTests : AcceptanceTestBase
             GetTestAdapterPath(),
             string.Empty, FrameworkArgValue,
             runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
-        // Empty TestCategory value should match tests without any TestCategory attribute.
+        // "None" is a reserved keyword that matches tests without any TestCategory attribute.
         // In SimpleTestProject: PassingTest (no category) and SkippingTest (no category, ignored).
         // FailingTest has TestCategory("CategoryA") and should NOT be matched.
-        arguments = string.Concat(arguments, " /TestCaseFilter:\"TestCategory=\"");
+        arguments = string.Concat(arguments, " /TestCaseFilter:\"TestCategory=None\"");
         InvokeVsTest(arguments);
         ValidateSummaryStatus(1, 0, 1);
     }
@@ -201,7 +201,7 @@ public class TestCaseFilterTests : AcceptanceTestBase
     [TestMethod]
     [NetFullTargetFrameworkDataSourceAttribute(inIsolation: true, inProcess: true)]
     [NetCoreTargetFrameworkDataSource]
-    public void RunSelectedTestsWithEmptyTestCategoryNotEqualFilterMatchesCategorizedTests(RunnerInfo runnerInfo)
+    public void RunSelectedTestsWithNoneTestCategoryNotEqualFilterMatchesCategorizedTests(RunnerInfo runnerInfo)
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
@@ -210,9 +210,9 @@ public class TestCaseFilterTests : AcceptanceTestBase
             GetTestAdapterPath(),
             string.Empty, FrameworkArgValue,
             runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
-        // NotEqual to empty TestCategory should match tests WITH categories.
+        // NotEqual to "None" should match tests WITH categories.
         // In SimpleTestProject: only FailingTest has TestCategory("CategoryA").
-        arguments = string.Concat(arguments, " /TestCaseFilter:\"TestCategory!=\"");
+        arguments = string.Concat(arguments, " /TestCaseFilter:\"TestCategory!=None\"");
         InvokeVsTest(arguments);
         ValidateSummaryStatus(0, 1, 0);
     }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/ConditionTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/ConditionTests.cs
@@ -331,5 +331,38 @@ public class ConditionTests
         Assert.IsFalse(condition.Evaluate(propertyName => null));
     }
 
+    [TestMethod]
+    public void EvaluateNoneEqualWithExplicitNoneCategoryShouldReturnTrue()
+    {
+        // A test with [TestCategory("None")] should also match TestCategory=None.
+        // "None" is reserved for uncategorized, but tests that literally use it
+        // are included as well (by design, to avoid silent mismatches).
+        var condition = new Condition("TestCategory", Operation.Equal, "None");
+        bool result = condition.Evaluate(propertyName => new[] { "None" });
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void EvaluateNoneNotEqualWithExplicitNoneCategoryShouldReturnFalse()
+    {
+        // A test with [TestCategory("None")] should NOT match TestCategory!=None.
+        var condition = new Condition("TestCategory", Operation.NotEqual, "None");
+        bool result = condition.Evaluate(propertyName => new[] { "None" });
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void EvaluateNoneEqualWithExplicitNoneCategoryAmongOthersShouldReturnTrue()
+    {
+        // A test with [TestCategory("None")] and [TestCategory("CategoryA")]
+        // should match TestCategory=None because one of the values equals "None".
+        var condition = new Condition("TestCategory", Operation.Equal, "None");
+        bool result = condition.Evaluate(propertyName => new[] { "None", "CategoryA" });
+
+        Assert.IsTrue(result);
+    }
+
     #endregion
 }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/ConditionTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/ConditionTests.cs
@@ -28,10 +28,13 @@ public class ConditionTests
     }
 
     [TestMethod]
-    public void ParseShouldThrownFormatExceptionOnIncompleteConditionString()
+    public void ParseShouldCreateConditionWithEmptyValueOnTrailingOperator()
     {
         var conditionString = "PropertyName=";
-        Assert.ThrowsExactly<FormatException>(() => Condition.Parse(conditionString));
+        Condition condition = Condition.Parse(conditionString);
+        Assert.AreEqual("PropertyName", condition.Name);
+        Assert.AreEqual(Operation.Equal, condition.Operation);
+        Assert.AreEqual(string.Empty, condition.Value);
     }
 
     [TestMethod]
@@ -235,4 +238,165 @@ public class ConditionTests
         Assert.AreEqual("FullyQualifiedName", tokens[0]);
         Assert.AreEqual("!", tokens[1]);
     }
+
+    #region Empty value filter tests (uncategorized tests support)
+
+    [TestMethod]
+    public void ParseEmptyValueWithNotEqualsShouldCreateConditionWithEmptyValue()
+    {
+        Condition condition = Condition.Parse("TestCategory!=");
+
+        Assert.AreEqual("TestCategory", condition.Name);
+        Assert.AreEqual(Operation.NotEqual, condition.Operation);
+        Assert.AreEqual(string.Empty, condition.Value);
+    }
+
+    [TestMethod]
+    public void ParseEmptyValueWithContainsShouldCreateConditionWithEmptyValue()
+    {
+        Condition condition = Condition.Parse("TestCategory~");
+
+        Assert.AreEqual("TestCategory", condition.Name);
+        Assert.AreEqual(Operation.Contains, condition.Operation);
+        Assert.AreEqual(string.Empty, condition.Value);
+    }
+
+    [TestMethod]
+    public void ParseEmptyValueWithNotContainsShouldCreateConditionWithEmptyValue()
+    {
+        Condition condition = Condition.Parse("TestCategory!~");
+
+        Assert.AreEqual("TestCategory", condition.Name);
+        Assert.AreEqual(Operation.NotContains, condition.Operation);
+        Assert.AreEqual(string.Empty, condition.Value);
+    }
+
+    [TestMethod]
+    public void ParseWhitespaceValueAfterEqualsShouldCreateConditionWithEmptyValue()
+    {
+        Condition condition = Condition.Parse("TestCategory= ");
+
+        Assert.AreEqual("TestCategory", condition.Name);
+        Assert.AreEqual(Operation.Equal, condition.Operation);
+        Assert.AreEqual(string.Empty, condition.Value);
+    }
+
+    [TestMethod]
+    public void EvaluateEmptyStringEqualWithNullPropertyShouldReturnTrue()
+    {
+        var condition = new Condition("TestCategory", Operation.Equal, string.Empty);
+        bool result = condition.Evaluate(propertyName => null);
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void EvaluateEmptyStringEqualWithEmptyArrayShouldReturnTrue()
+    {
+        var condition = new Condition("TestCategory", Operation.Equal, string.Empty);
+        bool result = condition.Evaluate(propertyName => Array.Empty<string>());
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void EvaluateEmptyStringEqualWithNonEmptyArrayShouldReturnFalse()
+    {
+        var condition = new Condition("TestCategory", Operation.Equal, string.Empty);
+        bool result = condition.Evaluate(propertyName => new[] { "CategoryA" });
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void EvaluateEmptyStringNotEqualWithNullPropertyShouldReturnFalse()
+    {
+        var condition = new Condition("TestCategory", Operation.NotEqual, string.Empty);
+        bool result = condition.Evaluate(propertyName => null);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void EvaluateEmptyStringNotEqualWithEmptyArrayShouldReturnFalse()
+    {
+        var condition = new Condition("TestCategory", Operation.NotEqual, string.Empty);
+        bool result = condition.Evaluate(propertyName => Array.Empty<string>());
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void EvaluateEmptyStringNotEqualWithNonEmptyArrayShouldReturnTrue()
+    {
+        var condition = new Condition("TestCategory", Operation.NotEqual, string.Empty);
+        bool result = condition.Evaluate(propertyName => new[] { "CategoryA" });
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void EvaluateEmptyStringContainsWithNullPropertyShouldReturnTrue()
+    {
+        var condition = new Condition("TestCategory", Operation.Contains, string.Empty);
+        bool result = condition.Evaluate(propertyName => null);
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void EvaluateEmptyStringContainsWithEmptyArrayShouldReturnTrue()
+    {
+        var condition = new Condition("TestCategory", Operation.Contains, string.Empty);
+        bool result = condition.Evaluate(propertyName => Array.Empty<string>());
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void EvaluateEmptyStringContainsWithNonEmptyArrayShouldReturnFalse()
+    {
+        var condition = new Condition("TestCategory", Operation.Contains, string.Empty);
+        bool result = condition.Evaluate(propertyName => new[] { "CategoryA" });
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void EvaluateEmptyStringNotContainsWithNullPropertyShouldReturnFalse()
+    {
+        var condition = new Condition("TestCategory", Operation.NotContains, string.Empty);
+        bool result = condition.Evaluate(propertyName => null);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void EvaluateEmptyStringNotContainsWithEmptyArrayShouldReturnFalse()
+    {
+        var condition = new Condition("TestCategory", Operation.NotContains, string.Empty);
+        bool result = condition.Evaluate(propertyName => Array.Empty<string>());
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void EvaluateEmptyStringNotContainsWithNonEmptyArrayShouldReturnTrue()
+    {
+        var condition = new Condition("TestCategory", Operation.NotContains, string.Empty);
+        bool result = condition.Evaluate(propertyName => new[] { "CategoryA" });
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void EvaluateNonEmptyStringEqualShouldStillWorkNormally()
+    {
+        var condition = new Condition("TestCategory", Operation.Equal, "CategoryA");
+        Assert.IsTrue(condition.Evaluate(propertyName => new[] { "CategoryA" }));
+        Assert.IsFalse(condition.Evaluate(propertyName => new[] { "CategoryB" }));
+        Assert.IsFalse(condition.Evaluate(propertyName => null));
+    }
+
+    #endregion
 }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/ConditionTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/ConditionTests.cs
@@ -398,5 +398,55 @@ public class ConditionTests
         Assert.IsFalse(condition.Evaluate(propertyName => null));
     }
 
+    [TestMethod]
+    public void EvaluateEmptyStringEqualWithEmptyStringPropertyShouldReturnTrue()
+    {
+        // When property provider returns a single empty string (not an array),
+        // GetPropertyValue wraps it into [""], which should match empty-value filter.
+        // This must be consistent with FastFilter's behavior.
+        var condition = new Condition("TestCategory", Operation.Equal, string.Empty);
+        bool result = condition.Evaluate(propertyName => string.Empty);
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void EvaluateEmptyStringEqualWithArrayContainingEmptyStringShouldReturnTrue()
+    {
+        // An array containing only an empty string (e.g. from [TestCategory("")])
+        // should be treated as uncategorized, consistent with FastFilter.
+        var condition = new Condition("TestCategory", Operation.Equal, string.Empty);
+        bool result = condition.Evaluate(propertyName => new[] { string.Empty });
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void EvaluateEmptyStringNotEqualWithEmptyStringPropertyShouldReturnFalse()
+    {
+        var condition = new Condition("TestCategory", Operation.NotEqual, string.Empty);
+        bool result = condition.Evaluate(propertyName => string.Empty);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void EvaluateEmptyStringContainsWithArrayContainingEmptyStringShouldReturnTrue()
+    {
+        var condition = new Condition("TestCategory", Operation.Contains, string.Empty);
+        bool result = condition.Evaluate(propertyName => new[] { string.Empty });
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void EvaluateEmptyStringNotContainsWithArrayContainingEmptyStringShouldReturnFalse()
+    {
+        var condition = new Condition("TestCategory", Operation.NotContains, string.Empty);
+        bool result = condition.Evaluate(propertyName => new[] { string.Empty });
+
+        Assert.IsFalse(result);
+    }
+
     #endregion
 }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/ConditionTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/ConditionTests.cs
@@ -28,13 +28,10 @@ public class ConditionTests
     }
 
     [TestMethod]
-    public void ParseShouldCreateConditionWithEmptyValueOnTrailingOperator()
+    public void ParseShouldThrownFormatExceptionOnIncompleteConditionString()
     {
         var conditionString = "PropertyName=";
-        Condition condition = Condition.Parse(conditionString);
-        Assert.AreEqual("PropertyName", condition.Name);
-        Assert.AreEqual(Operation.Equal, condition.Operation);
-        Assert.AreEqual(string.Empty, condition.Value);
+        Assert.ThrowsExactly<FormatException>(() => Condition.Parse(conditionString));
     }
 
     [TestMethod]
@@ -239,213 +236,99 @@ public class ConditionTests
         Assert.AreEqual("!", tokens[1]);
     }
 
-    #region Empty value filter tests (uncategorized tests support)
+    #region None filter value tests (uncategorized tests support)
 
     [TestMethod]
-    public void ParseEmptyValueWithNotEqualsShouldCreateConditionWithEmptyValue()
+    public void ParseNoneValueShouldCreateCondition()
     {
-        Condition condition = Condition.Parse("TestCategory!=");
-
-        Assert.AreEqual("TestCategory", condition.Name);
-        Assert.AreEqual(Operation.NotEqual, condition.Operation);
-        Assert.AreEqual(string.Empty, condition.Value);
-    }
-
-    [TestMethod]
-    public void ParseEmptyValueWithContainsShouldCreateConditionWithEmptyValue()
-    {
-        Condition condition = Condition.Parse("TestCategory~");
-
-        Assert.AreEqual("TestCategory", condition.Name);
-        Assert.AreEqual(Operation.Contains, condition.Operation);
-        Assert.AreEqual(string.Empty, condition.Value);
-    }
-
-    [TestMethod]
-    public void ParseEmptyValueWithNotContainsShouldCreateConditionWithEmptyValue()
-    {
-        Condition condition = Condition.Parse("TestCategory!~");
-
-        Assert.AreEqual("TestCategory", condition.Name);
-        Assert.AreEqual(Operation.NotContains, condition.Operation);
-        Assert.AreEqual(string.Empty, condition.Value);
-    }
-
-    [TestMethod]
-    public void ParseWhitespaceValueAfterEqualsShouldCreateConditionWithEmptyValue()
-    {
-        Condition condition = Condition.Parse("TestCategory= ");
+        Condition condition = Condition.Parse("TestCategory=None");
 
         Assert.AreEqual("TestCategory", condition.Name);
         Assert.AreEqual(Operation.Equal, condition.Operation);
-        Assert.AreEqual(string.Empty, condition.Value);
+        Assert.AreEqual("None", condition.Value);
     }
 
     [TestMethod]
-    public void EvaluateEmptyStringEqualWithNullPropertyShouldReturnTrue()
+    public void ParseNoneValueWithNotEqualShouldCreateCondition()
     {
-        var condition = new Condition("TestCategory", Operation.Equal, string.Empty);
+        Condition condition = Condition.Parse("TestCategory!=None");
+
+        Assert.AreEqual("TestCategory", condition.Name);
+        Assert.AreEqual(Operation.NotEqual, condition.Operation);
+        Assert.AreEqual("None", condition.Value);
+    }
+
+    [TestMethod]
+    public void EvaluateNoneEqualWithNullPropertyShouldReturnTrue()
+    {
+        var condition = new Condition("TestCategory", Operation.Equal, "None");
         bool result = condition.Evaluate(propertyName => null);
 
         Assert.IsTrue(result);
     }
 
     [TestMethod]
-    public void EvaluateEmptyStringEqualWithEmptyArrayShouldReturnTrue()
+    public void EvaluateNoneEqualWithEmptyArrayShouldReturnTrue()
     {
-        var condition = new Condition("TestCategory", Operation.Equal, string.Empty);
+        var condition = new Condition("TestCategory", Operation.Equal, "None");
         bool result = condition.Evaluate(propertyName => Array.Empty<string>());
 
         Assert.IsTrue(result);
     }
 
     [TestMethod]
-    public void EvaluateEmptyStringEqualWithNonEmptyArrayShouldReturnFalse()
+    public void EvaluateNoneEqualWithNonEmptyArrayShouldReturnFalse()
     {
-        var condition = new Condition("TestCategory", Operation.Equal, string.Empty);
+        var condition = new Condition("TestCategory", Operation.Equal, "None");
         bool result = condition.Evaluate(propertyName => new[] { "CategoryA" });
 
         Assert.IsFalse(result);
     }
 
     [TestMethod]
-    public void EvaluateEmptyStringNotEqualWithNullPropertyShouldReturnFalse()
+    public void EvaluateNoneEqualIsCaseInsensitive()
     {
-        var condition = new Condition("TestCategory", Operation.NotEqual, string.Empty);
+        var condition = new Condition("TestCategory", Operation.Equal, "none");
+        Assert.IsTrue(condition.Evaluate(propertyName => null));
+
+        var condition2 = new Condition("TestCategory", Operation.Equal, "NONE");
+        Assert.IsTrue(condition2.Evaluate(propertyName => null));
+    }
+
+    [TestMethod]
+    public void EvaluateNoneNotEqualWithNullPropertyShouldReturnFalse()
+    {
+        var condition = new Condition("TestCategory", Operation.NotEqual, "None");
         bool result = condition.Evaluate(propertyName => null);
 
         Assert.IsFalse(result);
     }
 
     [TestMethod]
-    public void EvaluateEmptyStringNotEqualWithEmptyArrayShouldReturnFalse()
+    public void EvaluateNoneNotEqualWithEmptyArrayShouldReturnFalse()
     {
-        var condition = new Condition("TestCategory", Operation.NotEqual, string.Empty);
+        var condition = new Condition("TestCategory", Operation.NotEqual, "None");
         bool result = condition.Evaluate(propertyName => Array.Empty<string>());
 
         Assert.IsFalse(result);
     }
 
     [TestMethod]
-    public void EvaluateEmptyStringNotEqualWithNonEmptyArrayShouldReturnTrue()
+    public void EvaluateNoneNotEqualWithNonEmptyArrayShouldReturnTrue()
     {
-        var condition = new Condition("TestCategory", Operation.NotEqual, string.Empty);
+        var condition = new Condition("TestCategory", Operation.NotEqual, "None");
         bool result = condition.Evaluate(propertyName => new[] { "CategoryA" });
 
         Assert.IsTrue(result);
     }
 
     [TestMethod]
-    public void EvaluateEmptyStringContainsWithNullPropertyShouldReturnTrue()
-    {
-        var condition = new Condition("TestCategory", Operation.Contains, string.Empty);
-        bool result = condition.Evaluate(propertyName => null);
-
-        Assert.IsTrue(result);
-    }
-
-    [TestMethod]
-    public void EvaluateEmptyStringContainsWithEmptyArrayShouldReturnTrue()
-    {
-        var condition = new Condition("TestCategory", Operation.Contains, string.Empty);
-        bool result = condition.Evaluate(propertyName => Array.Empty<string>());
-
-        Assert.IsTrue(result);
-    }
-
-    [TestMethod]
-    public void EvaluateEmptyStringContainsWithNonEmptyArrayShouldReturnFalse()
-    {
-        var condition = new Condition("TestCategory", Operation.Contains, string.Empty);
-        bool result = condition.Evaluate(propertyName => new[] { "CategoryA" });
-
-        Assert.IsFalse(result);
-    }
-
-    [TestMethod]
-    public void EvaluateEmptyStringNotContainsWithNullPropertyShouldReturnFalse()
-    {
-        var condition = new Condition("TestCategory", Operation.NotContains, string.Empty);
-        bool result = condition.Evaluate(propertyName => null);
-
-        Assert.IsFalse(result);
-    }
-
-    [TestMethod]
-    public void EvaluateEmptyStringNotContainsWithEmptyArrayShouldReturnFalse()
-    {
-        var condition = new Condition("TestCategory", Operation.NotContains, string.Empty);
-        bool result = condition.Evaluate(propertyName => Array.Empty<string>());
-
-        Assert.IsFalse(result);
-    }
-
-    [TestMethod]
-    public void EvaluateEmptyStringNotContainsWithNonEmptyArrayShouldReturnTrue()
-    {
-        var condition = new Condition("TestCategory", Operation.NotContains, string.Empty);
-        bool result = condition.Evaluate(propertyName => new[] { "CategoryA" });
-
-        Assert.IsTrue(result);
-    }
-
-    [TestMethod]
-    public void EvaluateNonEmptyStringEqualShouldStillWorkNormally()
+    public void EvaluateNonNoneValueShouldStillWorkNormally()
     {
         var condition = new Condition("TestCategory", Operation.Equal, "CategoryA");
         Assert.IsTrue(condition.Evaluate(propertyName => new[] { "CategoryA" }));
         Assert.IsFalse(condition.Evaluate(propertyName => new[] { "CategoryB" }));
         Assert.IsFalse(condition.Evaluate(propertyName => null));
-    }
-
-    [TestMethod]
-    public void EvaluateEmptyStringEqualWithEmptyStringPropertyShouldReturnTrue()
-    {
-        // When property provider returns a single empty string (not an array),
-        // GetPropertyValue wraps it into [""], which should match empty-value filter.
-        // This must be consistent with FastFilter's behavior.
-        var condition = new Condition("TestCategory", Operation.Equal, string.Empty);
-        bool result = condition.Evaluate(propertyName => string.Empty);
-
-        Assert.IsTrue(result);
-    }
-
-    [TestMethod]
-    public void EvaluateEmptyStringEqualWithArrayContainingEmptyStringShouldReturnTrue()
-    {
-        // An array containing only an empty string (e.g. from [TestCategory("")])
-        // should be treated as uncategorized, consistent with FastFilter.
-        var condition = new Condition("TestCategory", Operation.Equal, string.Empty);
-        bool result = condition.Evaluate(propertyName => new[] { string.Empty });
-
-        Assert.IsTrue(result);
-    }
-
-    [TestMethod]
-    public void EvaluateEmptyStringNotEqualWithEmptyStringPropertyShouldReturnFalse()
-    {
-        var condition = new Condition("TestCategory", Operation.NotEqual, string.Empty);
-        bool result = condition.Evaluate(propertyName => string.Empty);
-
-        Assert.IsFalse(result);
-    }
-
-    [TestMethod]
-    public void EvaluateEmptyStringContainsWithArrayContainingEmptyStringShouldReturnTrue()
-    {
-        var condition = new Condition("TestCategory", Operation.Contains, string.Empty);
-        bool result = condition.Evaluate(propertyName => new[] { string.Empty });
-
-        Assert.IsTrue(result);
-    }
-
-    [TestMethod]
-    public void EvaluateEmptyStringNotContainsWithArrayContainingEmptyStringShouldReturnFalse()
-    {
-        var condition = new Condition("TestCategory", Operation.NotContains, string.Empty);
-        bool result = condition.Evaluate(propertyName => new[] { string.Empty });
-
-        Assert.IsFalse(result);
     }
 
     #endregion

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FastFilterTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FastFilterTests.cs
@@ -494,5 +494,19 @@ public class FastFilterTests
         Assert.IsTrue(fastFilter.Evaluate(s => new[] { "CategoryA" }));
     }
 
+    [TestMethod]
+    public void FastFilterWithNoneEqualShouldAlsoMatchExplicitNoneCategory()
+    {
+        var filterExpressionWrapper = new FilterExpressionWrapper("TestCategory=None");
+        var fastFilter = filterExpressionWrapper.FastFilter;
+
+        Assert.IsNotNull(fastFilter);
+
+        // A test with [TestCategory("None")] should also match, since "None" is in the filter set.
+        Assert.IsTrue(fastFilter.Evaluate(s => new[] { "None" }));
+        // Case-insensitive: "none" should also match.
+        Assert.IsTrue(fastFilter.Evaluate(s => new[] { "none" }));
+    }
+
     #endregion
 }

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FastFilterTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FastFilterTests.cs
@@ -443,12 +443,12 @@ public class FastFilterTests
             }));
     }
 
-    #region Empty value filter tests (uncategorized tests support)
+    #region None filter value tests (uncategorized tests support)
 
     [TestMethod]
-    public void FastFilterWithEmptyEqualShouldMatchNullProperty()
+    public void FastFilterWithNoneEqualShouldMatchNullProperty()
     {
-        var filterExpressionWrapper = new FilterExpressionWrapper("TestCategory=");
+        var filterExpressionWrapper = new FilterExpressionWrapper("TestCategory=None");
         var fastFilter = filterExpressionWrapper.FastFilter;
 
         Assert.IsNotNull(fastFilter);
@@ -463,9 +463,9 @@ public class FastFilterTests
     }
 
     [TestMethod]
-    public void FastFilterWithEmptyEqualOrSpecificCategoryShouldMatchBoth()
+    public void FastFilterWithNoneEqualOrSpecificCategoryShouldMatchBoth()
     {
-        var filterExpressionWrapper = new FilterExpressionWrapper("TestCategory=|TestCategory=CategoryA");
+        var filterExpressionWrapper = new FilterExpressionWrapper("TestCategory=None|TestCategory=CategoryA");
         var fastFilter = filterExpressionWrapper.FastFilter;
 
         Assert.IsNotNull(fastFilter);
@@ -480,9 +480,9 @@ public class FastFilterTests
     }
 
     [TestMethod]
-    public void FastFilterWithEmptyNotEqualShouldMatchCategorizedTests()
+    public void FastFilterWithNoneNotEqualShouldMatchCategorizedTests()
     {
-        var filterExpressionWrapper = new FilterExpressionWrapper("TestCategory!=");
+        var filterExpressionWrapper = new FilterExpressionWrapper("TestCategory!=None");
         var fastFilter = filterExpressionWrapper.FastFilter;
 
         Assert.IsNotNull(fastFilter);

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FastFilterTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Filtering/FastFilterTests.cs
@@ -442,4 +442,57 @@ public class FastFilterTests
                 _ => null,
             }));
     }
+
+    #region Empty value filter tests (uncategorized tests support)
+
+    [TestMethod]
+    public void FastFilterWithEmptyEqualShouldMatchNullProperty()
+    {
+        var filterExpressionWrapper = new FilterExpressionWrapper("TestCategory=");
+        var fastFilter = filterExpressionWrapper.FastFilter;
+
+        Assert.IsNotNull(fastFilter);
+        Assert.IsFalse(fastFilter.IsFilteredOutWhenMatched);
+
+        // Null property value means uncategorized - should match.
+        Assert.IsTrue(fastFilter.Evaluate(s => null));
+        // Empty array means uncategorized - should match.
+        Assert.IsTrue(fastFilter.Evaluate(s => Array.Empty<string>()));
+        // Non-empty category - should not match.
+        Assert.IsFalse(fastFilter.Evaluate(s => new[] { "CategoryA" }));
+    }
+
+    [TestMethod]
+    public void FastFilterWithEmptyEqualOrSpecificCategoryShouldMatchBoth()
+    {
+        var filterExpressionWrapper = new FilterExpressionWrapper("TestCategory=|TestCategory=CategoryA");
+        var fastFilter = filterExpressionWrapper.FastFilter;
+
+        Assert.IsNotNull(fastFilter);
+        Assert.IsFalse(fastFilter.IsFilteredOutWhenMatched);
+
+        // Null property value means uncategorized - should match.
+        Assert.IsTrue(fastFilter.Evaluate(s => null));
+        // CategoryA - should match.
+        Assert.IsTrue(fastFilter.Evaluate(s => new[] { "CategoryA" }));
+        // CategoryB - should not match.
+        Assert.IsFalse(fastFilter.Evaluate(s => new[] { "CategoryB" }));
+    }
+
+    [TestMethod]
+    public void FastFilterWithEmptyNotEqualShouldMatchCategorizedTests()
+    {
+        var filterExpressionWrapper = new FilterExpressionWrapper("TestCategory!=");
+        var fastFilter = filterExpressionWrapper.FastFilter;
+
+        Assert.IsNotNull(fastFilter);
+        Assert.IsTrue(fastFilter.IsFilteredOutWhenMatched);
+
+        // Null property value means uncategorized - should NOT match (filtered out).
+        Assert.IsFalse(fastFilter.Evaluate(s => null));
+        // Non-empty category - should match (not filtered out).
+        Assert.IsTrue(fastFilter.Evaluate(s => new[] { "CategoryA" }));
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

Add support for filtering uncategorized tests using the reserved keyword `None` (e.g. `TestCategory=None`). This enables users to select or exclude tests that have no category assigned using standard filter syntax.

Inspired by [microsoft/testfx#6779](https://github.com/microsoft/testfx/pull/6779) and the design discussion in [microsoft/testfx#5136](https://github.com/microsoft/testfx/issues/5136).

## Motivation

Users want to find/run tests that haven't been categorized yet (e.g. to track categorization progress). Currently there is no way to filter for tests without a `TestCategory` using `--filter`. The agreed design uses `None` as a reserved keyword meaning "uncategorized".

## Changes

### `Condition.cs`
- Added `NoneFilterValue` constant (`"None"`)
- **EvaluateEqualOperation**: When `Value` equals `"None"` (case-insensitive) and property is `null` or empty array, returns `true` (uncategorized match). `NotEqual` gets the inverse behavior automatically.

### `FastFilter.cs`
- **Evaluate**: Check if filter set contains `"None"`. When property provider returns `null` or empty array and `"None"` is in the filter set, treat as matched.

## Filter semantics

| Filter | Matches |
|--------|---------|
| `TestCategory=None` | Tests with no category (null/empty property) |
| `TestCategory!=None` | Tests that have at least one category |
| `TestCategory=None\|TestCategory=CategoryA` | Uncategorized OR CategoryA |

## Tests

- **Unit tests** (ConditionTests.cs): 9 new tests covering parsing and evaluation with `None` for Equal/NotEqual, case-insensitivity, and null/empty/non-empty properties
- **Unit tests** (FastFilterTests.cs): 3 new tests for FastFilter with `None` equal, equal+OR, and not-equal
- **Acceptance tests** (TestCaseFilterTests.cs): 2 new end-to-end tests validating `TestCategory=None` and `TestCategory!=None` against the SimpleTestProject sample
