### PR TITLE
[rel/18.7] Remove stale Microsoft.Extensions.FileSystemGlobbing binding redirect

### DIFF
--- a/src/datacollector/app.config
+++ b/src/datacollector/app.config
@@ -17,10 +17,6 @@
         <bindingRedirect oldVersion="11.0.0.0-14.0.0.0" newVersion="15.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.FileSystemGlobbing" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>

--- a/src/testhost.x86/app.config
+++ b/src/testhost.x86/app.config
@@ -30,10 +30,6 @@
         <bindingRedirect oldVersion="9.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.FileSystemGlobbing" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>


### PR DESCRIPTION
Backport of #16082 to rel/18.7.

## What

Remove the stale `Microsoft.Extensions.FileSystemGlobbing` `<bindingRedirect>` from `src/testhost.x86/app.config` and `src/datacollector/app.config` (kept in `src/vstest.console/app.config`).

## Why

Neither `testhost.x86.exe` nor `datacollector.exe` references the assembly, and the DLL doesn't ship beside them in the `Microsoft.TestPlatform.CLI` nupkg's `TestHostNetFramework` folder. Same anti-pattern as the `DiagnosticSource` fix in #15776.

The active failure is on the rel/18.6 VMR build (see #16083); rel/18.7 carries the same stale redirect and the same missing `DotNetBuild != 'true'` skip on `_VerifyNuGetPackages`, so this backport keeps the branches consistent and prevents the same VMR failure if rel/18.7 packs in that context.