### PR TITLE
Fetch app.config from mirror repo at exact build commit during insertion

### DIFF
--- a/azure-pipelines-insertion.yml
+++ b/azure-pipelines-insertion.yml
@@ -86,7 +86,7 @@ extends:
               steps:
 
               - task: PowerShell@2
-                displayName: 'Install .NET SDK from global.json'
+                displayName: '🚀 Install .NET SDK from global.json'
                 inputs:
                   targetType: inline
                   script: |
@@ -96,12 +96,16 @@ extends:
                     & eng/common/dotnet-install.ps1 -version $version -runtime ''
 
               - task: AzureCLI@2
-                displayName: 'Run VS Insertion'
+                displayName: '🚀 Run VS Insertion'
                 inputs:
                   azureSubscription: 'DncEng Insertion: Roslyn and Razor'
                   scriptType: pscore
                   scriptLocation: inlineScript
                   inlineScript: |
+                    # Disable .NET first-time experience to avoid delays
+                    $env:DOTNET_NOLOGO = '1'
+                    $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = '1'
+
                     # Install Roslyn insertion tools from the dnceng feed, using --tool-path as a workaround to avoid resetting the process to pick up dotnet tool path changes
                     $dotnet = "$(Build.SourcesDirectory)\.dotnet\dotnet.exe"
                     & $dotnet tool install Microsoft.RoslynTools --prerelease --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json --tool-path .
@@ -173,21 +177,21 @@ extends:
                     $targetFilePath = "/src/vset/Agile/TestPlatform/RocksteadyCLI/App.config"
 
                     # Extract the PR number from roslyn-tools output.
-                    # The tool logs lines like "Created Pull Request #12345" or a PR URL containing the ID.
+                    # The tool logs a PR URL like: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/735439
+                    # We match the URL pattern specifically to avoid grabbing timestamps from PR titles.
                     $outputText = $roslynOutput -join "`n"
                     $prId = $null
-                    if ($outputText -match 'pullrequests/(\d+)') {
+                    if ($outputText -match '/pullrequest/(\d+)') {
                       $prId = $Matches[1]
-                    } elseif ($outputText -match 'Pull Request[^\d]*#?(\d+)') {
-                      $prId = $Matches[1]
-                    } elseif ($outputText -match '/pullrequest/(\d+)') {
+                    } elseif ($outputText -match 'pullrequests/(\d+)') {
                       $prId = $Matches[1]
                     }
 
                     if (-not $prId) {
-                      Write-Warning "Could not extract PR ID from roslyn-tools output. Skipping App.config insertion."
+                      Write-Error "Could not extract PR ID from roslyn-tools output. Cannot push App.config."
                       Write-Host "roslyn-tools output was:"
                       Write-Host $outputText
+                      exit 1
                     }
                     else {
                       Write-Host "Detected insertion PR #$prId, pushing App.config..."
@@ -256,8 +260,8 @@ extends:
                         Write-Host "Pushed App.config to insertion branch. Commit: $($pushResponse.commits[0].commitId)"
                       }
                       catch {
-                        Write-Warning "Failed to push App.config to insertion branch: $_"
-                        Write-Warning "The insertion PR was created successfully. App.config will need to be updated manually."
+                        Write-Error "Failed to push App.config to insertion branch: $_"
+                        exit 1
                       }
                     }
 

--- a/azure-pipelines-insertion.yml
+++ b/azure-pipelines-insertion.yml
@@ -214,15 +214,16 @@ extends:
                         $latestCommitId = $refResponse.value[0].objectId
 
                         # Check if the target file already exists to decide changeType
-                        $changeType = "edit"
+                        $changeType = "add"
                         try {
                           $encodedPath = [Uri]::EscapeDataString($targetFilePath)
-                          $itemUrl = "$devdivOrg/$project/_apis/git/repositories/$vsRepoId/items?path=$encodedPath&versionDescriptor.version=$refFilter&versionDescriptor.versionType=branch&api-version=7.1"
-                          $null = Invoke-RestMethod -Uri $itemUrl -Headers $headers -Method Head
+                          $itemUrl = "$devdivOrg/$project/_apis/git/repositories/$vsRepoId/items?path=$encodedPath&versionDescriptor.version=$refFilter&versionDescriptor.versionType=branch&`$format=json&api-version=7.1"
+                          $null = Invoke-RestMethod -Uri $itemUrl -Headers $headers -Method Get -ErrorAction Stop
+                          Write-Host "Target file exists, using 'edit' changeType."
+                          $changeType = "edit"
                         }
                         catch {
                           Write-Host "Target file does not exist yet, using 'add' changeType."
-                          $changeType = "add"
                         }
 
                         # Read the app.config from the vstest checkout

