### PR TITLE
[fix] Fix flaky PortArgumentProcessor test: cache port locally instead of re-reading singleton

### DIFF
--- a/src/vstest.console/Processors/PortArgumentProcessor.cs
+++ b/src/vstest.console/Processors/PortArgumentProcessor.cs
@@ -90,6 +90,11 @@ internal class PortArgumentExecutor : IArgumentExecutor
     private IDesignModeClient? _designModeClient;
 
     /// <summary>
+    /// Port number captured during Initialize, used in Execute to avoid re-reading the shared singleton.
+    /// </summary>
+    private int _port;
+
+    /// <summary>
     /// Process helper for process management actions.
     /// </summary>
     private readonly IProcessHelper _processHelper;
@@ -140,6 +145,7 @@ internal class PortArgumentExecutor : IArgumentExecutor
             throw new CommandLineException(CommandLineResources.InvalidPortArgument);
         }
 
+        _port = portNumber;
         _commandLineOptions.Port = portNumber;
         _commandLineOptions.IsDesignMode = true;
         RunSettingsHelper.Instance.IsDesignMode = true;
@@ -154,11 +160,11 @@ internal class PortArgumentExecutor : IArgumentExecutor
     {
         try
         {
-            _designModeClient?.ConnectToClientAndProcessRequests(_commandLineOptions.Port, _testRequestManager);
+            _designModeClient?.ConnectToClientAndProcessRequests(_port, _testRequestManager);
         }
         catch (TimeoutException ex)
         {
-            throw new CommandLineException(string.Format(CultureInfo.CurrentCulture, CommandLineResources.DesignModeClientTimeoutError, _commandLineOptions.Port), ex);
+            throw new CommandLineException(string.Format(CultureInfo.CurrentCulture, CommandLineResources.DesignModeClientTimeoutError, _port), ex);
         }
 
         return ArgumentProcessorResult.Success;


### PR DESCRIPTION
🤖 This is an automated fix generated by the Issue Repro Triage agent.

Fixes #15730

## Root Cause

`PortArgumentExecutor.Execute()` reads `_commandLineOptions.Port` from the shared `CommandLineOptions.Instance` singleton. `InProcessVsTestConsoleWrapper` starts vstest.console in-process by calling `executor.Execute(args)` on a background `Task.Run` thread. This eventually calls `PortArgumentExecutor.Initialize("1234")`, which sets `CommandLineOptions.Instance.Port = 1234`.

If this background thread races with another test that called `Initialize("2345")` and is about to call `Execute()`, the background thread overwrites `CommandLineOptions.Instance.Port` from 2345 to 1234 before `Execute()` reads it — causing the `ConnectToClientAndProcessRequests` mock to be invoked with the wrong port.

## Fix

Capture the port number in a private `_port` field during `Initialize()` and use that captured value in `Execute()` instead of re-reading the shared singleton. The assignment to `_commandLineOptions.Port` is preserved for callers that read it from `CommandLineOptions.Instance`.

## Test

The 11 existing `PortArgumentProcessorTests` all pass. The flaky test `ExecutorExecuteForValidConnectionReturnsArgumentProcessorResultSuccess` is directly covered by the fix — it now uses the locally-captured port rather than the shared mutable singleton.

> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/26229333372)*




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/26229333372)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 26229333372, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/26229333372 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->