### PR TITLE
[fix] Set IsPackable=false in Microsoft.NET.Test.Sdk.props

### DIFF
--- a/src/package/Microsoft.NET.Test.Sdk/Microsoft.NET.Test.Sdk.props
+++ b/src/package/Microsoft.NET.Test.Sdk/Microsoft.NET.Test.Sdk.props
@@ -15,6 +15,7 @@
   <PropertyGroup>
     <TestProject>true</TestProject>
     <IsTestProject>true</IsTestProject>
+    <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
🤖 This is an automated fix generated by the Issue Repro Triage agent.

Fixes #15309

## Root Cause

`Microsoft.NET.Test.Sdk.props` sets `IsTestProject=true` but does not set `IsPackable=false`. In an older version of the SDK (17.13), a dedicated target handled setting `IsPackable=false` when `IsTestProject=true`. That target was removed in version 18.0.

The .NET 10 SDK itself sets `IsPackable=false` when `IsTestProject=true` (explaining why the issue doesn't reproduce with the .NET 10 SDK), but .NET 9 does not — leaving test projects packable by default when `Microsoft.NET.Test.Sdk` 18.x is used.

## Fix

Added `<IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>` to `Microsoft.NET.Test.Sdk.props`. The condition ensures that users who explicitly set `IsPackable=true` in their project file can still override this default.

## Verification

Build succeeded with 0 warnings and 0 errors.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/25949147448)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 25949147448, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/25949147448 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->