### PR TITLE
[fix] Fix DataDrivenTest double-counted in TRX ResultSummary counters

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -302,7 +302,10 @@ public class TrxLogger : ITestLoggerWithParameters
         // Update test entries
         UpdateTestEntries(executionId, parentExecutionId, testElement, parentTestElement);
 
-        // Set various counts (passed tests, failed tests, total tests)
+        // Set various counts (passed tests, failed tests, total tests).
+        // Data-driven tests (DataRow) report both a parent aggregation result and individual child results.
+        // Only the child results represent actual test executions, so when the first child is processed
+        // (DataRowInfo == 1), we undo the parent's contribution to the counts to avoid double-counting.
         Interlocked.Increment(ref _totalTestCount);
         if (testResult.Outcome == TrxLoggerObjectModel.TestOutcome.Failed)
         {
@@ -312,6 +315,18 @@ public class TrxLogger : ITestLoggerWithParameters
         else if (testResult.Outcome == TrxLoggerObjectModel.TestOutcome.Passed)
         {
             Interlocked.Increment(ref _passedTestCount);
+        }
+
+        // Undo the parent DataDrivenTest aggregation's count when the first child result is processed.
+        if (testResult.ResultType == TrxLoggerConstants.InnerDataDrivenResultType
+            && testResult.DataRowInfo == 1
+            && parentTestResult != null)
+        {
+            Interlocked.Decrement(ref _totalTestCount);
+            if (parentTestResult.Outcome == TrxLoggerObjectModel.TestOutcome.Failed)
+                Interlocked.Decrement(ref _failedTestCount);
+            else if (parentTestResult.Outcome == TrxLoggerObjectModel.TestOutcome.Passed)
+                Interlocked.Decrement(ref _passedTestCount);
         }
     }
 

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -362,7 +362,8 @@ public class TrxLoggerTests
         _testableTrxLogger.TestResultHandler(new object(), resultEventArg3.Object);
 
         Assert.AreEqual(1, _testableTrxLogger.TestResultCount, "TestResultHandler is not creating hierarchical results when parent result is present.");
-        Assert.AreEqual(3, _testableTrxLogger.TotalTestCount, "TestResultHandler is not adding all inner results in parent test result.");
+        // The parent DataDrivenTest aggregation should not be counted; only the 2 child DataRow results.
+        Assert.AreEqual(2, _testableTrxLogger.TotalTestCount, "TestResultHandler should count only the child DataRow results, not the parent aggregation.");
     }
 
     [TestMethod]
@@ -423,6 +424,47 @@ public class TrxLoggerTests
         _testableTrxLogger.TestResultHandler(new object(), resultEventArg3.Object);
 
         Assert.AreEqual(1, _testableTrxLogger.TestEntryCount, "TestResultHandler is adding multiple test entries for data driven tests.");
+    }
+
+    [TestMethod]
+    public void TestResultHandlerShouldNotDoubleCountDataDrivenTestResults()
+    {
+        // Regression test for: DataDrivenTest double-counted in trx logging
+        // https://github.com/microsoft/vstest/issues/15643
+        //
+        // For a [DataTestMethod] with 2 [DataRow] attributes MSTest sends:
+        //   - 1 parent aggregation result (no parentExecId)
+        //   - 1 child result per DataRow (with parentExecId set)
+        // Only the 2 children represent actual test executions; the parent must not be counted.
+
+        TestCase testCase = CreateTestCase("DataDrivenTest");
+        Guid parentExecutionId = Guid.NewGuid();
+
+        // Parent aggregation result (passed overall)
+        VisualStudio.TestPlatform.ObjectModel.TestResult parent = new(testCase);
+        parent.Outcome = TestOutcome.Passed;
+        parent.SetPropertyValue(TrxLoggerConstants.ExecutionIdProperty, parentExecutionId);
+
+        // First DataRow child — passes
+        VisualStudio.TestPlatform.ObjectModel.TestResult child1 = new(testCase);
+        child1.Outcome = TestOutcome.Passed;
+        child1.SetPropertyValue(TrxLoggerConstants.ExecutionIdProperty, Guid.NewGuid());
+        child1.SetPropertyValue(TrxLoggerConstants.ParentExecIdProperty, parentExecutionId);
+
+        // Second DataRow child — fails
+        VisualStudio.TestPlatform.ObjectModel.TestResult child2 = new(testCase);
+        child2.Outcome = TestOutcome.Failed;
+        child2.SetPropertyValue(TrxLoggerConstants.ExecutionIdProperty, Guid.NewGuid());
+        child2.SetPropertyValue(TrxLoggerConstants.ParentExecIdProperty, parentExecutionId);
+
+        _testableTrxLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(parent).Object);
+        _testableTrxLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(child1).Object);
+        _testableTrxLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(child2).Object);
+
+        // Only the 2 DataRow children should be counted, not the parent aggregation.
+        Assert.AreEqual(2, _testableTrxLogger.TotalTestCount, "DataDrivenTest parent must not be counted; only each DataRow child counts.");
+        Assert.AreEqual(1, _testableTrxLogger.PassedTestCount, "Only the one passing DataRow child should be counted as passed.");
+        Assert.AreEqual(1, _testableTrxLogger.FailedTestCount, "Only the one failing DataRow child should be counted as failed.");
     }
 
     [TestMethod]


### PR DESCRIPTION
🤖 This is an automated fix generated by Copilot.

Fixes #15643

## Root Cause

When a `[DataTestMethod]` with `[DataRow]` attributes runs, MSTest reports two kinds of results to vstest:

1. **Parent aggregation result** — one result for the `DataTestMethod` itself (no `parentExecId`), which is a `DataDrivenTest` container.
2. **Child results** — one result per `DataRow` (with `parentExecId` pointing to the parent).

`TestResultHandler` was incrementing the total/passed/failed counters on **every** call without distinguishing between parent and child results. This meant the parent aggregation was counted once, then each child was counted again, inflating the `ResultSummary` counters in the TRX file.

**Example**: 1 test with 2 `[DataRow]`s → TRX reported `total=3`, `passed=3` instead of `total=2`, `passed=2`.

## Fix

When the first DataRow child result is processed (`DataRowInfo == 1`), the parent aggregation's contribution to the counters is undone via `Interlocked.Decrement`. Only the child results represent actual test executions.

Ordered tests are unaffected: their children use a different `ResultType` (`InnerDataDrivenResultType` is not set for ordered test children), so the decrement path is never taken.

## Testing

- Updated `TestResultHandlerShouldAddHierarchicalResultsIfParentTestResultIsPresent` to assert the correct count (`2` children, not `3` total).
- Added `TestResultHandlerShouldNotDoubleCountDataDrivenTestResults` — a dedicated regression test that verifies `TotalTestCount`, `PassedTestCount`, and `FailedTestCount` are all correct for a data-driven test with 2 DataRows.
- All 69 TrxLogger unit tests pass.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/25731263546)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 25731263546, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/25731263546 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->