### PR TITLE
Add open-vs.cmd and open-code.cmd shortcuts

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -38,8 +38,48 @@ Param(
   [switch] $excludePrereleaseVS,
   [switch] $nativeToolsOnMachine,
   [switch] $help,
+  [switch] $vs,
+  [switch] $vscode,
   [Parameter(ValueFromRemainingArguments = $true)][String[]]$properties
 )
+
+if ($vs -or $vscode) {
+  . $PSScriptRoot\common\tools.ps1
+
+  # This tells .NET Core to use the bootstrapped runtime
+  $env:DOTNET_ROOT = InitializeDotNetCli -install:$true -createSdkLocationFile:$true
+
+  # This tells MSBuild to load the SDK from the directory of the bootstrapped SDK
+  $env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR = $env:DOTNET_ROOT
+
+  # This tells .NET Core not to go looking for .NET Core in other places
+  $env:DOTNET_MULTILEVEL_LOOKUP = 0
+
+  # Put our local dotnet.exe on PATH first so Visual Studio knows which one to use
+  $env:PATH = ($env:DOTNET_ROOT + ";" + $env:PATH)
+
+  # Disable .NET runtime signature validation errors which errors for local builds
+  $env:VSDebugger_ValidateDotnetDebugLibSignatures = 0
+
+  if ($vs) {
+    # Launch Visual Studio with the locally defined environment variables
+    & "$PSScriptRoot\..\TestPlatform.slnx"
+  }
+  else {
+    if (Get-Command code -ErrorAction Ignore) {
+      & code "$PSScriptRoot\.."
+    }
+    elseif (Get-Command code-insiders -ErrorAction Ignore) {
+      & code-insiders "$PSScriptRoot\.."
+    }
+    else {
+      Write-Error "VS Code not found. Please install it from https://code.visualstudio.com/"
+      return
+    }
+  }
+
+  return
+}
 
 # Add steps that need to happen before build here
 

--- a/open-code.cmd
+++ b/open-code.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\build.ps1""" -vscode %*"

--- a/open-vs.cmd
+++ b/open-vs.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\build.ps1""" -vs %*"


### PR DESCRIPTION
Mirrors the testfx workflow (`open-vs.cmd` / `open-code.cmd`): from the repo root, launch Visual Studio (`TestPlatform.slnx`) or VS Code with `DOTNET_ROOT`, `PATH`, and the MSBuild SDK resolver pointed at the Arcade-bootstrapped .NET SDK, so VS picks up the local SDK instead of whatever's installed globally.

Usage:

```
open-vs.cmd       :: launches Visual Studio against TestPlatform.slnx
open-code.cmd     :: launches VS Code (falls back to code-insiders)
```

The `-vs` / `-vscode` switches on `eng/build.ps1` do the actual work; the `.cmd` files are just thin wrappers, same shape as testfx.

Env vars set before launch:
- `DOTNET_ROOT` → Arcade-installed SDK location
- `DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR` → same
- `DOTNET_MULTILEVEL_LOOKUP=0`
- `PATH` prepended with `DOTNET_ROOT`
- `VSDebugger_ValidateDotnetDebugLibSignatures=0`

Source pattern: https://github.com/microsoft/testfx/blob/main/open-vs.cmd