### PR TITLE
[fix] Warn when testhost is not found in project deps.json (missing Microsoft.NET.Test.Sdk)

### DIFF
--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -384,7 +384,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
                 if (_fileHelper.Exists(depsFilePath) && _fileHelper.Exists(runtimeConfigDevPath))
                 {
                     string message = string.Format(CultureInfo.CurrentCulture, Resources.MissingTestSdkWarning, sourcePath);
-                    EqtTrace.Warning("DotnetTestHostManager.GetTestHostStartInfo: {0}", message);
+                    EqtTrace.Warning("DotnetTestHostManager.GetTestHostProcessStartInfo: {0}", message);
                     _messageLogger?.SendMessage(TestMessageLevel.Warning, message);
                 }
 #if NETFRAMEWORK

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -69,6 +69,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
     private readonly IWindowsRegistryHelper _windowsRegistryHelper;
     private readonly IEnvironmentVariableHelper _environmentVariableHelper;
 
+    private IMessageLogger? _messageLogger;
     private ITestHostLauncher? _customTestHostLauncher;
     private Process? _testHostProcess;
     private StringBuilder? _testHostProcessStdError;
@@ -201,6 +202,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
         _createNoNewWindow = runConfiguration.CreateNoNewWindow;
         var forwardOutput = runConfiguration.ForwardStandardOutput;
         _testHostManagerCallbacks = new TestHostManagerCallbacks(forwardOutput, logger);
+        _messageLogger = logger;
 
         _architecture = runConfiguration.TargetPlatform;
         _targetFramework = runConfiguration.TargetFramework;
