### PR TITLE
[fix] Fix MsCoverageReferencedPathMaps: skip during design-time builds and parallelize project builds

### DIFF
--- a/src/package/Microsoft.CodeCoverage/Microsoft.CodeCoverage.targets
+++ b/src/package/Microsoft.CodeCoverage/Microsoft.CodeCoverage.targets
@@ -34,10 +34,11 @@
 
   <!-- This target required to store deterministic sources mapping.
        It is modified version of https://github.com/coverlet-coverage/coverlet/blob/d1ca364b7dbff38abce0457d94c4ce1b7e3a4cd9/src/coverlet.collector/build/coverlet.collector.targets#L35 -->
-  <Target Condition="'$(NETCoreSdkVersion)' != '' and '$(DisableMsCoverageReferencedPathMaps)' != 'true'" Name="MsCoverageReferencedPathMaps" BeforeTargets="CoreCompile" DependsOnTargets="ResolveProjectReferences" >
+  <Target Condition="'$(NETCoreSdkVersion)' != '' and '$(DisableMsCoverageReferencedPathMaps)' != 'true' and '$(DesignTimeBuild)' != 'true'" Name="MsCoverageReferencedPathMaps" BeforeTargets="CoreCompile" DependsOnTargets="ResolveProjectReferences" >
     <MSBuild Projects="@(AnnotatedProjects->'%(FullPath)')"
              Targets="$(_msCoverageSourceRootTargetName)"
              Properties="TargetFramework=%(AnnotatedProjects.NearestTargetFramework)"
+             BuildInParallel="true"
              SkipNonexistentTargets="true">
       <Output TaskParameter="TargetOutputs"
               ItemName="_msCoverageLocalTopLevelSourceRoot" />


### PR DESCRIPTION
🤖 This is an automated fix generated by GitHub Copilot.

Closes #15105
Partial fix for #15295

## Root Cause

The `MsCoverageReferencedPathMaps` target in `Microsoft.CodeCoverage.targets` ran unconditionally on every `CoreCompile` invocation, including during IDE **design-time builds**. Design-time builds happen frequently in the background while you type in Visual Studio (for IntelliSense, error squiggles, etc.) and are triggered far more often than real builds. Running `MSBuild` on all referenced projects on every design-time build caused significant IDE slowdowns — especially for solutions with large project graphs.

Additionally, the `MSBuild` task invoked referenced projects **sequentially** (one at a time, batched by TFM), even though the individual project invocations are independent.

## Fix

Two changes to `Microsoft.CodeCoverage.targets`:

1. **Skip during design-time builds** — Added `'$(DesignTimeBuild)' != 'true'` to the `MsCoverageReferencedPathMaps` target condition. The SDK sets `$(DesignTimeBuild)` to `true` during all IDE background build invocations; this is the standard pattern used across the MSBuild ecosystem (e.g., Roslyn analyzers, source generators) to avoid expensive work during design-time passes.

2. **Parallelize project invocations** — Added `BuildInParallel="true"` to the `MSBuild` task. This allows the build engine to invoke the `InitializeSourceRootMappedPaths`/`MsCoverageGetPathMap` target on multiple referenced projects concurrently, reducing wall-clock time for large project graphs.

## Testing

This is a `.targets` file change (MSBuild metadata, no C# code). There are no automated tests for this specific target behavior in the repo. The change follows the established SDK pattern for skipping work during design-time builds and is a minimal, low-risk addition to an existing condition.

> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/26037440020)*




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/26037440020)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 26037440020, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/26037440020 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->