### PR TITLE
Improve triage throughput and fix workflow bugs

### DIFF
--- a/.github/workflows/daily-qa.md
+++ b/.github/workflows/daily-qa.md
@@ -55,7 +55,7 @@ tools:
 
 Your name is ${{ github.workflow }}. You are the daily maintenance agent for `${{ github.repository }}`. You produce a **single digest issue** each day covering repo health and PR status. This is the maintainer's morning briefing — concise, actionable, one place.
 
-This repository has **one primary maintainer** who can approve and merge. Your job is to save them time.
+This repository has **one primary maintainer** (`@nohwnd`) who can approve and merge. Your job is to save them time. **Always mention `@nohwnd`** at the top of the digest so they get an email notification.
 
 ## Anti-Noise Rules
 
@@ -156,6 +156,8 @@ gh pr list --repo ${{ github.repository }} \
 
 ## Issues Backlog — YYYY-MM-DD
 
+To get label counts, list all open issues and count them by label. Do not write "unknown" or "unavailable" — actually paginate through the issues and count. If the repo has many issues, use search queries filtered by label (e.g. search for `is:issue is:open label:"Needs: Triage :mag:"`).
+
 | Category | Count |
 |---|---|
 | Total open issues | N |
@@ -165,9 +167,11 @@ gh pr list --repo ${{ github.repository }} \
 | Actionable bugs (has repro, no linked PR) | N |
 | Agent-created fix PRs in flight | N |
 
-**Today's pick**: The Issue Triage agent is working on #NNN — [brief title]. Check for a draft fix PR later today.
+**Issue Triage Progress**: The Issue Repro Triage agent runs daily and picks one issue to investigate. Check for recent `issue-repro-triage` workflow runs and report what it worked on. If it created a draft fix PR, mention it here.
 
 **Trend**: ↓ N issues closed this week / ↑ N new issues opened
