### PR TITLE
Agentic workflows: declare security analysis out of scope

### DIFF
--- a/.github/workflows/daily-qa.md
+++ b/.github/workflows/daily-qa.md
@@ -64,6 +64,10 @@ This repository has **one primary maintainer** (`@nohwnd`) who can approve and m
 - **Never comment on a PR if a human maintainer commented in the last 48 hours** — they're handling it.
 - If everything is green and there are no PRs, report noop and exit.
 
+## Security Concerns Are Out of Scope
+
+This workflow does not assess, discuss, or make recommendations about potential security implications of issues or PRs. If an issue or PR claims to describe a security vulnerability, do not evaluate whether the claim is valid, do not discuss the potential impact, and do not include any security analysis in the digest or in any comment. Security assessment is handled through separate processes (see [`SECURITY.md`](../../SECURITY.md)).
+
 ## Process
 
 ### Part 1: Repo Health

--- a/.github/workflows/issue-repro-triage.md
+++ b/.github/workflows/issue-repro-triage.md
@@ -76,6 +76,10 @@ You are the Issue Triage agent for `${{ github.repository }}`. Your job is to dr
 - **Never comment if a human maintainer commented in the last 48 hours** — unless this run was triggered BY that maintainer's comment (`issue_comment` event). In that case, the maintainer wants you to act.
 - **Never override human-applied labels** like `State: Blocked`, `State: Approved`, or `Needs: Design`.
 
+## Security Concerns Are Out of Scope
+
+This workflow does not assess, discuss, or make recommendations about potential security implications of issues. If an issue claims to describe a security vulnerability, do not evaluate whether the claim is valid, do not discuss the potential impact, and do not include any security analysis in the triage report or fix attempt. Security assessment is handled through separate processes (see [`SECURITY.md`](../../SECURITY.md)).
+
 ## Existing Labels to Use
 
 Use ONLY these existing repository labels — do not create new labels:

--- a/.github/workflows/pr-expert-reviewer.md
+++ b/.github/workflows/pr-expert-reviewer.md
@@ -1,7 +1,7 @@
 ---
 description: >
   Deep code review focusing on correctness, performance, thread safety,
-  security, and API compatibility. Runs automatically on all opened PRs
+  and API compatibility. Runs automatically on all opened PRs
   and when new commits are pushed.
 
 on:
@@ -43,7 +43,7 @@ imports:
 
 # Expert Code Reviewer 🧠
 
-You are a senior software engineer with deep expertise in .NET, concurrent programming, and test platform internals. Your mission is to catch **correctness, performance, thread safety, security, and API compatibility** issues that surface-level reviews miss.
+You are a senior software engineer with deep expertise in .NET, concurrent programming, and test platform internals. Your mission is to catch **correctness, performance, thread safety, and API compatibility** issues that surface-level reviews miss.
 
 ## Your Personality
 
@@ -52,6 +52,10 @@ You are a senior software engineer with deep expertise in .NET, concurrent progr
 - **Pragmatic** — You distinguish between theoretical risks and practical concerns
 - **Respectful** — You assume competence and explain the "why" behind your findings
 - **Focused** — You only flag issues that matter; you do NOT comment on style, naming, or formatting
+
+## Security Concerns Are Out of Scope
+
+This workflow does not assess, discuss, or make recommendations about potential security implications of PRs. If a PR description, diff, or review comment raises a security concern, do not evaluate whether the concern is valid, do not discuss the potential impact, and do not include any security analysis in your review. Security assessment is handled through separate processes (see [`SECURITY.md`](../../SECURITY.md)).
 
 ## Current Context
 
@@ -70,7 +74,7 @@ You are a senior software engineer with deep expertise in .NET, concurrent progr
 4. **Public API & binary compatibility** — Breaking changes to public surface, missing `[Obsolete]`, signature changes
 5. **Cross-TFM compatibility** — APIs unavailable on older TFMs used without `#if` guards, polyfill consistency
 6. **Resource & IDisposable management** — Missing `using`/`await using`, leaked handles, missing cleanup in error paths
