### PR TITLE
[fix] Improve error message when .NET Framework testhost not found on Linux

### DIFF
--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -217,12 +217,12 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
             if (!_environment.OperatingSystem.Equals(PlatformOperatingSystem.Windows)
                 && !processName.EndsWith(DotnetHostHelper.MONOEXENAME, StringComparison.OrdinalIgnoreCase))
             {
-                // On non-Windows, we use Mono to run the .NET Framework testhost. Validate that the
-                // testhost executable actually exists before handing control to Mono, so we can emit
+                // On Linux, source-built SDK packages (apt, dnf, rpm) may omit the TestHostNetFramework
+                // directory entirely. Validate existence before handing control to Mono so we can emit
                 // a clear diagnostic instead of an opaque "Cannot open assembly" error from Mono.
-                // Source-built SDK packages (e.g. from apt/dnf/rpm) may omit the TestHostNetFramework
-                // directory entirely, while the official .tar.gz installer from dot.net includes it.
-                if (!_fileHelper.Exists(testhostProcessPath))
+                // The check is scoped to Linux (Unix) only; on macOS the full SDK is typically present.
+                if (_environment.OperatingSystem.Equals(PlatformOperatingSystem.Unix)
+                    && !_fileHelper.Exists(testhostProcessPath))
                 {
                     throw new TestPlatformException(
                         string.Format(CultureInfo.CurrentCulture, Resources.NetFrameworkTestHostNotFoundOnLinux, testhostProcessPath));

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -217,6 +217,17 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
             if (!_environment.OperatingSystem.Equals(PlatformOperatingSystem.Windows)
                 && !processName.EndsWith(DotnetHostHelper.MONOEXENAME, StringComparison.OrdinalIgnoreCase))
             {
+                // On non-Windows, we use Mono to run the .NET Framework testhost. Validate that the
+                // testhost executable actually exists before handing control to Mono, so we can emit
+                // a clear diagnostic instead of an opaque "Cannot open assembly" error from Mono.
+                // Source-built SDK packages (e.g. from apt/dnf/rpm) may omit the TestHostNetFramework
+                // directory entirely, while the official .tar.gz installer from dot.net includes it.
+                if (!_fileHelper.Exists(testhostProcessPath))
+                {
+                    throw new TestPlatformException(
+                        string.Format(CultureInfo.CurrentCulture, Resources.NetFrameworkTestHostNotFoundOnLinux, testhostProcessPath));
+                }
+
                 launcherPath = _dotnetHostHelper.GetMonoPath();
                 argumentsString = testhostProcessPath.AddDoubleQuote() + " " + argumentsString;
             }

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.Designer.cs
@@ -111,5 +111,16 @@ namespace Microsoft.TestPlatform.TestHostProvider.Resources {
             }
         }
 
+        /// <summary>
+        ///   Looks up a localized string for when the .NET Framework testhost is not found on Linux (e.g. source-built SDK).
+        /// </summary>
+        internal static string NetFrameworkTestHostNotFoundOnLinux
+        {
+            get
+            {
+                return ResourceManager.GetString("NetFrameworkTestHostNotFoundOnLinux", resourceCulture);
+            }
+        }
+
     }
 }

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.Designer.cs
@@ -112,7 +112,7 @@ namespace Microsoft.TestPlatform.TestHostProvider.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string for when the .NET Framework testhost is not found on Linux (e.g. source-built SDK).
+        ///   Looks up a localized string similar to Could not find the .NET Framework test host at &apos;{0}&apos;....
         /// </summary>
         internal static string NetFrameworkTestHostNotFoundOnLinux
         {

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.resx
@@ -150,11 +150,9 @@ The specified framework can be found at:
   <data name="NetFrameworkTestHostNotFoundOnLinux" xml:space="preserve">
     <value>Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </value>
     <comment>'{0}' is the full path where testhost.exe was expected to be found.</comment>
   </data>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.resx
@@ -147,4 +147,15 @@ The specified framework can be found at:
 </value>
     <comment>'{0}' is the placeholder for 'dotnet.exe' or 'dotnet' value and depends on platform Windows/Unix, '{1}' is the placeholder for the architeture name like ARM64, X64 etc...</comment>
   </data>
+  <data name="NetFrameworkTestHostNotFoundOnLinux" xml:space="preserve">
+    <value>Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</value>
+    <comment>'{0}' is the full path where testhost.exe was expected to be found.</comment>
+  </data>
 </root>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.cs.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="cs">
     <body>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.cs.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="cs">
     <body>
@@ -52,6 +52,25 @@ Zadaná architektura se dá najít tady:
   – https://aka.ms/dotnet-download
 </target>
         <note>'{0}' is the placeholder for 'dotnet.exe' or 'dotnet' value and depends on platform Windows/Unix, '{1}' is the placeholder for the architeture name like ARM64, X64 etc...</note>
+      </trans-unit>
+      <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
+        <source>Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</source>
+        <target state="new">Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</target>
+        <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.cs.xlf
@@ -56,19 +56,15 @@ Zadaná architektura se dá najít tady:
       <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
         <source>Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </source>
         <target state="new">Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </target>
         <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.de.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="de">
     <body>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.de.xlf
@@ -56,19 +56,15 @@ Das angegebene Framework finden Sie unter:
       <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
         <source>Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </source>
         <target state="new">Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </target>
         <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.de.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="de">
     <body>
@@ -52,6 +52,25 @@ Das angegebene Framework finden Sie unter:
  – https://aka.ms/dotnet-download
 </target>
         <note>'{0}' is the placeholder for 'dotnet.exe' or 'dotnet' value and depends on platform Windows/Unix, '{1}' is the placeholder for the architeture name like ARM64, X64 etc...</note>
+      </trans-unit>
+      <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
+        <source>Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</source>
+        <target state="new">Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</target>
+        <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.es.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="es">
     <body>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.es.xlf
@@ -56,19 +56,15 @@ El marco especificado se puede encontrar en:
       <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
         <source>Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </source>
         <target state="new">Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </target>
         <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.es.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="es">
     <body>
@@ -52,6 +52,25 @@ El marco especificado se puede encontrar en:
   - https://aka.ms/dotnet-download
 </target>
         <note>'{0}' is the placeholder for 'dotnet.exe' or 'dotnet' value and depends on platform Windows/Unix, '{1}' is the placeholder for the architeture name like ARM64, X64 etc...</note>
+      </trans-unit>
+      <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
+        <source>Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</source>
+        <target state="new">Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</target>
+        <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.fr.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="fr">
     <body>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.fr.xlf
@@ -56,19 +56,15 @@ L’infrastructure spécifiée se trouve à l’adresse suivante :
       <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
         <source>Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </source>
         <target state="new">Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </target>
         <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.fr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="fr">
     <body>
@@ -52,6 +52,25 @@ L’infrastructure spécifiée se trouve à l’adresse suivante :
   - https://aka.ms/dotnet-download
 </target>
         <note>'{0}' is the placeholder for 'dotnet.exe' or 'dotnet' value and depends on platform Windows/Unix, '{1}' is the placeholder for the architeture name like ARM64, X64 etc...</note>
+      </trans-unit>
+      <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
+        <source>Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</source>
+        <target state="new">Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</target>
+        <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.it.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="it">
     <body>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.it.xlf
@@ -56,19 +56,15 @@ Il framework specificato è disponibile in:
       <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
         <source>Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </source>
         <target state="new">Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </target>
         <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.it.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="it">
     <body>
@@ -52,6 +52,25 @@ Il framework specificato è disponibile in:
   - https://aka.ms/dotnet-download
 </target>
         <note>'{0}' is the placeholder for 'dotnet.exe' or 'dotnet' value and depends on platform Windows/Unix, '{1}' is the placeholder for the architeture name like ARM64, X64 etc...</note>
+      </trans-unit>
+      <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
+        <source>Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</source>
+        <target state="new">Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</target>
+        <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ja.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="ja">
     <body>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ja.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="ja">
     <body>
@@ -52,6 +52,25 @@ The specified framework can be found at:
   - https://aka.ms/dotnet-download
 </target>
         <note>'{0}' is the placeholder for 'dotnet.exe' or 'dotnet' value and depends on platform Windows/Unix, '{1}' is the placeholder for the architeture name like ARM64, X64 etc...</note>
+      </trans-unit>
+      <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
+        <source>Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</source>
+        <target state="new">Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</target>
+        <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ja.xlf
@@ -56,19 +56,15 @@ The specified framework can be found at:
       <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
         <source>Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </source>
         <target state="new">Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </target>
         <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ko.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="ko">
     <body>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ko.xlf
@@ -56,19 +56,15 @@ The specified framework can be found at:
       <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
         <source>Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </source>
         <target state="new">Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </target>
         <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ko.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="ko">
     <body>
@@ -52,6 +52,25 @@ The specified framework can be found at:
   - https://aka.ms/dotnet-download
 </target>
         <note>'{0}' is the placeholder for 'dotnet.exe' or 'dotnet' value and depends on platform Windows/Unix, '{1}' is the placeholder for the architeture name like ARM64, X64 etc...</note>
+      </trans-unit>
+      <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
+        <source>Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</source>
+        <target state="new">Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</target>
+        <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pl.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="pl">
     <body>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pl.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="pl">
     <body>
@@ -52,6 +52,25 @@ Określoną strukturę można znaleźć pod adresem:
  — https://aka.ms/dotnet-download
 </target>
         <note>'{0}' is the placeholder for 'dotnet.exe' or 'dotnet' value and depends on platform Windows/Unix, '{1}' is the placeholder for the architeture name like ARM64, X64 etc...</note>
+      </trans-unit>
+      <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
+        <source>Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</source>
+        <target state="new">Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</target>
+        <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pl.xlf
@@ -56,19 +56,15 @@ Określoną strukturę można znaleźć pod adresem:
       <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
         <source>Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </source>
         <target state="new">Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </target>
         <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pt-BR.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="pt-BR">
     <body>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pt-BR.xlf
@@ -56,19 +56,15 @@ A estrutura especificada pode ser encontrada em:
       <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
         <source>Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </source>
         <target state="new">Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </target>
         <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pt-BR.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="pt-BR">
     <body>
@@ -52,6 +52,25 @@ A estrutura especificada pode ser encontrada em:
   - https://aka.ms/dotnet-download
 </target>
         <note>'{0}' is the placeholder for 'dotnet.exe' or 'dotnet' value and depends on platform Windows/Unix, '{1}' is the placeholder for the architeture name like ARM64, X64 etc...</note>
+      </trans-unit>
+      <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
+        <source>Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</source>
+        <target state="new">Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</target>
+        <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ru.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="ru">
     <body>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ru.xlf
@@ -56,19 +56,15 @@ The specified framework can be found at:
       <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
         <source>Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </source>
         <target state="new">Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </target>
         <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ru.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="ru">
     <body>
@@ -52,6 +52,25 @@ The specified framework can be found at:
   https://aka.ms/dotnet-download
 </target>
         <note>'{0}' is the placeholder for 'dotnet.exe' or 'dotnet' value and depends on platform Windows/Unix, '{1}' is the placeholder for the architeture name like ARM64, X64 etc...</note>
+      </trans-unit>
+      <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
+        <source>Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</source>
+        <target state="new">Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</target>
+        <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.tr.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="tr">
     <body>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.tr.xlf
@@ -56,19 +56,15 @@ Belirtilen çerçeve şu konumda bulunamadı:
       <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
         <source>Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </source>
         <target state="new">Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </target>
         <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.tr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="tr">
     <body>
@@ -52,6 +52,25 @@ Belirtilen çerçeve şu konumda bulunamadı:
   - https://aka.ms/dotnet-download
 </target>
         <note>'{0}' is the placeholder for 'dotnet.exe' or 'dotnet' value and depends on platform Windows/Unix, '{1}' is the placeholder for the architeture name like ARM64, X64 etc...</note>
+      </trans-unit>
+      <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
+        <source>Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</source>
+        <target state="new">Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</target>
+        <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hans.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="zh-Hans">
     <body>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hans.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="zh-Hans">
     <body>
@@ -52,6 +52,25 @@ The specified framework can be found at:
   - https://aka.ms/dotnet-download
 </target>
         <note>'{0}' is the placeholder for 'dotnet.exe' or 'dotnet' value and depends on platform Windows/Unix, '{1}' is the placeholder for the architeture name like ARM64, X64 etc...</note>
+      </trans-unit>
+      <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
+        <source>Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</source>
+        <target state="new">Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</target>
+        <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hans.xlf
@@ -56,19 +56,15 @@ The specified framework can be found at:
       <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
         <source>Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </source>
         <target state="new">Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </target>
         <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hant.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="zh-Hant">
     <body>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hant.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="zh-Hant">
     <body>
@@ -53,6 +53,25 @@ The specified framework can be found at:
   - https://aka.ms/dotnet-download
 </target>
         <note>'{0}' is the placeholder for 'dotnet.exe' or 'dotnet' value and depends on platform Windows/Unix, '{1}' is the placeholder for the architeture name like ARM64, X64 etc...</note>
+      </trans-unit>
+      <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
+        <source>Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</source>
+        <target state="new">Could not find the .NET Framework test host at '{0}'.
+
+Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+
+To resolve this issue, choose one of the following options:
+  - Install the complete .NET SDK from the official installer: https://dot.net/download
+  - Migrate your tests to target .NET instead of .NET Framework.
+</target>
+        <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hant.xlf
@@ -57,19 +57,15 @@ The specified framework can be found at:
       <trans-unit id="NetFrameworkTestHostNotFoundOnLinux">
         <source>Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </source>
         <target state="new">Could not find the .NET Framework test host at '{0}'.
 
-Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not include the .NET Framework test host components needed to run .NET Framework tests with Mono.
+This .NET SDK does not include the .NET Framework test host needed to run .NET Framework tests with Mono.
 
-To resolve this issue, choose one of the following options:
-  - Install the complete .NET SDK from the official installer: https://dot.net/download
-  - Migrate your tests to target .NET instead of .NET Framework.
+To fix this, migrate your tests to target .NET instead of .NET Framework.
 </target>
         <note>'{0}' is the full path where testhost.exe was expected to be found.</note>
       </trans-unit>

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -200,14 +200,14 @@ public class DefaultTestHostManagerTests
         _mockProcessHelper.Setup(p => p.GetCurrentProcessFileName()).Returns("/usr/bin/dotnet");
         _mockEnvironment.Setup(e => e.OperatingSystem).Returns(PlatformOperatingSystem.Unix);
         _mockDotnetHostHelper.Setup(d => d.GetMonoPath()).Returns("/usr/bin/mono");
-        // File helper returns false for all paths — simulates source-built SDK where TestHostNetFramework is absent.
+        // File helper returns false for all paths — simulates an SDK where TestHostNetFramework is absent.
         _mockFileHelper.Setup(fh => fh.Exists(It.IsAny<string>())).Returns(false);
 
         var ex = Assert.ThrowsExactly<TestPlatformException>(() =>
             _testHostManager.GetTestHostProcessStartInfo([], null, default));
 
         Assert.Contains("TestHostNetFramework", ex.Message);
-        Assert.Contains("https://dot.net/download", ex.Message);
+        Assert.Contains("does not include", ex.Message);
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -211,6 +211,21 @@ public class DefaultTestHostManagerTests
     }
 
     [TestMethod]
