### PR TITLE
[fix] Update HTTP link extractor to exclude duplicates

### DIFF
--- a/.github/workflows/http-link-checker.lock.yml
+++ b/.github/workflows/http-link-checker.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"7a2d5525779e910e67b3f135e213fe03a4a6a9e68529af64abb63266992cb62a","body_hash":"23545c7bb8115e7ff61bc27e03120d18246f8dc3089b44192c08bf5e5c0f98f3","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"025a7431741d8176bc18630402123fe674dc5e6cab19eeb03340bb5f6b168c43","body_hash":"23545c7bb8115e7ff61bc27e03120d18246f8dc3089b44192c08bf5e5c0f98f3","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -192,24 +192,24 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_aef809232cd03884_EOF'
+          cat << 'GH_AW_PROMPT_318d786c541aef43_EOF'
           <system>
-          GH_AW_PROMPT_aef809232cd03884_EOF
+          GH_AW_PROMPT_318d786c541aef43_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_aef809232cd03884_EOF'
+          cat << 'GH_AW_PROMPT_318d786c541aef43_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_aef809232cd03884_EOF
+          GH_AW_PROMPT_318d786c541aef43_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_aef809232cd03884_EOF'
+          cat << 'GH_AW_PROMPT_318d786c541aef43_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_aef809232cd03884_EOF
+          GH_AW_PROMPT_318d786c541aef43_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_aef809232cd03884_EOF'
+          cat << 'GH_AW_PROMPT_318d786c541aef43_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -238,12 +238,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_aef809232cd03884_EOF
+          GH_AW_PROMPT_318d786c541aef43_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_aef809232cd03884_EOF'
+          cat << 'GH_AW_PROMPT_318d786c541aef43_EOF'
           </system>
           {{#runtime-import .github/workflows/http-link-checker.md}}
-          GH_AW_PROMPT_aef809232cd03884_EOF
+          GH_AW_PROMPT_318d786c541aef43_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -392,7 +392,7 @@ jobs:
           persist-credentials: false
       - id: link-check
         name: Check and test all documentation links
-        run: "mkdir -p /tmp/gh-aw/agent\necho \"# Link Check Results\" > /tmp/gh-aw/agent/link-check-results.md\necho \"\" >> /tmp/gh-aw/agent/link-check-results.md\n\n# Find all markdown files in docs directory and README\necho \"Finding all markdown files...\"\nMARKDOWN_FILES=$(find docs README.md -type f -name \"*.md\" 2>/dev/null || echo \"\")\n\nif [ -z \"$MARKDOWN_FILES\" ]; then\n  echo \"No markdown files found\"\n  echo \"no_files=true\" >> $GITHUB_OUTPUT\n  exit 0\nfi\n\n# Extract all links from markdown files\necho \"## Links Found\" >> /tmp/gh-aw/agent/link-check-results.md\necho \"\" >> /tmp/gh-aw/agent/link-check-results.md\n\n# Use grep to find markdown links and HTTP(S) URLs\n# Format for relative links: \"source_file|url\" to allow path resolution\nfor file in $MARKDOWN_FILES; do\n  echo \"Checking $file...\"\n  # Extract markdown links [text](url)\n  grep -oP '\\[([^\\]]+)\\]\\(([^\\)]+)\\)' \"$file\" | grep -oP '\\(([^\\)]+)\\)' | tr -d '()' >> /tmp/gh-aw/agent/all-links.txt 2>/dev/null || true\n  # Extract plain HTTP(S) URLs\n  grep -oP 'https?://[^\\s<>\"]+' \"$file\" >> /tmp/gh-aw/agent/all-links.txt 2>/dev/null || true\ndone\n\n# Remove duplicates and sort\nif [ -f /tmp/gh-aw/agent/all-links.txt ]; then\n  sort -u /tmp/gh-aw/agent/all-links.txt > /tmp/gh-aw/agent/unique-links.txt\n  LINK_COUNT=$(wc -l < /tmp/gh-aw/agent/unique-links.txt)\n  echo \"Found $LINK_COUNT unique links\" >> /tmp/gh-aw/agent/link-check-results.md\n  echo \"\" >> /tmp/gh-aw/agent/link-check-results.md\nelse\n  echo \"No links found\" >> /tmp/gh-aw/agent/link-check-results.md\n  echo \"no_links=true\" >> $GITHUB_OUTPUT\n  exit 0\nfi\n\n# Helper: check if an explicit HTML anchor or markdown heading anchor exists in a file\ncheck_anchor() {\n  local file=\"$1\"\n  local anchor=\"$2\"\n  local html_anchor heading generated\n\n  while IFS= read -r html_anchor; do\n    if [[ \"$html_anchor\" == \"$anchor\" ]]; then\n      return 0\n    fi\n  done < <(grep -oiP \"<a\\\\b[^>]*\\\\b(?:name|id)\\\\s*=\\\\s*['\\\"]\\\\K[^'\\\"]+(?=['\\\"])\" \"$file\" 2>/dev/null)\n\n  while IFS= read -r heading; do\n    generated=$(printf '%s' \"$heading\" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//' | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g' | sed 's/[^a-z0-9_-]//g')\n    if [[ \"$generated\" == \"$anchor\" ]]; then\n      return 0\n    fi\n  done < <(grep -oP '^#{1,6}\\s+\\K.*' \"$file\" 2>/dev/null)\n\n  return 1\n}\n# Test each link\necho \"## Link Test Results\" >> /tmp/gh-aw/agent/link-check-results.md\necho \"\" >> /tmp/gh-aw/agent/link-check-results.md\necho \"Testing links...\" >> /tmp/gh-aw/agent/link-check-results.md\n\nBROKEN_COUNT=0\nWORKING_COUNT=0\n\nwhile IFS= read -r url; do\n  # Skip relative links and anchors\n  if [[ \"$url\" == \"#\"* ]] || [[ \"$url\" != \"http\"* ]]; then\n    continue\n  fi\n  \n  # Test the link with curl\n  HTTP_CODE=$(curl -L -s -o /dev/null -w \"%{http_code}\" --max-time 10 \"$url\" 2>/dev/null || echo \"000\")\n  \n  if [[ \"$HTTP_CODE\" =~ ^2 ]] || [[ \"$HTTP_CODE\" =~ ^3 ]]; then\n    WORKING_COUNT=$((WORKING_COUNT + 1))\n    echo \"✅ $url (HTTP $HTTP_CODE)\" >> /tmp/gh-aw/agent/link-check-results.md\n  else\n    BROKEN_COUNT=$((BROKEN_COUNT + 1))\n    echo \"❌ $url (HTTP $HTTP_CODE)\" >> /tmp/gh-aw/agent/link-check-results.md\n  fi\ndone < /tmp/gh-aw/agent/unique-links.txt\n\necho \"\" >> /tmp/gh-aw/agent/link-check-results.md\necho \"**Summary:** $WORKING_COUNT working, $BROKEN_COUNT broken\" >> /tmp/gh-aw/agent/link-check-results.md\n\n# Output results\necho \"broken_count=$BROKEN_COUNT\" >> $GITHUB_OUTPUT\necho \"working_count=$WORKING_COUNT\" >> $GITHUB_OUTPUT\n\ncat /tmp/gh-aw/agent/link-check-results.md\n"
+        run: "mkdir -p /tmp/gh-aw/agent\necho \"# Link Check Results\" > /tmp/gh-aw/agent/link-check-results.md\necho \"\" >> /tmp/gh-aw/agent/link-check-results.md\n\n# Find all markdown files in docs directory and README\necho \"Finding all markdown files...\"\nMARKDOWN_FILES=$(find docs README.md -type f -name \"*.md\" 2>/dev/null || echo \"\")\n\nif [ -z \"$MARKDOWN_FILES\" ]; then\n  echo \"No markdown files found\"\n  echo \"no_files=true\" >> $GITHUB_OUTPUT\n  exit 0\nfi\n\n# Extract all links from markdown files\necho \"## Links Found\" >> /tmp/gh-aw/agent/link-check-results.md\necho \"\" >> /tmp/gh-aw/agent/link-check-results.md\n\n# Use grep to find markdown links and HTTP(S) URLs\n# Format for relative links: \"source_file|url\" to allow path resolution\nfor file in $MARKDOWN_FILES; do\n  echo \"Checking $file...\"\n  # Extract markdown links [text](url)\n  grep -oP '\\[([^\\]]+)\\]\\(([^\\)]+)\\)' \"$file\" | grep -oP '\\(([^\\)]+)\\)' | tr -d '()' >> /tmp/gh-aw/agent/all-links.txt 2>/dev/null || true\n  # Extract plain HTTP(S) URLs from non-markdown-link text to avoid duplicates/trailing ')'\n  sed -E 's/\\[[^]]+\\]\\(([^)]+)\\)/ /g' \"$file\" | grep -oP 'https?://[^\\s<>\"\\)]+' >> /tmp/gh-aw/agent/all-links.txt 2>/dev/null || true\ndone\n\n# Remove duplicates and sort\nif [ -f /tmp/gh-aw/agent/all-links.txt ]; then\n  sort -u /tmp/gh-aw/agent/all-links.txt > /tmp/gh-aw/agent/unique-links.txt\n  LINK_COUNT=$(wc -l < /tmp/gh-aw/agent/unique-links.txt)\n  echo \"Found $LINK_COUNT unique links\" >> /tmp/gh-aw/agent/link-check-results.md\n  echo \"\" >> /tmp/gh-aw/agent/link-check-results.md\nelse\n  echo \"No links found\" >> /tmp/gh-aw/agent/link-check-results.md\n  echo \"no_links=true\" >> $GITHUB_OUTPUT\n  exit 0\nfi\n\n# Helper: check if an explicit HTML anchor or markdown heading anchor exists in a file\ncheck_anchor() {\n  local file=\"$1\"\n  local anchor=\"$2\"\n  local html_anchor heading generated\n\n  while IFS= read -r html_anchor; do\n    if [[ \"$html_anchor\" == \"$anchor\" ]]; then\n      return 0\n    fi\n  done < <(grep -oiP \"<a\\\\b[^>]*\\\\b(?:name|id)\\\\s*=\\\\s*['\\\"]\\\\K[^'\\\"]+(?=['\\\"])\" \"$file\" 2>/dev/null)\n\n  while IFS= read -r heading; do\n    generated=$(printf '%s' \"$heading\" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//' | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g' | sed 's/[^a-z0-9_-]//g')\n    if [[ \"$generated\" == \"$anchor\" ]]; then\n      return 0\n    fi\n  done < <(grep -oP '^#{1,6}\\s+\\K.*' \"$file\" 2>/dev/null)\n\n  return 1\n}\n# Test each link\necho \"## Link Test Results\" >> /tmp/gh-aw/agent/link-check-results.md\necho \"\" >> /tmp/gh-aw/agent/link-check-results.md\necho \"Testing links...\" >> /tmp/gh-aw/agent/link-check-results.md\n\nBROKEN_COUNT=0\nWORKING_COUNT=0\n\nwhile IFS= read -r url; do\n  # Skip relative links and anchors\n  if [[ \"$url\" == \"#\"* ]] || [[ \"$url\" != \"http\"* ]]; then\n    continue\n  fi\n  \n  # Test the link with curl\n  HTTP_CODE=$(curl -L -s -o /dev/null -w \"%{http_code}\" --max-time 10 \"$url\" 2>/dev/null || echo \"000\")\n  \n  if [[ \"$HTTP_CODE\" =~ ^2 ]] || [[ \"$HTTP_CODE\" =~ ^3 ]]; then\n    WORKING_COUNT=$((WORKING_COUNT + 1))\n    echo \"✅ $url (HTTP $HTTP_CODE)\" >> /tmp/gh-aw/agent/link-check-results.md\n  else\n    BROKEN_COUNT=$((BROKEN_COUNT + 1))\n    echo \"❌ $url (HTTP $HTTP_CODE)\" >> /tmp/gh-aw/agent/link-check-results.md\n  fi\ndone < /tmp/gh-aw/agent/unique-links.txt\n\necho \"\" >> /tmp/gh-aw/agent/link-check-results.md\necho \"**Summary:** $WORKING_COUNT working, $BROKEN_COUNT broken\" >> /tmp/gh-aw/agent/link-check-results.md\n\n# Output results\necho \"broken_count=$BROKEN_COUNT\" >> $GITHUB_OUTPUT\necho \"working_count=$WORKING_COUNT\" >> $GITHUB_OUTPUT\n\ncat /tmp/gh-aw/agent/link-check-results.md\n"
         shell: bash
 
       # Cache memory file share configuration from frontmatter processed below
@@ -480,9 +480,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_095af201b6e28ea0_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_b6d98eb8eabbc589_EOF'
           {"create_pull_request":{"draft":false,"if_no_changes":"warn","labels":["Area: Documentation","agentic-workflows"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","title_prefix":"[link-checker] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_095af201b6e28ea0_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_b6d98eb8eabbc589_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -695,7 +695,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_b1dd67d758a85c35_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_87e5460e5299cc0c_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -736,7 +736,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_b1dd67d758a85c35_EOF
+          GH_AW_MCP_CONFIG_87e5460e5299cc0c_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/http-link-checker.lock.yml
+++ b/.github/workflows/http-link-checker.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"025a7431741d8176bc18630402123fe674dc5e6cab19eeb03340bb5f6b168c43","body_hash":"23545c7bb8115e7ff61bc27e03120d18246f8dc3089b44192c08bf5e5c0f98f3","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"cc96c0b21d2576cbfa38b8e8de118f20a71ccfbbbdd7c1428c73e5693825b1cd","body_hash":"23545c7bb8115e7ff61bc27e03120d18246f8dc3089b44192c08bf5e5c0f98f3","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -192,24 +192,24 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_318d786c541aef43_EOF'
+          cat << 'GH_AW_PROMPT_b04855d0a3340a75_EOF'
           <system>
-          GH_AW_PROMPT_318d786c541aef43_EOF
+          GH_AW_PROMPT_b04855d0a3340a75_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_318d786c541aef43_EOF'
+          cat << 'GH_AW_PROMPT_b04855d0a3340a75_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_318d786c541aef43_EOF
+          GH_AW_PROMPT_b04855d0a3340a75_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_318d786c541aef43_EOF'
+          cat << 'GH_AW_PROMPT_b04855d0a3340a75_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_318d786c541aef43_EOF
+          GH_AW_PROMPT_b04855d0a3340a75_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_318d786c541aef43_EOF'
+          cat << 'GH_AW_PROMPT_b04855d0a3340a75_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -238,12 +238,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_318d786c541aef43_EOF
+          GH_AW_PROMPT_b04855d0a3340a75_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_318d786c541aef43_EOF'
+          cat << 'GH_AW_PROMPT_b04855d0a3340a75_EOF'
           </system>
           {{#runtime-import .github/workflows/http-link-checker.md}}
-          GH_AW_PROMPT_318d786c541aef43_EOF
+          GH_AW_PROMPT_b04855d0a3340a75_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -392,7 +392,7 @@ jobs:
           persist-credentials: false
       - id: link-check
         name: Check and test all documentation links
-        run: "mkdir -p /tmp/gh-aw/agent\necho \"# Link Check Results\" > /tmp/gh-aw/agent/link-check-results.md\necho \"\" >> /tmp/gh-aw/agent/link-check-results.md\n\n# Find all markdown files in docs directory and README\necho \"Finding all markdown files...\"\nMARKDOWN_FILES=$(find docs README.md -type f -name \"*.md\" 2>/dev/null || echo \"\")\n\nif [ -z \"$MARKDOWN_FILES\" ]; then\n  echo \"No markdown files found\"\n  echo \"no_files=true\" >> $GITHUB_OUTPUT\n  exit 0\nfi\n\n# Extract all links from markdown files\necho \"## Links Found\" >> /tmp/gh-aw/agent/link-check-results.md\necho \"\" >> /tmp/gh-aw/agent/link-check-results.md\n\n# Use grep to find markdown links and HTTP(S) URLs\n# Format for relative links: \"source_file|url\" to allow path resolution\nfor file in $MARKDOWN_FILES; do\n  echo \"Checking $file...\"\n  # Extract markdown links [text](url)\n  grep -oP '\\[([^\\]]+)\\]\\(([^\\)]+)\\)' \"$file\" | grep -oP '\\(([^\\)]+)\\)' | tr -d '()' >> /tmp/gh-aw/agent/all-links.txt 2>/dev/null || true\n  # Extract plain HTTP(S) URLs from non-markdown-link text to avoid duplicates/trailing ')'\n  sed -E 's/\\[[^]]+\\]\\(([^)]+)\\)/ /g' \"$file\" | grep -oP 'https?://[^\\s<>\"\\)]+' >> /tmp/gh-aw/agent/all-links.txt 2>/dev/null || true\ndone\n\n# Remove duplicates and sort\nif [ -f /tmp/gh-aw/agent/all-links.txt ]; then\n  sort -u /tmp/gh-aw/agent/all-links.txt > /tmp/gh-aw/agent/unique-links.txt\n  LINK_COUNT=$(wc -l < /tmp/gh-aw/agent/unique-links.txt)\n  echo \"Found $LINK_COUNT unique links\" >> /tmp/gh-aw/agent/link-check-results.md\n  echo \"\" >> /tmp/gh-aw/agent/link-check-results.md\nelse\n  echo \"No links found\" >> /tmp/gh-aw/agent/link-check-results.md\n  echo \"no_links=true\" >> $GITHUB_OUTPUT\n  exit 0\nfi\n\n# Helper: check if an explicit HTML anchor or markdown heading anchor exists in a file\ncheck_anchor() {\n  local file=\"$1\"\n  local anchor=\"$2\"\n  local html_anchor heading generated\n\n  while IFS= read -r html_anchor; do\n    if [[ \"$html_anchor\" == \"$anchor\" ]]; then\n      return 0\n    fi\n  done < <(grep -oiP \"<a\\\\b[^>]*\\\\b(?:name|id)\\\\s*=\\\\s*['\\\"]\\\\K[^'\\\"]+(?=['\\\"])\" \"$file\" 2>/dev/null)\n\n  while IFS= read -r heading; do\n    generated=$(printf '%s' \"$heading\" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//' | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g' | sed 's/[^a-z0-9_-]//g')\n    if [[ \"$generated\" == \"$anchor\" ]]; then\n      return 0\n    fi\n  done < <(grep -oP '^#{1,6}\\s+\\K.*' \"$file\" 2>/dev/null)\n\n  return 1\n}\n# Test each link\necho \"## Link Test Results\" >> /tmp/gh-aw/agent/link-check-results.md\necho \"\" >> /tmp/gh-aw/agent/link-check-results.md\necho \"Testing links...\" >> /tmp/gh-aw/agent/link-check-results.md\n\nBROKEN_COUNT=0\nWORKING_COUNT=0\n\nwhile IFS= read -r url; do\n  # Skip relative links and anchors\n  if [[ \"$url\" == \"#\"* ]] || [[ \"$url\" != \"http\"* ]]; then\n    continue\n  fi\n  \n  # Test the link with curl\n  HTTP_CODE=$(curl -L -s -o /dev/null -w \"%{http_code}\" --max-time 10 \"$url\" 2>/dev/null || echo \"000\")\n  \n  if [[ \"$HTTP_CODE\" =~ ^2 ]] || [[ \"$HTTP_CODE\" =~ ^3 ]]; then\n    WORKING_COUNT=$((WORKING_COUNT + 1))\n    echo \"✅ $url (HTTP $HTTP_CODE)\" >> /tmp/gh-aw/agent/link-check-results.md\n  else\n    BROKEN_COUNT=$((BROKEN_COUNT + 1))\n    echo \"❌ $url (HTTP $HTTP_CODE)\" >> /tmp/gh-aw/agent/link-check-results.md\n  fi\ndone < /tmp/gh-aw/agent/unique-links.txt\n\necho \"\" >> /tmp/gh-aw/agent/link-check-results.md\necho \"**Summary:** $WORKING_COUNT working, $BROKEN_COUNT broken\" >> /tmp/gh-aw/agent/link-check-results.md\n\n# Output results\necho \"broken_count=$BROKEN_COUNT\" >> $GITHUB_OUTPUT\necho \"working_count=$WORKING_COUNT\" >> $GITHUB_OUTPUT\n\ncat /tmp/gh-aw/agent/link-check-results.md\n"
+        run: "mkdir -p /tmp/gh-aw/agent\necho \"# Link Check Results\" > /tmp/gh-aw/agent/link-check-results.md\necho \"\" >> /tmp/gh-aw/agent/link-check-results.md\n\n# Find all markdown files in docs directory and README\necho \"Finding all markdown files...\"\nMARKDOWN_FILES=$(find docs README.md -type f -name \"*.md\" 2>/dev/null || echo \"\")\n\nif [ -z \"$MARKDOWN_FILES\" ]; then\n  echo \"No markdown files found\"\n  echo \"no_files=true\" >> $GITHUB_OUTPUT\n  exit 0\nfi\n\n# Extract all links from markdown files\necho \"## Links Found\" >> /tmp/gh-aw/agent/link-check-results.md\necho \"\" >> /tmp/gh-aw/agent/link-check-results.md\n\n# Use grep to find markdown links and HTTP(S) URLs\n# Format for relative links: \"source_file|url\" to allow path resolution\nfor file in $MARKDOWN_FILES; do\n  echo \"Checking $file...\"\n  # Extract markdown links [text](url)\n  grep -oP '\\[([^\\]]+)\\]\\(([^\\)]+)\\)' \"$file\" | grep -oP '\\(([^\\)]+)\\)' | tr -d '()' >> /tmp/gh-aw/agent/all-links.txt 2>/dev/null || true\n  # Extract plain HTTP(S) URLs from non-markdown-link text to avoid duplicates/trailing ')'\n  sed -E 's/\\[[^]]+\\]\\(([^)]+)\\)/ /g' \"$file\" | grep -oP 'https?://[^\\s<>\"]+' | awk '{ if (index($0,\"(\") == 0) sub(/\\)$/, \"\", $0); print }' >> /tmp/gh-aw/agent/all-links.txt 2>/dev/null || true\ndone\n\n# Remove duplicates and sort\nif [ -f /tmp/gh-aw/agent/all-links.txt ]; then\n  sort -u /tmp/gh-aw/agent/all-links.txt > /tmp/gh-aw/agent/unique-links.txt\n  LINK_COUNT=$(wc -l < /tmp/gh-aw/agent/unique-links.txt)\n  echo \"Found $LINK_COUNT unique links\" >> /tmp/gh-aw/agent/link-check-results.md\n  echo \"\" >> /tmp/gh-aw/agent/link-check-results.md\nelse\n  echo \"No links found\" >> /tmp/gh-aw/agent/link-check-results.md\n  echo \"no_links=true\" >> $GITHUB_OUTPUT\n  exit 0\nfi\n\n# Helper: check if an explicit HTML anchor or markdown heading anchor exists in a file\ncheck_anchor() {\n  local file=\"$1\"\n  local anchor=\"$2\"\n  local html_anchor heading generated\n\n  while IFS= read -r html_anchor; do\n    if [[ \"$html_anchor\" == \"$anchor\" ]]; then\n      return 0\n    fi\n  done < <(grep -oiP \"<a\\\\b[^>]*\\\\b(?:name|id)\\\\s*=\\\\s*['\\\"]\\\\K[^'\\\"]+(?=['\\\"])\" \"$file\" 2>/dev/null)\n\n  while IFS= read -r heading; do\n    generated=$(printf '%s' \"$heading\" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//' | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g' | sed 's/[^a-z0-9_-]//g')\n    if [[ \"$generated\" == \"$anchor\" ]]; then\n      return 0\n    fi\n  done < <(grep -oP '^#{1,6}\\s+\\K.*' \"$file\" 2>/dev/null)\n\n  return 1\n}\n# Test each link\necho \"## Link Test Results\" >> /tmp/gh-aw/agent/link-check-results.md\necho \"\" >> /tmp/gh-aw/agent/link-check-results.md\necho \"Testing links...\" >> /tmp/gh-aw/agent/link-check-results.md\n\nBROKEN_COUNT=0\nWORKING_COUNT=0\n\nwhile IFS= read -r url; do\n  # Skip relative links and anchors\n  if [[ \"$url\" == \"#\"* ]] || [[ \"$url\" != \"http\"* ]]; then\n    continue\n  fi\n  \n  # Test the link with curl\n  HTTP_CODE=$(curl -L -s -o /dev/null -w \"%{http_code}\" --max-time 10 \"$url\" 2>/dev/null || echo \"000\")\n  \n  if [[ \"$HTTP_CODE\" =~ ^2 ]] || [[ \"$HTTP_CODE\" =~ ^3 ]]; then\n    WORKING_COUNT=$((WORKING_COUNT + 1))\n    echo \"✅ $url (HTTP $HTTP_CODE)\" >> /tmp/gh-aw/agent/link-check-results.md\n  else\n    BROKEN_COUNT=$((BROKEN_COUNT + 1))\n    echo \"❌ $url (HTTP $HTTP_CODE)\" >> /tmp/gh-aw/agent/link-check-results.md\n  fi\ndone < /tmp/gh-aw/agent/unique-links.txt\n\necho \"\" >> /tmp/gh-aw/agent/link-check-results.md\necho \"**Summary:** $WORKING_COUNT working, $BROKEN_COUNT broken\" >> /tmp/gh-aw/agent/link-check-results.md\n\n# Output results\necho \"broken_count=$BROKEN_COUNT\" >> $GITHUB_OUTPUT\necho \"working_count=$WORKING_COUNT\" >> $GITHUB_OUTPUT\n\ncat /tmp/gh-aw/agent/link-check-results.md\n"
         shell: bash
 
       # Cache memory file share configuration from frontmatter processed below
@@ -480,9 +480,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_b6d98eb8eabbc589_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_085c681009b111a2_EOF'
           {"create_pull_request":{"draft":false,"if_no_changes":"warn","labels":["Area: Documentation","agentic-workflows"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","title_prefix":"[link-checker] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_b6d98eb8eabbc589_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_085c681009b111a2_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -695,7 +695,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_87e5460e5299cc0c_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_2a4afb1d39e4ac67_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -736,7 +736,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_87e5460e5299cc0c_EOF
+          GH_AW_MCP_CONFIG_2a4afb1d39e4ac67_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/http-link-checker.md
+++ b/.github/workflows/http-link-checker.md
@@ -44,7 +44,7 @@ steps:
         # Extract markdown links [text](url)
         grep -oP '\[([^\]]+)\]\(([^\)]+)\)' "$file" | grep -oP '\(([^\)]+)\)' | tr -d '()' >> /tmp/gh-aw/agent/all-links.txt 2>/dev/null || true
         # Extract plain HTTP(S) URLs from non-markdown-link text to avoid duplicates/trailing ')'
-        sed -E 's/\[[^]]+\]\(([^)]+)\)/ /g' "$file" | grep -oP 'https?://[^\s<>"\)]+' >> /tmp/gh-aw/agent/all-links.txt 2>/dev/null || true
+sed -E 's/\[[^]]+\]\(([^)]+)\)/ /g' "$file" | grep -oP 'https?://[^\s<>"]+' | awk '{ if (index($0,"(") == 0) sub(/\)$/, "", $0); print }' >> /tmp/gh-aw/agent/all-links.txt 2>/dev/null || true
       done
 
       # Remove duplicates and sort

--- a/.github/workflows/http-link-checker.md
+++ b/.github/workflows/http-link-checker.md
@@ -43,8 +43,8 @@ steps:
         echo "Checking $file..."
         # Extract markdown links [text](url)
         grep -oP '\[([^\]]+)\]\(([^\)]+)\)' "$file" | grep -oP '\(([^\)]+)\)' | tr -d '()' >> /tmp/gh-aw/agent/all-links.txt 2>/dev/null || true
-        # Extract plain HTTP(S) URLs
-        grep -oP 'https?://[^\s<>"]+' "$file" >> /tmp/gh-aw/agent/all-links.txt 2>/dev/null || true
+        # Extract plain HTTP(S) URLs from non-markdown-link text to avoid duplicates/trailing ')'
+        sed -E 's/\[[^]]+\]\(([^)]+)\)/ /g' "$file" | grep -oP 'https?://[^\s<>"\)]+' >> /tmp/gh-aw/agent/all-links.txt 2>/dev/null || true
       done
 
       # Remove duplicates and sort

--- a/.github/workflows/http-link-checker.md
+++ b/.github/workflows/http-link-checker.md
@@ -44,7 +44,7 @@ steps:
         # Extract markdown links [text](url)
         grep -oP '\[([^\]]+)\]\(([^\)]+)\)' "$file" | grep -oP '\(([^\)]+)\)' | tr -d '()' >> /tmp/gh-aw/agent/all-links.txt 2>/dev/null || true
         # Extract plain HTTP(S) URLs from non-markdown-link text to avoid duplicates/trailing ')'
-sed -E 's/\[[^]]+\]\(([^)]+)\)/ /g' "$file" | grep -oP 'https?://[^\s<>"]+' | awk '{ if (index($0,"(") == 0) sub(/\)$/, "", $0); print }' >> /tmp/gh-aw/agent/all-links.txt 2>/dev/null || true
+        sed -E 's/\[[^]]+\]\(([^)]+)\)/ /g' "$file" | grep -oP 'https?://[^\s<>"]+' | awk '{ if (index($0,"(") == 0) sub(/\)$/, "", $0); print }' >> /tmp/gh-aw/agent/all-links.txt 2>/dev/null || true
       done
 
       # Remove duplicates and sort


### PR DESCRIPTION
## Description

Fixes https://github.com/microsoft/vstest/issues/16112

The initial script was extracting inlined http links (i.e. `[text](url)`) twice: once correctly and once with a trailing `)` sign.  This resulted in each inlined http link being extracted twice and being reported as broken once. 
So many broken links burnt the token budget easily. 

## Related issue

Fixes https://github.com/microsoft/vstest/issues/16112
