### PR TITLE
[fix] Harden binding redirect validation to catch missing DLLs

### DIFF
--- a/eng/verify-binding-redirects.ps1
+++ b/eng/verify-binding-redirects.ps1
@@ -9,6 +9,16 @@ $script:isCI = $env:TF_BUILD -eq 'true' -or $env:CI -eq 'true'
 # In CI: validates and fails with instructions to run locally.
 # Locally: auto-fixes the source app.config files with the correct versions.
 
+# Assemblies that have binding redirects but are intentionally NOT shipped in the
+# CLI/SDK package. These are loaded from Visual Studio at runtime when testhost
+# runs inside VS. A redirect without a DLL is safe here because the DLL comes
+# from VS's probing path, not from the package layout.
+$script:AllowMissingDlls = @(
+    "Microsoft.VisualStudio.TestWindow.Interfaces"
+    "Microsoft.VisualStudio.QualityTools.UnitTestFramework"
+    "Microsoft.Extensions.FileSystemGlobbing"
+)
+
 # Each source app.config maps to a specific exe that ships in the packages.
 $script:AppConfigs = @(
     @{ Config = "src/vstest.console/app.config";  ExeName = "vstest.console.exe" }
@@ -110,7 +120,21 @@ function Verify-BindingRedirects {
             }
 
             if (-not $dllPath) {
-                Write-Host "  $assemblyName - not found in package layout, skipping."
+                if ($assemblyName -in $script:AllowMissingDlls) {
+                    Write-Host "  $assemblyName - SKIP (allowed missing — loaded from VS at runtime)"
+                    continue
+                }
+
+                # The deploy directory exists (package was found) but the DLL is missing.
+                # A binding redirect pointing to a DLL that doesn't ship causes runtime
+                # failures (e.g. #15765). Fail so the redirect gets removed.
+                $errors += "$($entry.ExeName): $assemblyName has a binding redirect but the DLL is not in the package layout"
+                if ($script:isCI) {
+                    Write-Host "  $assemblyName - ERROR: binding redirect exists but DLL not found in package" -ForegroundColor Red
+                }
+                else {
+                    Write-Host "  $assemblyName - ERROR: binding redirect exists but DLL not found in package — remove the redirect from $($entry.Config)" -ForegroundColor Red
+                }
                 continue
             }
 

--- a/eng/verify-binding-redirects.ps1
+++ b/eng/verify-binding-redirects.ps1
@@ -17,7 +17,6 @@ $script:hasUnfixableErrors = $false
 $script:AllowMissingDlls = @(
     "Microsoft.VisualStudio.TestWindow.Interfaces"
     "Microsoft.VisualStudio.QualityTools.UnitTestFramework"
-    "Microsoft.Extensions.FileSystemGlobbing"
 )
 
 # Each source app.config maps to a specific exe that ships in the packages.

--- a/eng/verify-binding-redirects.ps1
+++ b/eng/verify-binding-redirects.ps1
@@ -2,6 +2,7 @@ $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
 $script:isCI = $env:TF_BUILD -eq 'true' -or $env:CI -eq 'true'
+$script:hasUnfixableErrors = $false
 
 # Verifies that binding redirects in source app.config files match the actual
 # assembly versions of the DLLs shipped in the extracted nupkg packages.
@@ -128,9 +129,11 @@ function Verify-BindingRedirects {
                 # The deploy directory exists (package was found) but the DLL is missing.
                 # A binding redirect pointing to a DLL that doesn't ship causes runtime
                 # failures (e.g. #15765). Fail so the redirect gets removed.
+                # This cannot be auto-fixed — the redirect must be manually removed or the DLL shipped.
                 $errors += "$($entry.ExeName): $assemblyName has a binding redirect but the DLL is not in the package layout"
+                $script:hasUnfixableErrors = $true
                 if ($script:isCI) {
-                    Write-Host "  $assemblyName - ERROR: binding redirect exists but DLL not found in package" -ForegroundColor Red
+                    Write-Host "  $assemblyName - ERROR: binding redirect exists but DLL not found in package — remove the redirect or ship the DLL" -ForegroundColor Red
                 }
                 else {
                     Write-Host "  $assemblyName - ERROR: binding redirect exists but DLL not found in package — remove the redirect from $($entry.Config)" -ForegroundColor Red
@@ -217,16 +220,26 @@ function Verify-BindingRedirects {
 
     if ($errors) {
         if ($script:isCI) {
-            $message = "Assembly binding redirect mismatches detected:`n"
+            $message = "Assembly binding redirect errors detected:`n"
             $message += ($errors -join "`n")
-            $message += "`n`nTo fix this, run the following command locally after building and packing:`n"
-            $message += "  .\build.cmd -c $Configuration`n"
-            $message += "This will rebuild, pack, and auto-update the app.config files with the correct versions.`n"
-            $message += "Then commit the updated app.config files."
+            if ($configsToFix.Count -gt 0) {
+                $message += "`n`nFor version mismatches, run the following command locally after building and packing:`n"
+                $message += "  .\build.cmd -c $Configuration`n"
+                $message += "This will rebuild, pack, and auto-update the app.config files with the correct versions.`n"
+                $message += "Then commit the updated app.config files."
+            }
+            if ($script:hasUnfixableErrors) {
+                $message += "`n`nFor missing-DLL errors, remove the binding redirect from the app.config or add the DLL to the package."
+            }
             Write-Error $message
         }
         else {
-            Write-Host "`nFixed $($errors.Count) binding redirect(s). Please commit the updated app.config files." -ForegroundColor Green
+            if ($configsToFix.Count -gt 0) {
+                Write-Host "`nFixed $($configsToFix.Count) version mismatch(es). Please commit the updated app.config files." -ForegroundColor Green
+            }
+            if ($script:hasUnfixableErrors) {
+                Write-Error "Missing-DLL binding redirect errors detected — these cannot be auto-fixed. Remove the redirect(s) listed above from the app.config file(s)."
+            }
         }
     }
     else {

--- a/eng/verify-binding-redirects.ps1
+++ b/eng/verify-binding-redirects.ps1
@@ -122,21 +122,21 @@ function Verify-BindingRedirects {
 
             if (-not $dllPath) {
                 if ($assemblyName -in $script:AllowMissingDlls) {
-                    Write-Host "  $assemblyName - SKIP (allowed missing — loaded from VS at runtime)"
+                    Write-Host "  $assemblyName - SKIP (allowed missing - loaded from VS at runtime)"
                     continue
                 }
 
                 # The deploy directory exists (package was found) but the DLL is missing.
                 # A binding redirect pointing to a DLL that doesn't ship causes runtime
                 # failures (e.g. #15765). Fail so the redirect gets removed.
-                # This cannot be auto-fixed — the redirect must be manually removed or the DLL shipped.
+                # This cannot be auto-fixed - the redirect must be manually removed or the DLL shipped.
                 $errors += "$($entry.ExeName): $assemblyName has a binding redirect but the DLL is not in the package layout"
                 $script:hasUnfixableErrors = $true
                 if ($script:isCI) {
-                    Write-Host "  $assemblyName - ERROR: binding redirect exists but DLL not found in package — remove the redirect or ship the DLL" -ForegroundColor Red
+                    Write-Host "  $assemblyName - ERROR: binding redirect exists but DLL not found in package - remove the redirect or ship the DLL" -ForegroundColor Red
                 }
                 else {
-                    Write-Host "  $assemblyName - ERROR: binding redirect exists but DLL not found in package — remove the redirect from $($entry.Config)" -ForegroundColor Red
+                    Write-Host "  $assemblyName - ERROR: binding redirect exists but DLL not found in package - remove the redirect from $($entry.Config)" -ForegroundColor Red
                 }
                 continue
             }
@@ -238,7 +238,7 @@ function Verify-BindingRedirects {
                 Write-Host "`nFixed $($configsToFix.Count) version mismatch(es). Please commit the updated app.config files." -ForegroundColor Green
             }
             if ($script:hasUnfixableErrors) {
-                Write-Error "Missing-DLL binding redirect errors detected — these cannot be auto-fixed. Remove the redirect(s) listed above from the app.config file(s)."
+                Write-Error "Missing-DLL binding redirect errors detected - these cannot be auto-fixed. Remove the redirect(s) listed above from the app.config file(s)."
             }
         }
     }

--- a/src/vstest.console/app.config
+++ b/src/vstest.console/app.config
@@ -43,15 +43,6 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
 
-      <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.0" />
-      </dependentAssembly>
-
-      <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <appSettings>


### PR DESCRIPTION
`verify-binding-redirects.ps1` silently skipped redirects whose DLL wasn't in the package layout. This allowed #15765 — the DiagnosticSource redirect shipped in testhost.exe.config but the DLL was excluded from the `.nuspec`.

Now it's an error: if the package exists but a redirect's target DLL is missing, the script fails. The whole-package-missing case (e.g. VMR where the exe isn't found at all) is still a skip.