### PR TITLE
[fix] Throw when /diag is passed manually in integration tests

### DIFF
--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
@@ -133,7 +133,7 @@ public class BlameDataCollectorTests : AcceptanceTestBase
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, string.Empty, runnerInfo.InIsolationValue);
         arguments = string.Concat(arguments, $" /ResultsDirectory:{TempDirectory.Path}");
         // Don't reduce this, 10s is about the safe minimum to not have flakiness.
-        arguments = string.Concat(arguments, $@" /Blame:""CollectHangDump;HangDumpType=mini;TestTimeout=10s"" /Diag:{TempDirectory.Path}/log.txt");
+        arguments = string.Concat(arguments, $@" /Blame:""CollectHangDump;HangDumpType=mini;TestTimeout=10s""");
 
         var env = new Dictionary<string, string?>
         {

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/CodeCoverageTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/CodeCoverageTests.cs
@@ -257,11 +257,9 @@ public class CodeCoverageTests : CodeCoverageAcceptanceTestBase
         string traceDataCollectorDir = Path.Combine(IntegrationTestEnvironment.PublishDirectory,
             $"Microsoft.CodeCoverage.{IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}.nupkg", "build", "netstandard2.0");
 
-        string diagFileName = Path.Combine(tempDirectory.Path, "diaglog.txt");
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty,
             FrameworkArgValue, runnerInfo.InIsolationValue, tempDirectory.Path);
-        arguments = string.Concat(arguments, $" /Diag:{diagFileName}",
-            $" /TestAdapterPath:{traceDataCollectorDir}");
+        arguments = string.Concat(arguments, $" /TestAdapterPath:{traceDataCollectorDir}");
         arguments = string.Concat(arguments, $" /Platform:{testParameters.TargetPlatform}");
 
         trxFilePath = Path.Combine(tempDirectory.Path, Guid.NewGuid() + ".trx");

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/CreateNoNewWindowTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/CreateNoNewWindowTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
-using System.Linq;
 
 using Microsoft.TestPlatform.TestUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -23,10 +22,9 @@ public class CreateNoNewWindowTests : AcceptanceTestBase
             + "<CreateNoNewWindow>false</CreateNoNewWindow>"
             + "</RunConfiguration></RunSettings>";
         var runsettingsPath = GetRunsettingsFilePath(runsettingsXml);
-        var diagLogPath = Path.Combine(TempDirectory.Path, "logs", "log.txt");
 
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, string.Empty, runnerInfo.InIsolationValue);
-        arguments += $" /settings:{runsettingsPath} /Diag:{diagLogPath}";
+        arguments += $" /settings:{runsettingsPath}";
 
         InvokeVsTest(arguments);
 
@@ -46,10 +44,9 @@ public class CreateNoNewWindowTests : AcceptanceTestBase
             + "<CreateNoNewWindow>true</CreateNoNewWindow>"
             + "</RunConfiguration></RunSettings>";
         var runsettingsPath = GetRunsettingsFilePath(runsettingsXml);
-        var diagLogPath = Path.Combine(TempDirectory.Path, "logs", "log.txt");
 
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, string.Empty, runnerInfo.InIsolationValue);
-        arguments += $" /settings:{runsettingsPath} /Diag:{diagLogPath}";
+        arguments += $" /settings:{runsettingsPath}";
 
         InvokeVsTest(arguments);
 
@@ -64,10 +61,8 @@ public class CreateNoNewWindowTests : AcceptanceTestBase
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
         var assemblyPaths = GetAssetFullPath("SimpleTestProject.dll");
-        var diagLogPath = Path.Combine(TempDirectory.Path, "logs", "log.txt");
 
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, string.Empty, runnerInfo.InIsolationValue);
-        arguments += $" /Diag:{diagLogPath}";
 
         InvokeVsTest(arguments);
 
@@ -81,18 +76,5 @@ public class CreateNoNewWindowTests : AcceptanceTestBase
         var runsettingsPath = Path.Combine(TempDirectory.Path, "test.runsettings");
         File.WriteAllText(runsettingsPath, runsettingsXml);
         return runsettingsPath;
-    }
-
-    private string GetDiagLogContents()
-    {
-        var logsDir = Path.Combine(TempDirectory.Path, "logs");
-        if (!Directory.Exists(logsDir))
-        {
-            return string.Empty;
-        }
-
-        var logFiles = Directory.GetFiles(logsDir, "*.txt");
-
-        return string.Join("\n", logFiles.Select(File.ReadAllText));
     }
 }

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectionTests.cs
@@ -197,7 +197,6 @@ public class DataCollectionTests : AcceptanceTestBase
         // Verify attachments
         var isTestRunLevelAttachmentFound = false;
         var testCaseLevelAttachmentsCount = 0;
-        var diaglogsFileCount = 0;
 
         var resultFiles = Directory.GetFiles(resultsDir, "*.txt", SearchOption.AllDirectories);
 
@@ -214,15 +213,16 @@ public class DataCollectionTests : AcceptanceTestBase
             {
                 testCaseLevelAttachmentsCount++;
             }
