### PR TITLE
[fix] Include testhost process path in crash error messages

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -51,6 +51,7 @@ public class ProxyOperationManager
     private bool _testHostLaunched;
     private int _testHostProcessId;
     private string? _testHostProcessStdError;
+    private string? _testHostProcessFileName;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProxyOperationManager"/> class.
@@ -231,6 +232,7 @@ public class ProxyOperationManager
                 sources,
                 envVars,
                 connectionInfo));
+        _testHostProcessFileName = testHostStartInfo.FileName;
         try
         {
             // Launch the test host.
@@ -512,7 +514,7 @@ public class ProxyOperationManager
         // If not it reports timeout, if we don't set this before OnClientProcessExit we will
         // report timeout even though we exited the test host before even attempting the connect.
         _testHostExited.Set();
-        RequestSender.OnClientProcessExit(_testHostProcessStdError);
+        RequestSender.OnClientProcessExit(BuildCrashErrorContext(_testHostProcessFileName, _testHostProcessStdError));
     }
 
     private void ThrowOnTestHostExited(IEnumerable<string> sources, bool testHostExited)
@@ -521,7 +523,7 @@ public class ProxyOperationManager
         {
             // We might consider passing standard output here in case standard error is not
             // available because some errors don't end up in the standard error output.
-            throw new TestPlatformException(string.Format(CultureInfo.CurrentCulture, CrossPlatEngineResources.TestHostExitedWithError, string.Join("', '", sources), _testHostProcessStdError));
+            throw new TestPlatformException(string.Format(CultureInfo.CurrentCulture, CrossPlatEngineResources.TestHostExitedWithError, string.Join("', '", sources), BuildCrashErrorContext(_testHostProcessFileName, _testHostProcessStdError)));
         }
     }
 
@@ -552,12 +554,26 @@ public class ProxyOperationManager
         }
 
         // After testhost process launched failed with error.
-        if (!StringUtils.IsNullOrWhiteSpace(_testHostProcessStdError))
+        if (!StringUtils.IsNullOrWhiteSpace(_testHostProcessStdError) || !StringUtils.IsNullOrWhiteSpace(_testHostProcessFileName))
         {
             // Testhost failed with error.
-            errorMsg = string.Format(CultureInfo.CurrentCulture, CrossPlatEngineResources.TestHostExitedWithError, string.Join("', '", sources), _testHostProcessStdError);
+            errorMsg = string.Format(CultureInfo.CurrentCulture, CrossPlatEngineResources.TestHostExitedWithError, string.Join("', '", sources), BuildCrashErrorContext(_testHostProcessFileName, _testHostProcessStdError));
         }
 
         throw new TestPlatformException(errorMsg);
+    }
+
+    private static string BuildCrashErrorContext(string? processFileName, string? stdError)
+    {
+        var hasPath = !StringUtils.IsNullOrWhiteSpace(processFileName);
+        var hasError = !StringUtils.IsNullOrWhiteSpace(stdError);
+
+        return (hasPath, hasError) switch
+        {
+            (true, true) => $"Process path: {processFileName}{Environment.NewLine}{stdError}",
+            (true, false) => $"Process path: {processFileName}",
+            (false, true) => stdError!,
+            _ => string.Empty,
+        };
     }
 }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -561,7 +561,7 @@ public class ProxyOperationManager
         else if (!StringUtils.IsNullOrWhiteSpace(_testHostProcessFileName))
         {
             // Process launched but no stderr — append path as a diagnostic addendum without overwriting the timeout message.
-            errorMsg += $" Process path: {_testHostProcessFileName}";
+            errorMsg += BuildCrashErrorContext(_testHostProcessFileName, null);
         }
 
         throw new TestPlatformException(errorMsg);

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -556,7 +556,6 @@ public class ProxyOperationManager
         // After testhost process crashed (stderr present), replace the message with a diagnostic one.
         if (!StringUtils.IsNullOrWhiteSpace(_testHostProcessStdError))
         {
-            // Testhost failed with error.
             errorMsg = string.Format(CultureInfo.CurrentCulture, CrossPlatEngineResources.TestHostExitedWithError, string.Join("', '", sources), BuildCrashErrorContext(_testHostProcessFileName, _testHostProcessStdError));
         }
         else if (!StringUtils.IsNullOrWhiteSpace(_testHostProcessFileName))

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -553,11 +553,16 @@ public class ProxyOperationManager
             }
         }
 
