### PR TITLE
Remove stale Microsoft.Extensions.FileSystemGlobbing binding redirect from testhost.x86 and datacollector

### DIFF
--- a/src/datacollector/app.config
+++ b/src/datacollector/app.config
@@ -17,10 +17,6 @@
         <bindingRedirect oldVersion="11.0.0.0-14.0.0.0" newVersion="15.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.FileSystemGlobbing" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="1.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>

--- a/src/testhost.x86/app.config
+++ b/src/testhost.x86/app.config
@@ -25,10 +25,6 @@
         <bindingRedirect oldVersion="10.1.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.FileSystemGlobbing" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="1.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>


### PR DESCRIPTION
## What

Remove the stale `Microsoft.Extensions.FileSystemGlobbing` `<bindingRedirect>` from `src/testhost.x86/app.config` and `src/datacollector/app.config`. The redirect is kept in `src/vstest.console/app.config` (the only EXE that legitimately ships and uses the assembly, via `FilePatternParser`).

## Why

Neither `testhost.x86.exe` nor `datacollector.exe` references `Microsoft.Extensions.FileSystemGlobbing`, and the DLL doesn't ship beside them in the `Microsoft.TestPlatform.CLI` nupkg's `contentFiles/any/net10.0/TestHostNetFramework/` folder. A binding redirect pointing to a DLL that isn't on the probing path is the same anti-pattern fixed for `System.Diagnostics.DiagnosticSource` in #15776 (root cause of #15765 — `MissingMethodException` on net462 with `DisableAppDomain=true`).

## How it was discovered

This is the latent issue the hardened verifier from #15778 catches. The failure currently surfaces only on the rel/18.6 VMR build:

1. `Microsoft.TestPlatform.csproj` gates `IsPackable` on `'$(DotNetBuild)' != 'true'` (the package "relies on a VS license"), so in VMR mode it isn't produced. That nupkg is the one that ships `testhost.x86.exe`/`datacollector.exe` in `tools/net462/Common7/IDE/Extensions/TestPlatform/` with `Microsoft.Extensions.FileSystemGlobbing.dll` right next to them — which is what masks the stale redirect in vstest's normal pipeline (`Find-ExeInPackages` prefers non-`TestHostNetFramework` layouts).
2. Once that layout disappears, the verifier only finds the EXEs inside `Microsoft.TestPlatform.CLI`'s `TestHostNetFramework/` folder, where the DLL isn't shipped → error.
3. The `DotNetBuild != 'true'` skip on `_VerifyNuGetPackages` (commit 37087fcc2) is on main and rel/18.8 but **not** backported to rel/18.6 or rel/18.7, so the verifier still runs in the VMR pack on those branches.

This PR fixes the underlying issue. It should be cherry-picked to rel/18.6 (where it actively unblocks the VMR build) and rel/18.7 for consistency.