### PR TITLE
Fix lock-file-out-of-sync for pr-iteration workflow

### DIFF
--- a/.github/workflows/pr-iteration.lock.yml
+++ b/.github/workflows/pr-iteration.lock.yml
@@ -61,7 +61,7 @@ name: "PR Iteration Agent 🔧"
     types:
     - submitted
   schedule:
-  - cron: "11 4 * * *"
+  - cron: "37 4 * * *"
     # Friendly format: daily (scattered)
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pr-iteration.md
+++ b/.github/workflows/pr-iteration.md
@@ -13,9 +13,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
+  pull-requests: read
+  issues: read
 
 network:
   allowed:


### PR DESCRIPTION
Fixes #15756.

The committed `pr-iteration.lock.yml` was generated from a version of `pr-iteration.md` whose top-level `permissions:` block was read-only. After PR #15754 merged, the `.md` was edited to request `contents/pull-requests/issues: write` without rerunning `gh aw compile`, so the runtime stale-check refuses to start the workflow (computed hash `2de5a4a3…` vs committed `7a95995e…`).

Strict mode in gh-aw also rejects `contents: write` and steers writes through `safe-outputs`, which is the pattern this workflow already uses (`add-comment`, `noop`) — same as sibling `issue-repro-triage.md`. Reverting the permissions to read-only:

- matches the deployed lock's hash (no behavior change for jobs already running),
- lets `gh aw compile` regenerate cleanly under strict mode,
- keeps the diff to two files.

The one-line cron drift in the lock is gh-aw's per-compile fuzzy scattering and is not part of the frontmatter hash, so the stale-check is unaffected.