### PR TITLE
[fix] Fix tilde/exclamation characters corrupted in TerminalLogger test output

### DIFF
--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask2.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask2.cs
@@ -265,13 +265,48 @@ public class VSTestTask2 : ToolTask, ITestTask
         {
             var parts = singleLine.Split(_messageSplitterArray, StringSplitOptions.None);
             name = parts[1];
-            data = parts.Skip(2).Take(parts.Length).Select(p => p?.Replace("\x02", "\r").Replace("\x03", "\n")).ToArray();
+            data = parts.Skip(2).Take(parts.Length).Select(Unescape).ToArray();
             return true;
         }
 
         name = string.Empty;
         data = [];
         return false;
+    }
+
+    /// <summary>
+    /// Reverses MSBuildLogger.Escape. Single-pass scanner to correctly handle
+    /// sequences like <c>%%n</c> (literal <c>%n</c>, not <c>%</c> + newline).
+    /// </summary>
+    private static string? Unescape(string? input)
+    {
+        if (input == null)
+        {
+            return null;
+        }
+
+        var sb = new StringBuilder(input.Length);
+        for (int i = 0; i < input.Length; i++)
+        {
+            if (input[i] == '%' && i + 1 < input.Length)
+            {
+                char next = input[++i];
+                sb.Append(next switch
+                {
+                    '%' => '%',
+                    'p' => '|',
+                    'r' => '\r',
+                    'n' => '\n',
+                    _ => $"%{next}",
+                });
+            }
+            else
+            {
+                sb.Append(input[i]);
+            }
+        }
+
+        return sb.ToString();
     }
 
     protected override string? GenerateCommandLineCommands()

--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask2.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask2.cs
@@ -265,7 +265,7 @@ public class VSTestTask2 : ToolTask, ITestTask
         {
             var parts = singleLine.Split(_messageSplitterArray, StringSplitOptions.None);
             name = parts[1];
-            data = parts.Skip(2).Take(parts.Length).Select(p => p?.Replace("~~~~", "\r").Replace("!!!!", "\n")).ToArray();
+            data = parts.Skip(2).Take(parts.Length).Select(p => p?.Replace("\x02", "\r").Replace("\x03", "\n")).ToArray();
             return true;
         }
 

--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask2.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask2.cs
@@ -291,14 +291,14 @@ public class VSTestTask2 : ToolTask, ITestTask
             if (input[i] == '%' && i + 1 < input.Length)
             {
                 char next = input[++i];
-                sb.Append(next switch
+                switch (next)
                 {
-                    '%' => '%',
-                    'p' => '|',
-                    'r' => '\r',
-                    'n' => '\n',
-                    _ => $"%{next}",
-                });
+                    case '%': sb.Append('%'); break;
+                    case 'p': sb.Append('|'); break;
+                    case 'r': sb.Append('\r'); break;
+                    case 'n': sb.Append('\n'); break;
+                    default: sb.Append('%'); sb.Append(next); break;
+                }
             }
             else
             {

--- a/src/vstest.console/Internal/MSBuildLogger.cs
+++ b/src/vstest.console/Internal/MSBuildLogger.cs
@@ -229,11 +229,12 @@ internal class MSBuildLogger : ITestLoggerWithParameters
     }
 
     /// <summary>
-    /// Writes message to standard output, with the name of the message followed by the number of
-    /// parameters. With each parameter delimited by '||||', and special characters escaped with '%'.
+    /// Writes message to standard output, with the name of the message followed by
+    /// parameters. Each parameter is delimited by '||||', and special characters are
+    /// escaped with '%' (see <see cref="Escape"/>).
     /// Such as:
-    ///  ||||run-start1||||s:\t\mstest97\bin\Debug\net8.0\mstest97.dll
-    ///  ||||test-failed6||||TestMethod5||||Assert.IsTrue failed. ||||   at mstest97.UnitTest1.TestMethod5() in s:\t\mstest97\UnitTest1.cs:line 27%r%n   at Syste...
+    ///  ||||run-start||||s:\t\mstest97\bin\Debug\net8.0\mstest97.dll
+    ///  ||||test-failed||||TestMethod5||||Assert.IsTrue failed. ||||   at mstest97.UnitTest1.TestMethod5() in s:\t\mstest97\UnitTest1.cs:line 27%r%n   at Syste...
     /// </summary>
     /// <param name="name"></param>
     /// <param name="data"></param>
