### PR TITLE
[fix] Re-enable RunMultipleTestAssembliesWithCodeCoverage test

### DIFF
--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TestPlatformNugetPackageTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/TestPlatformNugetPackageTests.cs
@@ -22,7 +22,6 @@ public class TestPlatformNugetPackageTests : CodeCoverageAcceptanceTestBase
 
     [TestMethod]
     [TestCategory("Windows-Review")]
-    [Ignore("Code Coverage is using 17.x.x dependency, will be solved in other PR. https://github.com/microsoft/vstest/issues/15223")]
     [NetFullTargetFrameworkDataSourceAttribute(useCoreRunner: false)]
     [NetCoreTargetFrameworkDataSourceAttribute(useCoreRunner: false)]
     public void RunMultipleTestAssembliesWithCodeCoverage(RunnerInfo runnerInfo)


### PR DESCRIPTION
🤖 This is an automated fix.

Fixes #15223

## Root Cause

When vstest was upgraded to version 18, `Microsoft.VisualStudio.Diagnostics.Utilities` was bumped from 17.x.x to 18.x.x, but `Microsoft.IntelliTrace.Core` still referenced version 17.0.0.0. This caused a `FileLoadException` binding mismatch at runtime during code coverage, so the test was disabled.

## Fix

The DLL versions have since been aligned — both `Microsoft.VisualStudio.Diagnostics.Utilities` and `Microsoft.IntelliTrace.Core` are now at **version 18.0.0.0** (verified from build artifacts: `TestPlatformExternalsVersion = 18.2.0-preview-1-11429-120`, `MicrosoftVisualStudioDiagnosticsUtilitiesVersion = 18.3.11401.5`). The binding mismatch is resolved at the package level, so the `[Ignore]` attribute can simply be removed.

## Test

`RunMultipleTestAssembliesWithCodeCoverage` is the acceptance test that directly validates the scenario from the issue. It was the test disabled by the bug, and re-enabling it is both the fix and the verification.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/26761400056)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 26761400056, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/26761400056 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->