### PR TITLE
Remove DotNet-Symbol-Server-Pats group access

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -91,8 +91,6 @@ variables:
     - name: Codeql.Cadence 
       value: 0
 
-  # Group gives access to $microsoft-symbol-server-pat and $symweb-symbol-server-pat
-  - group: DotNet-Symbol-Server-Pats
   # Group gives access to $dn-bot-devdiv-drop-rw-code-rw and dn-bot-dnceng-build-rw-code-rw
   - group: DotNet-VSTS-Infra-Access
   # DevDiv drop access token is acquired via WIF service connection (dnceng-devdiv-drop-rw-code-rw-wif)


### PR DESCRIPTION
Removed access to the DotNet-Symbol-Server-Pats group.
