### PR TITLE
Fix VS insertion app.config push: drop spurious regex prefix and disambiguate build number

### DIFF
--- a/azure-pipelines-insertion.yml
+++ b/azure-pipelines-insertion.yml
@@ -221,9 +221,9 @@ extends:
 
                         $sourceCommit = $null
 
-                        # Extract the build ID from the "Updated Updating VS Test Platform from [...] to [buildnum](url) ([sha](sourcesUrl))" line.
+                        # Extract the build ID from the "Updating VS Test Platform from [...] to [buildnum](url) ([sha](sourcesUrl))" line.
                         # We use the build ID to resolve the full commit SHA via the builds API.
-                        if ($outputText -match 'Updated Updating VS Test Platform from .+ to \[\S+\]\([^)]+\) \(\[[0-9a-f]{7,40}\]\(https://dev\.azure\.com/dnceng/[^)]+/_apis/build/builds/(\d+)/sources\)\)') {
+                        if ($outputText -match 'Updating VS Test Platform from .+ to \[\S+\]\([^)]+\) \(\[[0-9a-f]{7,40}\]\(https://dev\.azure\.com/dnceng/[^)]+/_apis/build/builds/(\d+)/sources\)\)') {
                           $sourceBuildId = $Matches[1]
                           Write-Host "Resolving source commit from build ID $sourceBuildId"
                           $buildUrl = "$dncengBase/_apis/build/builds/${sourceBuildId}?api-version=7.1"
@@ -232,14 +232,17 @@ extends:
                         }
 
                         if (-not $sourceCommit) {
-                          # Fallback: resolve source commit from build number via AzDO API
+                          # Fallback: resolve source commit from build number via AzDO API.
+                          # buildNumber is not unique across pipelines (e.g. "20260514.9" matches dotnet-roslyn,
+                          # dotnet-runtime, microsoft-vstest, ...) so filter the result by the mirror pipeline name.
                           if ($outputText -match 'Found microsoft-vstest build number (\S+)') {
                             $buildNumber = $Matches[1]
                             Write-Host "Resolving source commit from build number $buildNumber"
                             $buildsUrl = "$dncengBase/_apis/build/builds?buildNumber=$buildNumber&api-version=7.1"
                             $buildsResponse = Invoke-RestMethod -Uri $buildsUrl -Headers $dncengHeaders -Method Get
-                            if ($buildsResponse.value -and $buildsResponse.value.Count -gt 0) {
-                              $sourceCommit = $buildsResponse.value[0].sourceVersion
+                            $matchingBuild = $buildsResponse.value | Where-Object { $_.definition.name -eq $mirrorRepoId } | Select-Object -First 1
+                            if ($matchingBuild) {
+                              $sourceCommit = $matchingBuild.sourceVersion
                             }
                           }
                         }


### PR DESCRIPTION
The post-roslyn-tools step in `azure-pipelines-insertion.yml` that pushes `vstest.console/app.config` and `revision.txt` into the VS insertion PR has been silently failing on every run since it landed. Latest example: insertion PR [#739004](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/739004) only has the roslyn-tools commit; build [2975466](https://dev.azure.com/dnceng/internal/_build/results?buildId=2975466) failed at the App.config push step with `TF401029: Couldn''t find Git commit with ID 036e7a58…`.

## Two compounding bugs in source-commit resolution

**1. Primary regex never matched.** It looked for `Updated Updating VS Test Platform from …`, but roslyn-tools actually logs `Updating VS Test Platform from …` (no `Updated` prefix). The primary path never fired, so the fallback always ran.

**2. Fallback wasn''t scoped to the vstest pipeline.** It did `/builds?buildNumber=20260514.9` and took `value[0]`. `buildNumber` is not unique across pipelines — on the failing run, **14 different pipelines** (dotnet-roslyn-official, dotnet-runtime, microsoft-vstest, microsoft-testfx, dotnet-wpf, …) all had a `20260514.9` build. The query returned `dotnet-roslyn-official` first (sourceVersion `036e7a58…`), then tried to fetch `app.config` from the microsoft-vstest mirror at that unrelated SHA — which doesn''t exist there, hence the failure.

## Fix

- Drop the bogus `Updated ` prefix from the primary regex (verified against the actual log line in build 2975466).
- Filter the fallback result by `definition.name -eq $mirrorRepoId` so the right pipeline is picked.

Verified the new regex matches the real log line and extracts build ID `2974998` (the actual microsoft-vstest build) → sourceVersion `039b7ea5…`, which exists in the mirror.