@@ -285,14 +286,14 @@ internal class MSBuildLogger : ITestLoggerWithParameters
             if (input[i] == '%' && i + 1 < input.Length)
             {
                 char next = input[++i];
-                sb.Append(next switch
+                switch (next)
                 {
-                    '%' => '%',
-                    'p' => '|',
-                    'r' => '\r',
-                    'n' => '\n',
-                    _ => $"%{next}", // unknown escape — preserve as-is
-                });
+                    case '%': sb.Append('%'); break;
+                    case 'p': sb.Append('|'); break;
+                    case 'r': sb.Append('\r'); break;
+                    case 'n': sb.Append('\n'); break;
+                    default: sb.Append('%'); sb.Append(next); break;
+                }
             }
             else
             {

--- a/src/vstest.console/Internal/MSBuildLogger.cs
+++ b/src/vstest.console/Internal/MSBuildLogger.cs
@@ -230,10 +230,10 @@ internal class MSBuildLogger : ITestLoggerWithParameters
 
     /// <summary>
     /// Writes message to standard output, with the name of the message followed by the number of
-    /// parameters. With each parameter delimited by '||||', and newlines replaced with ~~~~ and !!!!.
+    /// parameters. With each parameter delimited by '||||', and newlines replaced with STX (\x02) and ETX (\x03).
     /// Such as:
     ///  ||||run-start1||||s:\t\mstest97\bin\Debug\net8.0\mstest97.dll
-    ///  ||||test-failed6||||TestMethod5||||Assert.IsTrue failed. ||||   at mstest97.UnitTest1.TestMethod5() in s:\t\mstest97\UnitTest1.cs:line 27~~~~!!!!   at Syste...
+    ///  ||||test-failed6||||TestMethod5||||Assert.IsTrue failed. ||||   at mstest97.UnitTest1.TestMethod5() in s:\t\mstest97\UnitTest1.cs:line 27\x02\x03   at Syste...
     /// </summary>
     /// <param name="name"></param>
     /// <param name="data"></param>
@@ -259,10 +259,13 @@ internal class MSBuildLogger : ITestLoggerWithParameters
         }
 
         return input
-            // Cleanup characters that we are using ourselves to delimit the message
-            .Replace("||||", "____").Replace("~~~~", "____").Replace("!!!!", "____")
+            // Cleanup characters that we are using ourselves to delimit the message.
+            .Replace("||||", "____")
             // Replace new line characters that would change how the message is consumed.
-            .Replace("\r", "~~~~").Replace("\n", "!!!!");
+            // Use ASCII control characters STX (\x02) and ETX (\x03) which cannot appear in normal
+            // test output, rather than ~~~~ and !!!! which can appear in test data and get corrupted.
+            .Replace("\r", "\x02")
+            .Replace("\n", "\x03");
     }
 
     /// <summary>

--- a/src/vstest.console/Internal/MSBuildLogger.cs
+++ b/src/vstest.console/Internal/MSBuildLogger.cs
@@ -246,7 +246,7 @@ internal class MSBuildLogger : ITestLoggerWithParameters
         Output.Information(appendPrefix: false, message);
     }
 
-    private static string FormatMessage(string name, params string?[] data)
+    internal static string FormatMessage(string name, params string?[] data)
     {
         return $"||||{name}||||{string.Join("||||", data.Select(Escape))}";
     }

--- a/src/vstest.console/Internal/MSBuildLogger.cs
+++ b/src/vstest.console/Internal/MSBuildLogger.cs
@@ -230,10 +230,10 @@ internal class MSBuildLogger : ITestLoggerWithParameters
 
     /// <summary>
     /// Writes message to standard output, with the name of the message followed by the number of
-    /// parameters. With each parameter delimited by '||||', and newlines replaced with STX (\x02) and ETX (\x03).
+    /// parameters. With each parameter delimited by '||||', and special characters escaped with '%'.
     /// Such as:
     ///  ||||run-start1||||s:\t\mstest97\bin\Debug\net8.0\mstest97.dll
-    ///  ||||test-failed6||||TestMethod5||||Assert.IsTrue failed. ||||   at mstest97.UnitTest1.TestMethod5() in s:\t\mstest97\UnitTest1.cs:line 27\x02\x03   at Syste...
+    ///  ||||test-failed6||||TestMethod5||||Assert.IsTrue failed. ||||   at mstest97.UnitTest1.TestMethod5() in s:\t\mstest97\UnitTest1.cs:line 27%r%n   at Syste...
     /// </summary>
     /// <param name="name"></param>
     /// <param name="data"></param>
