### PR TITLE
[fix] Improve error message when testhost cannot be found

### DIFF
--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -459,7 +459,8 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
 
             if (testHostPath.IsNullOrEmpty())
             {
-                throw new TestPlatformException("Could not find testhost");
+                string message = string.Format(CultureInfo.CurrentCulture, Resources.CouldNotFindTesthost, sourcePath, sourceDirectory);
+                throw new TestPlatformException(message);
             }
 
             // We silently force x64 only if the target architecture is the default one and is not specified by user

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.Designer.cs
@@ -70,7 +70,18 @@ namespace Microsoft.TestPlatform.TestHostProvider.Resources {
                 return ResourceManager.GetString("MultipleFileVersions", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string for testhost not found with path and directory info.
+        /// </summary>
+        internal static string CouldNotFindTesthost
+        {
+            get
+            {
+                return ResourceManager.GetString("CouldNotFindTesthost", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Unable to find {0}. Make sure test project has a nuget reference of package &quot;Microsoft.NET.Test.Sdk&quot;..
         /// </summary>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.resx
@@ -127,6 +127,16 @@
   <data name="SuggestPublishTestProject" xml:space="preserve">
     <value>Unable to find {0}. Please publish your test project and retry.</value>
   </data>
+  <data name="CouldNotFindTesthost" xml:space="preserve">
+    <value>Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</value>
+    <comment>'{0}' is the path to the test source (DLL/EXE), '{1}' is the directory where testhost was searched.</comment>
+  </data>
   <data name="NoDotnetMuxerFoundForArchitecture" xml:space="preserve">
     <value>Could not find '{0}' host for the '{1}' architecture.
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.cs.xlf
@@ -2,6 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="cs">
     <body>
+      <trans-unit id="CouldNotFindTesthost">
+        <source>Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</source>
+        <target state="new">Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</target>
+        <note>'{0}' is the path to the test source (DLL/EXE), '{1}' is the directory where testhost was searched.</note>
+      </trans-unit>
       <trans-unit id="MultipleFileVersions">
         <source>Multiple versions of same extension found. Selecting the highest version.
 {0}</source>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.de.xlf
@@ -2,6 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="de">
     <body>
+      <trans-unit id="CouldNotFindTesthost">
+        <source>Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</source>
+        <target state="new">Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</target>
+        <note>'{0}' is the path to the test source (DLL/EXE), '{1}' is the directory where testhost was searched.</note>
+      </trans-unit>
       <trans-unit id="MultipleFileVersions">
         <source>Multiple versions of same extension found. Selecting the highest version.
 {0}</source>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.es.xlf
@@ -2,6 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="es">
     <body>
+      <trans-unit id="CouldNotFindTesthost">
+        <source>Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</source>
+        <target state="new">Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</target>
+        <note>'{0}' is the path to the test source (DLL/EXE), '{1}' is the directory where testhost was searched.</note>
+      </trans-unit>
       <trans-unit id="MultipleFileVersions">
         <source>Multiple versions of same extension found. Selecting the highest version.
 {0}</source>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.fr.xlf
@@ -2,6 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="fr">
     <body>
+      <trans-unit id="CouldNotFindTesthost">
+        <source>Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</source>
+        <target state="new">Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</target>
+        <note>'{0}' is the path to the test source (DLL/EXE), '{1}' is the directory where testhost was searched.</note>
+      </trans-unit>
       <trans-unit id="MultipleFileVersions">
         <source>Multiple versions of same extension found. Selecting the highest version.
 {0}</source>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.it.xlf
@@ -2,6 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="it">
     <body>
+      <trans-unit id="CouldNotFindTesthost">
+        <source>Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</source>
+        <target state="new">Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</target>
+        <note>'{0}' is the path to the test source (DLL/EXE), '{1}' is the directory where testhost was searched.</note>
+      </trans-unit>
       <trans-unit id="MultipleFileVersions">
         <source>Multiple versions of same extension found. Selecting the highest version.
 {0}</source>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ja.xlf
@@ -2,6 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="ja">
     <body>
+      <trans-unit id="CouldNotFindTesthost">
+        <source>Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</source>
+        <target state="new">Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</target>
+        <note>'{0}' is the path to the test source (DLL/EXE), '{1}' is the directory where testhost was searched.</note>
+      </trans-unit>
       <trans-unit id="MultipleFileVersions">
         <source>Multiple versions of same extension found. Selecting the highest version.
 {0}</source>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ko.xlf
@@ -2,6 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="ko">
     <body>
+      <trans-unit id="CouldNotFindTesthost">
+        <source>Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</source>
+        <target state="new">Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</target>
+        <note>'{0}' is the path to the test source (DLL/EXE), '{1}' is the directory where testhost was searched.</note>
+      </trans-unit>
       <trans-unit id="MultipleFileVersions">
         <source>Multiple versions of same extension found. Selecting the highest version.
 {0}</source>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pl.xlf
@@ -2,6 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="pl">
     <body>
+      <trans-unit id="CouldNotFindTesthost">
+        <source>Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</source>
+        <target state="new">Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</target>
+        <note>'{0}' is the path to the test source (DLL/EXE), '{1}' is the directory where testhost was searched.</note>
+      </trans-unit>
       <trans-unit id="MultipleFileVersions">
         <source>Multiple versions of same extension found. Selecting the highest version.
 {0}</source>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pt-BR.xlf
@@ -2,6 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="pt-BR">
     <body>
+      <trans-unit id="CouldNotFindTesthost">
+        <source>Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</source>
+        <target state="new">Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</target>
+        <note>'{0}' is the path to the test source (DLL/EXE), '{1}' is the directory where testhost was searched.</note>
+      </trans-unit>
       <trans-unit id="MultipleFileVersions">
         <source>Multiple versions of same extension found. Selecting the highest version.
 {0}</source>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ru.xlf
@@ -2,6 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="ru">
     <body>
+      <trans-unit id="CouldNotFindTesthost">
+        <source>Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</source>
+        <target state="new">Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</target>
+        <note>'{0}' is the path to the test source (DLL/EXE), '{1}' is the directory where testhost was searched.</note>
+      </trans-unit>
       <trans-unit id="MultipleFileVersions">
         <source>Multiple versions of same extension found. Selecting the highest version.
 {0}</source>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.tr.xlf
@@ -2,6 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="tr">
     <body>
+      <trans-unit id="CouldNotFindTesthost">
+        <source>Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</source>
+        <target state="new">Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</target>
+        <note>'{0}' is the path to the test source (DLL/EXE), '{1}' is the directory where testhost was searched.</note>
+      </trans-unit>
       <trans-unit id="MultipleFileVersions">
         <source>Multiple versions of same extension found. Selecting the highest version.
 {0}</source>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hans.xlf
@@ -2,6 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="zh-Hans">
     <body>
+      <trans-unit id="CouldNotFindTesthost">
+        <source>Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</source>
+        <target state="new">Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</target>
+        <note>'{0}' is the path to the test source (DLL/EXE), '{1}' is the directory where testhost was searched.</note>
+      </trans-unit>
       <trans-unit id="MultipleFileVersions">
         <source>Multiple versions of same extension found. Selecting the highest version.
 {0}</source>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hant.xlf
@@ -2,6 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="zh-Hant">
     <body>
+      <trans-unit id="CouldNotFindTesthost">
+        <source>Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</source>
+        <target state="new">Could not find testhost for test source '{0}'.
+
+Verify that:
+  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
+  - The project has been built and the output is in '{1}'.
+  - The project's target framework matches the installed .NET runtime.
+</target>
+        <note>'{0}' is the path to the test source (DLL/EXE), '{1}' is the directory where testhost was searched.</note>
+      </trans-unit>
       <trans-unit id="MultipleFileVersions">
         <source>Multiple versions of same extension found. Selecting the highest version.
 {0}</source>

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -544,6 +544,23 @@ public class DotnetTestHostManagerTests
     }
 
     [TestMethod]
+    public void GetTestHostProcessStartInfoShouldIncludeSourcePathInExceptionMessageWhenTesthostNotFound()
+    {
+        var sourcePath = Path.Combine(_temp, "mytest.dll");
+        var sourceDirectory = Path.GetDirectoryName(sourcePath)!;
+
+        // Ensure no testhost.dll exists anywhere
+        _mockFileHelper.Setup(fh => fh.Exists(It.IsAny<string>())).Returns(false);
+
+        Action action = () => _dotnetHostManager.GetTestHostProcessStartInfo(new[] { sourcePath }, null, _defaultConnectionInfo);
+
+        var exception = Assert.ThrowsExactly<TestPlatformException>(action);
+        Assert.Contains(sourcePath, exception.Message);
+        Assert.Contains(sourceDirectory, exception.Message);
+    }
+
+
+    [TestMethod]
     public void GetTestHostProcessStartInfoShouldIncludeSourceDirectoryAsWorkingDirectory()
     {
         // Absolute path to the source directory


### PR DESCRIPTION
## Summary

🤖 This is an automated fix generated by the Issue Repro Triage agent.

Fixes #15112

## Root Cause

When `DotnetTestHostManager` could not find `testhost.dll` anywhere on disk, it threw a `TestPlatformException` with the message `"Could not find testhost"`. This message provided no context about:
- Which test source was being processed
- Which directories were searched
- What steps the user could take to resolve it

This was reported when a NuGet package setup prevented `testhost.exe` from being copied to the output bin folder. The vague message made self-diagnosis impossible.

## Fix

Replace the generic message with one that includes:
1. **The test source path** — so the user knows which project triggered the failure
2. **The output directory** — so the user can verify what is/isn't there
3. **Actionable hints** — check `Microsoft.NET.Test.Sdk` NuGet reference, ensure the project is built, and verify the target framework

**Before:**
```
Could not find testhost
```

**After:**
```
Could not find testhost for test source '/path/to/my.test.dll'.

Verify that:
  - The test project references the 'Microsoft.NET.Test.Sdk' NuGet package.
  - The project has been built and the output is in '/path/to/'.
  - The project's target framework matches the installed .NET runtime.
```

## Testing

Added unit test `GetTestHostProcessStartInfoShouldIncludeSourcePathInExceptionMessageWhenTesthostNotFound` that verifies the exception message contains both the source path and directory when testhost cannot be found.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/26290087537)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 26290087537, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/26290087537 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->