### PR TITLE
[rel/18.6] Remove stale Microsoft.Extensions.FileSystemGlobbing binding redirect

### DIFF
--- a/src/datacollector/app.config
+++ b/src/datacollector/app.config
@@ -17,10 +17,6 @@
         <bindingRedirect oldVersion="11.0.0.0-14.0.0.0" newVersion="15.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.FileSystemGlobbing" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>

--- a/src/testhost.x86/app.config
+++ b/src/testhost.x86/app.config
@@ -30,10 +30,6 @@
         <bindingRedirect oldVersion="9.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.FileSystemGlobbing" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>


### PR DESCRIPTION
Backport of #16082 to rel/18.6.

## What

Remove the stale `Microsoft.Extensions.FileSystemGlobbing` `<bindingRedirect>` from `src/testhost.x86/app.config` and `src/datacollector/app.config` (kept in `src/vstest.console/app.config` — the only EXE that legitimately uses `FilePatternParser` and ships the DLL beside itself).

## Why this matters specifically for rel/18.6

The rel/18.6 VMR build is failing on this check (see [dnceng-public build 1435728](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1435728)):

```
testhost.x86.exe: Microsoft.Extensions.FileSystemGlobbing has a binding redirect but the DLL is not in the package layout
datacollector.exe: Microsoft.Extensions.FileSystemGlobbing has a binding redirect but the DLL is not in the package layout
```

In vstest's own pipeline this is masked because the verifier (`Find-ExeInPackages` in `eng/verify-binding-redirects.ps1`) prefers a non-`TestHostNetFramework` location and picks the EXEs from `Microsoft.TestPlatform.nupkg`'s `tools/net462/Common7/IDE/Extensions/TestPlatform/` folder, where `Microsoft.Extensions.FileSystemGlobbing.dll` is sitting next to them. In the VMR, `Microsoft.TestPlatform.csproj` gates `IsPackable` on `'$(DotNetBuild)' != 'true'` ("relies on a VS license"), so only `Microsoft.TestPlatform.CLI` is produced — and the EXEs end up in its `contentFiles/any/net10.0/TestHostNetFramework/` folder where the DLL doesn't ship.

On main/rel/18.8 `_VerifyNuGetPackages` itself is skipped under `DotNetBuild=true`, so the latent stale redirect doesn't surface there. That skip was not backported to rel/18.6, so the hardened verifier (from #15778) running in the VMR pack catches the issue here.

The cleanest fix is to remove the stale redirect (same anti-pattern as the `DiagnosticSource` fix in #15776 / #15765).