### PR TITLE
[fix] Fix flaky EnableLoggersArgumentProcessorTests on macOS

### DIFF
--- a/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
@@ -20,8 +20,8 @@ public class EnableLoggersArgumentProcessorTests
     [TestInitialize]
     public void Initialize()
     {
-        RunTestsArgumentProcessorTests.SetupMockExtensions();
         RunSettingsManager.Instance = null;
+        RunTestsArgumentProcessorTests.SetupMockExtensions();
     }
 
     [TestCleanup]

--- a/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
@@ -21,6 +21,13 @@ public class EnableLoggersArgumentProcessorTests
     public void Initialize()
     {
         RunTestsArgumentProcessorTests.SetupMockExtensions();
+        RunSettingsManager.Instance = null;
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        RunSettingsManager.Instance = null;
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

🤖 This is an automated fix by the Issue Repro Triage agent.

Fixes #15614

## Root Cause

`EnableLoggersArgumentProcessorTests` uses `RunSettingsManager.Instance` — a static singleton — but did not reset it in `[TestInitialize]` or `[TestCleanup]`. When tests from other classes run in parallel and mutate this shared singleton, the state bleeds into these tests, causing non-deterministic failures (particularly on macOS where test execution order can differ).

## Fix

Added `RunSettingsManager.Instance = null` in both `[TestInitialize]` and `[TestCleanup]`:

- **`TestInitialize`**: ensures a fresh `RunSettingsManager` before each test, regardless of what previous tests left behind
- **`TestCleanup`**: leaves the singleton in a clean state for subsequent tests

This matches the existing pattern in `RunSettingsManagerTests.cs`, which already resets `RunSettingsManager.Instance = null` in its `TestCleanup`.

## Verification

All 15 tests in `EnableLoggersArgumentProcessorTests` pass after the change.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/26319574293)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 26319574293, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/26319574293 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->