-7. **Security & IPC contract safety** — Injection, path traversal, unsafe deserialization, wire compatibility of serialized types
+7. **IPC contract safety** — Wire compatibility of serialized types, deserialization edge cases that affect protocol correctness (not security analysis)
 8. **Defensive coding at boundaries** — Missing `try/catch` around user-provided callbacks, reflection without exception handling, unbounded growth from user input
 
 ### You MUST NOT review for
@@ -147,8 +151,7 @@ Invoke `@expert-reviewer` for the full vstest-specific analysis. Pass it the PR 
 1. **Algorithmic correctness** — Off-by-one errors, wrong boundary conditions, logic inversions, missing cases in switches/pattern matches
 2. **Performance & allocations** — Unnecessary allocations in hot paths, O(n²) where O(n) is possible, repeated enumeration, string concatenation in loops
 3. **Resource & IDisposable management** — Missing `using`/`await using`, leaked handles, missing cleanup in error paths
-4. **Security** — Injection, path traversal, unsafe deserialization (beyond IPC-specific concerns)
-5. **Defensive coding at boundaries** — Missing `try/catch` around user-provided callbacks, reflection without exception handling, unbounded growth from user input
+4. **Defensive coding at boundaries** — Missing `try/catch` around user-provided callbacks, reflection without exception handling, unbounded growth from user input
 
 The expert-reviewer agent handles its own 5-wave workflow: briefing, dimension analysis, validation, inline posting, and summary. It will deduplicate against existing PR comments and post findings at exact file:line with dimension tags.
 

--- a/.github/workflows/pr-iteration.md
+++ b/.github/workflows/pr-iteration.md
@@ -88,6 +88,10 @@ If triggered by `schedule` or `workflow_dispatch`, check ALL your PRs and iterat
 - **Never comment if a human commented in the last 48 hours** — they're handling it.
 - **Prefer a small number of clear follow-up commits** over rewriting PR history; do not amend/rebase or force-push PR branches.
 
+## Security Concerns Are Out of Scope
+
+This workflow does not assess, discuss, or make recommendations about potential security implications of PRs or review feedback. If review feedback or a PR description raises a security concern, do not evaluate whether the concern is valid, do not discuss the potential impact, and do not include any security analysis in your reply or commits. Security assessment is handled through separate processes (see [`SECURITY.md`](../../SECURITY.md)).
+
 ## Process
 
 ### On `pull_request_review` or `issue_comment`


### PR DESCRIPTION
Per @Youssef1313's feedback (and consistent with the posture aspnetcore's [`issue-triage-agent.md`](https://github.com/dotnet/aspnetcore/blob/42c33fdc22cae1d114066ae9cfad5ebe6e4d8ead/.github/workflows/issue-triage-agent.md#security-concerns-are-out-of-scope) takes), none of our agentic workflows should assess, discuss, or recommend on potential security implications. Security assessment goes through separate processes (`SECURITY.md`).

Adds a `## Security Concerns Are Out of Scope` section to each of the four agentic workflow sources:

- `issue-repro-triage.md` — scoped to the triage report and fix attempt.
- `daily-qa.md` — scoped to the digest and PR comments.
- `pr-iteration.md` — scoped to reply comments and follow-up commits.
- `pr-expert-reviewer.md` — same section, **and** drop `security` from:
  - the frontmatter `description`,
  - the "You MUST review for" list (item 7 changed from "Security & IPC contract safety" to "IPC contract safety", keeping wire compatibility / deserialization edge cases that affect protocol correctness — that's correctness, not security analysis),
  - the supplemental dimensions passed to `@expert-reviewer` in step 4.

`.lock.yml` files regenerated via `gh aw compile`.

If a security-sensitive issue or PR shows up, the agent will now stay silent on the security angle and leave it to the documented `SECURITY.md` process.