@@ -376,6 +378,15 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
             if (testHostPath.IsNullOrEmpty())
             {
                 // We still did not find testhost.dll. Try finding it next to vstest.console, (or in next to vstest.console ./TestHostNet for .NET Framework)
+
+                // If the project has a proper deps.json but testhost is not listed in it, the most likely cause is
+                // a missing reference to 'Microsoft.NET.Test.Sdk'. Warn the user to help them diagnose the failure.
+                if (_fileHelper.Exists(depsFilePath) && _fileHelper.Exists(runtimeConfigDevPath))
+                {
+                    string message = string.Format(CultureInfo.CurrentCulture, Resources.MissingTestSdkWarning, sourcePath);
+                    EqtTrace.Warning("DotnetTestHostManager.GetTestHostStartInfo: {0}", message);
+                    _messageLogger?.SendMessage(TestMessageLevel.Warning, message);
+                }
 #if NETFRAMEWORK
                 var testHostNextToRunner = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly()!.Location)!, "TestHostNet", "testhost.dll");
 #else

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.Designer.cs
@@ -83,6 +83,17 @@ namespace Microsoft.TestPlatform.TestHostProvider.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string for a warning when testhost.dll is not found in the project's deps.json, suggesting a missing Microsoft.NET.Test.Sdk reference.
+        /// </summary>
+        internal static string MissingTestSdkWarning
+        {
+            get
+            {
+                return ResourceManager.GetString("MissingTestSdkWarning", resourceCulture)!;
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Unable to find {0}. Make sure test project has a nuget reference of package &quot;Microsoft.NET.Test.Sdk&quot;..
         /// </summary>
         internal static string UnableToFindDepsFile {

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.resx
@@ -137,6 +137,10 @@ Verify that:
 </value>
     <comment>'{0}' is the path to the test source (DLL/EXE), '{1}' is the directory where testhost was searched.</comment>
   </data>
+  <data name="MissingTestSdkWarning" xml:space="preserve">
+    <value>Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</value>
+    <comment>'{0}' is the path to the test source (DLL/EXE).</comment>
+  </data>
   <data name="NoDotnetMuxerFoundForArchitecture" xml:space="preserve">
     <value>Could not find '{0}' host for the '{1}' architecture.
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.cs.xlf
@@ -36,6 +36,11 @@ Verify that:
         <target state="translated">Nejde najít {0}. Publikujte prosím svůj testovací projekt a zkuste to znovu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingTestSdkWarning">
+        <source>Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</source>
+        <target state="new">Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</target>
+        <note>'{0}' is the path to the test source (DLL/EXE).</note>
+      </trans-unit>
       <trans-unit id="NoDotnetMuxerFoundForArchitecture">
         <source>Could not find '{0}' host for the '{1}' architecture.
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.de.xlf
@@ -36,6 +36,11 @@ Verify that:
         <target state="translated">"{0}" wurde nicht gefunden. Veröffentlichen Sie Ihr Testprojekt, und versuchen Sie es noch mal.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingTestSdkWarning">
+        <source>Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</source>
+        <target state="new">Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</target>
+        <note>'{0}' is the path to the test source (DLL/EXE).</note>
+      </trans-unit>
       <trans-unit id="NoDotnetMuxerFoundForArchitecture">
         <source>Could not find '{0}' host for the '{1}' architecture.
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.es.xlf
@@ -36,6 +36,11 @@ Verify that:
         <target state="translated">No se encuentra {0}. Publique el proyecto de prueba y vuelva a intentarlo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingTestSdkWarning">
+        <source>Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</source>
+        <target state="new">Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</target>
+        <note>'{0}' is the path to the test source (DLL/EXE).</note>
+      </trans-unit>
       <trans-unit id="NoDotnetMuxerFoundForArchitecture">
         <source>Could not find '{0}' host for the '{1}' architecture.
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.fr.xlf
@@ -36,6 +36,11 @@ Verify that:
         <target state="translated">{0} est introuvable. Publiez votre projet de test et réessayez.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingTestSdkWarning">
+        <source>Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</source>
+        <target state="new">Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</target>
+        <note>'{0}' is the path to the test source (DLL/EXE).</note>
+      </trans-unit>
       <trans-unit id="NoDotnetMuxerFoundForArchitecture">
         <source>Could not find '{0}' host for the '{1}' architecture.
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.it.xlf
@@ -36,6 +36,11 @@ Verify that:
         <target state="translated">Non è possibile trovare {0}. Pubblicare il progetto di test e riprovare.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingTestSdkWarning">
+        <source>Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</source>
+        <target state="new">Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</target>
+        <note>'{0}' is the path to the test source (DLL/EXE).</note>
+      </trans-unit>
       <trans-unit id="NoDotnetMuxerFoundForArchitecture">
         <source>Could not find '{0}' host for the '{1}' architecture.
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ja.xlf
@@ -36,6 +36,11 @@ Verify that:
         <target state="translated">{0} を見つけることができません。テスト プロジェクトを公開してもう一度お試しください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingTestSdkWarning">
+        <source>Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</source>
+        <target state="new">Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</target>
+        <note>'{0}' is the path to the test source (DLL/EXE).</note>
+      </trans-unit>
       <trans-unit id="NoDotnetMuxerFoundForArchitecture">
         <source>Could not find '{0}' host for the '{1}' architecture.
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ko.xlf
@@ -36,6 +36,11 @@ Verify that:
         <target state="translated">{0}을(를) 찾을 수 없습니다. 테스트 프로젝트를 게시하고 다시 시도하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingTestSdkWarning">
+        <source>Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</source>
+        <target state="new">Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</target>
+        <note>'{0}' is the path to the test source (DLL/EXE).</note>
+      </trans-unit>
       <trans-unit id="NoDotnetMuxerFoundForArchitecture">
         <source>Could not find '{0}' host for the '{1}' architecture.
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pl.xlf
@@ -36,6 +36,11 @@ Verify that:
         <target state="translated">Nie można znaleźć elementu {0}. Opublikuj swój projekt testowy i spróbuj ponownie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingTestSdkWarning">
+        <source>Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</source>
+        <target state="new">Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</target>
+        <note>'{0}' is the path to the test source (DLL/EXE).</note>
+      </trans-unit>
       <trans-unit id="NoDotnetMuxerFoundForArchitecture">
         <source>Could not find '{0}' host for the '{1}' architecture.
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pt-BR.xlf
@@ -36,6 +36,11 @@ Verify that:
         <target state="translated">Não foi possível localizar {0}. Publique o projeto de teste e tente novamente.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingTestSdkWarning">
+        <source>Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</source>
+        <target state="new">Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</target>
+        <note>'{0}' is the path to the test source (DLL/EXE).</note>
+      </trans-unit>
       <trans-unit id="NoDotnetMuxerFoundForArchitecture">
         <source>Could not find '{0}' host for the '{1}' architecture.
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ru.xlf
@@ -36,6 +36,11 @@ Verify that:
         <target state="translated">Не удалось найти {0}. Опубликуйте тестовый проект и повторите попытку.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingTestSdkWarning">
+        <source>Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</source>
+        <target state="new">Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</target>
+        <note>'{0}' is the path to the test source (DLL/EXE).</note>
+      </trans-unit>
       <trans-unit id="NoDotnetMuxerFoundForArchitecture">
         <source>Could not find '{0}' host for the '{1}' architecture.
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.tr.xlf
@@ -36,6 +36,11 @@ Verify that:
         <target state="translated">{0} bulunamıyor. Lütfen test projenizi yayımlayın ve yeniden deneyin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingTestSdkWarning">
+        <source>Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</source>
+        <target state="new">Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</target>
+        <note>'{0}' is the path to the test source (DLL/EXE).</note>
+      </trans-unit>
       <trans-unit id="NoDotnetMuxerFoundForArchitecture">
         <source>Could not find '{0}' host for the '{1}' architecture.
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hans.xlf
@@ -36,6 +36,11 @@ Verify that:
         <target state="translated">无法找到 {0}。请发布测试项目并重试。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingTestSdkWarning">
+        <source>Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</source>
+        <target state="new">Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</target>
+        <note>'{0}' is the path to the test source (DLL/EXE).</note>
+      </trans-unit>
       <trans-unit id="NoDotnetMuxerFoundForArchitecture">
         <source>Could not find '{0}' host for the '{1}' architecture.
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hant.xlf
@@ -36,6 +36,11 @@ Verify that:
         <target state="translated">找不到 {0}。請發佈您的測試專案並重試。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingTestSdkWarning">
+        <source>Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</source>
+        <target state="new">Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.</target>
+        <note>'{0}' is the path to the test source (DLL/EXE).</note>
+      </trans-unit>
       <trans-unit id="NoDotnetMuxerFoundForArchitecture">
         <source>Could not find '{0}' host for the '{1}' architecture.
 


### PR DESCRIPTION
> 🤖 This is an automated fix created by the Issue Triage agent.

Fixes #15403

## Root Cause

When a .NET test project has a proper `deps.json` and `runtimeconfig.dev.json` (indicating a managed .NET project), but doesn't reference `microsoft.testplatform.testhost` in its deps.json, `DotnetTestHostManager` silently falls back to using the testhost from the vstest.console installation directory. This fallback can succeed at process launch but then fail at runtime with a confusing error like:

```
An assembly specified in the application dependencies manifest (testhost.deps.json) was not found:
  package: 'testhost', version: '18.0.1-release-...'
  path: 'testhost.dll'
```

The root cause is typically a missing reference to `Microsoft.NET.Test.Sdk` in the test project, but the error message gives no indication of this.

## Fix

Added a user-visible `Warning` message emitted by `DotnetTestHostManager.GetTestHostStartInfo` when:
1. The test project has a `deps.json` file (managed project), AND
2. The test project has a `runtimeconfig.dev.json` file (proper SDK-style .NET project), AND
3. `testhost.dll` is **not** found in the project's deps.json (i.e., `Microsoft.NET.Test.Sdk` is likely missing)

The warning reads:
> Test source '{0}' does not include the test host assembly 'testhost.dll'. This can happen when the test project does not reference the 'Microsoft.NET.Test.Sdk' NuGet package. Falling back to the test host from the test runner installation, which may fail if the versions are incompatible.

This warning is shown before the fallback occurs, giving the user actionable information to diagnose the real cause of any subsequent failure.

## Changes

- `DotnetTestHostManager`: Added `_messageLogger` field to store the logger passed to `Initialize()`, and emit a warning when falling back to runner-side testhost with evidence of a managed project that lacks `Microsoft.NET.Test.Sdk`.
- `Resources.resx` + `Resources.Designer.cs`: Added `MissingTestSdkWarning` resource string.
- All `.xlf` files updated with the new resource string.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/26684244107)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 26684244107, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/26684244107 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->