### PR TITLE
[fix] InProcessVsTestConsoleWrapper drops Windows drive-relative env vars (#15740)

### DIFF
--- a/src/vstest.console/InProcessVsTestConsoleWrapper.cs
+++ b/src/vstest.console/InProcessVsTestConsoleWrapper.cs
@@ -8,6 +8,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -115,6 +116,18 @@ internal class InProcessVsTestConsoleWrapper : IVsTestConsoleWrapper
             foreach (DictionaryEntry? entry in _environmentVariableHelper.GetEnvironmentVariables())
             {
                 environmentVariableBaseline[entry?.Key.ToString()!] = entry?.Value?.ToString();
+            }
+
+            // On Windows, Environment.GetEnvironmentVariables() omits entries whose keys start
+            // with '=' (e.g. "=C:=C:\path" — drive-relative current directory entries kept by
+            // the native environment block). Supplement the managed snapshot with those entries
+            // so that testhost receives a complete environment.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                foreach (var (key, value) in GetWindowsNativeEqualsEnvironmentVariables())
+                {
+                    environmentVariableBaseline[key] = value;
+                }
             }
         }
 
@@ -1301,4 +1314,64 @@ internal class InProcessVsTestConsoleWrapper : IVsTestConsoleWrapper
         _testPlatformEventSource.TranslationLayerInitializeStop();
         return true;
     }
+
+    /// <summary>
+    /// On Windows, reads the raw native environment block via P/Invoke to collect entries
+    /// whose keys start with '=' (drive-relative current directory entries). These are silently
+    /// omitted by <see cref="Environment.GetEnvironmentVariables()"/> but are present in the
+    /// native environment block. They must be forwarded to the testhost so that drive-relative
+    /// paths resolve correctly.
+    /// </summary>
+    private static IEnumerable<(string Key, string? Value)> GetWindowsNativeEqualsEnvironmentVariables()
+    {
+        IntPtr block = GetEnvironmentStringsW();
+        if (block == IntPtr.Zero)
+        {
+            yield break;
+        }
+
+        try
+        {
+            int offset = 0;
+            while (true)
+            {
+                string entry = Marshal.PtrToStringUni(IntPtr.Add(block, offset * 2))!;
+                if (entry.Length == 0)
+                {
+                    break;
+                }
+
+                // Only yield entries whose key starts with '=' — these are the ones that the
+                // managed API drops. All other entries are already included via GetEnvironmentVariables().
+                if (entry.StartsWith("=", StringComparison.Ordinal))
+                {
+                    int separatorIndex = entry.IndexOf('=', 1);
+                    if (separatorIndex > 0)
+                    {
+                        string key = entry.Substring(0, separatorIndex);
+                        string value = entry.Substring(separatorIndex + 1);
+                        yield return (key, value);
+                    }
+                    else
+                    {
+                        // Key with no value (just "=key" or "=key=").
+                        yield return (entry, null);
+                    }
+                }
+
+                offset += entry.Length + 1;
+            }
+        }
+        finally
+        {
+            FreeEnvironmentStringsW(block);
+        }
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr GetEnvironmentStringsW();
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool FreeEnvironmentStringsW(IntPtr lpszEnvironmentBlock);
 }

--- a/src/vstest.console/InProcessVsTestConsoleWrapper.cs
+++ b/src/vstest.console/InProcessVsTestConsoleWrapper.cs
@@ -1354,7 +1354,7 @@ internal class InProcessVsTestConsoleWrapper : IVsTestConsoleWrapper
                     }
                     else
                     {
-                        // Key with no value (just "=key" or "=key=").
+                        // Key with no value (just "=key", no second '=').
                         yield return (entry, null);
                     }
                 }

--- a/test/vstest.console.UnitTests/InProcessVsTestConsoleWrapperTests.cs
+++ b/test/vstest.console.UnitTests/InProcessVsTestConsoleWrapperTests.cs
@@ -163,6 +163,38 @@ public class InProcessVsTestConsoleWrapperTests
     }
 
     [TestMethod]
+    [TestCategory("Windows")]
+    [OSCondition(OperatingSystems.Windows)]
+    public void InProcessWrapperConstructorWithRealEnvironmentHelper_OnWindows_IncludesNativeEqualsEnvironmentVariablesInProcessHelper()
+    {
+        var consoleParams = new ConsoleParameters { InheritEnvironmentVariables = true };
+
+        // Use a real IEnvironmentVariableHelper so that GetEnvironmentVariables() returns the
+        // actual managed snapshot (which omits '='-prefixed keys on Windows). The fix in
+        // InProcessVsTestConsoleWrapper must supplement that snapshot via P/Invoke so that
+        // testhost receives the full native environment block.
+        _ = new InProcessVsTestConsoleWrapper(
+            consoleParams,
+            new RealEnvironmentVariableHelper(),
+            _mockRequestSender.Object,
+            _mockTestRequestManager.Object,
+            new Executor(_mockOutput.Object, new Mock<ITestPlatformEventSource>().Object, new ProcessHelper(), new PlatformEnvironment()),
+            new Mock<ITestPlatformEventSource>().Object,
+            new());
+
+        // Windows always maintains at least one '=<Drive>:' entry in the native env block (e.g.
+        // "=C:=C:\..."). Without the fix these entries are invisible to the managed API and would
+        // not be forwarded to testhost.
+        var hasEqualsKey = ProcessHelper.ExternalEnvironmentVariables?.Keys
+            .Cast<string>()
+            .Any(k => k.StartsWith("=", StringComparison.Ordinal));
+
+        Assert.IsTrue(hasEqualsKey,
+            "ProcessHelper.ExternalEnvironmentVariables must contain at least one '='-prefixed " +
+            "drive-relative current-directory entry on Windows when InheritEnvironmentVariables is true.");
+    }
+
+    [TestMethod]
     public void InProcessWrapperConstructorShouldSetTheCultureSpecifiedByTheUser()
     {
         // Arrange
@@ -1116,5 +1148,33 @@ public class InProcessVsTestConsoleWrapperTests
                 It.IsAny<TestRunAttachmentsProcessingPayload>(),
                 It.IsAny<ITestRunAttachmentsProcessingEventsHandler>(),
                 It.IsAny<ProtocolConfig>()), Times.Once);
