### PR TITLE
Fix false "Empty parenthesis" error when filter contains an escaped open parenthesis

### DIFF
--- a/src/Microsoft.TestPlatform.Filter.Source/FilterExpression.cs
+++ b/src/Microsoft.TestPlatform.Filter.Source/FilterExpression.cs
@@ -188,7 +188,10 @@ internal sealed class FilterExpression
 #endif
 
         // Below parsing doesn't error out on pattern (), so explicitly search for that (empty parenthesis).
-        var invalidInput = Regex.Match(filterString, @"\(\s*\)");
+        // The negative lookbehind (?<!\\) ensures we don't flag an escaped open parenthesis (e.g., \()
+        // as an empty group. This is required to support filtering parametrized tests whose display
+        // names contain '(' (e.g., `DisplayName~MyTest \(`).
+        var invalidInput = Regex.Match(filterString, @"(?<!\\)\(\s*\)");
         if (invalidInput.Success)
         {
             throw new FormatException(string.Format(CultureInfo.CurrentCulture, TestCaseFilterFormatException, EmptyParenthesis));

--- a/src/Microsoft.TestPlatform.Filter.Source/FilterExpression.cs
+++ b/src/Microsoft.TestPlatform.Filter.Source/FilterExpression.cs
@@ -9,7 +9,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 
 #if !IS_VSTEST_REPO
 using Microsoft.CodeAnalysis;
@@ -187,17 +186,46 @@ internal sealed class FilterExpression
         ValidateArg.NotNull(filterString, nameof(filterString));
 #endif
 
-        // Below parsing doesn't error out on pattern (), so explicitly search for that (empty parenthesis).
-        // The negative lookbehind (?<!\\) ensures we don't flag an escaped open parenthesis (e.g., \()
-        // as an empty group. This is required to support filtering parametrized tests whose display
-        // names contain '(' (e.g., `DisplayName~MyTest \(`).
-        var invalidInput = Regex.Match(filterString, @"(?<!\\)\(\s*\)");
-        if (invalidInput.Success)
+        // Tokenize the filter once and reuse the materialized list for both the pre-check
+        // below and the parsing loop further down. The tokenizer already understands the
+        // escape semantics of the filter language (e.g., that "\(" is part of a value token
+        // and not an open-parenthesis grouping operator, and that "\\" is an escaped
+        // backslash so the following "(" is unescaped), so inspecting tokens rather than the
+        // raw string avoids the corner cases of a regex-based pre-check.
+        List<string> tokens = TokenizeFilterExpressionString(filterString).ToList();
+
+        // Below parsing doesn't error out on pattern (), so explicitly search for that
+        // (empty parenthesis). Token-based scan: an unescaped "(" immediately followed by
+        // an unescaped ")" (ignoring whitespace-only tokens, mirroring what the parser
+        // below does with token.Trim()) is an empty group.
+        for (int i = 0; i < tokens.Count; i++)
         {
-            throw new FormatException(string.Format(CultureInfo.CurrentCulture, TestCaseFilterFormatException, EmptyParenthesis));
+            if (tokens[i] != "(")
+            {
+                continue;
+            }
+
+            int j = i + 1;
+            while (j < tokens.Count)
+            {
+                var trimmed = tokens[j].Trim();
+#if IS_VSTEST_REPO
+                if (!trimmed.IsNullOrEmpty())
+#else
+                if (!string.IsNullOrEmpty(trimmed))
+#endif
+                {
+                    break;
+                }
+                j++;
+            }
+
+            if (j < tokens.Count && tokens[j] == ")")
+            {
+                throw new FormatException(string.Format(CultureInfo.CurrentCulture, TestCaseFilterFormatException, EmptyParenthesis));
+            }
         }
 
-        var tokens = TokenizeFilterExpressionString(filterString);
         var operatorStack = new Stack<Operator>();
         var filterStack = new Stack<FilterExpression>();
 

--- a/test/Microsoft.TestPlatform.Filter.Source.UnitTests/FilterExpressionWrapperTests.cs
+++ b/test/Microsoft.TestPlatform.Filter.Source.UnitTests/FilterExpressionWrapperTests.cs
@@ -43,6 +43,16 @@ public class FilterExpressionWrapperTests
     }
 
     [TestMethod]