--- a/azure-pipelines-insertion.yml
+++ b/azure-pipelines-insertion.yml
@@ -213,8 +213,11 @@ extends:
                         }
                         $latestCommitId = $refResponse.value[0].objectId
 
-                        # Read the app.config from the vstest checkout
-                        $appConfigContent = Get-Content -Raw -Path "$(Build.SourcesDirectory)/src/vstest.console/app.config"
+                        # Read the app.config from the ComponentBranchName, not from the checkout (which is always main)
+                        $componentBranch = "$(ComponentBranchName)"
+                        $appConfigUrl = "https://raw.githubusercontent.com/microsoft/vstest/$componentBranch/src/vstest.console/app.config"
+                        Write-Host "Fetching app.config from $appConfigUrl"
+                        $appConfigContent = Invoke-RestMethod -Uri $appConfigUrl
 
                         # Push the app.config to the insertion branch
                         $pushUrl = "$devdivOrg/$project/_apis/git/repositories/$vsRepoId/pushes?api-version=7.1"

--- a/azure-pipelines-insertion.yml
+++ b/azure-pipelines-insertion.yml
@@ -213,19 +213,6 @@ extends:
                         }
                         $latestCommitId = $refResponse.value[0].objectId
 
-                        # Check if the target file already exists to decide changeType
-                        $changeType = "add"
-                        try {
-                          $encodedPath = [Uri]::EscapeDataString($targetFilePath)
-                          $itemUrl = "$devdivOrg/$project/_apis/git/repositories/$vsRepoId/items?path=$encodedPath&versionDescriptor.version=$refFilter&versionDescriptor.versionType=branch&`$format=json&api-version=7.1"
-                          $null = Invoke-RestMethod -Uri $itemUrl -Headers $headers -Method Get -ErrorAction Stop
-                          Write-Host "Target file exists, using 'edit' changeType."
-                          $changeType = "edit"
-                        }
-                        catch {
-                          Write-Host "Target file does not exist yet, using 'add' changeType."
-                        }
-
                         # Read the app.config from the vstest checkout
                         $appConfigContent = Get-Content -Raw -Path "$(Build.SourcesDirectory)/src/vstest.console/app.config"
 
