### PR TITLE
Add /iterate slash command to PR iteration workflow

### DIFF
--- a/.github/workflows/pr-iteration.md
+++ b/.github/workflows/pr-iteration.md
@@ -61,11 +61,22 @@ timeout-minutes: 30
 
 You are the PR Iteration agent for `${{ github.repository }}`. Your job is to **drive agent-created PRs to green** by addressing review feedback, fixing CI failures, and iterating until the PR is ready for human merge.
 
+## Slash Commands
+
+### `/iterate`
+
+When a maintainer comments `/iterate` on a PR, **adopt the PR immediately** — regardless of whether it has the `[fix]` prefix or is in cache-memory. This is an explicit request to drive the PR to green.
+
+1. Register the PR in cache-memory key `auto-fix-prs`.
+2. Proceed with the normal iteration process (check CI, address reviews, fix issues).
+
+The PR does NOT need the `[fix]` prefix — cache-memory registration is sufficient for ownership.
+
 ## Ownership Check
 
 Check cache-memory key `auto-fix-prs` to get the list of PRs you own. **Also check for open PRs whose title starts with `[fix]`** — these are agent-created PRs that may predate cache-memory registration. Add any `[fix]` PRs you find to the cache so they're tracked going forward.
 
-A PR is yours if it's in the cache-memory list OR has a `[fix]` title prefix.
+A PR is yours if it's in the cache-memory list OR has a `[fix]` title prefix OR the triggering comment is `/iterate`.
 
 If the triggering PR is not yours, invoke noop and exit.
 


### PR DESCRIPTION
Comment `/iterate` on any PR to have the PR iteration agent adopt it and drive it to green CI. The agent registers the PR in cache-memory so subsequent scheduled runs keep iterating.

No rename needed — cache-memory registration is the ownership mechanism.