### PR TITLE
Add tests for null TestElement in DataCollectionManager

### DIFF
--- a/test/datacollector.UnitTests/DataCollectionManagerTests.cs
+++ b/test/datacollector.UnitTests/DataCollectionManagerTests.cs
@@ -445,6 +445,28 @@ public class DataCollectionManagerTests
     }
 
     [TestMethod]
+    public void TestCaseStartedShouldThrowIfTestElementIsNull()
+    {
+        SetupMockDataCollector((XmlElement a, DataCollectionEvents b, DataCollectionSink c, DataCollectionLogger d, DataCollectionEnvironmentContext e) => b.TestCaseStart += (sender, eventArgs) => { });
+
+        _dataCollectionManager.InitializeDataCollectors(_dataCollectorSettings);
+        var args = new TestCaseStartEventArgs() { TestElement = null };
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => _dataCollectionManager.TestCaseStarted(args));
+    }
+
+    [TestMethod]
+    public void TestCaseEndedShouldThrowIfTestElementIsNull()
+    {
+        SetupMockDataCollector((XmlElement a, DataCollectionEvents b, DataCollectionSink c, DataCollectionLogger d, DataCollectionEnvironmentContext e) => b.TestCaseEnd += (sender, eventArgs) => { });
+
+        _dataCollectionManager.InitializeDataCollectors(_dataCollectorSettings);
+        var args = new TestCaseEndEventArgs() { TestElement = null };
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => _dataCollectionManager.TestCaseEnded(args));
+    }
+
+    [TestMethod]
     public void TestCaseEndedShouldSendEventToDataCollector()
     {
         var isEndInvoked = false;


### PR DESCRIPTION
Tests for #16048. Verifies that `TestCaseStarted` and `TestCaseEnded` throw `InvalidOperationException` when `TestElement` is null, rather than crashing via `TPDebug.Assert`.