### PR TITLE
Fix HTML logger crash on invalid XML chars in test names

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
@@ -468,7 +468,7 @@ public class HtmlLogger : ITestLoggerWithParameters
     /// Removes characters that are invalid in XML 1.0 from a string.
     /// </summary>
     /// <remarks>
-    /// XML 1.0 valid characters: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD].
+    /// XML 1.0 valid characters: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF].
     /// Control characters in the range #x00-#x08, #x0B, #x0C, #x0E-#x1F are not valid and
     /// will cause <see cref="DataContractSerializer"/> to throw an <see cref="System.Xml.XmlException"/>.
     /// Invalid characters are replaced with their Unicode escape representation.

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
 using System.Threading;
 
 using Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger.ObjectModel;
@@ -195,10 +196,10 @@ public class HtmlLogger : ITestLoggerWithParameters
 
         var testResult = new ObjectModel.TestResult
         {
-            DisplayName = e.Result.DisplayName ?? e.Result.TestCase.FullyQualifiedName,
-            FullyQualifiedName = e.Result.TestCase.FullyQualifiedName,
-            ErrorStackTrace = e.Result.ErrorStackTrace,
-            ErrorMessage = e.Result.ErrorMessage,
+            DisplayName = RemoveInvalidXmlChars(e.Result.DisplayName ?? e.Result.TestCase.FullyQualifiedName),
+            FullyQualifiedName = RemoveInvalidXmlChars(e.Result.TestCase.FullyQualifiedName),
+            ErrorStackTrace = RemoveInvalidXmlChars(e.Result.ErrorStackTrace),
+            ErrorMessage = RemoveInvalidXmlChars(e.Result.ErrorMessage),
             TestResultId = e.Result.TestCase.Id,
             Duration = GetFormattedDurationString(e.Result.Duration),
             ResultOutcome = e.Result.Outcome
@@ -453,5 +454,27 @@ public class HtmlLogger : ITestLoggerWithParameters
         }
 
         return time.Count == 0 ? "< 1ms" : string.Join(" ", time);
+    }
+
+    /// <summary>
+    /// Removes characters that are invalid in XML 1.0 from a string.
+    /// </summary>
+    /// <remarks>
+    /// XML 1.0 valid characters: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD].
+    /// Control characters in the range #x00-#x08, #x0B, #x0C, #x0E-#x1F are not valid and
+    /// will cause <see cref="DataContractSerializer"/> to throw an <see cref="System.Xml.XmlException"/>.
+    /// Invalid characters are replaced with their Unicode escape representation.
+    /// </remarks>
+    private static string? RemoveInvalidXmlChars(string? str)
+    {
+        if (str is null)
+        {
+            return null;
+        }
+
+        // From xml spec (http://www.w3.org/TR/xml/#charsets) valid chars:
+        // #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+        const string invalidChar = @"[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD]";
+        return Regex.Replace(str, invalidChar, m => $@"\u{(ushort)m.Value[0]:x4}");
     }
 }

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
@@ -37,6 +37,14 @@ public class HtmlLogger : ITestLoggerWithParameters
     private readonly IHtmlTransformer _htmlTransformer;
     private Dictionary<string, string?>? _parametersDictionary;
 
+    // Matches XML 1.0 invalid characters (excluding valid surrogate pairs).
+    // Valid chars per spec: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+    // The pattern allows valid high+low surrogate pairs to pass through unchanged;
+    // lone surrogates are treated as invalid.
+    private static readonly Regex InvalidXmlCharsRegex = new(
+        @"[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\uD800-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]",
+        RegexOptions.Compiled);
+
     public HtmlLogger()
         : this(new FileHelper(), new HtmlTransformer(), new DataContractSerializer(typeof(TestRunDetails)))
     {
@@ -474,7 +482,8 @@ public class HtmlLogger : ITestLoggerWithParameters
 
         // From xml spec (http://www.w3.org/TR/xml/#charsets) valid chars:
         // #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
-        const string invalidChar = @"[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD]";
-        return Regex.Replace(str, invalidChar, m => $@"\u{(ushort)m.Value[0]:x4}");
+        // Valid surrogate pairs (representing U+10000–U+10FFFF) are allowed through unchanged;
+        // lone surrogates are replaced with their Unicode escape representation.
+        return InvalidXmlCharsRegex.Replace(str, m => $@"\u{(ushort)m.Value[0]:x4}");
     }
 }

--- a/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
@@ -273,6 +273,26 @@ public class HtmlLoggerTests
     }
 
     [TestMethod]