+
+cc @nohwnd
 ```
 
 If there are zero open PRs and everything is green:

--- a/.github/workflows/issue-repro-triage.lock.yml
+++ b/.github/workflows/issue-repro-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9de95beec81364e57dabc0baa462281229a7c64ce245414dcb63a2cc08930783","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ecb4db31843217b119f677ff638c754ae5f5147325336b3b50883d2460896628","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -55,12 +55,15 @@
 
 name: "Issue Repro Triage & Auto-Fix 🔍"
 "on":
+  issue_comment:
+    types:
+    - created
   issues:
     types:
     - opened
   schedule:
-  - cron: "38 17 * * *"
-    # Friendly format: daily (scattered)
+  - cron: "28 */12 * * *"
+    # Friendly format: every 12h (scattered)
   workflow_dispatch:
     inputs:
       aw_context:
@@ -208,28 +211,29 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
+          GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
         # poutine:ignore untrusted_checkout_exec
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_59685b873e75769b_EOF'
+          cat << 'GH_AW_PROMPT_c4a32377bf75c3fe_EOF'
           <system>
-          GH_AW_PROMPT_59685b873e75769b_EOF
+          GH_AW_PROMPT_c4a32377bf75c3fe_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_59685b873e75769b_EOF'
+          cat << 'GH_AW_PROMPT_c4a32377bf75c3fe_EOF'
           <safe-output-tools>
-          Tools: add_comment(max:3), create_pull_request(max:2), add_labels(max:5), remove_labels(max:5), missing_tool, missing_data, noop
-          GH_AW_PROMPT_59685b873e75769b_EOF
+          Tools: add_comment(max:10), create_pull_request(max:3), add_labels(max:15), remove_labels(max:15), missing_tool, missing_data, noop
+          GH_AW_PROMPT_c4a32377bf75c3fe_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_59685b873e75769b_EOF'
+          cat << 'GH_AW_PROMPT_c4a32377bf75c3fe_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_59685b873e75769b_EOF
+          GH_AW_PROMPT_c4a32377bf75c3fe_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_59685b873e75769b_EOF'
+          cat << 'GH_AW_PROMPT_c4a32377bf75c3fe_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -258,13 +262,16 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_59685b873e75769b_EOF
+          GH_AW_PROMPT_c4a32377bf75c3fe_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_59685b873e75769b_EOF'
+          if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
+            cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
+          fi
+          cat << 'GH_AW_PROMPT_c4a32377bf75c3fe_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/repo-build-setup.md}}
           {{#runtime-import .github/workflows/issue-repro-triage.md}}
-          GH_AW_PROMPT_59685b873e75769b_EOF
+          GH_AW_PROMPT_c4a32377bf75c3fe_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -293,6 +300,7 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
+          GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
           GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
@@ -317,6 +325,7 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
+                GH_AW_IS_PR_COMMENT: process.env.GH_AW_IS_PR_COMMENT,
                 GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST,
                 GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
               }
@@ -484,18 +493,18 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_990418aa8cce094a_EOF
-          {"add_comment":{"hide_older_comments":true,"max":3,"target":"*"},"add_labels":{"max":5},"create_pull_request":{"draft":true,"github-token":"${GH_AW_GITHUB_TOKEN}","max":2,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","title_prefix":"[fix] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"remove_labels":{"max":5},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_990418aa8cce094a_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_3771aa92578e02fd_EOF
+          {"add_comment":{"hide_older_comments":true,"max":10,"target":"*"},"add_labels":{"max":15},"create_pull_request":{"draft":true,"github-token":"${GH_AW_GITHUB_TOKEN}","max":3,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","title_prefix":"[fix] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"remove_labels":{"max":15},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_3771aa92578e02fd_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_comment": " CONSTRAINTS: Maximum 3 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading.",
-                "add_labels": " CONSTRAINTS: Maximum 5 label(s) can be added.",
-                "create_pull_request": " CONSTRAINTS: Maximum 2 pull request(s) can be created. Title will be prefixed with \"[fix] \". PRs will be created as drafts.",
-                "remove_labels": " CONSTRAINTS: Maximum 5 label(s) can be removed."
+                "add_comment": " CONSTRAINTS: Maximum 10 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading.",
+                "add_labels": " CONSTRAINTS: Maximum 15 label(s) can be added.",
+                "create_pull_request": " CONSTRAINTS: Maximum 3 pull request(s) can be created. Title will be prefixed with \"[fix] \". PRs will be created as drafts.",
+                "remove_labels": " CONSTRAINTS: Maximum 15 label(s) can be removed."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -755,7 +764,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_12f371816ec59d86_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_c5b4af8bd2426cc8_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -800,7 +809,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_12f371816ec59d86_EOF
+          GH_AW_MCP_CONFIG_c5b4af8bd2426cc8_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -825,7 +834,7 @@ jobs:
       - name: Execute GitHub Copilot CLI
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
-        timeout-minutes: 30
+        timeout-minutes: 45
         run: |
           set -o pipefail
           touch /tmp/gh-aw/agent-step-summary.md
@@ -1172,7 +1181,7 @@ jobs:
           GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
-          GH_AW_TIMEOUT_MINUTES: "30"
+          GH_AW_TIMEOUT_MINUTES: "45"
           GH_AW_CACHE_MEMORY_ENABLED: "true"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -1373,6 +1382,8 @@ jobs:
             }
 
   pre_activation:
+    if: >
+      github.event_name != 'issue_comment' && github.event_name != 'pull_request_review_comment' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
@@ -1531,7 +1542,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.vsblob.vsassets.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.nuget.org,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,builds.dotnet.microsoft.com,ci.dot.net,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,dist.nuget.org,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,pkgs.dev.azure.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.microsoft.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":3,\"target\":\"*\"},\"add_labels\":{\"max\":5},\"create_pull_request\":{\"draft\":true,\"github-token\":\"${{ secrets.GH_AW_GITHUB_TOKEN }}\",\"max\":2,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"title_prefix\":\"[fix] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"remove_labels\":{\"max\":5},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":10,\"target\":\"*\"},\"add_labels\":{\"max\":15},\"create_pull_request\":{\"draft\":true,\"github-token\":\"${{ secrets.GH_AW_GITHUB_TOKEN }}\",\"max\":3,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"title_prefix\":\"[fix] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"remove_labels\":{\"max\":15},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/issue-repro-triage.md
+++ b/.github/workflows/issue-repro-triage.md
@@ -7,7 +7,9 @@ description: >
 on:
   issues:
     types: [opened]
-  schedule: daily
+  issue_comment:
+    types: [created]
+  schedule: every 12h
   workflow_dispatch:
 
 permissions:
@@ -31,17 +33,17 @@ tools:
 
 safe-outputs:
   add-comment:
-    max: 3
+    max: 10
     target: "*"
     hide-older-comments: true
   add-labels:
-    max: 5
+    max: 15
   remove-labels:
-    max: 5
+    max: 15
   create-pull-request:
     draft: true
     title-prefix: "[fix] "
-    max: 2
+    max: 3
     protected-files: fallback-to-issue
     github-token: ${{ secrets.GH_AW_GITHUB_TOKEN }}
   noop:
@@ -49,7 +51,7 @@ safe-outputs:
   messages:
     footer: "> 🔍 *Triaged by [{workflow_name}]({run_url})*"
 
-timeout-minutes: 30
+timeout-minutes: 45
 
 imports:
   - shared/repo-build-setup.md
@@ -70,7 +72,7 @@ You are the Issue Triage agent for `${{ github.repository }}`. Your job is to dr
 
 - **Never post more than one comment per issue per run.**
 - **Prefer editing your previous comment** over adding a new one.
-- **Never comment if a human maintainer commented in the last 48 hours** — they're handling it.
+- **Never comment if a human maintainer commented in the last 48 hours** — unless this run was triggered BY that maintainer's comment (`issue_comment` event). In that case, the maintainer wants you to act.
 - **Never override human-applied labels** like `State: Blocked`, `State: Approved`, or `Needs: Design`.
 
 ## Existing Labels to Use
@@ -88,19 +90,28 @@ Use ONLY these existing repository labels — do not create new labels:
 
 Evaluate the new issue immediately.
 
-### On `schedule` (daily)
+### On `issue_comment` (maintainer comments on an issue)
 
-Your daily goal: **drive open issues to zero.** Process the backlog systematically:
+A maintainer commented on an issue — they likely added context, repro steps, or clarification. Treat this as a signal to act on the issue:
 
-1. **Follow-ups first**: Check issues labeled `Needs: Additional Info` that have been updated since labeling — the reporter may have added repro steps. Re-evaluate them.
-2. **Backlog nibble**: Pick **one** open bug issue to work on. Selection priority:
+1. Read the full issue and all comments.
+2. If the maintainer's comment explicitly says to hold off (e.g., "don't triage this yet", "leave this alone", "not now", "skip this") → `noop`.
+3. Otherwise, treat the issue as if it was just opened — evaluate completeness, attempt repro if possible, attempt fix if reproducible. The maintainer's comment likely provides additional context that makes the issue more actionable.
+
+### On `schedule` (every 12 hours)
+
+Your goal: **drive open issues to zero.** Process the backlog systematically:
+
+1. **Follow-ups first**: Check ALL issues labeled `Needs: Additional Info` or `Needs: Author Feedback` that have been updated since labeling — the reporter may have added repro steps. Re-evaluate every one of them.
+2. **New issues from external contributors**: Check issues opened in the last 24 hours that have NOT been triaged yet (no agent comment, no triage labels). These were skipped on creation because the author lacked write permission. Triage them now — they deserve the same treatment as maintainer-filed issues.
+3. **Backlog**: Work through open bug issues. Process **up to 3 issues** per run. Selection priority:
    a. Issues with `Needs: Triage :mag:` label (untriaged, newest first)
    b. Oldest open bug issues that have repro steps but no linked PR
    c. Issues without repro steps that you can investigate from the description alone
-3. **Skip**: issues labeled `State: Blocked`, `Needs: Design`, `State: Approved`, or `State: In-PR`
-4. **Skip**: issues you already commented on in the last 7 days (don't re-triage the same issue)
+4. **Skip**: issues labeled `State: Blocked`, `Needs: Design`, `State: Approved`, or `State: In-PR`
+5. **Skip**: issues you already commented on in the last 7 days (don't re-triage the same issue)
 
-The goal is steady progress: one issue per day = the backlog shrinks consistently. The maintainer wakes up to either a draft fix PR or a root cause analysis comment — actionable work ready to go.
+The goal is steady progress: the maintainer wakes up to draft fix PRs or root cause analysis comments — actionable work ready to go.
 
 ## Process
 

--- a/.github/workflows/pr-expert-reviewer.md
+++ b/.github/workflows/pr-expert-reviewer.md
@@ -187,6 +187,8 @@ Then submit an overall review using `submit-pull-request-review` with:
   - `COMMENT` — if findings are performance suggestions, defensive coding improvements, or minor concerns
   - `APPROVE` — if no issues found and the code is solid
 
+**Do NOT include a "Reviewed by" footer or signature in your review body.** The framework appends one automatically. Including your own causes duplication.
+
 ### Step 7: Update Memory Cache
 
 After the review, update:

--- a/.github/workflows/pr-iteration.md
+++ b/.github/workflows/pr-iteration.md
@@ -90,7 +90,8 @@ If triggered by `schedule` or `workflow_dispatch`, check ALL your PRs and iterat
    d. Make the requested changes
    e. Build and run tests to verify
    f. Push the fix
-   g. Reply briefly to the review comment confirming what you changed
+   g. Verify the PR description accurately describes the code changes. If it's a template placeholder or doesn't match the diff, rewrite it.
+   h. Reply briefly to the review comment confirming what you changed
 4. If the comment is just a question or discussion, reply if you can add useful context. Otherwise noop.
 
 ### On `schedule` (daily) or `workflow_dispatch`
@@ -103,7 +104,8 @@ If triggered by `schedule` or `workflow_dispatch`, check ALL your PRs and iterat
       - Determine if it's a code issue (fix it) or infrastructure flake (comment and skip)
       - Push a fix if possible
    c. Check for unaddressed review comments. If any, address them.
-   d. Check for merge conflicts. If conflicted, merge main and push.
+   d. Check that the PR description accurately describes the code changes. If it's a template placeholder or doesn't match the diff, rewrite it.
+   e. Check for merge conflicts. If conflicted, merge main and push.
 3. Update cache-memory with the cleaned-up list (remove merged/closed PRs).
 
 ### Deciding what to fix


### PR DESCRIPTION
Bunch of workflow improvements:

- Triage runs every 12h instead of daily, processes up to 3 issues per run (was 1). External contributor issues get explicitly picked up on schedule since they're skipped on \issues.opened\ by the gh-aw permission gate.
- PR description validation added to pr-iteration (flags + fixes stale descriptions).
- Fixed duplicate reviewer footer, broken label counting, missing @nohwnd mention in daily digest.