### PR TITLE
Revert insertion trigger back to main

### DIFF
--- a/azure-pipelines-insertion.yml
+++ b/azure-pipelines-insertion.yml
@@ -1,6 +1,6 @@
 parameters:
   - name: 'ComponentBranchName'
-    default: 'rel/18.7'
+    default: 'main'
   - name: 'CreateDraftPR'
     default: 'false'
   - name: 'OptionalTitlePrefix'
@@ -44,7 +44,7 @@ schedules:
     displayName: Daily midnight insertion to VS
     branches:
       include:
-      - rel/18.7
+      - main
     always: true
 
 resources:


### PR DESCRIPTION
With rel/18.7 in place this ends up triggering the insertion from 18.7 branch, which we don't want anymore, we are now back to inserting from main, because VS caught up to main and is 18.8 already.