### PR TITLE
[fix] fix: add RequestingAssembly to AssemblyResolveEventArgs for binary compat

### DIFF
--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/Runtime/IAssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/Runtime/IAssemblyResolver.cs
@@ -61,5 +61,11 @@ public class AssemblyResolveEventArgs : EventArgs
     /// <summary>
     /// Gets the assembly whose dependency is being resolved.
     /// </summary>
+    /// <remarks>
+    /// This property is populated on .NET Framework (net462+) where <c>AppDomain.AssemblyResolve</c>
+    /// exposes the requesting assembly via <see cref="ResolveEventArgs.RequestingAssembly"/>.
+    /// On .NET (Core), <c>AssemblyLoadContext.Resolving</c> does not expose the requesting assembly,
+    /// so this property is always <see langword="null"/> in that environment.
+    /// </remarks>
     public Assembly? RequestingAssembly { get; }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/Runtime/IAssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/Interfaces/Runtime/IAssemblyResolver.cs
@@ -43,7 +43,23 @@ public class AssemblyResolveEventArgs : EventArgs
     }
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="AssemblyResolveEventArgs"/> class.
+    /// </summary>
+    /// <param name="name">The full name of an assembly to resolve.</param>
+    /// <param name="requestingAssembly">The assembly whose dependency is being resolved, or <see langword="null"/> if the requesting assembly is not known.</param>
+    public AssemblyResolveEventArgs(string? name, Assembly? requestingAssembly)
+    {
+        Name = name;
+        RequestingAssembly = requestingAssembly;
+    }
+
+    /// <summary>
     /// Gets or sets the name of the item to resolve.
     /// </summary>
     public string? Name { get; set; }
+
+    /// <summary>
+    /// Gets the assembly whose dependency is being resolved.
+    /// </summary>
+    public Assembly? RequestingAssembly { get; }
 }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces.AssemblyResolveEventArgs.AssemblyResolveEventArgs(string? name, System.Reflection.Assembly? requestingAssembly) -> void
+Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces.AssemblyResolveEventArgs.RequestingAssembly.get -> System.Reflection.Assembly?

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net462/Runtime/PlatformAssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net462/Runtime/PlatformAssemblyResolver.cs
@@ -69,7 +69,7 @@ public class PlatformAssemblyResolver : IAssemblyResolver
     /// </returns>
     private Assembly? AssemblyResolverEvent(object sender, object eventArgs)
     {
-        return eventArgs is not ResolveEventArgs args ? null : AssemblyResolve?.Invoke(this, new AssemblyResolveEventArgs(args.Name));
+        return eventArgs is not ResolveEventArgs args ? null : AssemblyResolve?.Invoke(this, new AssemblyResolveEventArgs(args.Name, args.RequestingAssembly));
     }
 }
 

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/Runtime/PlatformAssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/Runtime/PlatformAssemblyResolver.cs
@@ -70,7 +70,8 @@ public class PlatformAssemblyResolver : IAssemblyResolver
     /// </returns>
     private Assembly? AssemblyResolverEvent(object sender, object eventArgs)
     {
-        return eventArgs is not AssemblyName args ? null : AssemblyResolve?.Invoke(this, new AssemblyResolveEventArgs(args.Name));
+        // AssemblyLoadContext.Resolving does not expose the requesting assembly, so null is passed explicitly.
+        return eventArgs is not AssemblyName args ? null : AssemblyResolve?.Invoke(this, new AssemblyResolveEventArgs(args.Name, requestingAssembly: null));
     }
 }
 

--- a/test/Microsoft.TestPlatform.Common.UnitTests/Utilities/AssemblyResolveEventArgsTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/Utilities/AssemblyResolveEventArgsTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TestPlatform.Common.UnitTests.Utilities;
+
+[TestClass]
+public class AssemblyResolveEventArgsTests
+{
+    [TestMethod]
+    public void SingleArgConstructorSetsNameAndLeavesRequestingAssemblyNull()
+    {
+        var args = new AssemblyResolveEventArgs("MyAssembly, Version=1.0.0.0");
+
+        Assert.AreEqual("MyAssembly, Version=1.0.0.0", args.Name);
+        Assert.IsNull(args.RequestingAssembly);
+    }
+
+    [TestMethod]
+    public void TwoArgConstructorSetsNameAndRequestingAssembly()
+    {
+        Assembly requesting = typeof(AssemblyResolveEventArgsTests).Assembly;
+        var args = new AssemblyResolveEventArgs("MyAssembly, Version=1.0.0.0", requesting);
+
+        Assert.AreEqual("MyAssembly, Version=1.0.0.0", args.Name);
+        Assert.AreSame(requesting, args.RequestingAssembly);
+    }
+
+    [TestMethod]
+    public void TwoArgConstructorWithNullRequestingAssemblyLeavesPropertyNull()
+    {
+        var args = new AssemblyResolveEventArgs("MyAssembly, Version=1.0.0.0", requestingAssembly: null);
+
+        Assert.AreEqual("MyAssembly, Version=1.0.0.0", args.Name);
+        Assert.IsNull(args.RequestingAssembly);
+    }
+}


### PR DESCRIPTION
🤖 *This is an automated fix by the Issue Triage agent.*

Fixes #15765

## Root Cause

SDK 10.0.300 ships a version of `Microsoft.TestPlatform.Common.dll` whose `AssemblyResolver.OnResolve` method calls `args.RequestingAssembly` on an `AssemblyResolveEventArgs` instance. However, `AssemblyResolveEventArgs` in `Microsoft.TestPlatform.PlatformAbstractions.dll` never had this property, causing a `MissingMethodException` at runtime:

```
System.MissingMethodException : Method not found: 'System.Reflection.Assembly
  Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces.AssemblyResolveEventArgs.get_RequestingAssembly()'.
  at Microsoft.VisualStudio.TestPlatform.Common.Utilities.AssemblyResolver.OnResolve(Object, AssemblyResolveEventArgs)
```

This only manifests with `RunConfiguration.DisableAppDomain=true` targeting `net462`, because that mode runs tests in the current AppDomain, loading vstest's assembly resolver into it. The `AppDomain.AssemblyResolve` event fires and hits `OnResolve`, which crashes.

## Fix

- Add `RequestingAssembly` property to `AssemblyResolveEventArgs`
- Add a new constructor overload `AssemblyResolveEventArgs(string? name, Assembly? requestingAssembly)`
- Update the net462 `PlatformAssemblyResolver` bridge to pass `ResolveEventArgs.RequestingAssembly` through to vstest's `AssemblyResolveEventArgs`
- Declare the new public API in `PublicAPI.Unshipped.txt`

## Testing

The fix restores binary compatibility between the two assemblies. The affected scenario (`DisableAppDomain=true` on net462) would no longer throw `MissingMethodException` when the assembly resolver fires.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/26670488104)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 26670488104, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/26670488104 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->