+    public void ParseErrorShouldBeSetForEmptyParenthesisAfterEscapedBackslash()
+    {
+        // An escaped backslash "\\" leaves the following "(" unescaped, so "\\()" is still
+        // a genuine empty parenthesis group and must be reported.
+        var wrapper = new FilterExpressionWrapper(@"Name~foo\\&()");
+        Assert.IsNotNull(wrapper.ParseError);
+        Assert.Contains("Empty parenthesis", wrapper.ParseError!);
+    }
+
+    [TestMethod]
     public void ParseErrorShouldNotBeSetWhenOpenParenthesisIsEscaped()
     {
         // Regression for https://github.com/microsoft/testfx/issues/7515 — an escaped

--- a/test/Microsoft.TestPlatform.Filter.Source.UnitTests/FilterExpressionWrapperTests.cs
+++ b/test/Microsoft.TestPlatform.Filter.Source.UnitTests/FilterExpressionWrapperTests.cs
@@ -35,6 +35,46 @@ public class FilterExpressionWrapperTests
     }
 
     [TestMethod]
+    public void ParseErrorShouldBeSetForEmptyParenthesis()
+    {
+        var wrapper = new FilterExpressionWrapper("Name=Test1 & ()");
+        Assert.IsNotNull(wrapper.ParseError);
+        Assert.Contains("Empty parenthesis", wrapper.ParseError!);
+    }
+
+    [TestMethod]
+    public void ParseErrorShouldNotBeSetWhenOpenParenthesisIsEscaped()
+    {
+        // Regression for https://github.com/microsoft/testfx/issues/7515 — an escaped
+        // open parenthesis must not be flagged as the start of an empty parenthesis group.
+        var wrapper = new FilterExpressionWrapper(@"Name~aaa \(");
+        Assert.IsNull(wrapper.ParseError);
+    }
+
+    [TestMethod]
+    public void ParseErrorShouldNotBeSetWhenWrappedEscapedOpenParenthesisIsAtEnd()
+    {
+        // Regression for https://github.com/microsoft/testfx/issues/7515 — when a caller
+        // wraps the filter in an outer parenthesis pair (as the MTP VSTestBridge does),
+        // the trailing `\()` must not be misinterpreted as an empty group.
+        var wrapper = new FilterExpressionWrapper(@"(Name~aaa \()");
+        Assert.IsNull(wrapper.ParseError);
+    }
+
+    [TestMethod]
+    public void EvaluateShouldMatchParametrizedTestNamePrefix()
+    {
+        // Regression for https://github.com/microsoft/testfx/issues/7515 — filtering
+        // parametrized tests by display-name prefix using an escaped `(` should match
+        // tests whose display name starts with the prefix followed by `(parameters)`.
+        var wrapper = new FilterExpressionWrapper(@"Name~aaa \(");
+
+        Assert.IsNull(wrapper.ParseError);
+        Assert.IsTrue(wrapper.Evaluate(prop => prop == "Name" ? "aaa (1, 2)" : null));
+        Assert.IsFalse(wrapper.Evaluate(prop => prop == "Name" ? "aaa2 (1, 2)" : null));
+    }
+
+    [TestMethod]
     public void EvaluateShouldReturnTrueWhenPropertyMatches()
     {
         var wrapper = new FilterExpressionWrapper("Name=Test1");


### PR DESCRIPTION
Fixes [microsoft/testfx#7515](https://github.com/microsoft/testfx/issues/7515).

## Problem

Filtering parametrized tests by display-name prefix is broken when the
expected prefix contains a `(`. For instance, given:

```
aaa (1, 2)
aaa2 (1, 2)
```

users want to match only the `aaa` instances by typing:

```
dotnet test --filter "Name~aaa \("
```

but `dotnet test` fails with:

```
Incorrect format for TestCaseFilter Error: Empty parenthesis ( ).
```

## Root cause

`FilterExpression.Parse` does a pre-check using the regex `\(\s*\)` to
flag empty parenthesis groups (because the parser itself silently accepts
them). The regex did not understand the `\` escape character, so the
escaped `\(` followed by `)` (which appears naturally when the
Microsoft.Testing.Platform VSTestBridge wraps every filter in outer
parens, turning `Name~aaa \(` into `(Name~aaa \()`) was incorrectly
flagged.

## Fix

Replace the regex with `(?<!\\)\(\s*\)` so an escaped open parenthesis is
no longer considered the start of an empty parenthesis group. Add
regression tests in `FilterExpressionWrapperTests` covering:

- escaped `\(` not flagged as empty parens,
- wrapped `(...\()` not flagged as empty parens,
- genuine `()` still flagged as empty parens,
- end-to-end `Evaluate` behaviour for the parametrized-name filtering
  scenario (`aaa (1, 2)` matches `Name~aaa \(`, `aaa2 (1, 2)` does
  not).

All existing tests in `Microsoft.TestPlatform.Filter.Source.UnitTests`
(44 tests) and `Microsoft.TestPlatform.Common.UnitTests` (388 tests)
continue to pass.

Once this ships, the `Microsoft.TestPlatform.Filter.Source` package
version can be bumped in microsoft/testfx and the fix will flow into the
VSTestBridge.