### PR TITLE
[link-checker] Fix broken documentation links

### DIFF
--- a/docs/RFCs/0029-Debugging-External-Test-Processes.md
+++ b/docs/RFCs/0029-Debugging-External-Test-Processes.md
@@ -4,7 +4,7 @@
 Introduce APIs to improve debugging support in Visual Studio for tests that run in an external process other than `testhost*.exe`.
 
 # Motivation
-Some test frameworks (examples include [TAEF](https://docs.microsoft.com/en-us/windows-hardware/drivers/taef/) and [Python](https://docs.microsoft.com/en-us/visualstudio/python/unit-testing-python-in-visual-studio)) need to execute tests in a external process other than `testhost*.exe`. When it comes to debugging such tests in Visual Studio today, there are a couple of problems. 
+Some test frameworks (examples include [TAEF](https://learn.microsoft.com/en-us/windows-hardware/drivers/taef/) and [Python](https://learn.microsoft.com/en-us/visualstudio/python/unit-testing-python-in-visual-studio)) need to execute tests in a external process other than `testhost*.exe`. When it comes to debugging such tests in Visual Studio today, there are a couple of problems. 
 
 1. A test adapter can request to launch a child process with debugger attached by calling  [`IFrameworkHandle.LaunchProcessWithDebuggerAttached()`](./src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/IFrameworkHandle.cs#L29) within adapter's implementation of [`ITestExecutor.RunTests()`](./src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/ITestExecutor.cs#L23) (after checking that [`IRunContext.IsBeingDebugged`](./src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/IRunContext.cs#L32) is `true`). However, there is no supported way for a test adapter to request that debugger should be attached to an **already running process**.
 

--- a/docs/RFCs/0031-Test-Run-Attachments-Processing.md
+++ b/docs/RFCs/0031-Test-Run-Attachments-Processing.md
@@ -6,7 +6,7 @@ This document details a data collector extensibility point to reprocess (combine
 # Motivation
 Today when Test Platform executes tests in parallel only code coverage reports are merged (data collector attachments with uri: `datacollector://microsoft/CodeCoverage/2.0`). For other data collector attachments reprocessing is skipped and all of them are returned by Test Platform.
 
-The [dotnet test](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test) command is used to execute unit tests in a given solution. The `dotnet test` command builds the solution and runs a test host application for each test project in the solution. However, currently there is no way to reprocess(combine/merge) data collector attachments associated with each project execution. Code coverage reports are not merged.
+The [dotnet test](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test) command is used to execute unit tests in a given solution. The `dotnet test` command builds the solution and runs a test host application for each test project in the solution. However, currently there is no way to reprocess(combine/merge) data collector attachments associated with each project execution. Code coverage reports are not merged.
 
 When `Run All Tests` is performed in VS, tests for projects can be executed separately based on target platform/target framework amongst other criteria. In this case also combining/merging of data collector attachments is not performed (e.g. code overage reports are not merged). `Analyze Code Coverage for All Tests` is showing coverage report for only some test projects in the run.
 
@@ -125,7 +125,7 @@ Interface provides callbacks from test run attachments processing. For every suc
 
 4. Use above logic to reprocess data collector attachments for parallel test executions and VS scenarios (e.g. `Run All Tests`, `Analyze Code Coverage for All Tests`). In case of `Analyze Code Coverage for All Tests` VS will use `vstest.console` in a variation of design mode and merge all code coverage reports. VS will show full code coverage report for all test projects.
 
-5. When [dotnet test](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test) command is used to execute unit tests in a given solution, attachments will also be reprocessed. Details regarding this process will be provided in separate RFC.
+5. When [dotnet test](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test) command is used to execute unit tests in a given solution, attachments will also be reprocessed. Details regarding this process will be provided in separate RFC.
 
 # Additional classes
 

--- a/docs/analyze.md
+++ b/docs/analyze.md
@@ -197,7 +197,7 @@ Use the `Analyze Code Coverage` context menu available in `Test Explorer` tool w
 
 After the coverage run is complete, a detailed report will be available in the `Code Coverage Results` tool window.
 
-Please refer the documentation for additional details: <https://docs.microsoft.com/en-us/visualstudio/test/using-code-coverage-to-determine-how-much-code-is-being-tested>
+Please refer the documentation for additional details: <https://learn.microsoft.com/en-us/visualstudio/test/using-code-coverage-to-determine-how-much-code-is-being-tested>
 
 ### Collect coverage with command line runner
 

--- a/docs/dotnetcoretests.md
+++ b/docs/dotnetcoretests.md
@@ -12,6 +12,6 @@ When dotnet build runs, the above mentioned packages are restored to the users' 
   }
 }
 
-In the case of the customer, the nuget packages aren't being restored to the paths defined in the <UnitTestProject>.runtimeconfig.dev.json resulting in the testhost.dll not being determined. The locations used for the nuget packages can be determined using the below : https://docs.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders#viewing-folder-locations
+In the case of the customer, the nuget packages aren't being restored to the paths defined in the <UnitTestProject>.runtimeconfig.dev.json resulting in the testhost.dll not being determined. The locations used for the nuget packages can be determined using the below : https://learn.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders#viewing-folder-locations
 
 To mitigate the issue and as a general recommendation for running dot net core tests with vstest task please ask the customer to publish the test project and point to the publish location for running tests. Publish ensures all needed dependencies are present for the tests to be executed alongside the test dll in case of dot net core tests.

--- a/docs/extensions/JSTestAdapter.md
+++ b/docs/extensions/JSTestAdapter.md
@@ -128,7 +128,7 @@ To run these tests with distribution across multiple agents:
 
    ![Imgur](https://i.imgur.com/Uv1IBRC.png)
 
-*Since multi-configuration and multi-agent job options are not exported to YAML. They can be configured by following this guide, https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml.*
+*Since multi-configuration and multi-agent job options are not exported to YAML. They can be configured by following this guide, https://learn.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml.*
 
 #### Limitations
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -277,7 +277,7 @@ Note: these logs could contain sensitive information (paths, project name...). M
 ## Use procdump on Windows
 
 Sometimes it's not possible to take the dump using test platform tool because the crash happen before we're able to attach to the process to take the dump self. In that situation we need a way to register for dump at process startup level.  
-To achieve it we can use [procdump](https://docs.microsoft.com/sysinternals/downloads/procdump) that will install machine wide Just-in-time (AeDebug) debugger.
+To achieve it we can use [procdump](https://learn.microsoft.com/sysinternals/downloads/procdump) that will install machine wide Just-in-time (AeDebug) debugger.
 
 ```shell
 PS C:\tools\Procdump> .\procdump.exe -i C:\tools\Procdump\dumps


### PR DESCRIPTION
## Summary

Updated 7 broken documentation links across 6 files. The `docs.microsoft.com` domain was migrated to `learn.microsoft.com` — all occurrences in active documentation have been updated to the new canonical URLs.

## Links Fixed (7)

| File | Old URL | New URL |
|------|---------|---------|
| `docs/RFCs/0029-Debugging-External-Test-Processes.md` | `docs.microsoft.com/en-us/windows-hardware/drivers/taef/` | `learn.microsoft.com/en-us/windows-hardware/drivers/taef/` |
| `docs/RFCs/0029-Debugging-External-Test-Processes.md` | `docs.microsoft.com/en-us/visualstudio/python/unit-testing-python-in-visual-studio` | `learn.microsoft.com/en-us/visualstudio/python/unit-testing-python-in-visual-studio` |
| `docs/RFCs/0031-Test-Run-Attachments-Processing.md` (×2) | `docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test` | `learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test` |
| `docs/troubleshooting.md` | `docs.microsoft.com/sysinternals/downloads/procdump` | `learn.microsoft.com/sysinternals/downloads/procdump` |
| `docs/analyze.md` | `docs.microsoft.com/en-us/visualstudio/test/using-code-coverage-to-determine-how-much-code-is-being-tested` | `learn.microsoft.com/en-us/visualstudio/test/using-code-coverage-to-determine-how-much-code-is-being-tested` |
| `docs/extensions/JSTestAdapter.md` | `docs.microsoft.com/en-us/azure/devops/pipelines/process/phases` | `learn.microsoft.com/en-us/azure/devops/pipelines/process/phases` |
| `docs/dotnetcoretests.md` | `docs.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders` | `learn.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders` |

## Links Added to Unfixable List

The following broken links were identified but cannot be fixed (historical records or permanently removed content):

- **`dotnet.myget.org`** — MyGet service shut down; all package feed links in `docs/RFCs/0005-Test-Platform-SDK.md` are historical
- **`github.com/karanjitsingh/JSTestAdapter`** — Repository deleted by owner
- **`github.com/dotnet/cli/blob/rel/1.0.0`** — Old deleted branch, content moved to dotnet/sdk
- **Old NuGet preview package versions** — Historical entries in `docs/releases.md` only
- **Old GitHub compare links** — Historical changelog entries referencing deleted tags
- **`(localhost/redacted) — Placeholder URL in XML schema examples




> [!WARNING]
> <details>
> <summary>Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `docs.microsoft.com`
>> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "docs.microsoft.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Daily Link Checker & Fixer](https://github.com/microsoft/vstest/actions/runs/27138550331) · sonnet46 1.9M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+link-checker%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/link-checker.md@c02eadfca420f2b351f9fcaee883c507a63ca316
```
</details>


<!-- gh-aw-agentic-workflow: Daily Link Checker & Fixer, engine: copilot, version: 1.0.55, model: claude-sonnet-4.6, id: 27138550331, workflow_id: link-checker, run: https://github.com/microsoft/vstest/actions/runs/27138550331 -->

<!-- gh-aw-workflow-id: link-checker -->