### PR TITLE
Restrict artifact temp directory permissions on Unix

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/PostProcessing/ArtifactProcessingManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/PostProcessing/ArtifactProcessingManager.cs
@@ -281,7 +281,7 @@ internal class ArtifactProcessingManager : IArtifactProcessingManager
         if (result != 0)
         {
             int error = Marshal.GetLastWin32Error();
-            EqtTrace.Warning($"ArtifactProcessingManager: Failed to set permissions on '{path}', errno: {error}");
+            throw new InvalidOperationException($"Failed to set permissions on '{path}', errno: {error}");
         }
     }
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/PostProcessing/ArtifactProcessingManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/PostProcessing/ArtifactProcessingManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -104,6 +105,9 @@ internal class ArtifactProcessingManager : IArtifactProcessingManager
             EqtTrace.Verbose($"ArtifactProcessingManager.CollectArtifacts: Saving data collectors artifacts for post process into {_processArtifactFolder}");
             Stopwatch watch = Stopwatch.StartNew();
             TPDebug.Assert(_testSessionProcessArtifactFolder is not null, "_testSessionProcessArtifactFolder is null");
+            TPDebug.Assert(_processArtifactFolder is not null, "_processArtifactFolder is null");
+
+            CreateDirectoryWithUserOnlyAccess(_processArtifactFolder);
             _fileHelper.CreateDirectory(_testSessionProcessArtifactFolder);
             EqtTrace.Verbose($"ArtifactProcessingManager.CollectArtifacts: Persist runsettings \n{runSettingsXml}");
             _fileHelper.WriteAllTextToFile(Path.Combine(_testSessionProcessArtifactFolder, RunsettingsFileName), runSettingsXml);
@@ -246,4 +250,42 @@ internal class ArtifactProcessingManager : IArtifactProcessingManager
     }
 
     private static bool IsTelemetryOptedIn() => Environment.GetEnvironmentVariable("VSTEST_TELEMETRY_OPTEDIN")?.Equals("1", StringComparison.Ordinal) == true;
+
+    /// <summary>
+    /// Creates a directory with permissions restricted to the current user on Unix.
+    /// </summary>
+    internal /* for testing */ static void CreateDirectoryWithUserOnlyAccess(string path)
+    {
+#if NETFRAMEWORK
+        Directory.CreateDirectory(path);
+#else
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Directory.CreateDirectory(path);
+        }
+        else
+        {
+            Directory.CreateDirectory(path);
+            SetUnixDirectoryPermissions(path);
+        }
+#endif
+    }
+
+#if !NETFRAMEWORK
+    private static void SetUnixDirectoryPermissions(string path)
+    {
+        // 0700 octal = owner read/write/execute only
+        const int ownerFullAccess = 0x1C0;
+
+        int result = NativeChmod(path, ownerFullAccess);
+        if (result != 0)
+        {
+            int error = Marshal.GetLastWin32Error();
+            EqtTrace.Warning($"ArtifactProcessingManager: Failed to set permissions on '{path}', errno: {error}");
+        }
+    }
+
+    [DllImport("libc", EntryPoint = "chmod", SetLastError = true)]
+    private static extern int NativeChmod(string pathname, int mode);
+#endif
 }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/PostProcessing/ArtifactProcessingManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/PostProcessing/ArtifactProcessingManager.cs
@@ -254,18 +254,12 @@ internal class ArtifactProcessingManager : IArtifactProcessingManager
     /// <summary>
     /// Creates a directory with permissions restricted to the current user on Unix.
     /// </summary>
-    internal /* for testing */ static void CreateDirectoryWithUserOnlyAccess(string path)
+    internal /* for testing */ void CreateDirectoryWithUserOnlyAccess(string path)
     {
-#if NETFRAMEWORK
-        Directory.CreateDirectory(path);
-#else
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        _fileHelper.CreateDirectory(path);
+#if !NETFRAMEWORK
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            Directory.CreateDirectory(path);
-        }
-        else
-        {
-            Directory.CreateDirectory(path);
             SetUnixDirectoryPermissions(path);
         }
 #endif

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/PostProcessing/ArtifactProcessingManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/PostProcessing/ArtifactProcessingManager.cs
@@ -258,7 +258,7 @@ internal class ArtifactProcessingManager : IArtifactProcessingManager
     {
         _fileHelper.CreateDirectory(path);
 #if !NETFRAMEWORK
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Directory.Exists(path))
         {
             SetUnixDirectoryPermissions(path);
         }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/PostProcessing/ArtifactProcessingTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/PostProcessing/ArtifactProcessingTests.cs
@@ -97,7 +97,7 @@ public class ArtifactProcessingTests
         _artifactProcessingManager.CollectArtifacts(testRunCompleteEventArgs, string.Empty);
 
         // assert
-        _fileHelperMock.Verify(x => x.CreateDirectory(It.IsAny<string>()), Times.Once);
+        _fileHelperMock.Verify(x => x.CreateDirectory(It.IsAny<string>()), Times.Exactly(2));
         _fileHelperMock.Verify(x => x.WriteAllTextToFile(It.IsAny<string>(), It.IsAny<string>()), Times.Exactly(2));
         _dataSerializer.Verify(x => x.SerializePayload(It.IsAny<string>(), It.IsAny<TestRunCompleteEventArgs>()), Times.Once);
     }


### PR DESCRIPTION
Set 0700 on the artifact processing directory on non-Windows so it is only accessible by the creating user.

Implicitly tested by `DotnetSDKSimulation_PostProcessing` which does a full collect + post-process round-trip through the real temp path.