### PR TITLE
[rel/18.6] Fix stale binding redirects for SCRU/Memory/Buffers/SCI

### DIFF
--- a/src/datacollector/app.config
+++ b/src/datacollector/app.config
@@ -18,21 +18,21 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
       </dependentAssembly>
 
       <dependentAssembly>
         <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
 
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/src/testhost.x86/app.config
+++ b/src/testhost.x86/app.config
@@ -31,21 +31,21 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
       </dependentAssembly>
 
       <dependentAssembly>
         <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
 
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />


### PR DESCRIPTION
The hardened binding-redirect verifier (#15778, now wired up on rel/18.6 after #16083) is catching four more stale binding redirects in `testhost.x86` and `datacollector` `app.config` files. Each one targets a higher version than what actually ships beside the exe in the `Microsoft.TestPlatform.CLI` nupkg `TestHostNetFramework` folder:

| Assembly                                | Redirect `newVersion` | Shipped DLL |
|-----------------------------------------|-------------------------|-------------|
| `System.Runtime.CompilerServices.Unsafe` | 6.0.3.0 | 6.0.0.0 |
| `System.Memory`                          | 4.0.5.0 | 4.0.1.2 |
| `System.Buffers`                         | 4.0.5.0 | 4.0.3.0 |
| `System.Collections.Immutable`           | 10.0.0.0 | 9.0.0.0 |

These four were bumped by the auto-fix in #15724 when the layout contained the newer AVs, but the rel/18.6 package layout has since reverted to the older transitive versions. A redirect pointing at a version that is not shipped causes `FileLoadException` in hosts without their own binding redirects (e.g. Azure DevOps Distributed Test Agent — same anti-pattern as #15776 and #16083).

This PR mirrors what `build.cmd -c Release` would produce locally via `eng/verify-binding-redirects.ps1` auto-fix: narrows both `newVersion` and the upper bound of `oldVersion` to the actual shipped DLL version, for both `src/testhost.x86/app.config` and `src/datacollector/app.config`.

`src/vstest.console/app.config` is intentionally left untouched — `vstest.console.exe` ships only in `Microsoft.TestPlatform` (NonShipping) packages, which are not in the verifier's checked set, so it can't be auto-fixed without risk to a layout we don't validate.

Failing build: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1448463