### PR TITLE
Add clarifying comment in vstest.console Program.Run (no-op, CI pipeline test)

### DIFF
--- a/src/vstest.console/Program.cs
+++ b/src/vstest.console/Program.cs
@@ -23,6 +23,7 @@ public static class Program
 
     internal static int Run(string[]? args, UiLanguageOverride uiLanguageOverride)
     {
+        // Console output is switched to UTF-8 unless the feature flag opts out.
         if (!FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_DISABLE_UTF8_CONSOLE_ENCODING))
         {
             Console.OutputEncoding = Encoding.UTF8;


### PR DESCRIPTION
## Summary

Comment-only, behavior-neutral change to `vstest.console`'s `Program.Run` documenting the existing UTF-8 console-encoding behavior.

## Why

This PR intentionally contains a tiny **source** change so that the full CI pipeline runs end-to-end. Doc-only changes (e.g. `.md`) cause the pipeline to skip the build/test legs; a source-file change is required to exercise the complete run (Windows/Source-Build/OtherOSes build + integration tests).

No functional impact — it only adds a single explanatory comment line.
