### PR TITLE
[review] [fix] Fix TRX LogFileName collision when testing multiple assemblies in a solution

### DIFF
--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/LoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/LoggerTests.cs
@@ -265,9 +265,7 @@ public class LoggerTests : AcceptanceTestBase
         // each should get a unique file (via iteration) instead of overwriting.
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
-        var assembly1 = GetAssetFullPath("SimpleTestProject.dll");
-        var assembly2 = GetAssetFullPath("SimpleTestProject2.dll");
-        var assemblyPaths = $"{assembly1}\" \"{assembly2}";
+        var assemblyPaths = BuildMultipleAssemblyPath("SimpleTestProject.dll", "SimpleTestProject2.dll");
         var trxFileName = "SharedName.trx";
         var arguments = PrepareArguments(assemblyPaths, null, string.Empty, FrameworkArgValue, runnerInfo.InIsolationValue, resultsDirectory: TempDirectory.Path);
         arguments = string.Concat(arguments, $" /logger:\"trx;LogFileName={trxFileName}\"");


### PR DESCRIPTION
> [!CAUTION]
> **This PR requires manual review** because threat detection produced a warning.
>
> **Reason:** parse_error
>
> Review the [workflow run logs](https://github.com/microsoft/vstest/actions/runs/26646624397) for details.

This PR contains changes that were originally intended for PR #15788 (`fix/issue-15673-0ae77a4bb78cb877`).
Please review the changes carefully before merging.