@@ -258,14 +258,49 @@ internal class MSBuildLogger : ITestLoggerWithParameters
             return null;
         }
 
+        // '%'-based escaping: escape the escape char first, then special chars.
+        // This is lossless (unlike the old ||||→____ replacement) and stays readable
+        // in MSBuild binary logs (unlike \x02/\x03 control chars).
         return input
-            // Cleanup characters that we are using ourselves to delimit the message.
-            .Replace("||||", "____")
-            // Replace new line characters that would change how the message is consumed.
-            // Use ASCII control characters STX (\x02) and ETX (\x03) which cannot appear in normal
-            // test output, rather than ~~~~ and !!!! which can appear in test data and get corrupted.
-            .Replace("\r", "\x02")
-            .Replace("\n", "\x03");
+            .Replace("%", "%%")
+            .Replace("|", "%p")
+            .Replace("\r", "%r")
+            .Replace("\n", "%n");
+    }
+
+    /// <summary>
+    /// Reverses <see cref="Escape"/>. Must be a single-pass scanner — chained Replace
+    /// would incorrectly decode <c>%%n</c> as <c>%\n</c> instead of <c>%n</c>.
+    /// </summary>
+    internal static string? Unescape(string? input)
+    {
+        if (input == null)
+        {
+            return null;
+        }
+
+        var sb = new StringBuilder(input.Length);
+        for (int i = 0; i < input.Length; i++)
+        {
+            if (input[i] == '%' && i + 1 < input.Length)
+            {
+                char next = input[++i];
+                sb.Append(next switch
+                {
+                    '%' => '%',
+                    'p' => '|',
+                    'r' => '\r',
+                    'n' => '\n',
+                    _ => $"%{next}", // unknown escape — preserve as-is
+                });
+            }
+            else
+            {
+                sb.Append(input[i]);
+            }
+        }
+
+        return sb.ToString();
     }
 
     /// <summary>

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestMSBuildOutputTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestMSBuildOutputTests.cs
@@ -39,6 +39,14 @@ public class DotnetTestMSBuildOutputTests : AcceptanceTestBase
         StdOutputContains("FailingTest (");
         StdOutputContains("Expected: \"ğğğ𦮙我們剛才從𓋴𓅓𓏏𓇏𓇌𓀀\"");
         StdOutputContains("at TerminalLoggerUnitTests.UnitTest1.FailingTest() in");
+
+        // Verify that ~, !, |, and % characters in test output survive the MSBuildLogger encoding round-trip.
+        StdOutputContains("FailingTestWithSpecialChars (");
+        StdOutputContains("~~~~~");
+        StdOutputContains("!!!!");
+        StdOutputContains("||||");
+        StdOutputContains("%n");
+
         // We are sending those as low prio messages, they won't show up on screen but will be in binlog.
         //StdOutputContains("passed PassingTest");
         //StdOutputContains("skipped SkippingTest");
@@ -57,7 +65,7 @@ public class DotnetTestMSBuildOutputTests : AcceptanceTestBase
         InvokeDotnetTest($@"{projectPath} -nodereuse:false /p:VsTestUseMSBuildOutput=false /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}", workingDirectory: Path.GetDirectoryName(projectPath));
 
         // Check that we see the summary that is printed from the console logger, meaning the new output is disabled.
-        StdOutputContains("Failed! - Failed: 1, Passed: 1, Skipped: 1, Total: 3, Duration:");
+        StdOutputContains("Failed! - Failed: 2, Passed: 1, Skipped: 1, Total: 4, Duration:");
         // We are sending those as low prio messages, they won't show up on screen but will be in binlog.
         //StdOutputContains("passed PassingTest");
         //StdOutputContains("skipped SkippingTest");
@@ -77,7 +85,7 @@ public class DotnetTestMSBuildOutputTests : AcceptanceTestBase
         InvokeDotnetTest($@"{projectPath} -nodereuse:false /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}", environmentVariables: new Dictionary<string, string?> { ["MSBUILDENSURESTDOUTFORTASKPROCESSES"] = "1" }, workingDirectory: Path.GetDirectoryName(projectPath));
 
         // Check that we see the summary that is printed from the console logger, meaning the new output is disabled.
-        StdOutputContains("Failed! - Failed: 1, Passed: 1, Skipped: 1, Total: 3, Duration:");
+        StdOutputContains("Failed! - Failed: 2, Passed: 1, Skipped: 1, Total: 4, Duration:");
 
         ExitCodeEquals(1);
     }

