### PR TITLE
Disallow APPROVE from the Expert Code Reviewer workflow

### DIFF
--- a/.github/workflows/pr-expert-reviewer.lock.yml
+++ b/.github/workflows/pr-expert-reviewer.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"977030a695ef9ddb3e54b19dd8b66897c884c28743a3e659a6b268b1c4f92768","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"55a2266988f4c741701060ac6bda2c3d22affa3a5c0cfa4a863486b28b147e60","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -214,21 +214,21 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_46cc5d203ce21648_EOF'
+          cat << 'GH_AW_PROMPT_18ae83114f27f0a4_EOF'
           <system>
-          GH_AW_PROMPT_46cc5d203ce21648_EOF
+          GH_AW_PROMPT_18ae83114f27f0a4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_46cc5d203ce21648_EOF'
+          cat << 'GH_AW_PROMPT_18ae83114f27f0a4_EOF'
           <safe-output-tools>
           Tools: create_pull_request_review_comment(max:5), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_46cc5d203ce21648_EOF
+          GH_AW_PROMPT_18ae83114f27f0a4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_46cc5d203ce21648_EOF'
+          cat << 'GH_AW_PROMPT_18ae83114f27f0a4_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -257,13 +257,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_46cc5d203ce21648_EOF
+          GH_AW_PROMPT_18ae83114f27f0a4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_46cc5d203ce21648_EOF'
+          cat << 'GH_AW_PROMPT_18ae83114f27f0a4_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/repo-build-setup.md}}
           {{#runtime-import .github/workflows/pr-expert-reviewer.md}}
-          GH_AW_PROMPT_46cc5d203ce21648_EOF
+          GH_AW_PROMPT_18ae83114f27f0a4_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -486,9 +486,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_299328192d90de29_EOF'
-          {"create_pull_request_review_comment":{"max":5,"side":"RIGHT"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{},"submit_pull_request_review":{"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_299328192d90de29_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4c86a60e9ab81882_EOF'
+          {"create_pull_request_review_comment":{"max":5,"side":"RIGHT"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{},"submit_pull_request_review":{"allowed_events":["COMMENT","REQUEST_CHANGES"],"max":1}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_4c86a60e9ab81882_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -709,7 +709,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_750416a42c43bd35_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_eea62c21b9eba9d2_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -754,7 +754,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_750416a42c43bd35_EOF
+          GH_AW_MCP_CONFIG_eea62c21b9eba9d2_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1425,7 +1425,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request_review_comment\":{\"max\":5,\"side\":\"RIGHT\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{},\"submit_pull_request_review\":{\"max\":1}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request_review_comment\":{\"max\":5,\"side\":\"RIGHT\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{},\"submit_pull_request_review\":{\"allowed_events\":[\"COMMENT\",\"REQUEST_CHANGES\"],\"max\":1}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pr-expert-reviewer.md
+++ b/.github/workflows/pr-expert-reviewer.md
@@ -29,6 +29,9 @@ safe-outputs:
     side: "RIGHT"
   submit-pull-request-review:
     max: 1
+    # Bots must never approve PRs in this repo — only human maintainers can.
+    # The agent may still leave a COMMENT review or REQUEST_CHANGES, but APPROVE is disallowed.
+    allowed-events: [COMMENT, REQUEST_CHANGES]
   messages:
     footer: "> 🧠 *Reviewed by [{workflow_name}]({run_url})*"
     run-started: "🔎 [{workflow_name}]({run_url}) is analyzing this PR for correctness, performance, and safety issues..."
@@ -180,10 +183,12 @@ After the review, update:
 
 ## Decision Framework
 
-The `@expert-reviewer` agent determines the review verdict (APPROVE / COMMENT / REQUEST_CHANGES) based on its dimension analysis. This workflow defers to the agent's decision framework for all code findings.
+The `@expert-reviewer` agent determines the review verdict (COMMENT / REQUEST_CHANGES) based on its dimension analysis. This workflow defers to the agent's decision framework for all code findings.
+
+**APPROVE is not available to this workflow.** Only human maintainers approve PRs in this repo. When the agent would otherwise have approved (no issues found), submit a `COMMENT`-state review summarizing what was checked and what looked clean — leave the approval decision to the maintainer. The safe-output layer enforces this via `allowed-events: [COMMENT, REQUEST_CHANGES]`, so emitting `APPROVE` will be rejected.
 
 This workflow adds one workflow-level override:
-- If the PR description is materially misleading about the change's scope or intent, escalate from APPROVE to COMMENT regardless of code findings.
+- If the PR description is materially misleading about the change's scope or intent, the review must be a `COMMENT` (never `REQUEST_CHANGES` solely on description grounds) regardless of code findings.
 
 ## Edge Cases
 

--- a/.github/workflows/pr-expert-reviewer.md
+++ b/.github/workflows/pr-expert-reviewer.md
@@ -188,7 +188,7 @@ The `@expert-reviewer` agent determines the review verdict (COMMENT / REQUEST_CH
 **APPROVE is not available to this workflow.** Only human maintainers approve PRs in this repo. When the agent would otherwise have approved (no issues found), submit a `COMMENT`-state review summarizing what was checked and what looked clean — leave the approval decision to the maintainer. The safe-output layer enforces this via `allowed-events: [COMMENT, REQUEST_CHANGES]`, so emitting `APPROVE` will be rejected.
 
 This workflow adds one workflow-level override:
-- If the PR description is materially misleading about the change's scope or intent, the review must be a `COMMENT` (never `REQUEST_CHANGES` solely on description grounds) regardless of code findings.
+- If the PR description is materially misleading about the change's scope or intent, that description issue by itself must result in a `COMMENT`, not `REQUEST_CHANGES`. However, if `@expert-reviewer` identifies code findings that independently warrant `REQUEST_CHANGES`, the review should still be `REQUEST_CHANGES`, and the misleading PR description should be mentioned in the review body.
 
 ## Edge Cases
 


### PR DESCRIPTION
## Why

On #16062 the Expert Code Reviewer 🧠 agentic workflow submitted an `APPROVED` review under my account. The review's body openly says it was the workflow (linked to the run), but GitHub shows the state as a real human approval because the workflow authenticates with my PAT (`GH_AW_GITHUB_TOKEN`). That bypasses the only intentional gate this repo has: a human read.

I dismissed the bad review on #16062. This PR closes the loophole.

## What changed

`submit-pull-request-review` in `pr-expert-reviewer.md` now restricts the agent to `[COMMENT, REQUEST_CHANGES]`. The agent keeps every useful capability — deep-review comments, inline review comments at file:line, requesting changes — but the `APPROVE` event is off the table.

gh-aw enforces this both at parse time (`pkg/workflow/submit_pr_review.go`) and at runtime in the safe-outputs handler (`actions/setup/js/submit_pr_review.cjs`), which has a regression test named *""should block APPROVE when allowed_events is [COMMENT, REQUEST_CHANGES]""*, so we get the behavior we want even if the agent insists on emitting APPROVE.

I also updated the Decision Framework prose so the agent doesn't waste a turn trying APPROVE and then getting rejected.

## Lock file

Recompiled with `gh aw v0.72.1` (the version the existing lock was compiled with) to avoid drift noise. The only meaningful change in `pr-expert-reviewer.lock.yml` is `"allowed_events":["COMMENT","REQUEST_CHANGES"]` appearing in the safe-outputs config in two places; the rest is heredoc-marker hashes that always change on recompile.

## Other workflows scanned

- `pr-iteration.md` — no review submission, only comments and `[fix]` commits. ✅
- `daily-qa.md`, `issue-repro-triage.md` — no review submission. ✅
- `enable-auto-merge.yml` — sets auto-merge on maestro PRs. It relies on branch protection's required-review count, so cutting off bot approvals on the same identity also closes that chain.
- The built-in `copilot-pull-request-reviewer` cannot approve, only comment. ✅

So this PR covers the only path a bot had to approve under my name.