### PR TITLE
Enable vscode 1ES template schema file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,5 @@
   "dotnet.automaticallyCreateSolutionInWorkspace": false,
   "dotnet.enableWorkspaceBasedDevelopment": false,
   "dotnet.solution.autoOpen": "TestPlatform.slnx",
-  "azure-pipelines.1ESPipelineTemplatesSchemaFile": true,
+  "azure-pipelines.1ESPipelineTemplatesSchemaFile": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "dotnet.automaticallyCreateSolutionInWorkspace": false,
+  "dotnet.enableWorkspaceBasedDevelopment": false,
+  "dotnet.solution.autoOpen": "TestPlatform.slnx",
+  "azure-pipelines.1ESPipelineTemplatesSchemaFile": true,
+}


### PR DESCRIPTION
Ports microsoft/testfx#8155 to vstest.

Adds `.vscode/settings.json` with:
- `dotnet.automaticallyCreateSolutionInWorkspace: false`
- `dotnet.enableWorkspaceBasedDevelopment: false`
- `dotnet.solution.autoOpen: TestPlatform.slnx`
- `azure-pipelines.1ESPipelineTemplatesSchemaFile: true`

The last setting enables the 1ES pipeline templates JSON schema for `.yml` files when using the Azure Pipelines VS Code extension. The other three pin VS Code's C# DevKit / dotnet extension to open the `TestPlatform.slnx` solution instead of auto-creating one from the workspace.

Force-added because `.vscode/` is in `.gitignore` (same approach as testfx).