-        // After testhost process launched failed with error.
-        if (!StringUtils.IsNullOrWhiteSpace(_testHostProcessStdError) || !StringUtils.IsNullOrWhiteSpace(_testHostProcessFileName))
+        // After testhost process crashed (stderr present), replace the message with a diagnostic one.
+        if (!StringUtils.IsNullOrWhiteSpace(_testHostProcessStdError))
         {
             // Testhost failed with error.
             errorMsg = string.Format(CultureInfo.CurrentCulture, CrossPlatEngineResources.TestHostExitedWithError, string.Join("', '", sources), BuildCrashErrorContext(_testHostProcessFileName, _testHostProcessStdError));
+        }
+        else if (!StringUtils.IsNullOrWhiteSpace(_testHostProcessFileName))
+        {
+            // Process launched but no stderr — append path as a diagnostic addendum without overwriting the timeout message.
+            errorMsg += $" Process path: {_testHostProcessFileName}";
         }
 
         throw new TestPlatformException(errorMsg);

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs
@@ -561,7 +561,7 @@ public class ProxyOperationManager
         else if (!StringUtils.IsNullOrWhiteSpace(_testHostProcessFileName))
         {
             // Process launched but no stderr — append path as a diagnostic addendum without overwriting the timeout message.
-            errorMsg += BuildCrashErrorContext(_testHostProcessFileName, null);
+            errorMsg += $" {BuildCrashErrorContext(_testHostProcessFileName, null)}";
         }
 
         throw new TestPlatformException(errorMsg);

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
@@ -188,7 +188,7 @@ public class ExecutionTests : AcceptanceTestBase
         var errorMessage = "Process is terminated due to StackOverflowException.";
         if (runnerInfo.IsNetTarget)
         {
-            errorMessage = "Test host process crashed : Stack overflow.";
+            errorMessage = "Stack overflow.";
         }
 
         ExitCodeEquals(1);

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
@@ -522,7 +522,7 @@ public class ProxyOperationManagerTests : ProxyBaseManagerTests
         var operationManager = new TestableProxyOperationManager(_mockRequestData.Object, _mockRequestSender.Object, _mockTestHostManager.Object);
 
         var ex = Assert.ThrowsExactly<TestPlatformException>(() => operationManager.SetupChannel(["test.dll"], DefaultRunSettings));
-        Assert.Contains($"Process path: {processPath}", ex.Message);
+        Assert.Contains($" Process path: {processPath}", ex.Message);
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
@@ -441,6 +441,153 @@ public class ProxyOperationManagerTests : ProxyBaseManagerTests
         _testOperationManager.Close();
     }
 
