### PR TITLE
[fix] Add RequestingAssembly to AssemblyResolveEventArgs for forward compatibility

### DIFF
--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/Runtime/IAssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/Runtime/IAssemblyResolver.cs
@@ -43,7 +43,23 @@ public class AssemblyResolveEventArgs : EventArgs
     }
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="AssemblyResolveEventArgs"/> class.
+    /// </summary>
+    /// <param name="name">The full name of an assembly to resolve.</param>
+    /// <param name="requestingAssembly">The assembly whose dependency is being resolved, or null if unknown.</param>
+    public AssemblyResolveEventArgs(string? name, Assembly? requestingAssembly)
+    {
+        Name = name;
+        RequestingAssembly = requestingAssembly;
+    }
+
+    /// <summary>
     /// Gets or sets the name of the item to resolve.
     /// </summary>
     public string? Name { get; set; }
+
+    /// <summary>
+    /// Gets the assembly whose dependency is being resolved.
+    /// </summary>
+    public Assembly? RequestingAssembly { get; }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces.AssemblyResolveEventArgs.AssemblyResolveEventArgs(string? name, System.Reflection.Assembly? requestingAssembly) -> void
+Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces.AssemblyResolveEventArgs.RequestingAssembly.get -> System.Reflection.Assembly?

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net462/Runtime/PlatformAssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net462/Runtime/PlatformAssemblyResolver.cs
@@ -69,7 +69,7 @@ public class PlatformAssemblyResolver : IAssemblyResolver
     /// </returns>
     private Assembly? AssemblyResolverEvent(object sender, object eventArgs)
     {
-        return eventArgs is not ResolveEventArgs args ? null : AssemblyResolve?.Invoke(this, new AssemblyResolveEventArgs(args.Name));
+        return eventArgs is not ResolveEventArgs args ? null : AssemblyResolve?.Invoke(this, new AssemblyResolveEventArgs(args.Name, args.RequestingAssembly));
     }
 }
 


### PR DESCRIPTION
🤖 This is an automated fix generated by the Issue Triage agent.

Closes #15765

## Root Cause

The `AssemblyResolveEventArgs` class in `Microsoft.TestPlatform.PlatformAbstractions` lacked a `RequestingAssembly` property. The .NET SDK 10.0.300 ships newer vstest extension assemblies that were compiled against a version of `PlatformAbstractions` that has this property.

When `RunConfiguration.DisableAppDomain=true` is used with `net462` targets, SDK extensions and test assemblies share the same AppDomain. When an assembly resolution is triggered, the newer SDK-shipped extension code calls `args.RequestingAssembly`, but the `PlatformAbstractions` loaded at runtime is older and doesn't have the property — resulting in:

```
System.MissingMethodException: Method not found: 'System.Reflection.Assembly 
Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces.AssemblyResolveEventArgs.get_RequestingAssembly()'
```

This then cascades into test failures like:
```
System.IO.FileLoadException: Could not load file or assembly 'System.Diagnostics.DiagnosticSource, Version=8.0.0.1'
```

## What the Fix Does

- Adds `RequestingAssembly` property to `AssemblyResolveEventArgs`
- Adds a new `AssemblyResolveEventArgs(string?, Assembly?)` constructor overload
- Updates the net462 `PlatformAssemblyResolver` to pass `ResolveEventArgs.RequestingAssembly` through when constructing the event args
- Declares the new public API surface in `PublicAPI.Unshipped.txt`

This makes the current codebase forward-compatible: once shipped, older test projects referencing this version will have the property that SDK-bundled extensions expect.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/25850934583)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 25850934583, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/25850934583 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->