+    public void TestResultHandlerShouldPreserveValidSurrogatePairsInDisplayName()
+    {
+        // Valid surrogate pairs (e.g. emoji U+1F600 = 😀) are valid XML 1.0 chars and must NOT be mangled.
+        var testCase = CreateTestCase("Pass1");
+        testCase.FullyQualifiedName = "fully";
+        testCase.Source = "abc/def.dll";
+
+        var testResult = new ObjectModel.TestResult(testCase)
+        {
+            DisplayName = "Test(😀)",  // 😀 is U+1F600, encoded as surrogate pair \uD83D\uDE00
+        };
+
+        _htmlLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(testResult).Object);
+
+        var result = _htmlLogger.TestRunDetails!.ResultCollectionList!.First().ResultList!.First();
+
+        Assert.AreEqual("Test(😀)", result.DisplayName, "Valid surrogate pairs should pass through unchanged.");
+    }
+
+    [TestMethod]
     public void GetFormattedDurationStringShouldGiveCorrectFormat()
     {
         TimeSpan ts1 = new(0, 0, 0, 0, 1);

--- a/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
@@ -253,8 +253,8 @@ public class HtmlLoggerTests
     {
         // Characters like \x01 (SOH) are invalid in XML 1.0 and would cause DataContractSerializer to throw.
         var testCase = CreateTestCase("Pass1");
-        testCase.FullyQualifiedName = "fully";
         testCase.Source = "abc/def.dll";
+        testCase.FullyQualifiedName = "Namespace.Class.\x04Method";
 
         var testResult = new ObjectModel.TestResult(testCase)
         {
@@ -268,6 +268,7 @@ public class HtmlLoggerTests
         var result = _htmlLogger.TestRunDetails!.ResultCollectionList!.First().ResultList!.First();
 
         Assert.AreEqual(@"TestMethod(\u0001value)", result.DisplayName);
+        Assert.AreEqual(@"Namespace.Class.\u0004Method", result.FullyQualifiedName);
         Assert.AreEqual(@"error\u0002message", result.ErrorMessage);
         Assert.AreEqual(@"stack\u0003trace", result.ErrorStackTrace);
     }

--- a/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
@@ -249,6 +249,30 @@ public class HtmlLoggerTests
     }
 
     [TestMethod]
+    public void TestResultHandlerShouldSanitizeInvalidXmlCharsInDisplayName()
+    {
+        // Characters like \x01 (SOH) are invalid in XML 1.0 and would cause DataContractSerializer to throw.
+        var testCase = CreateTestCase("Pass1");
+        testCase.FullyQualifiedName = "fully";
+        testCase.Source = "abc/def.dll";
+
+        var testResult = new ObjectModel.TestResult(testCase)
+        {
+            DisplayName = "TestMethod(\x01value)",
+            ErrorMessage = "error\x02message",
+            ErrorStackTrace = "stack\x03trace",
+        };
+
+        _htmlLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(testResult).Object);
+
+        var result = _htmlLogger.TestRunDetails!.ResultCollectionList!.First().ResultList!.First();
+
+        Assert.AreEqual(@"TestMethod(\u0001value)", result.DisplayName);
+        Assert.AreEqual(@"error\u0002message", result.ErrorMessage);
+        Assert.AreEqual(@"stack\u0003trace", result.ErrorStackTrace);
+    }
+
+    [TestMethod]
     public void GetFormattedDurationStringShouldGiveCorrectFormat()
     {
         TimeSpan ts1 = new(0, 0, 0, 0, 1);


### PR DESCRIPTION
Fix #10431

When test display names contain XML 1.0 invalid control characters (`\x01`–`\x08`, `\x0B`, `\x0C`, `\x0E`–`\x1F`), `DataContractSerializer` throws an `XmlException` and the HTML report is silently broken — test entries with those characters are missing from the output.

Sanitize those characters before storing them in the HTML logger object model — same approach as `TrxLogger` already uses. Invalid chars are replaced with their `\uXXXX` escape representation. Valid surrogate pairs (emoji etc.) pass through unchanged.

Applied to `DisplayName`, `FullyQualifiedName`, `ErrorStackTrace`, and `ErrorMessage` in `TestResultHandler`.

**Before** — HTML report with control chars in test names (test entries missing, only `Test(normal)` shows up):

![before](https://github.com/nohwnd/vstest/blob/pr-assets/10431/before.png?raw=true)

**After** — control chars sanitized to `\u0001`, all three tests visible:

![after](https://github.com/nohwnd/vstest/blob/pr-assets/10431/after.png?raw=true)