@@ -243,7 +230,7 @@ extends:
                               comment = "Update RocksteadyCLI App.config from vstest"
                               changes = @(
                                 @{
-                                  changeType = $changeType
+                                  changeType = "edit"
                                   item = @{
                                     path = $targetFilePath
                                   }

--- a/azure-pipelines-insertion.yml
+++ b/azure-pipelines-insertion.yml
@@ -1,6 +1,6 @@
 parameters:
   - name: 'ComponentBranchName'
-    default: 'rel/18.7'
+    default: 'main'
   - name: 'CreateDraftPR'
     default: 'false'
   - name: 'OptionalTitlePrefix'
@@ -44,7 +44,7 @@ schedules:
     displayName: Daily midnight insertion to VS
     branches:
       include:
-      - rel/18.7
+      - main
     always: true
 
 resources:
@@ -153,8 +153,111 @@ extends:
                     }
 
                     "Running: ./roslyn-tools.exe $($insertArgs -join ' ')"
-                    ./roslyn-tools.exe @insertArgs
+                    $roslynOutput = ./roslyn-tools.exe @insertArgs 2>&1 | ForEach-Object { Write-Host $_; $_ }
                     if ($LASTEXITCODE -ne 0) {
                       exit $LASTEXITCODE
+                    }
+
+                    # Push vstest.console app.config to the insertion PR branch in the VS repo.
+                    # The file maps to src/vset/Agile/TestPlatform/RocksteadyCLI/App.config in VS.
+                    $devdivToken = "$(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)"
+                    $base64Token = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":$devdivToken"))
+                    $headers = @{
+                      Authorization = "Basic $base64Token"
+                      'Content-Type' = 'application/json'
+                    }
+
+                    $devdivOrg = "https://dev.azure.com/devdiv"
+                    $project = "DevDiv"
+                    $vsRepoId = "a290117c-5a8a-40f7-bc2c-f14dbe3acf6d"
+                    $targetFilePath = "/src/vset/Agile/TestPlatform/RocksteadyCLI/App.config"
+
+                    # Extract the PR number from roslyn-tools output.
+                    # The tool logs lines like "Created Pull Request #12345" or a PR URL containing the ID.
+                    $outputText = $roslynOutput -join "`n"
+                    $prId = $null
+                    if ($outputText -match 'pullrequests/(\d+)') {
+                      $prId = $Matches[1]
+                    } elseif ($outputText -match 'Pull Request[^\d]*#?(\d+)') {
+                      $prId = $Matches[1]
+                    } elseif ($outputText -match '/pullrequest/(\d+)') {
+                      $prId = $Matches[1]
+                    }
+
+                    if (-not $prId) {
+                      Write-Warning "Could not extract PR ID from roslyn-tools output. Skipping App.config insertion."
+                      Write-Host "roslyn-tools output was:"
+                      Write-Host $outputText
+                    }
+                    else {
+                      Write-Host "Detected insertion PR #$prId, pushing App.config..."
+
+                      try {
+                        # Get the PR to find its source branch
+                        $prUrl = "$devdivOrg/$project/_apis/git/repositories/$vsRepoId/pullrequests/${prId}?api-version=7.1"
+                        $pr = Invoke-RestMethod -Uri $prUrl -Headers $headers -Method Get
+                        $sourceBranch = $pr.sourceRefName
+                        Write-Host "PR source branch: $sourceBranch"
+
+                        # Get the latest commit on the insertion branch
+                        $refFilter = ($sourceBranch -replace '^refs/', '')
+                        $encodedFilter = [Uri]::EscapeDataString($refFilter)
+                        $refUrl = "$devdivOrg/$project/_apis/git/repositories/$vsRepoId/refs?filter=$encodedFilter&api-version=7.1"
+                        $refResponse = Invoke-RestMethod -Uri $refUrl -Headers $headers -Method Get
+                        if (-not $refResponse.value -or $refResponse.value.Count -eq 0) {
+                          throw "Could not resolve ref for branch $sourceBranch"
+                        }
+                        $latestCommitId = $refResponse.value[0].objectId
+
+                        # Check if the target file already exists to decide changeType
+                        $changeType = "edit"
+                        try {
+                          $encodedPath = [Uri]::EscapeDataString($targetFilePath)
+                          $itemUrl = "$devdivOrg/$project/_apis/git/repositories/$vsRepoId/items?path=$encodedPath&versionDescriptor.version=$refFilter&versionDescriptor.versionType=branch&api-version=7.1"
+                          $null = Invoke-RestMethod -Uri $itemUrl -Headers $headers -Method Head
+                        }
+                        catch {
+                          Write-Host "Target file does not exist yet, using 'add' changeType."
+                          $changeType = "add"
+                        }
+
+                        # Read the app.config from the vstest checkout
+                        $appConfigContent = Get-Content -Raw -Path "$(Build.SourcesDirectory)/src/vstest.console/app.config"
+
+                        # Push the app.config to the insertion branch
+                        $pushUrl = "$devdivOrg/$project/_apis/git/repositories/$vsRepoId/pushes?api-version=7.1"
+                        $pushBody = @{
+                          refUpdates = @(
+                            @{
+                              name = $sourceBranch
+                              oldObjectId = $latestCommitId
+                            }
+                          )
+                          commits = @(
+                            @{
+                              comment = "Update RocksteadyCLI App.config from vstest"
+                              changes = @(
+                                @{
+                                  changeType = $changeType
+                                  item = @{
+                                    path = $targetFilePath
+                                  }
+                                  newContent = @{
+                                    content = $appConfigContent
+                                    contentType = "rawtext"
+                                  }
+                                }
+                              )
+                            }
+                          )
+                        } | ConvertTo-Json -Depth 10
+
+                        $pushResponse = Invoke-RestMethod -Uri $pushUrl -Headers $headers -Method Post -Body $pushBody
+                        Write-Host "Pushed App.config to insertion branch. Commit: $($pushResponse.commits[0].commitId)"
+                      }
+                      catch {
+                        Write-Warning "Failed to push App.config to insertion branch: $_"
+                        Write-Warning "The insertion PR was created successfully. App.config will need to be updated manually."
+                      }
                     }
 

--- a/azure-pipelines-insertion.yml
+++ b/azure-pipelines-insertion.yml
@@ -213,11 +213,42 @@ extends:
                         }
                         $latestCommitId = $refResponse.value[0].objectId
 
