### PR TITLE
[fix] Fix: use MSBuild output mode automatically with dotnet msbuild /t:VSTest when terminal logger is active

### DIFF
--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
@@ -15,6 +15,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <VSTestTaskAssemblyFile Condition="$(VSTestTaskAssemblyFile) == ''">Microsoft.TestPlatform.Build.dll</VSTestTaskAssemblyFile>
     <VSTestConsolePath Condition="$(VSTestConsolePath) == ''">$([System.IO.Path]::Combine($(MSBuildThisFileDirectory),"vstest.console.dll"))</VSTestConsolePath>
     <VSTestNoBuild Condition="'$(VSTestNoBuild)' == ''">False</VSTestNoBuild>
+    <!-- When terminal logger is active and user has not opted out, default to MSBuild output mode so
+         test output from parallel MSBuild nodes is not lost. Users can opt out with VsTestUseMSBuildOutput=false. -->
+    <VsTestUseMSBuildOutput Condition="'$(VsTestUseMSBuildOutput)' == '' AND '$(_MSBUILDTLENABLED)' == '1'">True</VsTestUseMSBuildOutput>
     <VsTestUseMSBuildOutput Condition="'$(VsTestUseMSBuildOutput)' == ''">False</VsTestUseMSBuildOutput>
   </PropertyGroup>
   <UsingTask TaskName="Microsoft.TestPlatform.Build.Tasks.VSTestTask" AssemblyFile="$(VSTestTaskAssemblyFile)" />
@@ -32,8 +35,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Fallback to this old view when terminal logger is not enabled (_MSBUILDTLENABLED==0) , or when user explicitly opts out (VsTestUseMSBuildOutput != true) -->
     <CallTarget Targets="_VSTestConsole" Condition="$(_MSBUILDTLENABLED) == '0' OR !$(VsTestUseMSBuildOutput) OR $(MSBUILDENSURESTDOUTFORTASKPROCESSES) == '1'" />
     <!-- Proper MSBuild integration, but no custom colorization -->
-    <!-- Use the new view whe terminal logger is enabled (_MSBUILDTLENABLED==0), and user did not opt out (VsTestUseMSBuildOutput == true) -->
-    <CallTarget Targets="_VSTestMSBuild" Condition="$(_MSBUILDTLENABLED) == '1' AND $(VsTestUseMSBuildOutput)" />
+    <!-- Use the new view when terminal logger is enabled (_MSBUILDTLENABLED==1), user did not opt out (VsTestUseMSBuildOutput == true),
+         and MSBUILDENSURESTDOUTFORTASKPROCESSES is not set (set by dotnet test, which uses the console path instead). -->
+    <CallTarget Targets="_VSTestMSBuild" Condition="$(_MSBUILDTLENABLED) == '1' AND $(VsTestUseMSBuildOutput) AND $(MSBUILDENSURESTDOUTFORTASKPROCESSES) != '1'" />
   </Target>
 
   <!--

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestMSBuildOutputTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestMSBuildOutputTests.cs
@@ -81,4 +81,23 @@ public class DotnetTestMSBuildOutputTests : AcceptanceTestBase
 
         ExitCodeEquals(1);
     }
+
+    [TestMethod]
+    // patched dotnet is not published on non-windows systems
+    [TestCategory("Windows-Review")]
+    [NetCoreTargetFrameworkDataSource(useDesktopRunner: false)]
+    public void MSBuildLoggerIsUsedAutomaticallyWithDotnetMSBuildWhenTerminalLoggerIsActive(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var projectPath = GetIsolatedTestAsset("TerminalLoggerTestProject.csproj", runnerInfo.TargetFramework);
+        // Invoke via dotnet msbuild /t:VSTest with terminal logger on and no explicit VsTestUseMSBuildOutput property.
+        // The MSBuild output path should be used automatically when the terminal logger is active.
+        InvokeDotnetMSBuildTest($@"-t:VSTest {projectPath} -tl:on -nodereuse:false /p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion}", workingDirectory: Path.GetDirectoryName(projectPath));
+
+        StdOutputContains("TESTERROR");
+        StdOutputContains("FailingTest (");
+        ExitCodeEquals(1);
+    }
+
 }

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -310,6 +310,20 @@ public class IntegrationTestBase
         FormatStandardOutCome();
     }
 
+    public void InvokeDotnetMSBuildTest(string arguments, Dictionary<string, string?>? environmentVariables = null, string? workingDirectory = null)
+    {
+        var debugEnvironmentVariables = AddDebugEnvironmentVariables(environmentVariables);
+
+        var vstestConsolePath = GetDotnetRunnerPath();
+        var consolePathParameter = $@" -p:VsTestConsolePath=""{vstestConsolePath}""";
+        arguments += consolePathParameter;
+
+        debugEnvironmentVariables["VSTEST_CONSOLE_PATH"] = vstestConsolePath;
+
+        IntegrationTestBase.ExecutePatchedDotnet("msbuild", arguments, out _standardTestOutput, out _standardTestError, out _runnerExitCode, debugEnvironmentVariables, workingDirectory);
+        FormatStandardOutCome();
+    }
+
     /// <summary>
     /// Invokes <c>vstest.console</c> to execute tests in a test assembly.
     /// </summary>


### PR DESCRIPTION
🤖 This is an automated fix generated by the Issue Triage agent.

Fixes #5156

## Root Cause

When running `dotnet msbuild /t:VSTest` with the MSBuild terminal logger enabled (`_MSBUILDTLENABLED == '1'`), test output from parallel MSBuild nodes was silently lost.

The cause: `VsTestUseMSBuildOutput` defaulted to `False`, so `_VSTestConsole` was always used. This target invokes vstest.console directly and writes to stdout — output that the terminal logger cannot properly attribute to individual projects when running on parallel MSBuild worker nodes.

## Fix

1. **`Microsoft.TestPlatform.targets`**: When the terminal logger is active (`_MSBUILDTLENABLED == '1'`) and the user hasn't set `VsTestUseMSBuildOutput` explicitly, default it to `True`. This causes `_VSTestMSBuild` (using `VSTestTask2` / `ToolTask`) to be used, which properly routes output through MSBuild's task logging — ensuring it is attributed and displayed correctly by the terminal logger.

2. Added `$(MSBUILDENSURESTDOUTFORTASKPROCESSES) != '1'` guard to the `_VSTestMSBuild` condition so it won't run when invoked from `dotnet test` (which sets this env var and uses `_VSTestConsole` for proper colorization).

**Backward compatibility**: Users who want the old console-colorized behavior can opt out: `/p:VsTestUseMSBuildOutput=false`.

## Test

Added `MSBuildLoggerIsUsedAutomaticallyWithDotnetMSBuildWhenTerminalLoggerIsActive` acceptance test in `DotnetTestMSBuildOutputTests` that invokes `dotnet msbuild -t:VSTest -tl:on` without setting `VsTestUseMSBuildOutput` and asserts that test error output appears in stdout.

Also added `InvokeDotnetMSBuildTest` helper to `IntegrationTestBase` to support invoking `dotnet msbuild` with the patched dotnet in acceptance tests.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/26361692310)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 26361692310, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/26361692310 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->