### PR TITLE
[fix] build -pack on Linux (#15508)

### DIFF
--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.csproj
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.csproj
@@ -4,7 +4,10 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <NuspecFile Condition="'$(DotNetBuildSourceOnly)' != 'true' ">Microsoft.TestPlatform.CLI.nuspec</NuspecFile>
+    <!-- On Windows use the full nuspec; on non-Windows (Linux/macOS) use the cross-platform sourcebuild nuspec
+         because the full nuspec references Windows-only executables (net48 .exe, DumpMinitool, etc.) -->
+    <NuspecFile Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(OS)' == 'Windows_NT'">Microsoft.TestPlatform.CLI.nuspec</NuspecFile>
+    <NuspecFile Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(OS)' != 'Windows_NT'">Microsoft.TestPlatform.CLI.sourcebuild.nuspec</NuspecFile>
     <NuspecFile Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildFromVMR)' != 'true'">Microsoft.TestPlatform.CLI.sourcebuild.nuspec</NuspecFile>
     <NuspecFile Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildFromVMR)' == 'true'">Microsoft.TestPlatform.CLI.sourcebuild.product.nuspec</NuspecFile>
     <IsPackable>true</IsPackable>
@@ -47,7 +50,7 @@
     <!-- EventLogCollector only works on Windows and .NET Framework. -->
     <ProjectReference Include="..\..\DataCollectors\Microsoft.TestPlatform.Extensions.EventLogCollector\Microsoft.TestPlatform.Extensions.EventLogCollector.csproj"
                       SetTargetFramework="TargetFramework=$(NetFrameworkRunnerTargetFramework)"
-                      Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
+                      Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(OS)' == 'Windows_NT'" />
     <ProjectReference Include="..\..\Microsoft.TestPlatform.Extensions.BlameDataCollector\Microsoft.TestPlatform.Extensions.BlameDataCollector.csproj" />
     <ProjectReference Include="..\..\Microsoft.TestPlatform.Extensions.TrxLogger\Microsoft.TestPlatform.Extensions.TrxLogger.csproj" />
     <ProjectReference Include="..\..\Microsoft.TestPlatform.Extensions.HtmlLogger\Microsoft.TestPlatform.Extensions.HtmlLogger.csproj" />
@@ -68,7 +71,7 @@
     <ProjectReference Include="..\..\testhost.arm64\testhost.arm64.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(OS)' == 'Windows_NT'">
     <!-- We are forcing the reference here to .NET Framework project for both .NET and .NET Framework builds.
     This is because we are offloading the dumping to this tool on Windows, and we need this tool to run anywhere with any selected architecture, and using .NET Framework (or eventually .NET Native)
     prevents us from having to lookup the correct .NET runtime. -->

--- a/src/package/Microsoft.TestPlatform.Portable/Microsoft.TestPlatform.Portable.csproj
+++ b/src/package/Microsoft.TestPlatform.Portable/Microsoft.TestPlatform.Portable.csproj
@@ -16,8 +16,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Don't produce this package when building the .NET product as it relies on a VS license. -->
-    <IsPackable Condition="'$(DotNetBuild)' != 'true'">true</IsPackable>
+    <!-- Don't produce this package when building the .NET product as it relies on a VS license.
+         Also don't produce on non-Windows as the package contains Windows-only executables (net48 .exe, DumpMinitool, etc.). -->
+    <IsPackable Condition="'$(DotNetBuild)' != 'true' and '$(OS)' == 'Windows_NT'">true</IsPackable>
     <NuspecFile>Microsoft.TestPlatform.Portable.nuspec</NuspecFile>
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
     <PackageId>Microsoft.TestPlatform.Portable</PackageId>

--- a/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.csproj
+++ b/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.csproj
@@ -15,8 +15,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Don't produce this package when building the .NET product as it relies on a VS license. -->
-    <IsPackable Condition="'$(DotNetBuild)' != 'true'">true</IsPackable>
+    <!-- Don't produce this package when building the .NET product as it relies on a VS license.
+         Also don't produce on non-Windows as the package contains Windows-only executables and references. -->
+    <IsPackable Condition="'$(DotNetBuild)' != 'true' and '$(OS)' == 'Windows_NT'">true</IsPackable>
     <NuspecFile>Microsoft.TestPlatform.nuspec</NuspecFile>
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
     <PackageId>Microsoft.TestPlatform</PackageId>

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
@@ -529,6 +529,8 @@ public class IntegrationTestBuild : IntegrationTestBase
 
         // Extract locally built packages that have our tools (like vstest.console.exe) into tmp directory,
         // so we can use them to run tests.