-                        # Read the app.config from the ComponentBranchName, not from the checkout (which is always main)
-                        $componentBranch = "$(ComponentBranchName)"
-                        $appConfigUrl = "https://raw.githubusercontent.com/microsoft/vstest/$componentBranch/src/vstest.console/app.config"
-                        Write-Host "Fetching app.config from $appConfigUrl"
-                        $appConfigContent = Invoke-RestMethod -Uri $appConfigUrl
+                        # Fetch the app.config from the mirror repo at the exact commit used by the insertion.
+                        # roslyn-tools logs "Found microsoft-vstest build number X" — resolve the source commit from that build.
+                        $mirrorRepoId = "microsoft-vstest"
+                        $dncengBase = "https://dnceng.visualstudio.com/internal"
+                        $dncengHeaders = @{
+                          Authorization = "Bearer $dncengToken"
+                        }
+
+                        $sourceCommit = $null
+
+                        # Try to extract the commit SHA from the markdown output: ([sha](sourcesUrl))
+                        if ($outputText -match '\[([0-9a-f]{7,40})\]\(https://dev\.azure\.com/dnceng/[^)]+/_apis/build/builds/\d+/sources\)') {
+                          $sourceCommit = $Matches[1]
+                        }
+
+                        if (-not $sourceCommit) {
+                          # Fallback: resolve source commit from build number via AzDO API
+                          if ($outputText -match 'Found microsoft-vstest build number (\S+)') {
+                            $buildNumber = $Matches[1]
+                            Write-Host "Resolving source commit from build number $buildNumber"
+                            $buildsUrl = "$dncengBase/_apis/build/builds?buildNumber=$buildNumber&api-version=7.1"
+                            $buildsResponse = Invoke-RestMethod -Uri $buildsUrl -Headers $dncengHeaders -Method Get
+                            if ($buildsResponse.value -and $buildsResponse.value.Count -gt 0) {
+                              $sourceCommit = $buildsResponse.value[0].sourceVersion
+                            }
+                          }
+                        }
+
+                        if (-not $sourceCommit) {
+                          throw "Could not determine source commit from roslyn-tools output"
+                        }
+
+                        Write-Host "Fetching app.config from mirror repo at commit $sourceCommit"
+                        $encodedPath = [Uri]::EscapeDataString("/src/vstest.console/app.config")
+                        $itemUrl = "$dncengBase/_apis/git/repositories/$mirrorRepoId/items?path=$encodedPath&versionDescriptor.version=$sourceCommit&versionDescriptor.versionType=commit&api-version=7.1"
+                        $appConfigContent = Invoke-RestMethod -Uri $itemUrl -Headers $dncengHeaders -Method Get
 
                         # Push the app.config to the insertion branch
                         $pushUrl = "$devdivOrg/$project/_apis/git/repositories/$vsRepoId/pushes?api-version=7.1"

--- a/azure-pipelines-insertion.yml
+++ b/azure-pipelines-insertion.yml
@@ -223,9 +223,14 @@ extends:
 
                         $sourceCommit = $null
 
-                        # Try to extract the commit SHA from the markdown output: ([sha](sourcesUrl))
-                        if ($outputText -match '\[([0-9a-f]{7,40})\]\(https://dev\.azure\.com/dnceng/[^)]+/_apis/build/builds/\d+/sources\)') {
-                          $sourceCommit = $Matches[1]
+                        # Extract the build ID from the "Updated Updating VS Test Platform from [...] to [buildnum](url) ([sha](sourcesUrl))" line.
+                        # We use the build ID to resolve the full commit SHA via the builds API.
+                        if ($outputText -match 'Updated Updating VS Test Platform from .+ to \[\S+\]\([^)]+\) \(\[[0-9a-f]{7,40}\]\(https://dev\.azure\.com/dnceng/[^)]+/_apis/build/builds/(\d+)/sources\)\)') {
+                          $sourceBuildId = $Matches[1]
+                          Write-Host "Resolving source commit from build ID $sourceBuildId"
+                          $buildUrl = "$dncengBase/_apis/build/builds/${sourceBuildId}?api-version=7.1"
+                          $buildResponse = Invoke-RestMethod -Uri $buildUrl -Headers $dncengHeaders -Method Get
+                          $sourceCommit = $buildResponse.sourceVersion
                         }
 
                         if (-not $sourceCommit) {

--- a/azure-pipelines-insertion.yml
+++ b/azure-pipelines-insertion.yml
@@ -86,7 +86,7 @@ extends:
               steps:
 
               - task: PowerShell@2
-                displayName: '🚀 Install .NET SDK from global.json'
+                displayName: 'Install .NET SDK from global.json'
                 inputs:
                   targetType: inline
                   script: |


### PR DESCRIPTION
The previous PR (#15736) reads app.config from the pipeline checkout directory, which is always main. This breaks rel/* insertions — they'd get main's binding redirects instead of the branch-specific ones.

This fix resolves the source commit from the roslyn-tools output (parses the build ID from the 'Updated' line), then fetches app.config from the mirror repo at that exact commit.

Tested on rel/18.7 → rel/insiders insertion (build 2967511) — pushed file content verified to match GitHub rel/18.7 source.