### PR TITLE
Allow issue triage workflow to create PRs on release branches

### DIFF
--- a/.github/workflows/issue-repro-triage.md
+++ b/.github/workflows/issue-repro-triage.md
@@ -44,6 +44,7 @@ safe-outputs:
     draft: true
     title-prefix: "[fix] "
     max: 3
+    allowed-base-branches: ["main", "rel/*"]
     protected-files: fallback-to-issue
     github-token: ${{ secrets.GH_AW_GITHUB_TOKEN }}
   noop:


### PR DESCRIPTION
The auto-fix workflow independently reproduced #15765 and tried to create fix PRs targeting rel/18.6 and rel/18.7, but was blocked because `allowed-base-branches` wasn't configured for release branches.

Add `rel/*` to `allowed-base-branches` so the triage workflow can land fixes on release branches too. PRs are still draft-only and need human review.