### PR TITLE
[fix] Fix DataDriven test results double-counted in TRX ResultSummary

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -313,6 +313,21 @@ public class TrxLogger : ITestLoggerWithParameters
         {
             Interlocked.Increment(ref _passedTestCount);
         }
+
+        // When the first inner DataDriven result is processed, the parent result is retroactively
+        // marked as a DataDriven parent. Undo the parent's count that was already incremented when
+        // the parent was first received as a top-level result, so that only the inner (DataRow)
+        // results are counted — not the aggregate parent.
+        if (testResult.ResultType == TrxLoggerConstants.InnerDataDrivenResultType
+            && parentTestResult is TrxLoggerObjectModel.TestResultAggregation dataDrivenParent
+            && dataDrivenParent.InnerResults.Count == 1)
+        {
+            Interlocked.Decrement(ref _totalTestCount);
+            if (dataDrivenParent.Outcome == TrxLoggerObjectModel.TestOutcome.Failed)
+                Interlocked.Decrement(ref _failedTestCount);
+            else if (dataDrivenParent.Outcome == TrxLoggerObjectModel.TestOutcome.Passed)
+                Interlocked.Decrement(ref _passedTestCount);
+        }
     }
 
     /// <summary>

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -362,7 +362,7 @@ public class TrxLoggerTests
         _testableTrxLogger.TestResultHandler(new object(), resultEventArg3.Object);
 
         Assert.AreEqual(1, _testableTrxLogger.TestResultCount, "TestResultHandler is not creating hierarchical results when parent result is present.");
-        Assert.AreEqual(3, _testableTrxLogger.TotalTestCount, "TestResultHandler is not adding all inner results in parent test result.");
+        Assert.AreEqual(2, _testableTrxLogger.TotalTestCount, "DataDriven parent result should not be counted; only inner (DataRow) results should contribute to the total.");
     }
 
     [TestMethod]
@@ -423,6 +423,42 @@ public class TrxLoggerTests
         _testableTrxLogger.TestResultHandler(new object(), resultEventArg3.Object);
 
         Assert.AreEqual(1, _testableTrxLogger.TestEntryCount, "TestResultHandler is adding multiple test entries for data driven tests.");
+    }
+
+    [TestMethod]
+    public void TestResultHandlerShouldNotDoubleCountDataDrivenTestResults()
+    {
+        // Regression test for https://github.com/microsoft/vstest/issues/15643
+        // DataDriven (data row) tests produce a parent result and N inner results.
+        // Only the inner results should be counted in the summary totals; the parent
+        // aggregate must not be counted, otherwise totals are inflated.
+        TestCase testCase1 = CreateTestCase("TestCase1");
+
+        Guid parentExecutionId = Guid.NewGuid();
+
+        // Parent result (aggregate, no parent execution id)
+        VisualStudio.TestPlatform.ObjectModel.TestResult parentResult = new(testCase1);
+        parentResult.SetPropertyValue(TrxLoggerConstants.ExecutionIdProperty, parentExecutionId);
+
+        // Inner result 1 – passed
+        VisualStudio.TestPlatform.ObjectModel.TestResult innerResult1 = new(testCase1);
+        innerResult1.Outcome = TestOutcome.Passed;
+        innerResult1.SetPropertyValue(TrxLoggerConstants.ExecutionIdProperty, Guid.NewGuid());
+        innerResult1.SetPropertyValue(TrxLoggerConstants.ParentExecIdProperty, parentExecutionId);
+
+        // Inner result 2 – failed
+        VisualStudio.TestPlatform.ObjectModel.TestResult innerResult2 = new(testCase1);
+        innerResult2.Outcome = TestOutcome.Failed;
+        innerResult2.SetPropertyValue(TrxLoggerConstants.ExecutionIdProperty, Guid.NewGuid());
+        innerResult2.SetPropertyValue(TrxLoggerConstants.ParentExecIdProperty, parentExecutionId);
+
+        _testableTrxLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(parentResult).Object);
+        _testableTrxLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(innerResult1).Object);
+        _testableTrxLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(innerResult2).Object);
+
+        Assert.AreEqual(2, _testableTrxLogger.TotalTestCount, "Parent DataDriven result must not be counted; only the 2 inner DataRow results should be counted.");
+        Assert.AreEqual(1, _testableTrxLogger.PassedTestCount, "Only 1 DataRow result passed.");
+        Assert.AreEqual(1, _testableTrxLogger.FailedTestCount, "Only 1 DataRow result failed.");
     }
 
     [TestMethod]


### PR DESCRIPTION
🤖 *This PR was created automatically by the Issue Triage agent.*

Fixes #15643

## Root Cause

When a `[DataRow]`-driven test runs, vstest fires one result event **per DataRow** (inner results) plus one **aggregate** event for the parent test method. The TRX logger was incrementing its pass/fail/total counters for **every** event, including the parent aggregate, so a test with N data rows was counted N+1 times instead of N.

The parent result's `ResultType` is only set retroactively to `"DataDrivenTest"` when the **first inner result** arrives (inside `CreateTestResult`). By that time the parent's counters had already been incremented, leaving no clean way to skip counting it at arrival time.

## Fix

After `CreateTestResult` returns, check whether the newly processed result is an inner DataDriven result (`ResultType == InnerDataDrivenResultType`) **and** is the first such result for its parent (`InnerResults.Count == 1`). If so, undo the parent's counter contribution (total, passed, or failed). Subsequent inner results are counted normally, so the final totals equal exactly the number of DataRow executions.

No change is made to Ordered test counting — that path does not set `InnerDataDrivenResultType`.

## Tests

- Updated existing test `TestResultHandlerShouldAddHierarchicalResultsIfParentTestResultIsPresent` — it previously asserted `TotalTestCount == 3` (parent + 2 inner), now correctly expects `2`.
- Added new regression test `TestResultHandlerShouldNotDoubleCountDataDrivenTestResults` that verifies total, passed, and failed counts are correct for a 2-DataRow test (1 passed, 1 failed).




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/25861657845)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 25861657845, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/25861657845 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->