### PR TITLE
[fix] Add TreatErrorMessagesAsWarnings parameter to TRX logger

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -149,8 +149,8 @@ public class TrxLogger : ITestLoggerWithParameters
         _treatErrorMessagesAsWarnings = parameters.TryGetValue(TrxLoggerConstants.TreatErrorMessagesAsWarnings, out string? treatErrorMessagesAsWarningsString)
             ? bool.TryParse(treatErrorMessagesAsWarningsString, out bool treatErrorMessagesAsWarningsValue)
                 ? treatErrorMessagesAsWarningsValue
-                // We found the option but could not parse the value, default to true.
-                : true
+                // We found the option but could not parse the value; preserve existing behavior.
+                : false
             // We did not find the option, default to false to preserve existing behavior.
             : false;
 

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -89,6 +89,7 @@ public class TrxLogger : ITestLoggerWithParameters
     /// </summary>
     private string? _testResultsDirPath;
     private bool _warnOnFileOverwrite;
+    private bool _treatErrorMessagesAsWarnings;
 
 
     #region ITestLogger
@@ -144,6 +145,14 @@ public class TrxLogger : ITestLoggerWithParameters
                 : true
             // We did not find the option and want to fallback to warning on write, because that was the default before.
             : true;
+
+        _treatErrorMessagesAsWarnings = parameters.TryGetValue(TrxLoggerConstants.TreatErrorMessagesAsWarnings, out string? treatErrorMessagesAsWarningsString)
+            ? bool.TryParse(treatErrorMessagesAsWarningsString, out bool treatErrorMessagesAsWarningsValue)
+                ? treatErrorMessagesAsWarningsValue
+                // We found the option but could not parse the value, default to true.
+                : true
+            // We did not find the option, default to false to preserve existing behavior.
+            : false;
 
         if (isLogFilePrefixParameterExists && isLogFileNameParameterExists)
         {
@@ -261,7 +270,11 @@ public class TrxLogger : ITestLoggerWithParameters
                 _runLevelErrorsAndWarnings.Add(runMessage);
                 break;
             case TestMessageLevel.Error:
-                TestResultOutcome = TrxLoggerObjectModel.TestOutcome.Failed;
+                if (!_treatErrorMessagesAsWarnings)
+                {
+                    TestResultOutcome = TrxLoggerObjectModel.TestOutcome.Failed;
+                }
+
                 runMessage = new RunInfo(e.Message, null, Environment.MachineName, TrxLoggerObjectModel.TestOutcome.Error);
                 _runLevelErrorsAndWarnings.Add(runMessage);
                 break;

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Constants.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Constants.cs
@@ -84,7 +84,7 @@ internal static class Constants
     /// Treat error-level run messages (e.g. from data collectors) as warnings,
     /// preventing them from marking the TRX result summary as Failed.
     /// </summary>
-    public static string TreatErrorMessagesAsWarnings = "TreatErrorMessagesAsWarnings";
+    public const string TreatErrorMessagesAsWarnings = "TreatErrorMessagesAsWarnings";
 
     /// <summary>
     /// Mstest adapter string

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Constants.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Constants.cs
@@ -81,6 +81,12 @@ internal static class Constants
     public static string WarnOnFileOverwrite = "WarnOnFileOverwrite";
 
     /// <summary>
+    /// Treat error-level run messages (e.g. from data collectors) as warnings,
+    /// preventing them from marking the TRX result summary as Failed.
+    /// </summary>
+    public static string TreatErrorMessagesAsWarnings = "TreatErrorMessagesAsWarnings";
+
+    /// <summary>
     /// Mstest adapter string
     /// </summary>
     public const string MstestAdapterString = "mstestadapter";

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/LoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/LoggerTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -185,6 +186,64 @@ public class LoggerTests : AcceptanceTestBase
         arguments = string.Concat(arguments, " -- RunConfiguration.TreatNoTestsAsError=false");
 
         InvokeVsTest(arguments);
+
+        string? outcomeValue = GetElementAttributeValueFromTrx(trxFilePath, "ResultSummary", "outcome");
+
+        Assert.AreEqual("Completed", outcomeValue);
+    }
+
+    [TestMethod]
+    [NetFullTargetFrameworkDataSource]
+    [NetCoreTargetFrameworkDataSource]
+    public void TrxLoggerResultSummaryOutcomeValueShouldBeFailedWhenDataCollectorLogsError(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var assemblyPath = GetSampleTestAssembly();
+        var extensionsPath = Path.GetDirectoryName(GetTestDllForFramework("OutOfProcDataCollector.dll", "netstandard2.0"));
+        var trxFilePath = Path.Combine(TempDirectory.Path, "TrxLogger.trx");
+
+        var arguments = PrepareArguments(assemblyPath, null, null, FrameworkArgValue, runnerInfo.InIsolationValue, TempDirectory.Path);
+        arguments = string.Concat(arguments, $" /TestCaseFilter:PassingTest");
+        arguments = string.Concat(arguments, $" /Collect:SampleDataCollector");
+        arguments = string.Concat(arguments, $" /TestAdapterPath:{extensionsPath}");
+        arguments = string.Concat(arguments, $" /logger:\"trx;LogFileName={trxFilePath}\"");
+
+        var env = new Dictionary<string, string?>
+        {
+            ["TEST_ASSET_SAMPLE_COLLECTOR_PATH"] = TempDirectory.Path,
+        };
+
+        InvokeVsTest(arguments, env);
+
+        string? outcomeValue = GetElementAttributeValueFromTrx(trxFilePath, "ResultSummary", "outcome");
+
+        Assert.AreEqual("Failed", outcomeValue);
+    }
+
+    [TestMethod]
+    [NetFullTargetFrameworkDataSource]
+    [NetCoreTargetFrameworkDataSource]
+    public void TrxLoggerResultSummaryOutcomeValueShouldBeCompletedWhenDataCollectorLogsErrorAndTreatErrorMessagesAsWarningsIsTrue(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var assemblyPath = GetSampleTestAssembly();
+        var extensionsPath = Path.GetDirectoryName(GetTestDllForFramework("OutOfProcDataCollector.dll", "netstandard2.0"));
+        var trxFilePath = Path.Combine(TempDirectory.Path, "TrxLogger.trx");
+
+        var arguments = PrepareArguments(assemblyPath, null, null, FrameworkArgValue, runnerInfo.InIsolationValue, TempDirectory.Path);
+        arguments = string.Concat(arguments, $" /TestCaseFilter:PassingTest");
+        arguments = string.Concat(arguments, $" /Collect:SampleDataCollector");
+        arguments = string.Concat(arguments, $" /TestAdapterPath:{extensionsPath}");
+        arguments = string.Concat(arguments, $" /logger:\"trx;LogFileName={trxFilePath};TreatErrorMessagesAsWarnings=true\"");
+
+        var env = new Dictionary<string, string?>
+        {
+            ["TEST_ASSET_SAMPLE_COLLECTOR_PATH"] = TempDirectory.Path,
+        };
+
+        InvokeVsTest(arguments, env);
 
         string? outcomeValue = GetElementAttributeValueFromTrx(trxFilePath, "ResultSummary", "outcome");
 

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -146,6 +146,56 @@ public class TrxLoggerTests
     }
 
     [TestMethod]