+    [TestMethod]
+    public void SetupChannelShouldIncludeProcessPathAndStdErrorWhenTestHostExitsWithBoth()
+    {
+        var processPath = @"C:\testhost.exe";
+        var stdError = "Unhandled exception. System.Exception: Boom";
+
+        _mockTestHostManager.Setup(
+                m => m.GetTestHostProcessStartInfo(
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<IDictionary<string, string?>>(),
+                    It.IsAny<TestRunnerConnectionInfo>()))
+            .Returns(new TestProcessStartInfo { FileName = processPath });
+
+        _mockTestHostManager.Setup(tmh => tmh.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>()))
+            .Callback(() =>
+            {
+                _mockTestHostManager.Raise(t => t.HostLaunched += null, new HostProviderEventArgs(string.Empty));
+                _mockTestHostManager.Raise(t => t.HostExited += null, new HostProviderEventArgs(stdError));
+            })
+            .Returns(Task.FromResult(true));
+
+        _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
+
+        var operationManager = new TestableProxyOperationManager(_mockRequestData.Object, _mockRequestSender.Object, _mockTestHostManager.Object);
+
+        var ex = Assert.ThrowsExactly<TestPlatformException>(() => operationManager.SetupChannel(["test.dll"], DefaultRunSettings));
+        Assert.Contains("Process path:", ex.Message);
+        Assert.Contains(processPath, ex.Message);
+        Assert.Contains(stdError, ex.Message);
+    }
+
+    [TestMethod]
+    public void SetupChannelShouldIncludeOnlyStdErrorWhenProcessPathIsNull()
+    {
+        var stdError = "Unhandled exception. System.Exception: Boom";
+
+        _mockTestHostManager.Setup(
+                m => m.GetTestHostProcessStartInfo(
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<IDictionary<string, string?>>(),
+                    It.IsAny<TestRunnerConnectionInfo>()))
+            .Returns(new TestProcessStartInfo { FileName = null });
+
+        _mockTestHostManager.Setup(tmh => tmh.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>()))
+            .Callback(() =>
+            {
+                _mockTestHostManager.Raise(t => t.HostLaunched += null, new HostProviderEventArgs(string.Empty));
+                _mockTestHostManager.Raise(t => t.HostExited += null, new HostProviderEventArgs(stdError));
+            })
+            .Returns(Task.FromResult(true));
+
+        _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
+
+        var operationManager = new TestableProxyOperationManager(_mockRequestData.Object, _mockRequestSender.Object, _mockTestHostManager.Object);
+
+        var ex = Assert.ThrowsExactly<TestPlatformException>(() => operationManager.SetupChannel(["test.dll"], DefaultRunSettings));
+        Assert.Contains(stdError, ex.Message);
+        Assert.DoesNotContain(ex.Message, "Process path:");
+    }
+
+    [TestMethod]
+    public void SetupChannelShouldIncludeProcessPathWhenTestHostTimesOutWithNoStdError()
+    {
+        var processPath = @"C:\testhost.exe";
+
+        _mockTestHostManager.Setup(
+                m => m.GetTestHostProcessStartInfo(
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<IDictionary<string, string?>>(),
+                    It.IsAny<TestRunnerConnectionInfo>()))
+            .Returns(new TestProcessStartInfo { FileName = processPath });
+
+        _mockTestHostManager.Setup(tmh => tmh.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>()))
+            .Callback(() => _mockTestHostManager.Raise(t => t.HostLaunched += null, new HostProviderEventArgs(string.Empty)))
+            .Returns(Task.FromResult(true));
+
+        _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
+
+        var operationManager = new TestableProxyOperationManager(_mockRequestData.Object, _mockRequestSender.Object, _mockTestHostManager.Object);
+
+        var ex = Assert.ThrowsExactly<TestPlatformException>(() => operationManager.SetupChannel(["test.dll"], DefaultRunSettings));
+        Assert.Contains($"Process path: {processPath}", ex.Message);
+    }
+
+    [TestMethod]
+    public void SetupChannelShouldPassCrashContextToRequestSenderOnTestHostExit()
+    {
+        var processPath = @"C:\testhost.exe";
+        var stdError = "Fatal error";
+
+        _mockTestHostManager.Setup(
+                m => m.GetTestHostProcessStartInfo(
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<IDictionary<string, string?>>(),
+                    It.IsAny<TestRunnerConnectionInfo>()))
+            .Returns(new TestProcessStartInfo { FileName = processPath });
+
+        _mockTestHostManager.Setup(tmh => tmh.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>()))
+            .Callback(() =>
+            {
+                _mockTestHostManager.Raise(t => t.HostLaunched += null, new HostProviderEventArgs(string.Empty));
+                _mockTestHostManager.Raise(t => t.HostExited += null, new HostProviderEventArgs(stdError));
+            })
+            .Returns(Task.FromResult(true));
+
+        _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
+
+        var operationManager = new TestableProxyOperationManager(_mockRequestData.Object, _mockRequestSender.Object, _mockTestHostManager.Object);
+
+        Assert.ThrowsExactly<TestPlatformException>(() => operationManager.SetupChannel(["test.dll"], DefaultRunSettings));
+
+        // Verify OnClientProcessExit was called with the crash context containing both path and error.
+        _mockRequestSender.Verify(
+            rs => rs.OnClientProcessExit(It.Is<string>(s => s.Contains(processPath) && s.Contains(stdError))),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public void SetupChannelShouldIncludeProcessPathInErrorWhenTestHostExitsWithOnlyPath()
+    {
+        var processPath = @"C:\testhost.exe";
+
+        _mockTestHostManager.Setup(
+                m => m.GetTestHostProcessStartInfo(
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<IDictionary<string, string?>>(),
+                    It.IsAny<TestRunnerConnectionInfo>()))
+            .Returns(new TestProcessStartInfo { FileName = processPath });
+
+        _mockTestHostManager.Setup(tmh => tmh.LaunchTestHostAsync(It.IsAny<TestProcessStartInfo>(), It.IsAny<CancellationToken>()))
+            .Callback(() =>
+            {
+                _mockTestHostManager.Raise(t => t.HostLaunched += null, new HostProviderEventArgs(string.Empty));
+                // Host exits with empty stderr (no error output).
+                _mockTestHostManager.Raise(t => t.HostExited += null, new HostProviderEventArgs(string.Empty));
+            })
+            .Returns(Task.FromResult(true));
+
+        _mockRequestSender.Setup(rs => rs.WaitForRequestHandlerConnection(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
+
+        var operationManager = new TestableProxyOperationManager(_mockRequestData.Object, _mockRequestSender.Object, _mockTestHostManager.Object);
+
+        var ex = Assert.ThrowsExactly<TestPlatformException>(() => operationManager.SetupChannel(["test.dll"], DefaultRunSettings));
+        // ThrowOnTestHostExited fires first; with no stderr the crash context is just the path.
+        Assert.Contains(processPath, ex.Message);
+    }
+
     private void SetupWaitForTestHostExit()
     {
         // Raise host exited when end session is called

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
@@ -498,7 +498,7 @@ public class ProxyOperationManagerTests : ProxyBaseManagerTests
 
         var ex = Assert.ThrowsExactly<TestPlatformException>(() => operationManager.SetupChannel(["test.dll"], DefaultRunSettings));
         Assert.Contains(stdError, ex.Message);
-        Assert.DoesNotContain(ex.Message, "Process path:");
+        Assert.DoesNotContain("Process path:", ex.Message);
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Library.IntegrationTests/TranslationLayerTests/RunTests.cs
+++ b/test/Microsoft.TestPlatform.Library.IntegrationTests/TranslationLayerTests/RunTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -186,8 +187,8 @@ public class RunTests : AcceptanceTestBase
             _runEventHandler);
 
         var errorMessagePattern = runnerInfo.IsNetFrameworkTarget
-            ? $"The active test run was aborted. Reason: Test host process crashed : Process is terminated due to StackOverflowException.*"
-            : $"The active test run was aborted. Reason: Test host process crashed : Stack overflow.*";
+            ? $"The active test run was aborted. Reason: Test host process crashed : Process path: *{Environment.NewLine}Process is terminated due to StackOverflowException.*"
+            : $"The active test run was aborted. Reason: Test host process crashed : Process path: *{Environment.NewLine}Stack overflow.*";
 
         _runEventHandler.Errors.Should().ContainSingle()
             .Which.Should().Match(errorMessagePattern);


### PR DESCRIPTION
🤖 This is an automated fix.

**Related #2952**

## Root Cause

When testhost process crashes, the error messages (`Test host process crashed` and `Testhost process for source(s) '...' exited with error`) include the stderr output from the crashed process but do not include the path to the testhost executable that was launched. This makes it difficult for users to verify which testhost was actually launched, especially when debugging path-related or version-related issues.

The `ProxyOperationManager` already tracks `_testHostProcessId` and calls `GetTestHostProcessStartInfo` to get the launch info — but the `FileName` from the `TestProcessStartInfo` was not being preserved for use in error messages.

## Fix

Added a `_testHostProcessFileName` field to `ProxyOperationManager` that stores the testhost executable path when the process start info is prepared. A new private helper method `BuildCrashErrorContext` constructs the diagnostic message by combining the process path and stderr output:

- Both available: `"Process path: /path/to/testhost\n{stderr}"`
- Only path: `"Process path: /path/to/testhost"`
- Only stderr: `"{stderr}"` (backward-compatible, no change in behavior)
- Neither: `""` (backward-compatible)

This is used in three error paths:
1. **Crash during communication** (`TestHostManagerHostExited` → `RequestSender.OnClientProcessExit`)
2. **Startup crash** (`ThrowOnTestHostExited`)
3. **Connection timeout with crash** (`ThrowExceptionOnConnectionFailure`)

No public API changes were made. The `ITestRequestSender` interface is unchanged.

## Before
```
Test host process crashed : NullReferenceException: Object reference not set to an instance of an object
```

## After
```
Test host process crashed : Process path: C:\path\to\testhost.exe
NullReferenceException: Object reference not set to an instance of an object
```




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/27317667925)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 27317667925, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/27317667925 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->