### PR TITLE
[fix] Use RuntimeInformation for architecture detection in netstandard2.0 builds

### DIFF
--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net462/System/PlatformEnvironment.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net462/System/PlatformEnvironment.cs
@@ -6,6 +6,9 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
+#if NETSTANDARD2_0_OR_GREATER
+using System.Runtime.InteropServices;
+#endif
 
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
 
@@ -31,6 +34,9 @@ public class PlatformEnvironment : IEnvironment
 
     private static bool IsArm64()
     {
+#if NETSTANDARD2_0_OR_GREATER
+        return RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.Arm64;
+#else
         try
         {
             var currentProcess = Process.GetCurrentProcess();
@@ -53,6 +59,7 @@ public class PlatformEnvironment : IEnvironment
         }
 
         return false;
+#endif
     }
 
     /// <inheritdoc />

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net462/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net462/System/ProcessHelper.cs
@@ -41,9 +41,13 @@ public partial class ProcessHelper : IProcessHelper
         {
             Architecture.X86 => PlatformArchitecture.X86,
             Architecture.X64 => PlatformArchitecture.X64,
-            Architecture.Arm64 => PlatformArchitecture.ARM64,
             Architecture.Arm => PlatformArchitecture.ARM,
-            _ => PlatformArchitecture.X64,
+            Architecture.Arm64 => PlatformArchitecture.ARM64,
+            (Architecture)5 => PlatformArchitecture.S390x,
+            (Architecture)6 => PlatformArchitecture.LoongArch64,
+            (Architecture)8 => PlatformArchitecture.Ppc64le,
+            (Architecture)9 => PlatformArchitecture.RiscV64,
+            _ => throw new NotSupportedException(),
         };
 #else
         // When this is current process, we can just check if IntPointer size to get if we are 64-bit or 32-bit.

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/net462/System/ProcessHelper.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/net462/System/ProcessHelper.cs
@@ -36,6 +36,16 @@ public partial class ProcessHelper : IProcessHelper
             return _currentProcessArchitecture.Value;
         }
 
+#if NETSTANDARD2_0_OR_GREATER
+        _currentProcessArchitecture = RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X86 => PlatformArchitecture.X86,
+            Architecture.X64 => PlatformArchitecture.X64,
+            Architecture.Arm64 => PlatformArchitecture.ARM64,
+            Architecture.Arm => PlatformArchitecture.ARM,
+            _ => PlatformArchitecture.X64,
+        };
+#else
         // When this is current process, we can just check if IntPointer size to get if we are 64-bit or 32-bit.
         // When it is 32-bit we can just return, if it is 64-bit we need to clarify if x64 or arm64.
         if (IntPtr.Size == 4)
@@ -45,6 +55,7 @@ public partial class ProcessHelper : IProcessHelper
         }
 
         _currentProcessArchitecture ??= GetProcessArchitecture(_currentProcess.Id);
+#endif
         return _currentProcessArchitecture.Value;
     }
 #endif


### PR DESCRIPTION
## Summary

Fixes #15330 — replaces `IsWow64Process2` P/Invoke with `RuntimeInformation` APIs for `NETSTANDARD2_0_OR_GREATER` builds.

> 🤖 This is an automated fix created by the Issue Triage agent.

## Root Cause

Two methods in `PlatformAbstractions/net462/` used the Windows-only `IsWow64Process2` kernel32.dll API to detect CPU architecture. When code targeting `netstandard2.0` runs on Linux/macOS ARM64:

- **`PlatformEnvironment.IsArm64()`** — called `IsWow64Process2` which threw a `DllNotFoundException` on non-Windows, the catch block silently returned `false`, causing `Architecture` to report `X64` instead of `ARM64`.
- **`ProcessHelper.GetCurrentProcessArchitecture()`** — on 64-bit non-Windows, fell through to `GetProcessArchitecture(processId)` which explicitly `throw new NotImplementedException()` for non-Windows.

The `net8.0+` builds already use `RuntimeInformation` (in `netcore/System/`) and were unaffected. Only `netstandard2.0` consumers on non-Windows were broken.

## Fix

For `NETSTANDARD2_0_OR_GREATER` builds:

- `PlatformEnvironment.IsArm64()` now returns `RuntimeInformation.OSArchitecture == Architecture.Arm64`, which works correctly on all platforms.
- `ProcessHelper.GetCurrentProcessArchitecture()` now returns a value based on `RuntimeInformation.ProcessArchitecture`, avoiding the `IsWow64Process2` path entirely.

The `NETFRAMEWORK` (net462) path is unchanged — `IsWow64Process2` is correct and required there.

The `GetProcessArchitecture(int processId)` method (for querying *other* processes' architecture) is also unchanged — there is no managed cross-platform equivalent for that.

## Testing

Build and unit tests pass (`./test.sh`). The fix is in code paths exercised by the existing `DotnetHostHelperTest` and related tests.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/27659787848)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 27659787848, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/27659787848 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->