+    public void TestMessageHandlerShouldSetOutcomeToFailedWhenErrorMessageIsReceived()
+    {
+        string message = "An error message";
+        TestRunMessageEventArgs trme = new(TestMessageLevel.Error, message);
+        _testableTrxLogger.TestMessageHandler(new object(), trme);
+
+        Assert.AreEqual(TrxLoggerObjectModel.TestOutcome.Failed, _testableTrxLogger.TestResultOutcome);
+    }
+
+    [TestMethod]
+    public void TestMessageHandlerShouldNotSetOutcomeToFailedWhenTreatErrorMessagesAsWarningsIsEnabled()
+    {
+        var events = new Mock<TestLoggerEvents>();
+        var parameters = new Dictionary<string, string?>
+        {
+            [DefaultLoggerParameterNames.TestRunDirectory] = DefaultTestRunDirectory,
+            [TrxLoggerConstants.LogFileNameKey] = "test.trx",
+            [TrxLoggerConstants.TreatErrorMessagesAsWarnings] = "true",
+        };
+        var logger = new TestableTrxLogger();
+        logger.Initialize(events.Object, parameters);
+
+        string message = "A data collector error message";
+        TestRunMessageEventArgs trme = new(TestMessageLevel.Error, message);
+        logger.TestMessageHandler(new object(), trme);
+
+        Assert.AreEqual(TrxLoggerObjectModel.TestOutcome.Passed, logger.TestResultOutcome);
+    }
+
+    [TestMethod]
+    public void TestMessageHandlerShouldStillRecordErrorMessageWhenTreatErrorMessagesAsWarningsIsEnabled()
+    {
+        var events = new Mock<TestLoggerEvents>();
+        var parameters = new Dictionary<string, string?>
+        {
+            [DefaultLoggerParameterNames.TestRunDirectory] = DefaultTestRunDirectory,
+            [TrxLoggerConstants.LogFileNameKey] = "test.trx",
+            [TrxLoggerConstants.TreatErrorMessagesAsWarnings] = "true",
+        };
+        var logger = new TestableTrxLogger();
+        logger.Initialize(events.Object, parameters);
+
+        string message = "A data collector error message";
+        TestRunMessageEventArgs trme = new(TestMessageLevel.Error, message);
+        logger.TestMessageHandler(new object(), trme);
+
+        Assert.HasCount(1, logger.GetRunLevelErrorsAndWarnings());
+    }
+
+    [TestMethod]
     public void TestResultHandlerShouldCaptureStartTimeInSummaryWithTimeStampDuringIntialize()
     {
         TestCase testCase = CreateTestCase("dummy string");


### PR DESCRIPTION
## 🤖 Automated Fix

Fixes issue #10391: Data Collector Errors Cause TRX Result to be Failed.

## Root Cause

In `TrxLogger.TestMessageHandler`, the `case TestMessageLevel.Error:` branch unconditionally sets `TestResultOutcome = TestOutcome.Failed`. This means any error-level message — including those from data collectors that fail during session teardown — marks the entire TRX result as failed, even when all tests actually passed.

## Fix

Adds a new `TreatErrorMessagesAsWarnings` logger parameter. When set to `true`, error-level run messages no longer update `TestResultOutcome`, so the overall TRX outcome reflects actual test results rather than data collector errors.

**Usage:**
```
dotnet test ... --logger "trx;TreatErrorMessagesAsWarnings=true"
```
or with vstest.console:
```
vstest.console.exe ... /logger:"trx;TreatErrorMessagesAsWarnings=true"
```

Error messages are still recorded in the TRX file's `ErrorInfo` section — they are not silenced, just excluded from the pass/fail decision.

## Changes

- **`Constants.cs`**: Add `TreatErrorMessagesAsWarnings` string constant (follows the same pattern as `WarnOnFileOverwrite`)
- **`TrxLogger.cs`**: Read the parameter in `Initialize(TestLoggerEvents, Dictionary<string, string?>)` and skip setting `TestResultOutcome = Failed` when `_treatErrorMessagesAsWarnings` is `true`
- **`TrxLoggerTests.cs`**: Unit tests for default behavior (backward compatible) and new parameter behavior
- **`LoggerTests.cs`**: Acceptance tests using `OutOfProcDataCollector` (which logs errors in `SessionEnded_Handler`) to verify the real end-to-end pipeline:
  - Without parameter: TRX outcome is `Failed` even when only `PassingTest` ran ✓
  - With `TreatErrorMessagesAsWarnings=true`: TRX outcome is `Completed` ✓

## Default Behavior

The default remains unchanged (backward compatible): `TreatErrorMessagesAsWarnings` defaults to `false`, preserving existing behavior where any error message marks the run as failed.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/27280507487)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 27280507487, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/27280507487 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->