### PR TITLE
Migrate dn-bot-devdiv-drop-rw-code-rw PAT to WIF service connection

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -95,8 +95,9 @@ variables:
   - group: DotNet-Symbol-Server-Pats
   # Group gives access to $dn-bot-devdiv-drop-rw-code-rw and dn-bot-dnceng-build-rw-code-rw
   - group: DotNet-VSTS-Infra-Access
+  # DevDiv drop access token is acquired via WIF service connection (dnceng-devdiv-drop-rw-code-rw-wif)
   - name: _DevDivDropAccessToken
-    value: $(dn-bot-devdiv-drop-rw-code-rw)
+    value: ''
   - name: _SignType
     value: real
   - name: _SignArgs
@@ -337,6 +338,16 @@ extends:
 
               # Publishes setup VSIXes to a drop.
               # Note: The insertion tool looks for the display name of this task in the logs.
+              - task: AzureCLI@2
+                displayName: Get DevDiv Drop Access Token
+                inputs:
+                  azureSubscription: 'dnceng-devdiv-drop-rw-code-rw-wif'
+                  scriptType: pscore
+                  scriptLocation: inlineScript
+                  inlineScript: |
+                    $token = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+                    Write-Host "##vso[task.setvariable variable=_DevDivDropAccessToken;issecret=true]$token"
+                condition: succeeded()
               - task: 1ES.MicroBuildVstsDrop@1
                 displayName: Upload VSTS Drop
                 inputs:


### PR DESCRIPTION
## Summary

Replaces the \dn-bot-devdiv-drop-rw-code-rw\ PAT with a WIF-based service connection (\dnceng-devdiv-drop-rw-code-rw-wif\) for DevDiv drop access.

## Changes

- **Add AzureCLI@2 task** in the Publish job to acquire an Entra token via the WIF service connection before the MicroBuildVstsDrop task
- **Set \_DevDivDropAccessToken\** at runtime using the WIF-acquired token instead of the static PAT from \DotNet-VSTS-Infra-Access\ variable group
- **Remove static PAT variable reference** from the variable declarations

## Context

This is part of the PAT-to-Entra migration tracked by [AB#10146](https://dev.azure.com/dnceng/internal/_workitems/edit/10146). The WIF service connection \dnceng-devdiv-drop-rw-code-rw-wif\ (backed by app registration \dnceng-devdiv-drop-rw-code-rw-wif\, App ID: \7106a410-fbcb-4750-a202-879077f925ec\) was previously created and verified. The same pattern was successfully deployed in [dotnet/fsharp#19598](https://github.com/dotnet/fsharp/pull/19598).

## Validation

> **Note:** PR validation pipelines read YAML from \main\, not the PR branch. The actual WIF migration will be validated on the first post-merge CI build.