### PR TITLE
[fix] fix: guard GenerateProgramFile target against UseWinUI/UseUwpTools evaluation order

### DIFF
--- a/src/package/Microsoft.NET.Test.Sdk/netcoreapp/Microsoft.NET.Test.Sdk.targets
+++ b/src/package/Microsoft.NET.Test.Sdk/netcoreapp/Microsoft.NET.Test.Sdk.targets
@@ -41,7 +41,7 @@
     ============================================================
   -->
   <Target Name="GenerateProgramFile"
-          Condition="'$(GenerateProgramFile)' == 'true'">
+          Condition="'$(GenerateProgramFile)' == 'true' AND '$(UseWinUI)' != 'true' AND '$(UseUwpTools)' != 'true'">
 
     <ItemGroup Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'">
       <RemoveExistingMicrosoftNETTestSdkProgram Include="@(Compile)" Condition="'%(FileName)' == 'Microsoft.NET.Test.Sdk.Program'" />


### PR DESCRIPTION
> 🤖 This is an automated fix generated by the Issue Triage agent.

Fixes #16071

## Root Cause

`Microsoft.NET.Test.Sdk.targets` uses `InitialTargets="GenerateProgramFile"` so the `GenerateProgramFile` target runs before any user targets. The `PropertyGroup` at the top of the file tries to set `GenerateProgramFile=false` when `UseWinUI=true`:

```xml
<GenerateProgramFile Condition="'$(GenerateProgramFile)' == '' AND ('$(UseWinUI)' == 'true' OR '$(UseUwpTools)' == 'true')">false</GenerateProgramFile>
<GenerateProgramFile Condition="'$(GenerateProgramFile)' == ''">true</GenerateProgramFile>
```

However, when `UseWinUI` is **not set explicitly in the project file** but is instead set by the Windows App SDK's own NuGet package targets, the import order matters. NuGet package targets are auto-imported alphabetically; `Microsoft.NET.Test.Sdk` sorts before `WindowsAppSDK`, so the Test SDK's PropertyGroup is evaluated when `UseWinUI` is still empty. As a result, `GenerateProgramFile` ends up set to `true`, and the `GenerateProgramFile` target generates a `Program.cs` with a `Main` method — conflicting with the entry point that the WinUI XAML compiler generates, causing **CS0017: Program has more than one entry point defined**.

## Fix

Add the same `UseWinUI`/`UseUwpTools` guard directly to the target's `Condition`, so even if `GenerateProgramFile` was incorrectly set to `true` during static property evaluation, the target will never execute for WinUI or UWP test apps:

```xml
<Target Name="GenerateProgramFile"
        Condition="'$(GenerateProgramFile)' == 'true' AND '$(UseWinUI)' != 'true' AND '$(UseUwpTools)' != 'true'">
```

Target conditions are re-evaluated at execution time, by which point all package targets have been imported and `UseWinUI` is correctly set.

## Testing

The fix is a one-line change in a `.targets` file. The change makes the `GenerateProgramFile` target's behaviour consistent with the comment in the file ("We always skip the generated entry point for UWP apps... We also do the same for WinUI apps").

A targeted acceptance test for this scenario would require a WinUI test project on Windows with the Windows App SDK — that environment is not available in this CI setup. The logic change mirrors the existing `OutputType` guard on line 21 of the same file.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/26612362512)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 26612362512, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/26612362512 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->