+    public void GetTestHostProcessStartInfoShouldNotThrowWhenNetFrameworkTestHostNotFoundOnOSX()
+    {
+        // On macOS (OSX) the existence check is skipped — only Linux (Unix) applies.
+        _mockProcessHelper.Setup(p => p.GetCurrentProcessFileName()).Returns("/usr/bin/dotnet");
+        _mockEnvironment.Setup(e => e.OperatingSystem).Returns(PlatformOperatingSystem.OSX);
+        _mockDotnetHostHelper.Setup(d => d.GetMonoPath()).Returns("/usr/bin/mono");
+        // All paths are reported as absent — should NOT throw on macOS.
+        _mockFileHelper.Setup(fh => fh.Exists(It.IsAny<string>())).Returns(false);
+
+        var info = _testHostManager.GetTestHostProcessStartInfo([], null, default);
+
+        Assert.AreEqual("/usr/bin/mono", info.FileName);
+    }
+
+    [TestMethod]
     public void GetTestHostProcessStartInfoShouldNotUseMonoAsHostOnNonWindowsIfStartedWithMono()
     {
         _mockProcessHelper.Setup(p => p.GetCurrentProcessFileName()).Returns("/usr/bin/mono");

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -182,6 +182,7 @@ public class DefaultTestHostManagerTests
         _mockProcessHelper.Setup(p => p.GetCurrentProcessFileName()).Returns("/usr/bin/dotnet");
         _mockEnvironment.Setup(e => e.OperatingSystem).Returns(PlatformOperatingSystem.Unix);
         _mockDotnetHostHelper.Setup(d => d.GetMonoPath()).Returns("/usr/bin/mono");
+        _mockFileHelper.Setup(fh => fh.Exists(It.Is<string>(p => p.Contains("TestHostNetFramework")))).Returns(true);
         var source = @"C:\temp\a.dll";
 
         var info = _testHostManager.GetTestHostProcessStartInfo(
@@ -191,6 +192,22 @@ public class DefaultTestHostManagerTests
 
         Assert.AreEqual("/usr/bin/mono", info.FileName);
         Assert.Contains(Path.Combine("TestHostNetFramework", "testhost.exe"), info.Arguments!);
+    }
+
+    [TestMethod]
+    public void GetTestHostProcessStartInfoShouldThrowWhenNetFrameworkTestHostNotFoundOnLinux()
+    {
+        _mockProcessHelper.Setup(p => p.GetCurrentProcessFileName()).Returns("/usr/bin/dotnet");
+        _mockEnvironment.Setup(e => e.OperatingSystem).Returns(PlatformOperatingSystem.Unix);
+        _mockDotnetHostHelper.Setup(d => d.GetMonoPath()).Returns("/usr/bin/mono");
+        // File helper returns false for all paths — simulates source-built SDK where TestHostNetFramework is absent.
+        _mockFileHelper.Setup(fh => fh.Exists(It.IsAny<string>())).Returns(false);
+
+        var ex = Assert.ThrowsExactly<TestPlatformException>(() =>
+            _testHostManager.GetTestHostProcessStartInfo([], null, default));
+
+        Assert.Contains("TestHostNetFramework", ex.Message);
+        Assert.Contains("https://dot.net/download", ex.Message);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

Fixes #15340.

> 🤖 This is an automated fix created by the Issue Repro Triage agent.

## Root Cause

When running .NET Framework tests on Linux with Mono, vstest resolves `testhost.exe` to `<sdk>/TestHostNetFramework/testhost.exe`. Source-built .NET SDK packages installed via package managers (apt, dnf, rpm) **do not include** the `TestHostNetFramework` directory — only the official `.tar.gz` installer from dot.net ships it.

Previously, vstest would invoke Mono with this non-existent path and report the opaque error:
```
Cannot open assembly '.../TestHostNetFramework/testhost.exe': No such file or directory.
Testhost process for source(s) '...' exited with error: ...
```

This gives users no guidance on why it failed or how to fix it.

## Fix

Added a pre-launch existence check in `DefaultTestHostManager.GetTestHostProcessStartInfo`. On non-Windows platforms (when Mono would be used), if the resolved `testhost.exe` path does not exist, a `TestPlatformException` is thrown with a clear diagnostic message:

```
Could not find the .NET Framework test host at '<path>'.

Source-built .NET SDK packages installed via a Linux package manager (apt, dnf, rpm) may not
include the .NET Framework test host components needed to run .NET Framework tests with Mono.

To resolve this issue, choose one of the following options:
  - Install the complete .NET SDK from the official installer: https://dot.net/download
  - Migrate your tests to target .NET instead of .NET Framework.
```

## Changes

- `DefaultTestHostManager.cs`: Added file existence check before using Mono
- `Resources.resx` + `Resources.Designer.cs`: New `NetFrameworkTestHostNotFoundOnLinux` resource
- All `*.xlf` files: Added new trans-unit entry (pending localization)
- `DefaultTestHostManagerTests.cs`: Updated existing mono test to properly mock file existence; added new test for the missing-testhost case

## Testing

Unit test `GetTestHostProcessStartInfoShouldThrowWhenNetFrameworkTestHostNotFoundOnLinux` verifies that when all file paths return non-existent (simulating a source-built SDK), a `TestPlatformException` is thrown with the expected message fragments.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/27730820860)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 27730820860, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/27730820860 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->