+    }
+
+    /// <summary>
+    /// A non-mocked <see cref="IEnvironmentVariableHelper"/> that delegates to the real
+    /// <see cref="Environment"/> APIs. Used to exercise the native Windows P/Invoke code path
+    /// inside <see cref="InProcessVsTestConsoleWrapper"/> that supplements the managed env snapshot
+    /// with <c>=</c>-prefixed drive-relative current-directory entries.
+    /// </summary>
+    private sealed class RealEnvironmentVariableHelper : IEnvironmentVariableHelper
+    {
+        public IDictionary GetEnvironmentVariables() => Environment.GetEnvironmentVariables();
+
+        public string? GetEnvironmentVariable(string variable) => Environment.GetEnvironmentVariable(variable);
+
+        public TEnum GetEnvironmentVariableAsEnum<TEnum>(string variable, TEnum defaultValue = default)
+            where TEnum : struct, Enum
+        {
+            var value = Environment.GetEnvironmentVariable(variable);
+            if (string.IsNullOrEmpty(value))
+            {
+                return defaultValue;
+            }
+
+            return Enum.TryParse<TEnum>(value, out var result) ? result : defaultValue;
+        }
+
+        public void SetEnvironmentVariable(string variable, string value) =>
+            Environment.SetEnvironmentVariable(variable, value);
     }
 }

--- a/test/vstest.console.UnitTests/InProcessVsTestConsoleWrapperTests.cs
+++ b/test/vstest.console.UnitTests/InProcessVsTestConsoleWrapperTests.cs
@@ -147,7 +147,13 @@ public class InProcessVsTestConsoleWrapperTests
             new Mock<ITestPlatformEventSource>().Object,
             new());
 
-        Assert.AreEqual(3, ProcessHelper.ExternalEnvironmentVariables?.Count);
+        // On Windows, GetWindowsNativeEqualsEnvironmentVariables() may add '='-prefixed
+        // drive-relative current-directory entries (e.g. "=C:=C:\...") from the native
+        // environment block. Exclude those when verifying the expected managed-API count.
+        int nonNativeCount = ProcessHelper.ExternalEnvironmentVariables?.Keys
+            .Cast<string>()
+            .Count(k => !k.StartsWith("=", StringComparison.Ordinal)) ?? 0;
+        Assert.AreEqual(3, nonNativeCount);
         Assert.IsTrue(ProcessHelper.ExternalEnvironmentVariables?.ContainsKey(environmentVariableName1));
         Assert.AreEqual("1", ProcessHelper.ExternalEnvironmentVariables?[environmentVariableName1]);
         Assert.IsTrue(ProcessHelper.ExternalEnvironmentVariables?.ContainsKey(environmentVariableName2));


### PR DESCRIPTION
## Summary

> 🤖 This is an automated fix generated by [Issue Repro Triage & Auto-Fix](https://github.com/microsoft/vstest/actions/runs/25851624544).

Fixes #15740

## Root Cause

On Windows, `Environment.GetEnvironmentVariables()` (managed API) silently omits environment entries whose keys start with `=` (e.g. `=C:=C:\path`). These are **drive-relative current directory** entries maintained by the native Windows environment block (`GetEnvironmentStringsW`).

In the in-process vstest path, `InProcessVsTestConsoleWrapper` snapshots the current process environment via the managed API and passes it to the testhost process via `ProcessHelper.ExternalEnvironmentVariables`. Because the managed API omits `=`-prefixed entries, the testhost never receives them, causing drive-relative path resolution to behave differently in the testhost than in the host process.

The out-of-process path is unaffected: it uses `ProcessStartInfo` with OS-level inheritance, so the native environment block (including `=`-prefixed entries) is inherited automatically.

## Fix

In `InProcessVsTestConsoleWrapper.cs`, after populating `environmentVariableBaseline` from the managed snapshot, supplement it on Windows with entries from the raw native environment block obtained via `GetEnvironmentStringsW` / `FreeEnvironmentStringsW` P/Invoke. Only `=`-prefixed entries are extracted from the native block; all other entries are already present in the managed snapshot.

## Changes

- `src/vstest.console/InProcessVsTestConsoleWrapper.cs`: Added `GetWindowsNativeEqualsEnvironmentVariables()` private static helper and called it when `InheritEnvironmentVariables = true` on Windows.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/25851624544)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 25851624544, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/25851624544 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->