-
-            if (file.Contains("diaglog"))
-            {
-                diaglogsFileCount++;
-            }
         }
 
         Assert.IsTrue(isTestRunLevelAttachmentFound);
         Assert.AreEqual(3, testCaseLevelAttachmentsCount);
+
+        // Diag logs are placed in DiagLogsDirectory by the auto-injected --diag flag.
+        // The files are named log.txt, log.host.*.txt, log.datacollector.*.txt.
+        var diaglogsFileCount = Directory.Exists(DiagLogsDirectory)
+            ? Directory.GetFiles(DiagLogsDirectory, "log*", SearchOption.TopDirectoryOnly).Length
+            : 0;
         Assert.AreEqual(3, diaglogsFileCount);
     }
 

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectionTests.cs
@@ -28,10 +28,9 @@ public class DataCollectionTests : AcceptanceTestBase
 
         var assemblyPaths = GetAssetFullPath("SimpleTestProject2.dll");
         string runSettings = GetRunsettingsFilePath(TempDirectory.Path);
-        string diagFileName = Path.Combine(TempDirectory.Path, "diaglog.txt");
         var extensionsPath = Path.GetDirectoryName(GetTestDllForFramework("OutOfProcDataCollector.dll", "netstandard2.0"));
         var arguments = PrepareArguments(assemblyPaths, null, runSettings, FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
-        arguments = string.Concat(arguments, $" /Diag:{diagFileName}", $" /TestAdapterPath:{extensionsPath}");
+        arguments = string.Concat(arguments, $" /TestAdapterPath:{extensionsPath}");
 
         var env = new Dictionary<string, string?>
         {
@@ -52,11 +51,10 @@ public class DataCollectionTests : AcceptanceTestBase
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
         var assemblyPaths = GetAssetFullPath("SimpleTestProject2.dll");
-        string diagFileName = Path.Combine(TempDirectory.Path, "diaglog.txt");
         var extensionsPath = Path.GetDirectoryName(GetTestDllForFramework("OutOfProcDataCollector.dll", "netstandard2.0"));
 
         var arguments = PrepareArguments(assemblyPaths, null, null, FrameworkArgValue, runnerInfo.InIsolationValue, TempDirectory.Path);
-        arguments = string.Concat(arguments, $" /Diag:{diagFileName}", $" /Collect:SampleDataCollector", $" /TestAdapterPath:{extensionsPath}");
+        arguments = string.Concat(arguments, $" /Collect:SampleDataCollector", $" /TestAdapterPath:{extensionsPath}");
 
         var env = new Dictionary<string, string?>
         {
@@ -104,10 +102,9 @@ public class DataCollectionTests : AcceptanceTestBase
         var assemblyPath = GetAssetFullPath("SimpleTestProject.dll");
         var secondAssemblyPath = GetAssetFullPath("SimpleTestProject2.dll");
         string runSettings = GetRunsettingsFilePath(TempDirectory.Path);
-        string diagFileName = Path.Combine(TempDirectory.Path, "diaglog.txt");
         var extensionsPath = Path.GetDirectoryName(GetTestDllForFramework("AttachmentProcessorDataCollector.dll", "netstandard2.0"));
         var arguments = PrepareArguments([assemblyPath, secondAssemblyPath], null, runSettings, FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
-        arguments = string.Concat(arguments, $" /Diag:{diagFileName}", $" /TestAdapterPath:{extensionsPath}");
+        arguments = string.Concat(arguments, $" /TestAdapterPath:{extensionsPath}");
 
         XElement runSettingsXml = XElement.Load(runSettings);
 
@@ -147,7 +144,7 @@ public class DataCollectionTests : AcceptanceTestBase
 
         Assert.AreEqual(2, fileContent.Distinct().Count());
 
-        var dataCollectorsLogs = Directory.GetFiles(TempDirectory.Path, "*.datacollector.*", SearchOption.TopDirectoryOnly);
+        var dataCollectorsLogs = Directory.GetFiles(DiagLogsDirectory, "*.datacollector.*", SearchOption.TopDirectoryOnly);
         Assert.AreEqual(2, dataCollectorsLogs.Distinct().Count());
         foreach (var dataCollectorLogFile in dataCollectorsLogs)
         {

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectorTests.Coverlet.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectorTests.Coverlet.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
 using System.Linq;
 
@@ -30,25 +29,22 @@ public class DataCollectorTestsCoverlets : IntegrationTestBase
         var resultsDir = new TempDirectory();
 
         string coverletAdapterPath = Path.GetDirectoryName(Directory.GetFiles(_testEnvironment.GetNugetPackage("coverlet.collector"), "coverlet.collector.dll", SearchOption.AllDirectories).Single())!;
-        string logId = Guid.NewGuid().ToString("N");
         string assemblyPath = GetAssetFullPath("CoverletCoverageTestProject.dll").Trim('\"');
-        string logPath = Path.Combine(Path.GetDirectoryName(assemblyPath)!, $"coverletcoverage.{logId}.log");
-        string logPathDirectory = Path.GetDirectoryName(logPath)!;
-        string argument = $"--collect:{"XPlat Code Coverage".AddDoubleQuote()} {PrepareArguments(assemblyPath, coverletAdapterPath, "", ".NETCoreApp,Version=v2.1", resultsDirectory: resultsDir.Path)} --diag:{logPath.AddDoubleQuote()}";
+        string argument = $"--collect:{"XPlat Code Coverage".AddDoubleQuote()} {PrepareArguments(assemblyPath, coverletAdapterPath, "", ".NETCoreApp,Version=v2.1", resultsDirectory: resultsDir.Path)}";
         InvokeVsTest(argument);
 
         // Verify vstest.console.dll CollectArgumentProcessor fix codeBase for coverlet package
         // This assert check that we're sure that we've updated collector setting code base with full path,
         // otherwise without "custom coverlet code" inside ProxyExecutionManager coverlet dll won't be resolved inside testhost.
-        var log = Directory.GetFiles(logPathDirectory, $"coverletcoverage.{logId}.log").Single();
+        var log = Directory.GetFiles(DiagLogsDirectory, "log.txt").Single();
         Assert.Contains("CoverletDataCollector in-process codeBase path", File.ReadAllText(log));
 
         // Verify out-of-proc coverlet collector load
-        var dataCollectorLog = Directory.GetFiles(logPathDirectory, $"coverletcoverage.{logId}.datacollector*log").Single();
+        var dataCollectorLog = Directory.GetFiles(DiagLogsDirectory, "log.txt.datacollector*").Single();
         Assert.Contains("[coverlet]Initializing CoverletCoverageDataCollector", File.ReadAllText(dataCollectorLog));
 
         // Verify in-proc coverlet collector load
-        var hostLog = Directory.GetFiles(logPathDirectory, $"coverletcoverage.{logId}.host*log").Single();
+        var hostLog = Directory.GetFiles(DiagLogsDirectory, "log.txt.host*").Single();
         Assert.Contains("[coverlet]Initialize CoverletInProcDataCollector", File.ReadAllText(hostLog));
 
         // Verify default coverage file is generated

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectorTests.Coverlet.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DataCollectorTests.Coverlet.cs
@@ -11,26 +11,21 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.TestPlatform.AcceptanceTests;
 
 [TestClass]
-public class DataCollectorTestsCoverlets : IntegrationTestBase
+public class DataCollectorTestsCoverlets : AcceptanceTestBase
 {
     [TestMethod]
-    public void RunCoverletCoverage()
+    [NetCoreRunner(HOST_NET)]
+    public void RunCoverletCoverage(RunnerInfo runnerInfo)
     {
-        // REVIEW ME: @Marco do we need to update this test?
-        // Collector is supported only for netcoreapp2.1, is compiled for netcoreapp2.1 and packaged as netstandard
-        if (_testEnvironment.TargetFramework != CoreRunnerFramework)
-        {
-            return;
-        }
+        SetTestEnvironment(_testEnvironment, runnerInfo);
 
         // We use netcoreapp runner
-        // "...\vstest\tools\dotnet\dotnet.exe "...\vstest\artifacts\Debug\net8.0\vstest.console.dll" --collect:"XPlat Code Coverage" ...
-        _testEnvironment.RunnerFramework = CoreRunnerFramework;
+        // "...\vstest\tools\dotnet\dotnet.exe "...\vstest\artifacts\Debug\net11.0\vstest.console.dll" --collect:"XPlat Code Coverage" ...
         var resultsDir = new TempDirectory();
 
         string coverletAdapterPath = Path.GetDirectoryName(Directory.GetFiles(_testEnvironment.GetNugetPackage("coverlet.collector"), "coverlet.collector.dll", SearchOption.AllDirectories).Single())!;
         string assemblyPath = GetAssetFullPath("CoverletCoverageTestProject.dll").Trim('\"');
-        string argument = $"--collect:{"XPlat Code Coverage".AddDoubleQuote()} {PrepareArguments(assemblyPath, coverletAdapterPath, "", ".NETCoreApp,Version=v2.1", resultsDirectory: resultsDir.Path)}";
+        string argument = $"--collect:{"XPlat Code Coverage".AddDoubleQuote()} {PrepareArguments(assemblyPath, coverletAdapterPath, "", FrameworkArgValue, resultsDirectory: resultsDir.Path)}";
         InvokeVsTest(argument);
 
         // Verify vstest.console.dll CollectArgumentProcessor fix codeBase for coverlet package
@@ -40,11 +35,12 @@ public class DataCollectorTestsCoverlets : IntegrationTestBase
         Assert.Contains("CoverletDataCollector in-process codeBase path", File.ReadAllText(log));
 
         // Verify out-of-proc coverlet collector load
-        var dataCollectorLog = Directory.GetFiles(DiagLogsDirectory, "log.txt.datacollector*").Single();
+        // Diag log naming: Path.ChangeExtension("log.txt", "datacollector.{ts}_{tid}.txt") produces "log.datacollector.*.txt"
+        var dataCollectorLog = Directory.GetFiles(DiagLogsDirectory, "log.datacollector*").Single();
         Assert.Contains("[coverlet]Initializing CoverletCoverageDataCollector", File.ReadAllText(dataCollectorLog));
 
         // Verify in-proc coverlet collector load
-        var hostLog = Directory.GetFiles(DiagLogsDirectory, "log.txt.host*").Single();
+        var hostLog = Directory.GetFiles(DiagLogsDirectory, "log.host*").Single();
         Assert.Contains("[coverlet]Initialize CoverletInProcDataCollector", File.ReadAllText(hostLog));
 
         // Verify default coverage file is generated

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DiagFlagPatternTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DiagFlagPatternTests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.TestPlatform.TestUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.TestPlatform.AcceptanceTests;
+
+[TestClass]
+public class DiagFlagPatternTests
+{
+    // Positive cases — should match (diag flag present as standalone token)
+    [TestMethod]
+    [DataRow("/diag")]
+    [DataRow("/diag:foo.txt")]
+    [DataRow("/diag=foo.txt")]
+    [DataRow("--diag")]
+    [DataRow("--diag bar.txt")]
+    [DataRow("-diag:x")]
+    [DataRow("--DIAG")]
+    [DataRow("/DIAG:path")]
+    [DataRow("assembly.dll /diag:log.txt")]
+    [DataRow("assembly.dll --diag log.txt --logger trx")]
+    [DataRow("/diag:log.txt assembly.dll")]
+    public void DiagFlagPattern_MatchesStandaloneDiagFlags(string arguments)
+        => Assert.IsTrue(IntegrationTestBase.DiagFlagPattern.IsMatch(arguments), $"Expected a match for: {arguments}");
+
+    // Negative cases — should NOT match
+    [TestMethod]
+    [DataRow("--logger:my-diagnostics.trx")]
+    [DataRow("--diagnostic")]
+    [DataRow("/diagnostics")]
+    [DataRow("--no-diag-mode")]
+    [DataRow("--logger:console;verbosity=normal")]
+    [DataRow("nodiagsuffix")]
+    [DataRow("assembly.dll --logger:my-diag.trx")]
+    public void DiagFlagPattern_DoesNotMatchNonDiagTokens(string arguments)
+        => Assert.IsFalse(IntegrationTestBase.DiagFlagPattern.IsMatch(arguments), $"Expected no match for: {arguments}");
+}

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestTests.cs
@@ -96,7 +96,7 @@ public class DotnetTestTests : AcceptanceTestBase
         string assemblyRelativePath = @"microsoft.testplatform.testasset.nativecpp\2.0.0\contentFiles\any\any\x64\Microsoft.TestPlatform.TestAsset.NativeCPP.dll";
         var assemblyAbsolutePath = Path.Combine(_testEnvironment.GlobalPackageDirectory, assemblyRelativePath);
 
-        InvokeDotnetTest($@"{assemblyAbsolutePath} --logger:""Console;Verbosity=normal"" --diag:c:\temp\logscpp\", workingDirectory: Path.GetDirectoryName(assemblyAbsolutePath));
+        InvokeDotnetTest($@"{assemblyAbsolutePath} --logger:""Console;Verbosity=normal""", workingDirectory: Path.GetDirectoryName(assemblyAbsolutePath));
 
         ValidateSummaryStatus(1, 1, 0);
         ExitCodeEquals(1);

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
@@ -116,7 +116,6 @@ public class ExecutionTests : AcceptanceTestBase
         var arguments = PrepareArguments(assemblyPaths, testAdapterPath: null, runSettings: null, FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
         arguments = string.Concat(arguments, " /Parallel");
         arguments = string.Concat(arguments, " /Platform:x86");
-        arguments += GetDiagArg(TempDirectory.Path);
 
         // for the desktop we will run testhost.x86 in two copies, but for core
         // we will run a combination of testhost.x86 and dotnet, where the dotnet will be
@@ -129,7 +128,7 @@ public class ExecutionTests : AcceptanceTestBase
 
         InvokeVsTest(arguments);
 
-        AssertExpectedNumberOfHostProcesses(expectedNumOfProcessCreated, TempDirectory.Path, testHostProcessNames);
+        AssertExpectedNumberOfHostProcesses(expectedNumOfProcessCreated, DiagLogsDirectory, testHostProcessNames);
         ValidateSummaryStatus(2, 2, 2);
         ExitCodeEquals(1); // failing tests
     }
@@ -180,13 +179,9 @@ public class ExecutionTests : AcceptanceTestBase
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        var diagLogFilePath = Path.Combine(TempDirectory.Path, $"std_error_log_{Guid.NewGuid()}.txt");
-        File.Delete(diagLogFilePath);
-
         var assemblyPaths = GetAssetFullPath("SimpleTestProject3.dll");
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
         arguments = string.Concat(arguments, " /testcasefilter:ExitWithStackoverFlow");
-        arguments = string.Concat(arguments, $" /diag:{diagLogFilePath}");
 
         InvokeVsTest(arguments);
 
@@ -197,9 +192,9 @@ public class ExecutionTests : AcceptanceTestBase
         }
 
         ExitCodeEquals(1);
-        FileAssert.Contains(diagLogFilePath, errorMessage);
+        Assert.Contains(errorMessage, GetDiagLogContents(),
+            $"Expected '{errorMessage}' in diag logs but not found.");
         StdErrorContains(errorMessage);
-        File.Delete(diagLogFilePath);
     }
 
     [TestMethod]
@@ -209,14 +204,10 @@ public class ExecutionTests : AcceptanceTestBase
     {
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        var diagLogFilePath = Path.Combine(TempDirectory.Path, $"std_error_log_{Guid.NewGuid()}.txt");
-        File.Delete(diagLogFilePath);
-
         var assemblyPaths =
             GetAssetFullPath("SimpleTestProject3.dll");
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
         arguments = string.Concat(arguments, " /testcasefilter:ExitwithUnhandleException");
-        arguments = string.Concat(arguments, $" /diag:{diagLogFilePath}");
 
         InvokeVsTest(arguments);
 
@@ -224,8 +215,8 @@ public class ExecutionTests : AcceptanceTestBase
             runnerInfo.IsNetTarget
             ? "Test host standard error line: Unhandled exception. System.InvalidOperationException: Operation is not valid due to the current state of the object."
             : "Test host standard error line: Unhandled Exception: System.InvalidOperationException: Operation is not valid due to the current state of the object.";
-        FileAssert.Contains(diagLogFilePath, errorFirstLine);
-        File.Delete(diagLogFilePath);
+        Assert.Contains(errorFirstLine, GetDiagLogContents(),
+            $"Expected '{errorFirstLine}' in diag logs but not found.");
     }
 
     [TestMethod]
@@ -262,7 +253,7 @@ public class ExecutionTests : AcceptanceTestBase
             GetAssetFullPath("SimpleTestProjectx86.dll");
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
 
-        InvokeVsTest(arguments + " /diag:logs\\");
+        InvokeVsTest(arguments);
 
         ValidateSummaryStatus(1, 0, 0);
         ExitCodeEquals(0);

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/PlatformTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/PlatformTests.cs
@@ -48,10 +48,10 @@ public class PlatformTests : AcceptanceTestBase
             string.Empty, FrameworkArgValue,
             _testEnvironment.InIsolationValue, resultsDirectory: TempDirectory.Path);
 
-        arguments = string.Concat(arguments, platformArg, GetDiagArg(TempDirectory.Path));
+        arguments = string.Concat(arguments, platformArg);
         InvokeVsTest(arguments);
 
-        AssertExpectedNumberOfHostProcesses(expectedNumOfProcessCreated, TempDirectory.Path, new[] { testhostProcessName }, arguments, GetConsoleRunnerPath());
+        AssertExpectedNumberOfHostProcesses(expectedNumOfProcessCreated, DiagLogsDirectory, new[] { testhostProcessName }, arguments, GetConsoleRunnerPath());
         ValidateSummaryStatus(1, 1, 1);
     }
 }

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/RunsettingsTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/RunsettingsTests.cs
@@ -362,7 +362,6 @@ public class RunsettingsTests : AcceptanceTestBase
         }
 
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), runsettingsPath, FrameworkArgValue, _testEnvironment.InIsolationValue, resultsDirectory: TempDirectory.Path);
-        arguments += GetDiagArg(TempDirectory.Path);
 
         if (!string.IsNullOrWhiteSpace(additionalArgs))
         {
@@ -377,7 +376,7 @@ public class RunsettingsTests : AcceptanceTestBase
         InvokeVsTest(arguments);
 
         // assert
-        AssertExpectedNumberOfHostProcesses(expectedNumOfProcessCreated, TempDirectory.Path, testhostProcessNames, arguments, GetConsoleRunnerPath());
+        AssertExpectedNumberOfHostProcesses(expectedNumOfProcessCreated, DiagLogsDirectory, testhostProcessNames, arguments, GetConsoleRunnerPath());
         ValidateSummaryStatus(2, 2, 2);
 
         //cleanup

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/SerializerSelectionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/SerializerSelectionTests.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.IO;
-using System.Linq;
-
 using Microsoft.TestPlatform.TestUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -19,8 +16,6 @@ public class SerializerSelectionTests : AcceptanceTestBase
         SetTestEnvironment(_testEnvironment, runnerInfo);
         var assemblyPaths = GetAssetFullPath("SimpleTestProject.dll");
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, string.Empty, runnerInfo.InIsolationValue);
-        var diagLogPath = Path.Combine(TempDirectory.Path, "logs", "log.txt");
-        arguments = string.Concat(arguments, $" /Diag:{diagLogPath}");
 
         InvokeVsTest(arguments);
 
