### PR TITLE
Recompile pr-expert-reviewer.lock.yml to match .md

### DIFF
--- a/.github/workflows/pr-expert-reviewer.lock.yml
+++ b/.github/workflows/pr-expert-reviewer.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9894fd1bb6a3a2366023f178561cc406b2d94b9508e8082427775a31b4b07a6f","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"977030a695ef9ddb3e54b19dd8b66897c884c28743a3e659a6b268b1c4f92768","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Deep code review focusing on correctness, performance, thread safety, security, and API compatibility. Runs automatically on all opened PRs and when new commits are pushed.
+# Deep code review focusing on correctness, performance, thread safety, and API compatibility. Runs automatically on all opened PRs and when new commits are pushed.
 #
 # Resolved workflow manifest:
 #   Imports:
@@ -214,21 +214,21 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_563786338ba06f99_EOF'
+          cat << 'GH_AW_PROMPT_46cc5d203ce21648_EOF'
           <system>
-          GH_AW_PROMPT_563786338ba06f99_EOF
+          GH_AW_PROMPT_46cc5d203ce21648_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_563786338ba06f99_EOF'
+          cat << 'GH_AW_PROMPT_46cc5d203ce21648_EOF'
           <safe-output-tools>
           Tools: create_pull_request_review_comment(max:5), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_563786338ba06f99_EOF
+          GH_AW_PROMPT_46cc5d203ce21648_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_563786338ba06f99_EOF'
+          cat << 'GH_AW_PROMPT_46cc5d203ce21648_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -257,13 +257,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_563786338ba06f99_EOF
+          GH_AW_PROMPT_46cc5d203ce21648_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_563786338ba06f99_EOF'
+          cat << 'GH_AW_PROMPT_46cc5d203ce21648_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/repo-build-setup.md}}
           {{#runtime-import .github/workflows/pr-expert-reviewer.md}}
-          GH_AW_PROMPT_563786338ba06f99_EOF
+          GH_AW_PROMPT_46cc5d203ce21648_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -486,9 +486,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f79defec9264e2d2_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_299328192d90de29_EOF'
           {"create_pull_request_review_comment":{"max":5,"side":"RIGHT"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{},"submit_pull_request_review":{"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_f79defec9264e2d2_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_299328192d90de29_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -709,7 +709,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_bf7eb0d5fc15bec8_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_750416a42c43bd35_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -754,7 +754,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_bf7eb0d5fc15bec8_EOF
+          GH_AW_MCP_CONFIG_750416a42c43bd35_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1222,7 +1222,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           WORKFLOW_NAME: "Expert Code Reviewer 🧠"
-          WORKFLOW_DESCRIPTION: "Deep code review focusing on correctness, performance, thread safety, security, and API compatibility. Runs automatically on all opened PRs and when new commits are pushed."
+          WORKFLOW_DESCRIPTION: "Deep code review focusing on correctness, performance, thread safety, and API compatibility. Runs automatically on all opened PRs and when new commits are pushed."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |


### PR DESCRIPTION
Fixes #16040.

#16038 (security out of scope) edited ``pr-expert-reviewer.md`` to drop ``security`` from the description and review scope, but git CRLF normalization at commit time absorbed the regenerated ``.lock.yml`` as "unchanged", so ``main`` shipped with a stale lock. The frontmatter hash on ``main`` no longer matches the ``.md``, so the Expert Code Reviewer workflow refuses to run with "Lock File Out of Sync".

Running ``gh aw compile pr-expert-reviewer`` regenerates the lock with the matching hash and the updated description comment. Only this one file has real content drift (verified: ``daily-qa``, ``issue-repro-triage``, ``pr-iteration`` lock files only show CRLF normalization noise when recompiled).