### PR TITLE
Remove DiagnosticSource binding redirect (rel/18.7)

### DIFF
--- a/eng/verify-binding-redirects.ps1
+++ b/eng/verify-binding-redirects.ps1
@@ -2,12 +2,22 @@ $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
 $script:isCI = $env:TF_BUILD -eq 'true' -or $env:CI -eq 'true'
+$script:hasUnfixableErrors = $false
 
 # Verifies that binding redirects in source app.config files match the actual
 # assembly versions of the DLLs shipped in the extracted nupkg packages.
 #
 # In CI: validates and fails with instructions to run locally.
 # Locally: auto-fixes the source app.config files with the correct versions.
+
+# Assemblies that have binding redirects but are intentionally NOT shipped in the
+# CLI/SDK package. These are loaded from Visual Studio at runtime when testhost
+# runs inside VS. A redirect without a DLL is safe here because the DLL comes
+# from VS's probing path, not from the package layout.
+$script:AllowMissingDlls = @(
+    "Microsoft.VisualStudio.TestWindow.Interfaces"
+    "Microsoft.VisualStudio.QualityTools.UnitTestFramework"
+)
 
 # Each source app.config maps to a specific exe that ships in the packages.
 $script:AppConfigs = @(
@@ -110,7 +120,23 @@ function Verify-BindingRedirects {
             }
 
             if (-not $dllPath) {
-                Write-Host "  $assemblyName - not found in package layout, skipping."
+                if ($assemblyName -in $script:AllowMissingDlls) {
+                    Write-Host "  $assemblyName - SKIP (allowed missing - loaded from VS at runtime)"
+                    continue
+                }
+
+                # The deploy directory exists (package was found) but the DLL is missing.
+                # A binding redirect pointing to a DLL that doesn't ship causes runtime
+                # failures (e.g. #15765). Fail so the redirect gets removed.
+                # This cannot be auto-fixed - the redirect must be manually removed or the DLL shipped.
+                $errors += "$($entry.ExeName): $assemblyName has a binding redirect but the DLL is not in the package layout"
+                $script:hasUnfixableErrors = $true
+                if ($script:isCI) {
+                    Write-Host "  $assemblyName - ERROR: binding redirect exists but DLL not found in package - remove the redirect or ship the DLL" -ForegroundColor Red
+                }
+                else {
+                    Write-Host "  $assemblyName - ERROR: binding redirect exists but DLL not found in package - remove the redirect from $($entry.Config)" -ForegroundColor Red
+                }
                 continue
             }
 
@@ -193,16 +219,26 @@ function Verify-BindingRedirects {
 
     if ($errors) {
         if ($script:isCI) {
-            $message = "Assembly binding redirect mismatches detected:`n"
+            $message = "Assembly binding redirect errors detected:`n"
             $message += ($errors -join "`n")
-            $message += "`n`nTo fix this, run the following command locally after building and packing:`n"
-            $message += "  .\build.cmd -c $Configuration`n"
-            $message += "This will rebuild, pack, and auto-update the app.config files with the correct versions.`n"
-            $message += "Then commit the updated app.config files."
+            if ($configsToFix.Count -gt 0) {
+                $message += "`n`nFor version mismatches, run the following command locally after building and packing:`n"
+                $message += "  .\build.cmd -c $Configuration`n"
+                $message += "This will rebuild, pack, and auto-update the app.config files with the correct versions.`n"
+                $message += "Then commit the updated app.config files."
+            }
+            if ($script:hasUnfixableErrors) {
+                $message += "`n`nFor missing-DLL errors, remove the binding redirect from the app.config or add the DLL to the package."
+            }
             Write-Error $message
         }
         else {
-            Write-Host "`nFixed $($errors.Count) binding redirect(s). Please commit the updated app.config files." -ForegroundColor Green
+            if ($configsToFix.Count -gt 0) {
+                Write-Host "`nFixed $($configsToFix.Count) version mismatch(es). Please commit the updated app.config files." -ForegroundColor Green
+            }
+            if ($script:hasUnfixableErrors) {
+                Write-Error "Missing-DLL binding redirect errors detected - these cannot be auto-fixed. Remove the redirect(s) listed above from the app.config file(s)."
+            }
         }
     }
     else {

--- a/src/datacollector/app.config
+++ b/src/datacollector/app.config
@@ -40,10 +40,7 @@
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="1.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
-      </dependentAssembly>
+
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/testhost.x86/app.config
+++ b/src/testhost.x86/app.config
@@ -53,10 +53,7 @@
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="1.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
-      </dependentAssembly>
+
     </assemblyBinding>
   </runtime>
   <system.diagnostics>

--- a/src/vstest.console/app.config
+++ b/src/vstest.console/app.config
@@ -49,16 +49,6 @@
       </dependentAssembly>
 
 
-      
-      <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
-      </dependentAssembly>
-      
-      <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.11" newVersion="6.0.0.0" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <appSettings>

--- a/src/vstest.console/app.config
+++ b/src/vstest.console/app.config
@@ -48,10 +48,7 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
 
-      <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
-      </dependentAssembly>
+
       
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />


### PR DESCRIPTION
Port of #15776 to rel/18.7.

Remove the `System.Diagnostics.DiagnosticSource` binding redirect from testhost, datacollector, and vstest.console app.configs.

The redirect (added in #15567) points to assembly version 8.0.0.1, but the DLL is excluded from the CLI package in the `.nuspec`. On net462 with `DisableAppDomain=true`, the testhost's redirect is active in the test AppDomain — it rewrites DiagnosticSource requests to 8.0.0.1, which doesn't exist, causing `MissingMethodException` in the assembly resolver.

Fixes #15765