### PR TITLE
[review] [fix] Fix LoggerRunSettings verbosity being silently overridden when using --settings

### DIFF
--- a/docs/RFCs/0002-Test-Discovery-Protocol.md
+++ b/docs/RFCs/0002-Test-Discovery-Protocol.md
@@ -28,23 +28,23 @@ Here is what the changed wire protocol looks like after TPV2 integrates with dot
 ![dotnet-test v2 protocol](Images/dotnet-test-protocol-v2-discovery.png)
 
 ### Breaking changes for Adapter(IDE)
-1. The object model used via the wire protocol will change from using [Microsoft.Extensions.Testing.Abstractions.Test](https://github.com/dotnet/cli/blob/rel/1.0.0/src/Microsoft.Extensions.Testing.Abstractions/Test.cs) to [Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase](./src/Microsoft.TestPlatform.ObjectModel/TestCase.cs). 
+1. The object model used via the wire protocol will change from using [Microsoft.Extensions.Testing.Abstractions.Test](https://github.com/dotnet/cli/blob/rel/1.0.0/src/Microsoft.Extensions.Testing.Abstractions/Test.cs) to [Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase](../../src/Microsoft.TestPlatform.ObjectModel/TestCase.cs). 
 2. The IDE adapter would now be sending the test Containers along with test platform settings to dotnet-test.
 3. The IDE adapter would now receive test cases in a batch as opposed to a single test case earlier to improve performance.
-4. The IDE adapter would now receive a [DiscoveryCompletePayload](./src/Microsoft.TestPlatform.CommunicationUtilities/Messages/DiscoveryCompletePayload.cs) message with the TestDiscovery.Completed message. This would have the run stats and the last set of test cases found.
+4. The IDE adapter would now receive a [DiscoveryCompletePayload](../../src/Microsoft.TestPlatform.CommunicationUtilities/Messages/DiscoveryCompletePayload.cs) message with the TestDiscovery.Completed message. This would have the run stats and the last set of test cases found.
 
 ### Breaking Changes for Frameworks
 1. TestRunner would cease to exist. Framework writers would have to port their Rocksteady adapters to Core CLR to support all .NET Core scenarios.
 
 ### New Flow
 1. After the optional version check, the IDE adapter can choose to optionally send paths to extensions it wants to initialize the test platform with.
-2. It then sends a TestDiscovery.Start message with a [DiscoveryRequestPayload](./src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Payloads/DiscoveryRequestPayload.cs) which contains the sources and settings. Dotnet-test will start the test host process and pass on the containers and settings to it.
+2. It then sends a TestDiscovery.Start message with a [DiscoveryRequestPayload](../../src/Microsoft.TestPlatform.ObjectModel/Client/Payloads/DiscoveryRequestPayload.cs) which contains the sources and settings. Dotnet-test will start the test host process and pass on the containers and settings to it.
 3. The testhost then invokes the rocksteady adapter with the containers to discover tests. It uses the ITestDiscoverer.DiscoverTests as its entry point to the Rocksteady Adapter.
 4. The Rocksteady adapter then sends each test case discovered to the test host which caches this information.
 5. The test host passes on the cached test cases to dotnet-test in batches when a cache size is hit which then forwards it over to the IDE adapter.
-6. Optionally the IDE adapter may also receive a TestSession.Message with a [TestMessagePayload](./src/Microsoft.TestPlatform.CommunicationUtilities/Messages/TestMessagePayload.cs) notifying of any issues during discovery.
-7. After all tests are discovered, the test host sends a TestDiscovery.Completed message with a [DiscoveryCompletePayload](./src/Microsoft.TestPlatform.CommunicationUtilities/Messages/DiscoveryCompletePayload.cs), which has the stats and the last set of test cases found, to dotnet-test. 
-8. dotnet-test then sends a TestDiscovery.Completed with the [DiscoveryCompletePayload](./src/Microsoft.TestPlatform.CommunicationUtilities/Messages/DiscoveryCompletePayload.cs) to the IDE adapter.
+6. Optionally the IDE adapter may also receive a TestSession.Message with a [TestMessagePayload](../../src/Microsoft.TestPlatform.CommunicationUtilities/Messages/TestMessagePayload.cs) notifying of any issues during discovery.
+7. After all tests are discovered, the test host sends a TestDiscovery.Completed message with a [DiscoveryCompletePayload](../../src/Microsoft.TestPlatform.CommunicationUtilities/Messages/DiscoveryCompletePayload.cs), which has the stats and the last set of test cases found, to dotnet-test. 
+8. dotnet-test then sends a TestDiscovery.Completed with the [DiscoveryCompletePayload](../../src/Microsoft.TestPlatform.CommunicationUtilities/Messages/DiscoveryCompletePayload.cs) to the IDE adapter.
 9. Once the IDE adapter is done, it sends dotnet-test a TestSession.Terminate which will cause dotnet test to shutdown.
 
 ### Notes

--- a/docs/RFCs/0003-Test-Execution-Protocol.md
+++ b/docs/RFCs/0003-Test-Execution-Protocol.md
@@ -32,33 +32,33 @@ And this protocol helps one launch a custom host or perform debugging:
 ![dotnet-test v2 protocol for custom host](Images/dotnet-test-protocol-v2-execution-customhost.png)
 
 ### Breaking changes for Adapter(IDE)
-1. The object model used via the wire protocol will change from using [Microsoft.Extensions.Testing.Abstractions.Test](https://github.com/dotnet/cli/blob/rel/1.0.0/src/Microsoft.Extensions.Testing.Abstractions/Test.cs) and [Microsoft.Extensions.Testing.Abstractions.TestResult](https://github.com/dotnet/cli/blob/rel/1.0.0/src/Microsoft.Extensions.Testing.Abstractions/TestResult.cs) to [Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase](./src/Microsoft.TestPlatform.ObjectModel/TestCase.cs) and [Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult](./src/Microsoft.TestPlatform.ObjectModel/TestCase.cs) appropriately.
+1. The object model used via the wire protocol will change from using [Microsoft.Extensions.Testing.Abstractions.Test](https://github.com/dotnet/cli/blob/rel/1.0.0/src/Microsoft.Extensions.Testing.Abstractions/Test.cs) and [Microsoft.Extensions.Testing.Abstractions.TestResult](https://github.com/dotnet/cli/blob/rel/1.0.0/src/Microsoft.Extensions.Testing.Abstractions/TestResult.cs) to [Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase](../../src/Microsoft.TestPlatform.ObjectModel/TestCase.cs) and [Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult](../../src/Microsoft.TestPlatform.ObjectModel/TestResult.cs) appropriately.
 2. The IDE adapter would now be sending the test Containers along with test platform settings to dotnet-test.
-3. The IDE adapter would now receive test results in a batch in the [TestRunStatsPayload](./src/Microsoft.TestPlatform.CommunicationUtilities/Messages/TestRunStatsPayload.cs) as opposed to a test start, test result and a test end earlier. The TestRunStatsPayload will also have the statistics of passed/failed/skipped tests so far along with list of tests currently being run.
-4. The IDE Adapter would now receive a [TestRunCompletePayload](./src/Microsoft.TestPlatform.CommunicationUtilities/Messages/TestRunCompletePayload.cs) with TestExecution.Completed which would have the run statistics along with the results for last set of tests run.
+3. The IDE adapter would now receive test results in a batch in the [TestRunStatsPayload](../../src/Microsoft.TestPlatform.CommunicationUtilities/Messages/TestRunStatsPayload.cs) as opposed to a test start, test result and a test end earlier. The TestRunStatsPayload will also have the statistics of passed/failed/skipped tests so far along with list of tests currently being run.
+4. The IDE Adapter would now receive a [TestRunCompletePayload](../../src/Microsoft.TestPlatform.CommunicationUtilities/Messages/TestRunCompletePayload.cs) with TestExecution.Completed which would have the run statistics along with the results for last set of tests run.
 
 ### Breaking Changes for Frameworks
 1. TestRunner would cease to exist. Framework writers would have to port their Rocksteady adapters to Core CLR to support all .NET Core scenarios.
 
 ### New Flow for Run Tests:
 1. After the optional version check,  the IDE adapter can choose to optionally send paths to extensions it wants to initialize the test platform with.
-2. The IDE adapter then sends either a TestExecution.RunTestsWithContainersOnDefaultHost (or) TestExecution.RunTestsWithTestsOnDefaultHost with a [TestRunRequestPayload](./src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Payloads/TestRunRequestPayload.cs) that contains containers (or) tests respectively.
+2. The IDE adapter then sends either a TestExecution.RunTestsWithContainersOnDefaultHost (or) TestExecution.RunTestsWithTestsOnDefaultHost with a [TestRunRequestPayload](../../src/Microsoft.TestPlatform.ObjectModel/Client/Payloads/TestRunRequestPayload.cs) that contains containers (or) tests respectively.
 3. dotnet-test would then spawn an instance of the default test host process for the configuration specified. 
 4. dotnet-test then sends across the extensions if the IDE adapter has specified any, followed by the containers/test cases to run tests on. 
 5. The test host then invokes the Rocksteady adapter with the containers/tests to run via the ITestExeuctor.RunTests entry point. 
 6. The Rocksteady adapter runs each test and calls back to the test host when a test starts, when a test result is received and when a test ends.
 7. The test host process maintains a cache of the test results received above.
-8. When the cache size is met the test host process sends a TestExecution.TestResults with a [TestRunStatsPayload](./src/Microsoft.TestPlatform.CommunicationUtilities/Messages/TestRunStatsPayload.cs), which contains the cached results in a batch, to dotnet-test which then forwards it to the IDE adapater.
-9. Optionally the IDE adapter may also receive a TestSession.Message with a [TestMessagePayload](./src/Microsoft.TestPlatform.CommunicationUtilities/Messages/TestMessagePayload.cs) notifying of any issues during execution.
-10. When execution is complete, the test host process sends a TestExecution.Completed message to dotnet-test with a [TestRunCompletePayload](./src/Microsoft.TestPlatform.CommunicationUtilities/Messages/TestRunCompletePayload.cs) which contains the run statistics along with the results for the last set of tests run.
+8. When the cache size is met the test host process sends a TestExecution.TestResults with a [TestRunStatsPayload](../../src/Microsoft.TestPlatform.CommunicationUtilities/Messages/TestRunStatsPayload.cs), which contains the cached results in a batch, to dotnet-test which then forwards it to the IDE adapater.
+9. Optionally the IDE adapter may also receive a TestSession.Message with a [TestMessagePayload](../../src/Microsoft.TestPlatform.CommunicationUtilities/Messages/TestMessagePayload.cs) notifying of any issues during execution.
+10. When execution is complete, the test host process sends a TestExecution.Completed message to dotnet-test with a [TestRunCompletePayload](../../src/Microsoft.TestPlatform.CommunicationUtilities/Messages/TestRunCompletePayload.cs) which contains the run statistics along with the results for the last set of tests run.
 11. dotnet-test then forwards this message to the IDE adapter.
 12. Once the IDE adapter is done, it sends dotnet-test a TestSession.Terminate which will cause dotnet-test to shutdown.
 
 ### New Flow for Debug Tests/Custom test host process:
 This flow would have the same protocol to bootstrap the test platform which is essentially #1 in the default flow above. Here is the sequence of steps after the initialization phase:
 
-1. The IDE adapter sends a TestExecution.GetProcessStartInfo with a [TestRunRequestPayload](./src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Payloads/TestRunRequestPayload.cs) that contains the container/tests it wants to execute.
-2. dotnet-test then reverts back to the IDE adapter with a TestExecution.CustomTestHostLaunch with a [ProcessStartInfo](./src/Microsoft.TestPlatform.ObjectModel/TestProcessStartInfo.cs) payload which has the process start info of the default test host. As part of the arguments, we send a port that the test host should connect to communicate with dotnet-test.
+1. The IDE adapter sends a TestExecution.GetProcessStartInfo with a [TestRunRequestPayload](../../src/Microsoft.TestPlatform.ObjectModel/Client/Payloads/TestRunRequestPayload.cs) that contains the container/tests it wants to execute.
+2. dotnet-test then reverts back to the IDE adapter with a TestExecution.CustomTestHostLaunch with a [ProcessStartInfo](../../src/Microsoft.TestPlatform.ObjectModel/TestProcessStartInfo.cs) payload which has the process start info of the default test host. As part of the arguments, we send a port that the test host should connect to communicate with dotnet-test.
 3. At this point, the adapter can launch the test host process (and attach to it for debugging if it chooses to).
 4. Once the test host starts, it sends dotnet-test a handshake TestHost.Connected message that indicates it is ready to receive commands.
 

--- a/docs/RFCs/0004-Adapter-Extensibility.md
+++ b/docs/RFCs/0004-Adapter-Extensibility.md
@@ -153,7 +153,7 @@ An attachment here, could be any file that the adapter generates during the run 
 Data driven test cases can have multiple test results, one against each data value. In that case adapters would post a RecordStart, RecordEnd and RecordResult for each data value. If the TestResult objects posted for all the data values are associated with the same TestCase object, then the VS IDE client would create a single entry in the Test Explorer with the aggregated outcome along with a summary for each test case in a separate view. If the TestResult objects posted for all the data values are associated with their own TestCase objects with different ID's, then each test result would be different entries in the VS IDE Test Explorer.
 
 #### Filtering
-The user might optionally also pass in a test case filter to run a subset of tests. In such cases along with invoking the adapters with the container set, the test platform also provides a callback in the run context instance in the form of [GetTestCaseFilter](./src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/IRunContext.cs#L38) that enables adapters to filter a [TestCase](./src/Microsoft.TestPlatform.ObjectModel/TestCase.cs) object. The adapters can query this API with the set of properties it supports filtering on, along with a provider of TestProperty instances  for each property. From the filter expression returned by this API, the adapter would then just have to perform a [ITestCaseFilterExpression.MatchTestCase](./src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/ITestCaseFilterExpression.cs#L20) on each test case which returns false if the test case has been filtered out. Below is sample code that demonstrates filtering:
+The user might optionally also pass in a test case filter to run a subset of tests. In such cases along with invoking the adapters with the container set, the test platform also provides a callback in the run context instance in the form of [GetTestCaseFilter](../../src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/IRunContext.cs#L38) that enables adapters to filter a [TestCase](../../src/Microsoft.TestPlatform.ObjectModel/TestCase.cs) object. The adapters can query this API with the set of properties it supports filtering on, along with a provider of TestProperty instances  for each property. From the filter expression returned by this API, the adapter would then just have to perform a [ITestCaseFilterExpression.MatchTestCase](../../src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/ITestCaseFilterExpression.cs#L20) on each test case which returns false if the test case has been filtered out. Below is sample code that demonstrates filtering:
 
 ```csharp
 static readonly TestProperty PriorityProperty = TestProperty.Register(
@@ -187,7 +187,7 @@ if (filterExpression != null &&
 ```
 
 #### TestCase Extensibility
-Adapters can choose to fill in custom data into the [TestCase](./src/Microsoft.TestPlatform.ObjectModel/TestCase.cs) object through its [Property](./src/Microsoft.TestPlatform.ObjectModel/TestObject.cs#L112) bag. This data can be:
+Adapters can choose to fill in custom data into the [TestCase](../../src/Microsoft.TestPlatform.ObjectModel/TestCase.cs) object through its [Property](../../src/Microsoft.TestPlatform.ObjectModel/TestObject.cs#L112) bag. This data can be:
 
 1. If the test case is adorned by a "Do Not Run"  attribute.
 2. If the test case is data driven, the values of the data to drive it with.

--- a/docs/RFCs/0015-Telemetry.md
+++ b/docs/RFCs/0015-Telemetry.md
@@ -17,7 +17,7 @@ Following telemetry data points will be collected by vstest and also enabled for
 For more details please refer to the **Detailed List of Data Points** section at the end
 
 ## Conceptual Flow
-![alt text](./RFCs/Images/vstest.telemetry.png) 
+![alt text](./Images/vstest.telemetry.png) 
 
 ## Scope
 * vstest and vstest.console.exe will emit telemetry data points that any vstest consuming platform can listen to
@@ -77,9 +77,9 @@ The Microsoft distribution of vstest is licensed with the [Link](https://www.vis
 ## Sending Consent for collecting Telemetry Metrics in Test Platform in Design Mode
 **Collection in Test Platform will only happen if TestPlatform receives consent from the consumers.**
 
-The "CollectMetrics" field has been added in [TestPlatformOptions](./src/Microsoft.TestPlatform.ObjectModel/Client/TestPlatformOptions.cs) to send consent from Design Mode Scenarios(VS, VSCode etc) to TestPlatform. The users have to set "CollectMetrics" to "true" so that TestPlatform can collect Metrics and send it back to the client.
+The "CollectMetrics" field has been added in [TestPlatformOptions](../../src/Microsoft.TestPlatform.ObjectModel/Client/TestPlatformOptions.cs) to send consent from Design Mode Scenarios(VS, VSCode etc) to TestPlatform. The users have to set "CollectMetrics" to "true" so that TestPlatform can collect Metrics and send it back to the client.
 
-The [IVsTestConsoleWrapper](./src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IVsTestConsoleWrapper.cs) and [IVsTestConsoleWrapperAsync](./src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IVsTestConsoleWrapperAsync.cs) contains API's that support TestPlatformOptions. Users must use these API's to send consent to the TestPlatform for collecting Metrics.
+The [IVsTestConsoleWrapper](../../src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IVsTestConsoleWrapper.cs) and [IVsTestConsoleWrapperAsync](../../src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IVsTestConsoleWrapperAsync.cs) contains API's that support TestPlatformOptions. Users must use these API's to send consent to the TestPlatform for collecting Metrics.
 
 **For Instance**
 For Discovery : Users have to use this API to pass TestPlatform Options.
@@ -107,11 +107,11 @@ For Execution using sources: Users have to use this API to pass TestPlatform Opt
 Similarly, while running tests using TestCases, there are API's available to send TestPlatformOptions along with them.
 
 ## Consuming Metrics in Design Mode Scenarios from Test Platform
-The whole aggregated metrics will be appended in vstest.console process in the final Execution/Disocvery Complete message and it will be send back to the consumers. When users use API's that are available in [IVSTestConsoleWrapper](./src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IVsTestConsoleWrapper.cs), they have to pass the event handler which will contain metrics from TestPlatform.
+The whole aggregated metrics will be appended in vstest.console process in the final Execution/Discovery Complete message and it will be sent back to the consumers. When users use API's that are available in [IVSTestConsoleWrapper](../../src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IVsTestConsoleWrapper.cs), they have to pass the event handler which will contain metrics from TestPlatform.
 
-In Case of Execution, users will pass [ITestRunEventsHandler](./src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestRunEventsHandler.cs), which contains [TestRunCompleteEventArgs](./src/Microsoft.TestPlatform.ObjectModel/Client/Events/TestRunCompleteEventArgs.cs) which will have Metrics in it which users can consume.
+In Case of Execution, users will pass [ITestRunEventsHandler](../../src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestRunEventsHandler.cs), which contains [TestRunCompleteEventArgs](../../src/Microsoft.TestPlatform.ObjectModel/Client/Events/TestRunCompleteEventArgs.cs) which will have Metrics in it which users can consume.
 
-In Case of Discovery, users have to pass new interface [ITestDiscoveryEventsHandler2](./src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestDiscoveryEventsHandler2.cs) which contains [DiscoveryCompleteEventArgs](./src/Microsoft.TestPlatform.ObjectModel/Client/Events/DiscoveryCompleteEventArgs.cs) which will have metrics in it which users can consume.
+In Case of Discovery, users have to pass new interface [ITestDiscoveryEventsHandler2](../../src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestDiscoveryEventsHandler2.cs) which contains [DiscoveryCompleteEventArgs](../../src/Microsoft.TestPlatform.ObjectModel/Client/Events/DiscoveryCompleteEventArgs.cs) which will have metrics in it which users can consume.
 
 ## Telemetry Design
 ### Collecting Data
@@ -129,10 +129,10 @@ We have to collect Total Discovery Time taken, Total Tests Run in case of parall
 * It may happen that TestHost is on a newer version whereas vstest.console is on older version. So, TestHost process should not collect Metrics by default. So, it should only collect Metrics when users give consent to collect Metrics.
 So, for sending consent from Vstest.console process to Test Host, Command line argument i.e. boolean **TelemetryOptedIn** is sent to TestHost Process from Vstest.console process.
 
-The interface [IRequestData](./src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/IRequestData.cs) has been has been exposed to TestHost process which contains [IMetricCollection](./src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/IMetricsCollection.cs) which will collect the Metrics in a dictionary.
+The interface [IRequestData](../../src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/IRequestData.cs) has been exposed to TestHost process which contains [IMetricsCollection](../../src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/IMetricsCollection.cs) which will collect the Metrics in a dictionary.
 
 #### Sending Metrics from TestHost process to vstest.console process
-Currently, At the end of Discovery Complete, we are sending **TestDiscovery.Complete** message event along with DiscoveryCompletePayload, so we will add our collected Metrics along with [DiscoveryCompletePayload](./src/Microsoft.TestPlatform.CommunicationUtilities/Messages/DiscoveryCompletePayload.cs). Similar will be done at end of **TestExecution.Complete** event where we will add the Metrics in [TestRunCompleteEventArgs](./src/Microsoft.TestPlatform.ObjectModel/Client/Events/TestRunCompleteEventArgs.cs). This helps us in sending whole metrics in one go and helps us to decrease performance overhead of sending messages from test host process to vstest.console process.
+Currently, At the end of Discovery Complete, we are sending **TestDiscovery.Complete** message event along with DiscoveryCompletePayload, so we will add our collected Metrics along with [DiscoveryCompletePayload](../../src/Microsoft.TestPlatform.CommunicationUtilities/Messages/DiscoveryCompletePayload.cs). Similar will be done at end of **TestExecution.Complete** event where we will add the Metrics in [TestRunCompleteEventArgs](../../src/Microsoft.TestPlatform.ObjectModel/Client/Events/TestRunCompleteEventArgs.cs). This helps us in sending whole metrics in one go and helps us to decrease performance overhead of sending messages from test host process to vstest.console process.
 
 In VsTestConsole process, the metrics which will be received from TestHost process will be aggregated with the VsTestConsole own metrics.
 

--- a/docs/RFCs/0025-Test-Host-Runtime-Provider.md
+++ b/docs/RFCs/0025-Test-Host-Runtime-Provider.md
@@ -15,11 +15,11 @@ This design will be detailed through the following sections:
 	3. Choosing appropriate TestHost
 
 ### RunTime Provider Contract
-A Test RunTime provider will implement [ITestRunTimeProvider](./src/Microsoft.TestPlatform.ObjectModel/Host/ITestRunTimeProvider.cs#L18)
+A Test RunTime provider will implement [ITestRunTimeProvider](../../src/Microsoft.TestPlatform.ObjectModel/Host/ITestRunTimeProvider.cs#L18)
 
 ITestRunTimeProvider provides set of API's needed for any Test RunTime provider to be able to deploy, & launch the Test RunTime.
 
-Interface [ITestHostLauncher](./src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher.cs) provides an Extension point for IDE's to start TestHost process themselves. For example, in case of debugging/profiling test, the VS IDE would need to launch the TestHost itself.
+Interface [ITestHostLauncher](../../src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher.cs) provides an Extension point for IDE's to start TestHost process themselves. For example, in case of debugging/profiling test, the VS IDE would need to launch the TestHost itself.
 The interfaces would be part of Object Model.
 
 ### Discovering TestHost

--- a/docs/RFCs/0029-Debugging-External-Test-Processes.md
+++ b/docs/RFCs/0029-Debugging-External-Test-Processes.md
@@ -6,7 +6,7 @@ Introduce APIs to improve debugging support in Visual Studio for tests that run 
 # Motivation
 Some test frameworks (examples include [TAEF](https://learn.microsoft.com/en-us/windows-hardware/drivers/taef/) and [Python](https://learn.microsoft.com/en-us/visualstudio/python/unit-testing-python-in-visual-studio)) need to execute tests in a external process other than `testhost*.exe`. When it comes to debugging such tests in Visual Studio today, there are a couple of problems. 
 
-1. A test adapter can request to launch a child process with debugger attached by calling  [`IFrameworkHandle.LaunchProcessWithDebuggerAttached()`](./src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/IFrameworkHandle.cs#L29) within adapter's implementation of [`ITestExecutor.RunTests()`](./src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/ITestExecutor.cs#L23) (after checking that [`IRunContext.IsBeingDebugged`](./src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/IRunContext.cs#L32) is `true`). However, there is no supported way for a test adapter to request that debugger should be attached to an **already running process**.
+1. A test adapter can request to launch a child process with debugger attached by calling  [`IFrameworkHandle.LaunchProcessWithDebuggerAttached()`](../../src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/IFrameworkHandle.cs#L29) within adapter's implementation of [`ITestExecutor.RunTests()`](../../src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/ITestExecutor.cs#L23) (after checking that [`IRunContext.IsBeingDebugged`](../../src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/IRunContext.cs#L32) is `true`). However, there is no supported way for a test adapter to request that debugger should be attached to an **already running process**.
 
 2. Even though a test adapter can launch a child process with debugger attached as described above, today the debugger is always attached to the `testhost*.exe` process as well. This means that **Visual Studio ends up debugging two processes** instead of just the single process where tests are running.
 
@@ -15,7 +15,7 @@ Debugging of Python tests is supported in VS today. However, the Python adapter 
 While this works for Python, not all test frameworks that need to support debugging of tests running in external processes would want their users to also install a VS extension. For this reason, debugging of TAEF tests is currently not supported in VS.
 
 # Proposed Changes
-1. Introduce a new `IFrameworkHandle2` interface that inherits [`IFrameworkHandle`](./src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/IFrameworkHandle.cs#L12) and adds the following `AttachDebuggerToProcess()` API that an adapter can invoke from within [`ITestExecutor.RunTests()`](./src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/ITestExecutor.cs#L23) to attach debugger to an already running process. 
+1. Introduce a new `IFrameworkHandle2` interface that inherits [`IFrameworkHandle`](../../src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/IFrameworkHandle.cs#L12) and adds the following `AttachDebuggerToProcess()` API that an adapter can invoke from within [`ITestExecutor.RunTests()`](../../src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/ITestExecutor.cs#L23) to attach debugger to an already running process. 
 
 ```
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter
@@ -50,7 +50,7 @@ void ITestExecutor.RunTests(IEnumerable<TestCase> tests, IRunContext runContext,
 }
 ```
 
-2. Introduce a new `ITestExecutor2` interface that inherits [`ITestExecutor`](./src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/ITestExecutor.cs#L15) and adds the following `ShouldAttachToTestHost()` API. Newer adapters can choose to implement `ITestExecutor2` instead of `ITestExecutor`. If implemented, `ITestExecutor.ShouldAttachToTestHost()` will be invoked before `ITestExecutor.RunTests()` is invoked for any test execution. `ITestExecutor2.ShouldAttachToTestHost()` will also be supplied the same set of inputs as `ITestExecutor.RunTests()`. This would allow adapters to control whether or not the debugger should be attached to `testhost*.exe` for the subsequent invocation of `ITestExecutor.RunTests()`.
+2. Introduce a new `ITestExecutor2` interface that inherits [`ITestExecutor`](../../src/Microsoft.TestPlatform.ObjectModel/Adapter/Interfaces/ITestExecutor.cs#L15) and adds the following `ShouldAttachToTestHost()` API. Newer adapters can choose to implement `ITestExecutor2` instead of `ITestExecutor`. If implemented, `ITestExecutor.ShouldAttachToTestHost()` will be invoked before `ITestExecutor.RunTests()` is invoked for any test execution. `ITestExecutor2.ShouldAttachToTestHost()` will also be supplied the same set of inputs as `ITestExecutor.RunTests()`. This would allow adapters to control whether or not the debugger should be attached to `testhost*.exe` for the subsequent invocation of `ITestExecutor.RunTests()`.
 
 ```
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter
 }
 ```
 
-3. Introduce a new `ITestHostLauncher2` interface that inherits [`ITestHostLauncher`](./src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher.cs#L11) and adds the following `AttachToProcess()` API. Visual Studio's Test Explorer will supply an implementation of this interface via [`IVsTestConsoleWrapper.RunTestsWithCustomTestHost()`](./src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IVsTestConsoleWrapper.cs#L120) and `ITestHostLauncher2.AttachToProcess()` will be called when  `IFrameworkHandle2.AttachDebuggerToProcess()` is called within an adapter.
+3. Introduce a new `ITestHostLauncher2` interface that inherits [`ITestHostLauncher`](../../src/Microsoft.TestPlatform.ObjectModel/Client/Interfaces/ITestHostLauncher.cs#L11) and adds the following `AttachToProcess()` API. Visual Studio's Test Explorer will supply an implementation of this interface via [`IVsTestConsoleWrapper.RunTestsWithCustomTestHost()`](../../src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IVsTestConsoleWrapper.cs#L286) and `ITestHostLauncher2.AttachToProcess()` will be called when  `IFrameworkHandle2.AttachDebuggerToProcess()` is called within an adapter.
 
 ```
 namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces

--- a/docs/RFCs/0031-Test-Run-Attachments-Processing.md
+++ b/docs/RFCs/0031-Test-Run-Attachments-Processing.md
@@ -62,7 +62,7 @@ If `SupportsIncrementalProcessing` is `False` then Test Platform will wait for a
 
 
 
-2. Introduce a new `ProcessTestRunAttachmentsAsync` method in [IVsTestConsoleWrapper](./src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IVsTestConsoleWrapper.cs) interface:
+2. Introduce a new `ProcessTestRunAttachmentsAsync` method in [IVsTestConsoleWrapper](../../src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Interfaces/IVsTestConsoleWrapper.cs) interface:
 
 ```cs
 /// <summary>

--- a/docs/RFCs/0032- Extensions versioning attribute.md
+++ b/docs/RFCs/0032- Extensions versioning attribute.md
@@ -7,7 +7,7 @@ This document explain how to use the `TestExtensionTypesAttribute` and `TestExte
 The test platform offers many extensions points like custom test adapters, test execution providers, data collectors, etc...   
 The main problem with the extensions is that the platform is in continuous evolution. Therefore, we need to keep the back-compatibility; we want to load new extensions in the old test platform implementation and vice versa.
 
-The logic used to load the extensions if inside the [TestPluginDiscoverer.cs](./src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs) file.  
+The logic used to load the extensions is inside the [TestPluginDiscoverer.cs](../../src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs) file.  
 
 # How to use `TestExtensionTypesAttribute` and `TestExtensionTypesV2Attribute`
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1906,7 +1906,7 @@ See full log [here](https://github.com/Microsoft/vstest/compare/v16.5.0-preview-
 
 ### Drops
 
-* TestPlatform vsix: [15.7.2]( https://vsdrop.corp.microsoft.com/file/v1/Products/DevDiv/Microsoft/vstest/15.7/20180514-03;/TestPlatform.vsix)
+* TestPlatform vsix: [15.7.2](https://vsdrop.corp.microsoft.com/file/v1/Products/DevDiv/Microsoft/vstest/15.7/20180514-03;/TestPlatform.vsix)
 * Microsoft.TestPlatform.ObjectModel: [15.7.2](https://www.nuget.org/packages/Microsoft.TestPlatform.ObjectModel/15.7.2)
 
 ## 15.7.0
@@ -1925,7 +1925,7 @@ See full log [here](https://github.com/Microsoft/vstest/compare/v16.5.0-preview-
 
 ### Drops
 
-* TestPlatform vsix: [15.7.0]( https://vsdrop.corp.microsoft.com/file/v1/Products/DevDiv/Microsoft/vstest/15.7/20180403-02;/TestPlatform.vsix)
+* TestPlatform vsix: [15.7.0](https://vsdrop.corp.microsoft.com/file/v1/Products/DevDiv/Microsoft/vstest/15.7/20180403-02;/TestPlatform.vsix)
 * Microsoft.TestPlatform.ObjectModel: [15.7.0](https://www.nuget.org/packages/Microsoft.TestPlatform.ObjectModel/15.7.0)
 
 ## 15.7.0-preview-20180320-02

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.cs.xlf
@@ -124,17 +124,17 @@
       </trans-unit>
       <trans-unit id="DataCollectionContextNotInitialized">
         <source>The data collection environment context has not been initialized. Ensure that session started before processing test case events.</source>
-        <target state="new">The data collection environment context has not been initialized. Ensure that session started before processing test case events.</target>
+        <target state="translated">Kontext prostředí shromažďování dat nebyl inicializován. Ujistěte se, že se relace spustila před zpracováním událostí testovacího případu.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseEndMissingTestElement">
         <source>TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</source>
-        <target state="new">TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</target>
+        <target state="translated">TestCaseEndEventArgs.TestElement má hodnotu null. Kolekce dat nemůže ukončit testovací případ bez testovacího elementu.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseStartMissingTestElement">
         <source>TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</source>
-        <target state="new">TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</target>
+        <target state="translated">TestCaseStartEventArgs.TestElement má hodnotu null. Kolekce dat nemůže spustit testovací případ bez testovacího elementu.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectorRequestedDuplicateEnvironmentVariable">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.de.xlf
@@ -124,17 +124,17 @@
       </trans-unit>
       <trans-unit id="DataCollectionContextNotInitialized">
         <source>The data collection environment context has not been initialized. Ensure that session started before processing test case events.</source>
-        <target state="new">The data collection environment context has not been initialized. Ensure that session started before processing test case events.</target>
+        <target state="translated">Der Kontext der Datensammlungsumgebung wurde nicht initialisiert. Stellen Sie sicher, dass die Sitzung vor der Verarbeitung von Testfallereignissen gestartet wurde.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseEndMissingTestElement">
         <source>TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</source>
-        <target state="new">TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</target>
+        <target state="translated">TestCaseEndEventArgs.TestElement ist NULL. Der Datensammler kann keinen Testfall ohne Testelement beenden.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseStartMissingTestElement">
         <source>TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</source>
-        <target state="new">TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</target>
+        <target state="translated">TestCaseStartEventArgs.TestElement ist NULL. Der Datensammler kann keinen Testfall ohne Testelement starten.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectorRequestedDuplicateEnvironmentVariable">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.es.xlf
@@ -124,17 +124,17 @@
       </trans-unit>
       <trans-unit id="DataCollectionContextNotInitialized">
         <source>The data collection environment context has not been initialized. Ensure that session started before processing test case events.</source>
-        <target state="new">The data collection environment context has not been initialized. Ensure that session started before processing test case events.</target>
+        <target state="translated">No se ha inicializado el contexto del entorno de recopilación de datos. Asegúrese de que la sesión se inició antes de procesar los eventos del caso de prueba.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseEndMissingTestElement">
         <source>TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</source>
-        <target state="new">TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</target>
+        <target state="translated">TestCaseEndEventArgs.TestElement es null. El recopilador de datos no puede finalizar un caso de prueba sin un elemento de prueba.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseStartMissingTestElement">
         <source>TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</source>
-        <target state="new">TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</target>
+        <target state="translated">TestCaseStartEventArgs.TestElement es null. El recopilador de datos no puede iniciar un caso de prueba sin un elemento de prueba.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectorRequestedDuplicateEnvironmentVariable">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.fr.xlf
@@ -124,17 +124,17 @@
       </trans-unit>
       <trans-unit id="DataCollectionContextNotInitialized">
         <source>The data collection environment context has not been initialized. Ensure that session started before processing test case events.</source>
-        <target state="new">The data collection environment context has not been initialized. Ensure that session started before processing test case events.</target>
+        <target state="translated">Le contexte de l’environnement de la collecte de données n’a pas été initialisé. Vérifiez que la session a été lancée avant de traiter les événements du cas de test.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseEndMissingTestElement">
         <source>TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</source>
-        <target state="new">TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</target>
+        <target state="translated">TestCaseEndEventArgs.TestElement a une valeur nulle. Le collecteur de données ne peut pas terminer un cas de test sans avoir d’élément de test.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseStartMissingTestElement">
         <source>TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</source>
-        <target state="new">TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</target>
+        <target state="translated">TestCaseStartEventArgs.TestElement a une valeur nulle. Le collecteur de données ne peut pas lancer un cas de test sans avoir d’élément de test.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectorRequestedDuplicateEnvironmentVariable">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.it.xlf
@@ -124,17 +124,17 @@
       </trans-unit>
       <trans-unit id="DataCollectionContextNotInitialized">
         <source>The data collection environment context has not been initialized. Ensure that session started before processing test case events.</source>
-        <target state="new">The data collection environment context has not been initialized. Ensure that session started before processing test case events.</target>
+        <target state="translated">Il contesto dell'ambiente di raccolta dati non è stato inizializzato. Assicurarsi che la sessione sia stata avviata prima di elaborare gli eventi del test case.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseEndMissingTestElement">
         <source>TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</source>
-        <target state="new">TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</target>
+        <target state="translated">TestCaseEndEventArgs.TestElement is null. L'agente di raccolta dati non può terminare un test case senza un elemento di test.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseStartMissingTestElement">
         <source>TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</source>
-        <target state="new">TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</target>
+        <target state="translated">TestCaseStartEventArgs.TestElement is null. L'agente di raccolta dati non può avviare un test case senza un elemento di test.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectorRequestedDuplicateEnvironmentVariable">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ja.xlf
@@ -124,17 +124,17 @@
       </trans-unit>
       <trans-unit id="DataCollectionContextNotInitialized">
         <source>The data collection environment context has not been initialized. Ensure that session started before processing test case events.</source>
-        <target state="new">The data collection environment context has not been initialized. Ensure that session started before processing test case events.</target>
+        <target state="translated">データ コレクション環境コンテキストが初期化されていません。テスト ケース イベントを処理する前に、セッションが開始されていることを確認してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseEndMissingTestElement">
         <source>TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</source>
-        <target state="new">TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</target>
+        <target state="translated">TestCaseEndEventArgs.TestElement が null 値です。データ コレクターは、テスト要素がないとテスト ケースを終了できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseStartMissingTestElement">
         <source>TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</source>
-        <target state="new">TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</target>
+        <target state="translated">TestCaseStartEventArgs.TestElement が null 値です。データ コレクターは、テスト要素がないとテスト ケースを開始できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectorRequestedDuplicateEnvironmentVariable">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ko.xlf
@@ -124,17 +124,17 @@
       </trans-unit>
       <trans-unit id="DataCollectionContextNotInitialized">
         <source>The data collection environment context has not been initialized. Ensure that session started before processing test case events.</source>
-        <target state="new">The data collection environment context has not been initialized. Ensure that session started before processing test case events.</target>
+        <target state="translated">데이터 수집 환경 컨텍스트가 초기화되지 않았습니다. 테스트 케이스 이벤트를 처리하기 전에 세션이 시작되었는지 확인하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseEndMissingTestElement">
         <source>TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</source>
-        <target state="new">TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</target>
+        <target state="translated">TestCaseEndEventArgs.TestElement is null. 데이터 수집기는 테스트 요소 없이 테스트 사례를 종료할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseStartMissingTestElement">
         <source>TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</source>
-        <target state="new">TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</target>
+        <target state="translated">TestCaseStartEventArgs.TestElement is null. 데이터 수집기는 테스트 요소 없이 테스트 케이스를 시작할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectorRequestedDuplicateEnvironmentVariable">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pl.xlf
@@ -124,17 +124,17 @@
       </trans-unit>
       <trans-unit id="DataCollectionContextNotInitialized">
         <source>The data collection environment context has not been initialized. Ensure that session started before processing test case events.</source>
-        <target state="new">The data collection environment context has not been initialized. Ensure that session started before processing test case events.</target>
+        <target state="translated">Kontekst środowiska zbierania danych nie został zainicjowany. Upewnij się, że sesja została uruchomiona przed przetwarzaniem zdarzeń przypadku testowego.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseEndMissingTestElement">
         <source>TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</source>
-        <target state="new">TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</target>
+        <target state="translated">Element TestCaseEndEventArgs.TestElement ma wartość null. Moduł zbierający dane nie może zakończyć przypadku testowego bez elementu testowego.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseStartMissingTestElement">
         <source>TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</source>
-        <target state="new">TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</target>
+        <target state="translated">Element TestCaseStartEventArgs.TestElement ma wartość null. Moduł zbierający dane nie może uruchomić przypadku testowego bez elementu testowego.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectorRequestedDuplicateEnvironmentVariable">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pt-BR.xlf
@@ -124,17 +124,17 @@
       </trans-unit>
       <trans-unit id="DataCollectionContextNotInitialized">
         <source>The data collection environment context has not been initialized. Ensure that session started before processing test case events.</source>
-        <target state="new">The data collection environment context has not been initialized. Ensure that session started before processing test case events.</target>
+        <target state="translated">O contexto do ambiente de coleta de dados não foi inicializado. Verifique se a sessão foi iniciada antes de processar os eventos do caso de teste.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseEndMissingTestElement">
         <source>TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</source>
-        <target state="new">TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</target>
+        <target state="translated">TestCaseEndEventArgs.TestElement está nulo. O coletor de dados não pode encerrar um caso de teste sem um elemento de teste.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseStartMissingTestElement">
         <source>TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</source>
-        <target state="new">TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</target>
+        <target state="translated">TestCaseStartEventArgs.TestElement está nulo. O coletor de dados não pode iniciar um caso de teste sem um elemento de teste.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectorRequestedDuplicateEnvironmentVariable">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ru.xlf
@@ -124,17 +124,17 @@
       </trans-unit>
       <trans-unit id="DataCollectionContextNotInitialized">
         <source>The data collection environment context has not been initialized. Ensure that session started before processing test case events.</source>
-        <target state="new">The data collection environment context has not been initialized. Ensure that session started before processing test case events.</target>
+        <target state="translated">Контекст среды сбора данных не был инициализирован. Убедитесь, что сеанс запущен, прежде чем приступать к обработке событий тестового сценария.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseEndMissingTestElement">
         <source>TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</source>
-        <target state="new">TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</target>
+        <target state="translated">TestCaseEndEventArgs.TestElement имеет значение null. Сборщик данных не может завершить тестовый сценарий без тестового элемента.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseStartMissingTestElement">
         <source>TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</source>
-        <target state="new">TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</target>
+        <target state="translated">TestCaseStartEventArgs.TestElement имеет значение null. Сборщику данных не удается запустить тестовый сценарий без тестового элемента.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectorRequestedDuplicateEnvironmentVariable">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.tr.xlf
@@ -124,17 +124,17 @@
       </trans-unit>
       <trans-unit id="DataCollectionContextNotInitialized">
         <source>The data collection environment context has not been initialized. Ensure that session started before processing test case events.</source>
-        <target state="new">The data collection environment context has not been initialized. Ensure that session started before processing test case events.</target>
+        <target state="translated">Veri toplama ortamı bağlamı başlatılmadı. Test çalışması olaylarını işlemeye başlamadan önce oturumun başlatıldığından emin olun.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseEndMissingTestElement">
         <source>TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</source>
-        <target state="new">TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</target>
+        <target state="translated">TestCaseEndEventArgs.TestElement değeri null. Veri toplayıcı, test öğesi olmadan bir test çalışmasını bitiremez.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseStartMissingTestElement">
         <source>TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</source>
-        <target state="new">TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</target>
+        <target state="translated">TestCaseStartEventArgs.TestElement değeri null. Veri toplayıcı, test öğesi olmadan bir test çalışması başlatamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectorRequestedDuplicateEnvironmentVariable">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hans.xlf
@@ -124,17 +124,17 @@
       </trans-unit>
       <trans-unit id="DataCollectionContextNotInitialized">
         <source>The data collection environment context has not been initialized. Ensure that session started before processing test case events.</source>
-        <target state="new">The data collection environment context has not been initialized. Ensure that session started before processing test case events.</target>
+        <target state="translated">尚未初始化数据收集环境上下文。确保会话在处理测试用例事件之前启动。</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseEndMissingTestElement">
         <source>TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</source>
-        <target state="new">TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</target>
+        <target state="translated">TestCaseEndEventArgs.TestElement 为 null。如果没有测试元素，数据收集器无法结束测试用例。</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseStartMissingTestElement">
         <source>TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</source>
-        <target state="new">TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</target>
+        <target state="translated">TestCaseStartEventArgs.TestElement 为 null。如果没有测试元素，数据收集器无法启动测试用例。</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectorRequestedDuplicateEnvironmentVariable">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hant.xlf
@@ -124,17 +124,17 @@
       </trans-unit>
       <trans-unit id="DataCollectionContextNotInitialized">
         <source>The data collection environment context has not been initialized. Ensure that session started before processing test case events.</source>
-        <target state="new">The data collection environment context has not been initialized. Ensure that session started before processing test case events.</target>
+        <target state="translated">資料收集環境內容尚未初始化。請確認工作階段在處理測試案例事件之前已啟動。</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseEndMissingTestElement">
         <source>TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</source>
-        <target state="new">TestCaseEndEventArgs.TestElement is null. The data collector cannot end a test case without a test element.</target>
+        <target state="translated">TestCaseEndEventArgs.TestElement 為 null。資料收集器無法在沒有測試元素的情況下結束測試案例。</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectionTestCaseStartMissingTestElement">
         <source>TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</source>
-        <target state="new">TestCaseStartEventArgs.TestElement is null. The data collector cannot start a test case without a test element.</target>
+        <target state="translated">TestCaseStartEventArgs.TestElement 為 null。資料收集器無法在沒有測試元素的情況下開始測試案例。</target>
         <note />
       </trans-unit>
       <trans-unit id="DataCollectorRequestedDuplicateEnvironmentVariable">


### PR DESCRIPTION
> [!CAUTION]
> **This PR requires manual review** because threat detection produced a warning.
>
> **Reason:** threat_detected
>
> Review the [workflow run logs](https://github.com/microsoft/vstest/actions/runs/27673147428) for details.

This PR contains changes that were originally intended for PR #16044 (`fix/issue-10369-8a2bbfcf1b265926`).
Please review the changes carefully before merging.