--- a/test/Microsoft.TestPlatform.Build.UnitTests/VSTestTask2RegressionTests.cs
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/VSTestTask2RegressionTests.cs
@@ -178,11 +178,10 @@ public class VSTestTask2RegressionTests
     [TestMethod]
     public void LogEventsFromTextOutput_TestFailed_TildeCharsInMessage_ShouldNotBeCorrupted()
     {
-        // Regression test for #15268 — tilde characters in test output were being replaced with underscores
         var task = CreateVSTestTask2();
         var engine = (RecordingBuildEngine)task.BuildEngine;
 
-        // 5 tilde chars in the error message — the old encoding replaced ~~~~ (4 tildes) with ____
+        // 5 tilde chars — the old encoding replaced ~~~~ (4 tildes) with ____
         var tildeString = new string('~', 5);
         task.TestLogEventsFromTextOutput($"||||test-failed||||{tildeString}||||TestFile.cs||||42", MessageImportance.High);
 
@@ -193,11 +192,10 @@ public class VSTestTask2RegressionTests
     [TestMethod]
     public void LogEventsFromTextOutput_TestFailed_ExclamationCharsInMessage_ShouldNotBeCorrupted()
     {
-        // Regression test for #15268 — exclamation characters in test output were being replaced with underscores
         var task = CreateVSTestTask2();
         var engine = (RecordingBuildEngine)task.BuildEngine;
 
-        // 4 exclamation marks in the error message — the old encoding replaced !!!! (4 bangs) with ____
+        // 4 exclamation marks — the old encoding replaced !!!! (4 bangs) with ____
         var bangString = new string('!', 4);
         task.TestLogEventsFromTextOutput($"||||test-failed||||{bangString}||||TestFile.cs||||42", MessageImportance.High);
 
@@ -206,23 +204,46 @@ public class VSTestTask2RegressionTests
     }
 
     [TestMethod]
-    public void LogEventsFromTextOutput_TestFailed_NewlinesEncodedWithControlChars_ShouldBeRestored()
+    public void LogEventsFromTextOutput_TestFailed_NewlinesEncodedWithPercentEscapes_ShouldBeRestored()
     {
-        // Regression test for #15268 — newlines must survive the encode/decode round-trip
-        // MSBuildLogger now encodes \r as \x02 and \n as \x03.
-        // Full encoder→decoder round-trip tests (using MSBuildLogger.FormatMessage) are in
-        // vstest.console.UnitTests/Internal/MSBuildLoggerEncoderTests.cs.
         var task = CreateVSTestTask2();
         var engine = (RecordingBuildEngine)task.BuildEngine;
 
-        // Simulate what MSBuildLogger.Escape produces: \r → \x02, \n → \x03
-        var messageWithNewlines = "Assert failed\x02\x03  at MyTest()";
+        // Simulate what MSBuildLogger.Escape produces: \r → %r, \n → %n
+        var messageWithNewlines = "Assert failed%r%n  at MyTest()";
         task.TestLogEventsFromTextOutput($"||||test-failed||||{messageWithNewlines}||||TestFile.cs||||42", MessageImportance.High);
 
         Assert.HasCount(1, engine.Errors);
         Assert.Contains("Assert failed\r\n  at MyTest()", engine.Errors[0].Message ?? string.Empty);
     }
 
+    [TestMethod]
+    public void LogEventsFromTextOutput_TestFailed_PipesInMessage_ShouldNotBreakParsing()
+    {
+        var task = CreateVSTestTask2();
+        var engine = (RecordingBuildEngine)task.BuildEngine;
+
+        // Pipes are escaped as %p by MSBuildLogger.Escape, so they can't break the |||| delimiter.
+        var messageWithPipes = "expected: a]%p%p%p%p[b";
+        task.TestLogEventsFromTextOutput($"||||test-failed||||{messageWithPipes}||||TestFile.cs||||42", MessageImportance.High);
+
+        Assert.HasCount(1, engine.Errors);
+        Assert.Contains("expected: a]||||[b", engine.Errors[0].Message ?? string.Empty);
+    }
+
+    [TestMethod]
+    public void LogEventsFromTextOutput_TestFailed_PercentInMessage_ShouldNotBeCorrupted()
+    {
+        var task = CreateVSTestTask2();
+        var engine = (RecordingBuildEngine)task.BuildEngine;
+
+        // %% is the escape for literal %, and %%n must decode to %n not to %+newline.
+        var messageWithPercent = "100%%%% done %%n not a newline";
+        task.TestLogEventsFromTextOutput($"||||test-failed||||{messageWithPercent}||||TestFile.cs||||42", MessageImportance.High);
+
+        Assert.HasCount(1, engine.Errors);
+        Assert.Contains("100%% done %n not a newline", engine.Errors[0].Message ?? string.Empty);
+    }
 
     private static TestableVSTestTask2 CreateVSTestTask2()
     {

--- a/test/Microsoft.TestPlatform.Build.UnitTests/VSTestTask2RegressionTests.cs
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/VSTestTask2RegressionTests.cs
@@ -175,6 +175,53 @@ public class VSTestTask2RegressionTests
         task.TestLogEventsFromTextOutput("||||output-info||||", MessageImportance.High);
     }
 
+    [TestMethod]
+    public void LogEventsFromTextOutput_TestFailed_TildeCharsInMessage_ShouldNotBeCorrupted()
+    {
+        // Regression test for #15268 — tilde characters in test output were being replaced with underscores
+        var task = CreateVSTestTask2();
+        var engine = (RecordingBuildEngine)task.BuildEngine;
+
+        // 5 tilde chars in the error message — the old encoding replaced ~~~~ (4 tildes) with ____
+        var tildeString = new string('~', 5);
+        task.TestLogEventsFromTextOutput($"||||test-failed||||{tildeString}||||TestFile.cs||||42", MessageImportance.High);
+
+        Assert.HasCount(1, engine.Errors);
+        Assert.Contains(tildeString, engine.Errors[0].Message ?? string.Empty);
+    }
+
+    [TestMethod]
+    public void LogEventsFromTextOutput_TestFailed_ExclamationCharsInMessage_ShouldNotBeCorrupted()
+    {
+        // Regression test for #15268 — exclamation characters in test output were being replaced with underscores
+        var task = CreateVSTestTask2();
+        var engine = (RecordingBuildEngine)task.BuildEngine;
+
+        // 4 exclamation marks in the error message — the old encoding replaced !!!! (4 bangs) with ____
+        var bangString = new string('!', 4);
+        task.TestLogEventsFromTextOutput($"||||test-failed||||{bangString}||||TestFile.cs||||42", MessageImportance.High);
+
+        Assert.HasCount(1, engine.Errors);
+        Assert.Contains(bangString, engine.Errors[0].Message ?? string.Empty);
+    }
+
+    [TestMethod]
+    public void LogEventsFromTextOutput_TestFailed_NewlinesEncodedWithControlChars_ShouldBeRestored()
+    {
+        // Regression test for #15268 — newlines must survive the encode/decode round-trip
+        // MSBuildLogger now encodes \r as \x02 and \n as \x03
+        var task = CreateVSTestTask2();
+        var engine = (RecordingBuildEngine)task.BuildEngine;
+
+        // Simulate what MSBuildLogger.Escape produces: \r → \x02, \n → \x03
+        var messageWithNewlines = "Assert failed\x02\x03  at MyTest()";
+        task.TestLogEventsFromTextOutput($"||||test-failed||||{messageWithNewlines}||||TestFile.cs||||42", MessageImportance.High);
+
+        Assert.HasCount(1, engine.Errors);
+        Assert.Contains("Assert failed\r\n  at MyTest()", engine.Errors[0].Message ?? string.Empty);
+    }
+
+
     private static TestableVSTestTask2 CreateVSTestTask2()
     {
         var engine = new RecordingBuildEngine();

--- a/test/Microsoft.TestPlatform.Build.UnitTests/VSTestTask2RegressionTests.cs
+++ b/test/Microsoft.TestPlatform.Build.UnitTests/VSTestTask2RegressionTests.cs
@@ -209,7 +209,9 @@ public class VSTestTask2RegressionTests
     public void LogEventsFromTextOutput_TestFailed_NewlinesEncodedWithControlChars_ShouldBeRestored()
     {
         // Regression test for #15268 — newlines must survive the encode/decode round-trip
-        // MSBuildLogger now encodes \r as \x02 and \n as \x03
+        // MSBuildLogger now encodes \r as \x02 and \n as \x03.
+        // Full encoder→decoder round-trip tests (using MSBuildLogger.FormatMessage) are in
+        // vstest.console.UnitTests/Internal/MSBuildLoggerEncoderTests.cs.
         var task = CreateVSTestTask2();
         var engine = (RecordingBuildEngine)task.BuildEngine;
 

--- a/test/TestAssets/TerminalLoggerTestProject/UnitTest1.cs
+++ b/test/TestAssets/TerminalLoggerTestProject/UnitTest1.cs
@@ -36,6 +36,20 @@ namespace TerminalLoggerUnitTests
         }
 
         /// <summary>
+        /// Validates that ~, !, |, and % in assertion messages are not corrupted
+        /// by the MSBuildLogger encoding used by the TerminalLogger.
+        /// </summary>
+        [TestMethod]
+        public void FailingTestWithSpecialChars()
+        {
+            // These characters were corrupted by the old ~~~~, !!!!, |||| encoding.
+            // 5 tildes, 4 bangs, 4 pipes, and percent-n which could be confused with a newline escape.
+#pragma warning disable MSTEST0025 // Use 'Assert.Fail' instead of an always-failing assert
+            Assert.AreEqual("~~~~~!!!!||||%n", "not the same");
+#pragma warning restore MSTEST0025 // Use 'Assert.Fail' instead of an always-failing assert
+        }
+
+        /// <summary>
         /// The skipping test.
         /// </summary>
         [Ignore]

--- a/test/vstest.console.UnitTests/Internal/MSBuildLoggerEncoderTests.cs
+++ b/test/vstest.console.UnitTests/Internal/MSBuildLoggerEncoderTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+
+using Microsoft.VisualStudio.TestPlatform.CommandLine.Internal;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace vstest.console.UnitTests.Internal;
+
+/// <summary>
+/// Round-trip tests verifying that MSBuildLogger's encoder and VSTestTask2's decoder stay in sync.
+/// </summary>
+[TestClass]
+public class MSBuildLoggerEncoderTests
+{
+    // Mirrors VSTestTask2.TryGetMessage decode logic to keep the round-trip self-contained.
+    private static string?[] Decode(string encoded)
+    {
+        var parts = encoded.Split(new[] { "||||" }, StringSplitOptions.None);
+        // parts[0] is empty (before first ||||), parts[1] is the event name
+        return parts.Skip(2).Select(p => p?.Replace("\x02", "\r").Replace("\x03", "\n")).ToArray();
+    }
+
+    [TestMethod]
+    public void FormatMessage_TildeCharsInMessage_SurviveRoundTrip()
+    {
+        // Regression test for #15268 — 5 tildes must not be corrupted by the old ~~~~ → ____ sanitization
+        var rawMessage = new string('~', 5);
+
+        var encoded = MSBuildLogger.FormatMessage("test-failed", rawMessage, "TestFile.cs", "42");
+        var decoded = Decode(encoded);
+
+        Assert.AreEqual(rawMessage, decoded[0]);
+    }
+
+    [TestMethod]
+    public void FormatMessage_ExclamationCharsInMessage_SurviveRoundTrip()
+    {
+        // Regression test for #15268 — 4 exclamation marks must not be corrupted by the old !!!! → ____ sanitization
+        var rawMessage = new string('!', 4);
+
+        var encoded = MSBuildLogger.FormatMessage("test-failed", rawMessage, "TestFile.cs", "42");
+        var decoded = Decode(encoded);
+
+        Assert.AreEqual(rawMessage, decoded[0]);
+    }
+
+    [TestMethod]
+    public void FormatMessage_NewlinesInMessage_SurviveRoundTrip()
+    {
+        // Regression test for #15268 — \r\n must survive encode/decode via \x02/\x03 control chars
+        var rawMessage = "Assert failed.\r\n  at MyTest()";
+
+        var encoded = MSBuildLogger.FormatMessage("test-failed", rawMessage, "TestFile.cs", "42");
+        var decoded = Decode(encoded);
+
+        Assert.AreEqual(rawMessage, decoded[0]);
+    }
+
+    [TestMethod]
+    public void FormatMessage_MultipleFields_AllFieldsSurviveRoundTrip()
+    {
+        // Verify that all fields (message, file, line) are preserved intact across encode/decode
+        var rawMessage = "Assert failed.\r\n  at MyTest()";
+        var rawFile = "TestFile.cs";
+        var rawLine = "42";
+
+        var encoded = MSBuildLogger.FormatMessage("test-failed", rawMessage, rawFile, rawLine);
+        var decoded = Decode(encoded);
+
+        Assert.HasCount(3, decoded);
+        Assert.AreEqual(rawMessage, decoded[0]);
+        Assert.AreEqual(rawFile, decoded[1]);
+        Assert.AreEqual(rawLine, decoded[2]);
+    }
+}

--- a/test/vstest.console.UnitTests/Internal/MSBuildLoggerEncoderTests.cs
+++ b/test/vstest.console.UnitTests/Internal/MSBuildLoggerEncoderTests.cs
@@ -1,81 +1,106 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
-
 using Microsoft.VisualStudio.TestPlatform.CommandLine.Internal;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace vstest.console.UnitTests.Internal;
 
 /// <summary>
-/// Round-trip tests verifying that MSBuildLogger's encoder and VSTestTask2's decoder stay in sync.
+/// Round-trip tests for MSBuildLogger Escape/Unescape.
 /// </summary>
 [TestClass]
 public class MSBuildLoggerEncoderTests
 {
-    // Mirrors VSTestTask2.TryGetMessage decode logic to keep the round-trip self-contained.
-    // WARNING: This must stay in sync with the actual decode logic in VSTestTask2.TryGetMessage.
-    // If VSTestTask2's decoder changes (e.g., different control chars), update this helper too,
-    // otherwise these round-trip tests will pass while real round-trips break.
-    private static string?[] Decode(string encoded)
-    {
-        var parts = encoded.Split(new[] { "||||" }, StringSplitOptions.None);
-        // parts[0] is empty (before first ||||), parts[1] is the event name
-        return parts.Skip(2).Select(p => p?.Replace("\x02", "\r").Replace("\x03", "\n")).ToArray();
-    }
-
     [TestMethod]
     public void FormatMessage_TildeCharsInMessage_SurviveRoundTrip()
     {
-        // Regression test for #15268 — 5 tildes must not be corrupted by the old ~~~~ → ____ sanitization
         var rawMessage = new string('~', 5);
 
         var encoded = MSBuildLogger.FormatMessage("test-failed", rawMessage, "TestFile.cs", "42");
-        var decoded = Decode(encoded);
+        var decoded = DecodeFirstField(encoded);
 
-        Assert.AreEqual(rawMessage, decoded[0]);
+        Assert.AreEqual(rawMessage, decoded);
     }
 
     [TestMethod]
     public void FormatMessage_ExclamationCharsInMessage_SurviveRoundTrip()
     {
-        // Regression test for #15268 — 4 exclamation marks must not be corrupted by the old !!!! → ____ sanitization
         var rawMessage = new string('!', 4);
 
         var encoded = MSBuildLogger.FormatMessage("test-failed", rawMessage, "TestFile.cs", "42");
-        var decoded = Decode(encoded);
+        var decoded = DecodeFirstField(encoded);
 
-        Assert.AreEqual(rawMessage, decoded[0]);
+        Assert.AreEqual(rawMessage, decoded);
     }
 
     [TestMethod]
     public void FormatMessage_NewlinesInMessage_SurviveRoundTrip()
     {
-        // Regression test for #15268 — \r\n must survive encode/decode via \x02/\x03 control chars
         var rawMessage = "Assert failed.\r\n  at MyTest()";
 
         var encoded = MSBuildLogger.FormatMessage("test-failed", rawMessage, "TestFile.cs", "42");
-        var decoded = Decode(encoded);
+        var decoded = DecodeFirstField(encoded);
 
-        Assert.AreEqual(rawMessage, decoded[0]);
+        Assert.AreEqual(rawMessage, decoded);
+    }
+
+    [TestMethod]
+    public void FormatMessage_PipesInMessage_SurviveRoundTrip()
+    {
+        // 4 pipes would have been eaten by the old ||||→____ replacement.
+        var rawMessage = "expected: a]||||[b";
+
+        var encoded = MSBuildLogger.FormatMessage("test-failed", rawMessage, "TestFile.cs", "42");
+        var decoded = DecodeFirstField(encoded);
+
+        Assert.AreEqual(rawMessage, decoded);
+    }
+
+    [TestMethod]
+    public void FormatMessage_PercentInMessage_SurviveRoundTrip()
+    {
+        // The escape char itself must round-trip.
+        var rawMessage = "100% done";
+
+        var encoded = MSBuildLogger.FormatMessage("test-failed", rawMessage, "TestFile.cs", "42");
+        var decoded = DecodeFirstField(encoded);
+
+        Assert.AreEqual(rawMessage, decoded);
+    }
+
+    [TestMethod]
+    public void FormatMessage_PercentN_NotConfusedWithNewline()
+    {
+        // "%n" in user data must not become a newline after round-trip.
+        var rawMessage = "url-encoded: %n %r %p";
+
+        var encoded = MSBuildLogger.FormatMessage("test-failed", rawMessage, "TestFile.cs", "42");
+        var decoded = DecodeFirstField(encoded);
+
+        Assert.AreEqual(rawMessage, decoded);
     }
 
     [TestMethod]
     public void FormatMessage_MultipleFields_AllFieldsSurviveRoundTrip()
     {
-        // Verify that all fields (message, file, line) are preserved intact across encode/decode
         var rawMessage = "Assert failed.\r\n  at MyTest()";
-        var rawFile = "TestFile.cs";
+        var rawFile = @"C:\src\TestFile.cs";
         var rawLine = "42";
 
         var encoded = MSBuildLogger.FormatMessage("test-failed", rawMessage, rawFile, rawLine);
-        var decoded = Decode(encoded);
+        var parts = encoded.Split(new[] { "||||" }, System.StringSplitOptions.None);
+        // parts[0] = empty, parts[1] = name, parts[2..] = fields
+        var decoded = new[] { MSBuildLogger.Unescape(parts[2]), MSBuildLogger.Unescape(parts[3]), MSBuildLogger.Unescape(parts[4]) };
 
-        Assert.HasCount(3, decoded);
         Assert.AreEqual(rawMessage, decoded[0]);
         Assert.AreEqual(rawFile, decoded[1]);
         Assert.AreEqual(rawLine, decoded[2]);
+    }
+
+    private static string? DecodeFirstField(string encoded)
+    {
+        var parts = encoded.Split(new[] { "||||" }, System.StringSplitOptions.None);
+        return MSBuildLogger.Unescape(parts[2]);
     }
 }

--- a/test/vstest.console.UnitTests/Internal/MSBuildLoggerEncoderTests.cs
+++ b/test/vstest.console.UnitTests/Internal/MSBuildLoggerEncoderTests.cs
@@ -16,6 +16,9 @@ namespace vstest.console.UnitTests.Internal;
 public class MSBuildLoggerEncoderTests
 {
     // Mirrors VSTestTask2.TryGetMessage decode logic to keep the round-trip self-contained.
+    // WARNING: This must stay in sync with the actual decode logic in VSTestTask2.TryGetMessage.
+    // If VSTestTask2's decoder changes (e.g., different control chars), update this helper too,
+    // otherwise these round-trip tests will pass while real round-trips break.
     private static string?[] Decode(string encoded)
     {
         var parts = encoded.Split(new[] { "||||" }, StringSplitOptions.None);


### PR DESCRIPTION
> [!CAUTION]
> **Security scanning requires review** for [Issue Repro Triage & Auto-Fix 🔌](https://github.com/microsoft/vstest/actions/runs/26100663149)
>
> <details>
> <summary>Details</summary>
>
> Potential security threats were detected in the agent output. The workflow output should be reviewed before merging.
>
> Review the [workflow run logs](https://github.com/microsoft/vstest/actions/runs/26100663149) for details.
> </details>


## Summary

> 🛠 This is an automated fix for issue #15268.

Fixes #15268 — `~`, `!`, and `|` characters in test output (assertion messages, test display names, stack traces) were being corrupted when using the TerminalLogger (`dotnet test` with live logger enabled).

## Root Cause

`MSBuildLogger.Escape()` serializes test messages to a single line for transport over stdout between `vstest.console` and `VSTestTask2`. The old encoding used `~~~~` for `\r` and `!!!!` for `\n`, with a pre-sanitization step that replaced those sequences in user data with `____` — lossy, and also ate `||||` (4 pipes) in the same way.

## Fix

Switch to `%`-based escaping, same idea as URL encoding:

| Character | Escaped |
|-----------|---------|
| `%`       | `%%`    |
| `\|`      | `%p`    |
| `\r`      | `%r`    |
| `\n`      | `%n`    |

This is **lossless** — no user data is ever replaced with underscores. It also stays **readable in MSBuild binary logs** (unlike the intermediate `\x02`/`\x03` control char approach, which would show up as invisible garbage in binlog viewers).

The decoder is a single-pass scanner, not chained `Replace` calls. Chained `Replace` would incorrectly decode `%%n` as `%` + newline instead of literal `%n`.

## Tests

- `MSBuildLoggerEncoderTests` — round-trip tests through `FormatMessage`/`Unescape` for tildes, bangs, pipes, `%`, `%n` in user data, and multi-field messages.
- `VSTestTask2RegressionTests` — decoder-side tests verifying `%r%n` restores newlines, `%p` restores pipes, `%%` restores percent, and tilde/exclamation chars survive unchanged.

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔌, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 26100663149, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/26100663149 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->