### PR TITLE
[fix] Fix TRX attachment paths when LogFileName contains a subdirectory

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -154,7 +154,23 @@ public class TrxLogger : ITestLoggerWithParameters
         }
 
         _parametersDictionary = parameters;
-        Initialize(events, _parametersDictionary[DefaultLoggerParameterNames.TestRunDirectory]!);
+
+        var testRunDirectory = _parametersDictionary[DefaultLoggerParameterNames.TestRunDirectory]!;
+
+        // If LogFileName contains a directory component, attachments should be placed relative
+        // to the directory that will contain the TRX file so that TRX viewers can resolve them.
+        if (!isLogFilePrefixParameterExists
+            && _parametersDictionary.TryGetValue(TrxLoggerConstants.LogFileNameKey, out string? logFileNameInit)
+            && !logFileNameInit.IsNullOrWhiteSpace())
+        {
+            var logFileDir = Path.GetDirectoryName(logFileNameInit);
+            if (!logFileDir.IsNullOrWhiteSpace())
+            {
+                testRunDirectory = Path.Combine(testRunDirectory, logFileDir);
+            }
+        }
+
+        Initialize(events, testRunDirectory);
     }
     #endregion
 
@@ -511,7 +527,9 @@ public class TrxLogger : ITestLoggerWithParameters
             }
             else if (isLogFileNameParameterExists)
             {
-                filePath = Path.Combine(_testResultsDirPath, logFileNameValue!);
+                // _testResultsDirPath already includes any subdirectory from LogFileName (adjusted in Initialize),
+                // so use only the filename portion here to avoid duplicating the directory.
+                filePath = Path.Combine(_testResultsDirPath, Path.GetFileName(logFileNameValue!));
                 shouldOverwrite = true;
             }
         }

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/LoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/LoggerTests.cs
@@ -254,4 +254,33 @@ public class LoggerTests : AcceptanceTestBase
 
         return null;
     }
+
+    [TestMethod]
+    [NetFullTargetFrameworkDataSource]
+    [NetCoreTargetFrameworkDataSource]
+    public void TrxLoggerShouldPlaceTrxFileInSubdirectoryWhenLogFileNameContainsPath(RunnerInfo runnerInfo)
+    {
+        // Regression test for https://github.com/microsoft/vstest/issues/15271
+        // When LogFileName contains a subdirectory (e.g. "subdir/results.trx"),
+        // the TRX file and its attachments should be placed under that subdirectory.
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var assemblyPaths = GetAssetFullPath("SimpleTestProject2.dll");
+        var subDir = "custom-subdir";
+        var trxFileName = "results.trx";
+        var logFileName = Path.Combine(subDir, trxFileName);
+        var arguments = PrepareArguments(assemblyPaths, null, string.Empty, FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
+        arguments = string.Concat(arguments, $" /logger:\"trx;LogFileName={logFileName}\"");
+
+        InvokeVsTest(arguments);
+
+        ValidateSummaryStatus(1, 1, 1);
+
+        // Verify the TRX file is in the expected subdirectory
+        var expectedTrxPath = Path.Combine(TempDirectory.Path, subDir, trxFileName);
+        Assert.IsTrue(File.Exists(expectedTrxPath),
+            $"Expected TRX file at '{expectedTrxPath}' but it was not found. " +
+            $"Files in results dir: {string.Join(", ", Directory.GetFiles(TempDirectory.Path, "*.trx", SearchOption.AllDirectories))}");
+        Assert.IsTrue(IsValidXml(expectedTrxPath), "TRX file content should be valid XML.");
+    }
 }

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -770,6 +770,37 @@ public class TrxLoggerTests
         Assert.AreEqual(Path.Combine(DefaultTestRunDirectory, DefaultLogFileNameParameterValue), _testableTrxLogger.TrxFile, "Wrong Trx file name");
     }
 
+    [TestMethod]
+    public void CustomTrxFileNameWithSubdirectoryShouldPlaceTrxAndAttachmentsUnderSameDirectory()
+    {
+        // Arrange: LogFileName contains a subdirectory component
+        var logger = new TestableTrxLogger();
+        var subDir = "subdir";
+        var fileName = "results.trx";
+        var parameters = new Dictionary<string, string?>
+        {
+            [DefaultLoggerParameterNames.TestRunDirectory] = DefaultTestRunDirectory,
+            [TrxLoggerConstants.LogFileNameKey] = Path.Combine(subDir, fileName),
+        };
+        logger.Initialize(_events.Object, parameters);
+
+        MakeTestRunComplete(logger);
+
+        try
+        {
+            // The TRX file must be at <TestRunDirectory>/<subDir>/<fileName>
+            var expectedTrxPath = Path.Combine(DefaultTestRunDirectory, subDir, fileName);
+            Assert.AreEqual(expectedTrxPath, logger.TrxFile, "TRX file should be in the specified subdirectory.");
+        }
+        finally
+        {
+            if (!string.IsNullOrEmpty(logger.TrxFile) && File.Exists(logger.TrxFile))
+            {
+                File.Delete(logger.TrxFile);
+            }
+        }
+    }
+
     /// <summary>
     /// Unit test for reading TestCategories from the TestCase which is part of test result.
     /// </summary>


### PR DESCRIPTION
🤖 This is an automated fix generated by the Issue Triage agent.

Fixes #15271

## Root Cause

When `--logger trx;LogFileName=subdir/results.trx` is used, the TRX file is placed at `<TestRunDirectory>/subdir/results.trx`. However, the internal `_testResultsDirPath` (used to organize test attachments) remained set to the original `TestRunDirectory`.

TRX viewers resolve the `runDeploymentRoot` attribute relative to the directory containing the TRX file. So a viewer opening `subdir/results.trx` expects attachments at `subdir/<runDeploymentRoot>/In/...`, but they were actually placed at `<runDeploymentRoot>/In/...` (one level up) — making them unreachable.

## Fix

In `Initialize(events, parameters)`, detect when `LogFileName` has a directory component and pre-adjust `_testResultsDirPath` to point to the directory that will contain the TRX file. This ensures both the TRX and its attachment folder are co-located.

In `GetTrxFilePath`, use `Path.GetFileName(logFileNameValue)` instead of the full `logFileNameValue` so the directory portion isn't appended twice (it's already in `_testResultsDirPath`).

The fix is backward-compatible: when `LogFileName` is a plain filename with no directory component, `Path.GetDirectoryName` returns an empty string and no adjustment is made.

## Test

Added `CustomTrxFileNameWithSubdirectoryShouldPlaceTrxAndAttachmentsUnderSameDirectory` which verifies that when `LogFileName=subdir/results.trx`, the TRX file lands at `<TestRunDirectory>/subdir/results.trx`.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/25919396337)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 25919396337, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/25919396337 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->