@@ -36,29 +31,11 @@ public class SerializerSelectionTests : AcceptanceTestBase
         SetTestEnvironment(_testEnvironment, runnerInfo);
         var assemblyPaths = GetAssetFullPath("SimpleTestProject.dll");
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, string.Empty, runnerInfo.InIsolationValue);
-        var diagLogPath = Path.Combine(TempDirectory.Path, "logs", "log.txt");
-        arguments = string.Concat(arguments, $" /Diag:{diagLogPath}");
 
         InvokeVsTest(arguments);
 
         var diagLogs = GetDiagLogContents();
         Assert.Contains("Using Jsonite serializer", diagLogs,
             "Expected 'Using Jsonite serializer' in diag logs but not found.");
-    }
-
-    /// <summary>
-    /// Reads all diag log files from the test's temp directory and returns their combined content.
-    /// </summary>
-    private string GetDiagLogContents()
-    {
-        var logsDir = Path.Combine(TempDirectory.Path, "logs");
-        if (!Directory.Exists(logsDir))
-        {
-            return string.Empty;
-        }
-
-        var logFiles = Directory.GetFiles(logsDir, "*.txt");
-
-        return string.Join("\n", logFiles.Select(File.ReadAllText));
     }
 }

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TestPlatformNugetPackageTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TestPlatformNugetPackageTests.cs
@@ -59,12 +59,10 @@ public class TestPlatformNugetPackageTests : CodeCoverageAcceptanceTestBase
         string assemblyPaths,
         out string trxFilePath)
     {
-        string diagFileName = Path.Combine(TempDirectory.Path, "diaglog.txt");
-
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty,
             FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
 
-        arguments = string.Concat(arguments, $" /Diag:{diagFileName}", $" /EnableCodeCoverage");
+        arguments = string.Concat(arguments, $" /EnableCodeCoverage");
 
         trxFilePath = Path.Combine(TempDirectory.Path, Guid.NewGuid() + ".trx");
         arguments = string.Concat(arguments, " /logger:trx;logfilename=" + trxFilePath);

--- a/test/Microsoft.TestPlatform.TestUtilities/Friends.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/Friends.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.TestPlatform.Acceptance.IntegrationTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -223,7 +223,20 @@ public class IntegrationTestBase
         if (collectDiagnostics && !IsDiagAlreadyEnabled(arguments ?? ""))
         {
             Directory.CreateDirectory(DiagLogsDirectory);
-            arguments = string.Concat(arguments, GetDiagArg(DiagLogsDirectory));
+            var diagArg = GetDiagArg(DiagLogsDirectory);
+
+            // Insert --diag before the -- separator so it's treated as a vstest.console argument,
+            // not as a runsettings parameter.
+            var separatorPos = arguments?.IndexOf(" -- ") ?? -1;
+            if (separatorPos == -1)
+            {
+                arguments = string.Concat(arguments, diagArg);
+            }
+            else
+            {
+                arguments = arguments!.Insert(separatorPos, diagArg);
+            }
+
             _attachments.Add(DiagLogsDirectory);
             Console.WriteLine($"Diagnostic logs directory: {DiagLogsDirectory}");
         }

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -220,7 +220,8 @@ public class IntegrationTestBase
     /// <param name="collectDiagnostics">When true, automatically adds --diag flag and attaches logs to test results on failure.</param>
     public void InvokeVsTest(string? arguments, Dictionary<string, string?>? environmentVariables = null, bool collectDiagnostics = true)
     {
-        if (collectDiagnostics && !IsDiagAlreadyEnabled(arguments ?? ""))
+        ThrowIfDiagInArguments(arguments ?? "");
+        if (collectDiagnostics && !IsDiagInEnvironment())
         {
             Directory.CreateDirectory(DiagLogsDirectory);
             var diagArg = GetDiagArg(DiagLogsDirectory);
@@ -302,7 +303,8 @@ public class IntegrationTestBase
         // https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/commands/dotnet-test/VSTestForwardingApp.cs#L30-L39
         debugEnvironmentVariables["VSTEST_CONSOLE_PATH"] = vstestConsolePath;
 
-        if (collectDiagnostics && !IsDiagAlreadyEnabled(arguments))
+        ThrowIfDiagInArguments(arguments);
+        if (collectDiagnostics && !IsDiagInEnvironment())
         {
             Directory.CreateDirectory(DiagLogsDirectory);
             var diagPath = Path.Combine(DiagLogsDirectory, "log.txt");
@@ -1093,22 +1095,25 @@ public class IntegrationTestBase
         return string.Join(" ", GetTestDlls(assetNames).Select(a => a.AddDoubleQuote()));
     }
 
-    private static bool IsDiagAlreadyEnabled(string arguments)
+    // Matches /diag, --diag, or -diag as a standalone flag token (preceded by whitespace or start of string,
+    // followed by '=', ':', whitespace, or end of string). Avoids false positives from substrings like
+    // "--logger:my-diagnostics.trx". Internal for testability.
+    internal static readonly Regex DiagFlagPattern = new(@"(^|\s)(--diag|/diag|-diag)([:=\s]|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static void ThrowIfDiagInArguments(string arguments)
     {
-        // If user passed /diag, --diag, or -diag as a standalone flag, throw to prevent silently skipping
-        // the auto-injected diag and losing the attachment. Tests that need to inspect diagnostic logs
-        // should use DiagLogsDirectory instead of passing /diag manually.
-        // The pattern requires the flag to appear as a standalone token (preceded by whitespace or start of
-        // string) to avoid false positives from substrings like "--logger:my-diagnostics.trx".
-        if (Regex.IsMatch(arguments, @"(^|\s)(--diag|/diag|-diag)([:=\s]|$)", RegexOptions.IgnoreCase))
+        var match = DiagFlagPattern.Match(arguments);
+        if (match.Success)
         {
             throw new InvalidOperationException(
-                "Do not pass /diag (or --diag / -diag) directly in test arguments. " +
+                $"Do not pass diag flags directly in test arguments (found '{match.Value.Trim()}' in '{arguments}'). " +
                 "The test framework auto-injects diagnostics and attaches them on failure. " +
-                "Use the DiagLogsDirectory property to find the path to the diagnostic log files.");
+                "Use IntegrationTestBase.DiagLogsDirectory to find the path to the diagnostic log files.");
         }
+    }
 
-        // Check environment variable
+    private static bool IsDiagInEnvironment()
+    {
         var envDiag = Environment.GetEnvironmentVariable("VSTEST_DIAG");
         return !StringUtils.IsNullOrEmpty(envDiag);
     }
@@ -1126,7 +1131,7 @@ public class IntegrationTestBase
             return string.Empty;
         }
 
-        return string.Join("\n", Directory.GetFiles(DiagLogsDirectory, "*.txt", SearchOption.AllDirectories).Select(File.ReadAllText));
+        return string.Join("\n", Directory.GetFiles(DiagLogsDirectory, "*.txt", SearchOption.TopDirectoryOnly).Select(File.ReadAllText));
     }
 
     /// <summary>

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -87,6 +87,12 @@ public class IntegrationTestBase
 
     public TempDirectory TempDirectory { get; }
 
+    /// <summary>
+    /// Returns the directory where diagnostic log files are automatically placed by <see cref="InvokeVsTest"/> and <see cref="InvokeDotnetTest"/>.
+    /// Use this property in tests that need to inspect the diagnostic log files.
+    /// </summary>
+    protected string DiagLogsDirectory => Path.Combine(TempDirectory.Path, "logs");
+
     public TestContext TestContext { get; set; } = null!;
 
     public string BuildConfiguration { get; }
@@ -216,11 +222,10 @@ public class IntegrationTestBase
     {
         if (collectDiagnostics && !IsDiagAlreadyEnabled(arguments ?? ""))
         {
-            var diagLogsDir = Path.Combine(TempDirectory.Path, "logs");
-            Directory.CreateDirectory(diagLogsDir);
-            arguments = string.Concat(arguments, GetDiagArg(diagLogsDir));
-            _attachments.Add(diagLogsDir);
-            Console.WriteLine($"Diagnostic logs directory: {diagLogsDir}");
+            Directory.CreateDirectory(DiagLogsDirectory);
+            arguments = string.Concat(arguments, GetDiagArg(DiagLogsDirectory));
+            _attachments.Add(DiagLogsDirectory);
+            Console.WriteLine($"Diagnostic logs directory: {DiagLogsDirectory}");
         }
 
         var debugEnvironmentVariables = AddDebugEnvironmentVariables(environmentVariables);
@@ -286,9 +291,8 @@ public class IntegrationTestBase
 
         if (collectDiagnostics && !IsDiagAlreadyEnabled(arguments))
         {
-            var diagLogsDir = Path.Combine(TempDirectory.Path, "logs");
-            Directory.CreateDirectory(diagLogsDir);
-            var diagPath = Path.Combine(diagLogsDir, "log.txt");
+            Directory.CreateDirectory(DiagLogsDirectory);
+            var diagPath = Path.Combine(DiagLogsDirectory, "log.txt");
             var diagArg = " --diag " + diagPath.AddDoubleQuote();
 
             // Insert --diag before the -- separator so dotnet test forwards it to vstest.console.
@@ -302,8 +306,8 @@ public class IntegrationTestBase
                 arguments = arguments.Insert(separatorPos, diagArg);
             }
 
-            _attachments.Add(diagLogsDir);
-            Console.WriteLine($"Diagnostic logs directory: {diagLogsDir}");
+            _attachments.Add(DiagLogsDirectory);
+            Console.WriteLine($"Diagnostic logs directory: {DiagLogsDirectory}");
         }
 
         IntegrationTestBase.ExecutePatchedDotnet("test", arguments, out _standardTestOutput, out _standardTestError, out _runnerExitCode, debugEnvironmentVariables, workingDirectory);
@@ -1078,12 +1082,17 @@ public class IntegrationTestBase
 
     private static bool IsDiagAlreadyEnabled(string arguments)
     {
-        // Check args for --diag, /diag, -diag (case-insensitive)
+        // If user passed /diag, --diag, or -diag, throw to prevent silently skipping the auto-injected
+        // diag and losing the attachment. Tests that need to inspect diagnostic logs should use
+        // DiagLogsDirectory instead of passing /diag manually.
         if (arguments.Contains("--diag", StringComparison.OrdinalIgnoreCase)
             || arguments.Contains("/diag", StringComparison.OrdinalIgnoreCase)
             || arguments.Contains("-diag", StringComparison.OrdinalIgnoreCase))
         {
-            return true;
+            throw new InvalidOperationException(
+                "Do not pass /diag (or --diag / -diag) directly in test arguments. " +
+                "The test framework auto-injects diagnostics and attaches them on failure. " +
+                "Use the DiagLogsDirectory property to find the path to the diagnostic log files.");
         }
 
         // Check environment variable
@@ -1093,6 +1102,19 @@ public class IntegrationTestBase
 
     protected static string GetDiagArg(string rootDir)
         => " --diag:" + Path.Combine(rootDir, "log.txt");
+
+    /// <summary>
+    /// Reads all diagnostic log files from <see cref="DiagLogsDirectory"/> and returns their combined content.
+    /// </summary>
+    protected string GetDiagLogContents()
+    {
+        if (!Directory.Exists(DiagLogsDirectory))
+        {
+            return string.Empty;
+        }
+
+        return string.Join("\n", Directory.GetFiles(DiagLogsDirectory, "*.txt", SearchOption.AllDirectories).Select(File.ReadAllText));
+    }
 
     /// <summary>
     /// Counts the number of logs following the '*.host.*' pattern in the given folder.

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -1082,12 +1082,12 @@ public class IntegrationTestBase
 
     private static bool IsDiagAlreadyEnabled(string arguments)
     {
-        // If user passed /diag, --diag, or -diag, throw to prevent silently skipping the auto-injected
-        // diag and losing the attachment. Tests that need to inspect diagnostic logs should use
-        // DiagLogsDirectory instead of passing /diag manually.
-        if (arguments.Contains("--diag", StringComparison.OrdinalIgnoreCase)
-            || arguments.Contains("/diag", StringComparison.OrdinalIgnoreCase)
-            || arguments.Contains("-diag", StringComparison.OrdinalIgnoreCase))
+        // If user passed /diag, --diag, or -diag as a standalone flag, throw to prevent silently skipping
+        // the auto-injected diag and losing the attachment. Tests that need to inspect diagnostic logs
+        // should use DiagLogsDirectory instead of passing /diag manually.
+        // The pattern requires the flag to appear as a standalone token (preceded by whitespace or start of
+        // string) to avoid false positives from substrings like "--logger:my-diagnostics.trx".
+        if (Regex.IsMatch(arguments, @"(^|\s)(--diag|/diag|-diag)([:=\s]|$)", RegexOptions.IgnoreCase))
         {
             throw new InvalidOperationException(
                 "Do not pass /diag (or --diag / -diag) directly in test arguments. " +


### PR DESCRIPTION
Fixes #15625.

> 🤖 This is an automated fix generated by [Issue Repro Triage & Auto-Fix](https://github.com/microsoft/vstest/actions/runs/26333096992).

## Root Cause

Integration tests that passed `/diag` (or `--diag` / `-diag`) manually in their arguments would cause `IsDiagAlreadyEnabled` to return `true`, silently skipping the auto-injection of diagnostic logging. This meant those tests would not have their diagnostic logs collected as attachments on failure — making failures harder to diagnose.

## What the Fix Does

1. **`IntegrationTestBase.cs`**:
   - `IsDiagAlreadyEnabled` now **throws `InvalidOperationException`** when it detects a manual `/diag` argument, with a helpful message directing the test author to use `DiagLogsDirectory` instead.
   - Added `DiagLogsDirectory` property (`{TempDirectory.Path}/logs`) so tests can reference the auto-injected diag path.
   - Added `GetDiagLogContents()` protected helper that reads all `.txt` log files from `DiagLogsDirectory` — promoted from several test classes that each had their own copy.
   - Simplified `InvokeVsTest` and `InvokeDotnetTest` to use `DiagLogsDirectory` directly.

2. **All tests that manually passed `/diag`**: Updated to remove the manual argument. The auto-injection now ensures diag logs are always collected.

3. **Tests that checked diag file content** (`ExecutionTests.cs`, `DataCollectorTests.Coverlet.cs`, `DataCollectionTests.cs`): Updated to use `DiagLogsDirectory`-based search patterns instead of custom paths.

4. **`CreateNoNewWindowTests.cs` / `SerializerSelectionTests.cs`**: Removed duplicate `GetDiagLogContents()` private methods — now using the base class version.

## Tests

The existing acceptance tests verify this behavior. The fix ensures diagnostic logs are always attached on test failure, which improves debuggability in CI.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/26333096992)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 26333096992, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/26333096992 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->