+        // Some packages (Microsoft.TestPlatform, Microsoft.TestPlatform.Portable) are only produced on Windows;
+        // on Linux/macOS they may not exist and are skipped gracefully.
         var packagesToExtract = new[]
 {
             $"Microsoft.TestPlatform.{netTestSdkVersion}.nupkg",
@@ -543,6 +545,13 @@ public class IntegrationTestBuild : IntegrationTestBase
         {
             var packagePath = Path.Combine(IntegrationTestEnvironment.LocalPackageSource, packageName);
             var unzipPath = Path.Combine(IntegrationTestEnvironment.PublishDirectory, packageName);
+
+            if (!File.Exists(packagePath))
+            {
+                // Package was not produced in this build (e.g. Windows-only packages on Linux/macOS). Skip it.
+                Debug.WriteLine($"Package not found, skipping extraction: {packagePath}");
+                continue;
+            }
 
             var cacheMarkerPath = Path.Combine(unzipPath, packageName + ".cache");
             if (File.Exists(cacheMarkerPath))


### PR DESCRIPTION
🤖 **Automated fix by Copilot**

Fixes #15508

## Root Cause

`./build.sh --pack` fails on Linux for three reasons:

1. **`Microsoft.TestPlatform.CLI.csproj`** unconditionally selects `Microsoft.TestPlatform.CLI.nuspec` for non-source-builds. That nuspec references Windows-only content (net48 `.exe` executables, `DumpMinitool` binaries, net462 frame content) that doesn't exist on Linux.

2. **`Microsoft.TestPlatform.Portable.csproj`** and **`Microsoft.TestPlatform.csproj`** both reference Windows-only SDK packages (`Microsoft.Internal.*`, `Microsoft.VisualStudio.*`, `Microsoft.VSSDK.BuildTools`, etc.) and Windows-only executables. These packages can't be restored or their content produced on Linux.

3. **`IntegrationTestBuild.cs`** unconditionally expects all 5 packages to exist when running integration tests — it throws errors if any are missing.

## Fix

- **`Microsoft.TestPlatform.CLI.csproj`**: On non-Windows, use `Microsoft.TestPlatform.CLI.sourcebuild.nuspec` (same nuspec already used for `DotNetBuildSourceOnly` builds). It produces a cross-platform `contentFiles/any/net10.0/` layout which is exactly what `IntegrationTestBase.GetDotnetRunnerPath()` already expects.

- **`Microsoft.TestPlatform.CLI.csproj`**: Skip `EventLogCollector` and `DumpMinitool` project references on non-Windows, since they produce Windows-only binaries not needed by the sourcebuild nuspec.

- **`Microsoft.TestPlatform.Portable.csproj`** and **`Microsoft.TestPlatform.csproj`**: Set `IsPackable = false` on non-Windows. The packing infrastructure for these packages relies on Windows-only internal NuGet packages that can't be resolved on Linux.

- **`IntegrationTestBuild.cs`**: Check `File.Exists(packagePath)` before extracting — packages not produced on the current OS are silently skipped. The .NET Core integration test path (`GetDotnetRunnerPath()`) only needs `Microsoft.TestPlatform.CLI`, which is now produced on Linux.

## Result

After these changes:
- `./build.sh --pack` succeeds on Linux, producing `Microsoft.TestPlatform.CLI.{version}.nupkg` (and other cross-platform packages)
- .NET Core integration tests can run on Linux using the locally built CLI package
- Windows CI behavior is unchanged (all new conditions are gated on `'$(OS)' == 'Windows_NT'`)
- Desktop runner tests (using `vstest.console.exe` + net462) still require Windows packages




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/26989740248)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 26989740248, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/26989740248 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->