### PR TITLE
[rel/18.7] Skip nupkg verifier in .NET product build mode

### DIFF
--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -4,7 +4,13 @@
     <SourceBranchName Condition=" '$(SourceBranchName)' == '' ">dev</SourceBranchName>
   </PropertyGroup>
 
-  <Target Name="_VerifyNuGetPackages" AfterTargets="Pack" Condition=" '$(OS)' == 'Windows_NT' ">
+  <!--
+    Verify binding redirects and framework targeting in nupkgs.
+    Skip in .NET product build mode: source-built dependency packages have different assembly versions
+    than NuGet.org packages (e.g. System.Collections.Immutable 11.0.0-ci ships assembly version 9.0.0.0),
+    so the binding redirect check produces false positives.
+  -->
+  <Target Name="_VerifyNuGetPackages" AfterTargets="Pack" Condition=" '$(OS)' == 'Windows_NT' and '$(DotNetBuild)' != 'true' ">
     <Exec Command="powershell -NoProfile -NoLogo -ExecutionPolicy Bypass $(RepositoryEngineeringDir)\verify-nupkgs.ps1 -configuration $(Configuration) -versionPrefix $(versionPrefix) -currentBranch $(SourceBranchName)" />
   </Target>
 


### PR DESCRIPTION
## What
Back-port to rel/18.7 the same `_VerifyNuGetPackages` VMR skip already present on rel/18.8 and main: gate the target on `DotNetBuild != 'true'`.

## Why
The binding-redirect verifier in `eng/verify-nupkgs.ps1` validates that the `newVersion` of each `bindingRedirect` in `vstest.console` / `testhost.x86` / `datacollector` app.configs matches the AssemblyVersion of the corresponding DLL shipped beside the exe. The DLLs shipped beside the exe in `Microsoft.TestPlatform.CLI`'s `contentFiles/any/net10.0/TestHostNetFramework` folder come from whatever the build environment resolved them as:

| Build | DLL source | Sample AssemblyVersion (SCRU / SCI) |
|---|---|---|
| dotnet/dotnet VMR (dnceng-public) | source-built BCL / runtime | 6.0.0.0 / 9.0.0.0 |
| dnceng internal & local pack | NuGet.org | 6.0.3.0 / 10.0.0.0 |

A single `bindingRedirect newVersion` cannot match both layouts, and the actually-shipped package is the internal pipeline's. The VMR check is the false positive — exactly the situation already documented and skipped on rel/18.8 and main:

> *Skip in .NET product build mode: source-built dependency packages have different assembly versions than NuGet.org packages (e.g. System.Collections.Immutable 11.0.0-ci ships assembly version 9.0.0.0), so the binding redirect check produces false positives.*

This is the same problem that just hit rel/18.6 ([VMR build 1448463](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1448463) and the follow-up internal pipeline failure [build 2991657](https://dnceng.visualstudio.com/internal/_build/results?buildId=2991657)). Back-porting the skip pre-empts the same break landing on rel/18.7 next time a VMR build runs.

This change is **VMR-only** — local builds and the internal pipeline still run the verifier unchanged.