### PR TITLE
[fix] Fix missing dumps for .NET Framework child processes in NetClientHangDumper

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/NetClientHangDumper.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/NetClientHangDumper.cs
@@ -79,9 +79,10 @@ internal class NetClientHangDumper : IHangDumper
                     {
                         EqtTrace.Error($"NetClientHangDumper.Dump: Error dumping process {p.Id} - {p.ProcessName} via DiagnosticsClient: {ex}.");
 
-                        // DiagnosticsClient can only connect to .NET Core/5+ processes. For .NET Framework or native
-                        // child processes there is no diagnostics socket, so WriteDump throws. On Windows, fall back
-                        // to MiniDumpWriteDump which works for any Windows process.
+                        // DiagnosticsClient can only connect to .NET Core/5+ processes. On Windows, fall back
+                        // to MiniDumpWriteDump for any DiagnosticsClient failure — this primarily covers .NET Framework
+                        // and native child processes with no diagnostics socket, but also acts as a last resort for
+                        // other transient failures. FileMode.Create in CollectDump ensures any partial output is replaced.
                         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                         {
                             EqtTrace.Verbose($"NetClientHangDumper.Dump: Falling back to MiniDumpWriteDump for process {p.Id} - {p.ProcessName}.");

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/NetClientHangDumper.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/NetClientHangDumper.cs
@@ -6,11 +6,13 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
 
 namespace Microsoft.TestPlatform.Extensions.BlameDataCollector;
@@ -62,9 +64,9 @@ internal class NetClientHangDumper : IHangDumper
             tasks.Add(Task.Run(
                 () =>
                 {
+                    var outputFile = Path.Combine(outputDirectory, $"{p.ProcessName}_{p.Id}_{DateTime.Now:yyyyMMddTHHmmss}_hangdump.dmp");
                     try
                     {
-                        var outputFile = Path.Combine(outputDirectory, $"{p.ProcessName}_{p.Id}_{DateTime.Now:yyyyMMddTHHmmss}_hangdump.dmp");
                         EqtTrace.Verbose($"NetClientHangDumper.CollectDump: Selected dump type {type}. Dumping {p.Id} - {p.ProcessName} in {outputFile}. ");
 
                         var client = new DiagnosticsClient(p.Id);
@@ -75,7 +77,23 @@ internal class NetClientHangDumper : IHangDumper
                     }
                     catch (Exception ex)
                     {
-                        EqtTrace.Error($"NetClientHangDumper.Dump: Error dumping process {p.Id} - {p.ProcessName}: {ex}.");
+                        EqtTrace.Error($"NetClientHangDumper.Dump: Error dumping process {p.Id} - {p.ProcessName} via DiagnosticsClient: {ex}.");
+
+                        // DiagnosticsClient can only connect to .NET Core/5+ processes. For .NET Framework or native
+                        // child processes there is no diagnostics socket, so WriteDump throws. On Windows, fall back
+                        // to MiniDumpWriteDump which works for any Windows process.
+                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        {
+                            EqtTrace.Verbose($"NetClientHangDumper.Dump: Falling back to MiniDumpWriteDump for process {p.Id} - {p.ProcessName}.");
+                            try
+                            {
+                                WindowsHangDumper.CollectDump(new ProcessHelper(), p, outputFile, type);
+                            }
+                            catch (Exception fallbackEx)
+                            {
+                                EqtTrace.Error($"NetClientHangDumper.Dump: Fallback dump also failed for process {p.Id} - {p.ProcessName}: {fallbackEx}.");
+                            }
+                        }
                     }
                 }, timeout.Token));
         }


### PR DESCRIPTION
## Summary

🤖 *This is an automated fix created by the Issue Repro Triage & Auto-Fix agent.*

Fixes #15580

## Root Cause

`NetClientHangDumper` is used on Windows for `.NETCoreApp` targets and on all platforms for Linux/macOS. It uses `DiagnosticsClient.WriteDump()` (from `Microsoft.Diagnostics.NETCore.Client`) to collect hang dumps from the process tree.

However, `DiagnosticsClient` can only connect to **managed .NET Core/5+** processes via the diagnostics IPC socket. When a .NET Core test host has **child processes that target .NET Framework** (net462, net48, etc.) or native processes, there is no diagnostics socket — `WriteDump()` throws after a 30-second timeout. The exception was silently swallowed with only an error log, resulting in missing dump files for those child processes.

## Fix

On Windows, when `DiagnosticsClient.WriteDump()` fails, fall back to `WindowsHangDumper.CollectDump()` which uses `MiniDumpWriteDump` via P/Invoke (`dbghelp.dll`). This API works for **any Windows process**, regardless of runtime (.NET Framework, native, etc.).

Changes:
- Move `outputFile` path computation before the `try` block so it's accessible in the catch
- Add Windows fallback to `WindowsHangDumper.CollectDump()` in the catch block
- Both the primary failure and any secondary fallback failure are logged clearly

## Testing

Existing unit tests pass. The existing `HangDumpChildProcesses` acceptance test in `BlameDataCollectorTests.cs` covers the child-process dump collection path (for .NET Core child processes). A new test specifically for .NET Framework child processes would require a Windows-only test asset and is not added here — the fallback path is exercised whenever `DiagnosticsClient` fails for any reason on Windows.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/27048597282)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 27048597282, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/27048597282 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->