### PR TITLE
[efficiency-improver] perf: avoid redundant dictionary lookups in FastFilter.Evaluate

### DIFF
--- a/src/Microsoft.TestPlatform.Filter.Source/FastFilter.cs
+++ b/src/Microsoft.TestPlatform.Filter.Source/FastFilter.cs
@@ -68,9 +68,8 @@ internal sealed class FastFilter
             return null;
         }
 
-        return FilterProperties.Keys.All(name => properties.Contains(name))
-            ? null
-            : FilterProperties.Keys.Where(name => !properties.Contains(name)).ToArray();
+        string[] invalid = FilterProperties.Keys.Where(name => !properties.Contains(name)).ToArray();
+        return invalid.Length == 0 ? null : invalid;
     }
 
     internal bool Evaluate(Func<string, object?> propertyValueProvider)
@@ -80,13 +79,15 @@ internal sealed class FastFilter
 #endif
 
         bool matched = false;
-        foreach (var name in FilterProperties.Keys)
+        foreach (var kvp in FilterProperties)
         {
+            var filterValues = kvp.Value;
+
             // Reserved keyword: "None" matches tests with no value for this property (uncategorized).
-            bool hasNoneFilter = FilterProperties[name].Contains(Condition.NoneFilterValue);
+            bool hasNoneFilter = filterValues.Contains(Condition.NoneFilterValue);
 
             // If there is no value corresponding to given name, treat it as unmatched unless filtering for "None".
-            if (!TryGetPropertyValue(name, propertyValueProvider, out var singleValue, out var multiValues))
+            if (!TryGetPropertyValue(kvp.Key, propertyValueProvider, out var singleValue, out var multiValues))
             {
                 if (hasNoneFilter)
                 {
@@ -100,12 +101,12 @@ internal sealed class FastFilter
             if (singleValue != null)
             {
                 var value = PropertyValueRegex == null ? singleValue : ApplyRegex(singleValue);
-                matched = value != null && FilterProperties[name].Contains(value);
+                matched = value != null && filterValues.Contains(value);
             }
             else if (multiValues is { Length: > 0 })
             {
                 var values = PropertyValueRegex == null ? multiValues : multiValues?.Select(value => ApplyRegex(value));
-                matched = values?.Any(result => result != null && FilterProperties[name].Contains(result)) == true;
+                matched = values?.Any(result => result != null && filterValues.Contains(result)) == true;
             }
             else if (hasNoneFilter)
             {


### PR DESCRIPTION
## Goal and Rationale

`FastFilter.Evaluate` is called **once per test case** whenever a test filter is active (e.g. `--filter "TestCategory=UnitTests"`). The previous implementation iterated over `FilterProperties.Keys` and then called `FilterProperties[name]` 2–3 times per property per call, resulting in repeated hash-compute-and-compare dictionary lookups.

For a test suite with 10,000 tests and a single-property filter, this is ~20,000–30,000 extra dictionary lookups that can be eliminated with no behaviour change.

## Focus Area

**Code-Level Efficiency** — eliminating redundant computation in a tight per-test-case loop.

## Approach

Two changes in `FastFilter.cs`:

1. **`Evaluate`** — changed `foreach (var name in FilterProperties.Keys)` to `foreach (var kvp in FilterProperties)`, obtaining the value set once per property (`kvp.Value`) instead of looking it up via `FilterProperties[name]` on each access.

2. **`ValidForProperties`** — replaced the double-scan pattern  
   ```csharp
   FilterProperties.Keys.All(name => properties.Contains(name))
       ? null
       : FilterProperties.Keys.Where(name => !properties.Contains(name)).ToArray();
   ```
   with a single-pass:
   ```csharp
   string[] invalid = FilterProperties.Keys.Where(name => !properties.Contains(name)).ToArray();
   return invalid.Length == 0 ? null : invalid;
   ```
   `ValidForProperties` is called once per test source (not per test case), so the impact here is smaller, but the simplification is clear.

## Energy Efficiency Evidence

**Proxy metric:** CPU instruction count / execution time (faster code = fewer CPU cycles = less energy drawn).

`ImmutableDictionary<TKey, TValue>` lookup involves:
1. Computing the key hash (string hashing — O(n) over key length)
2. Bucket lookup
3. Key equality comparison

For the common single-string-value case the previous code did 2 lookups per property per `Evaluate` call; the new code does 0. For the multi-value case it did 3 lookups; now 0. Given `Evaluate` is called O(tests) times per run, and typical filters have 1–3 properties, savings compound across large test suites.

**Reproducibility:** Run `dotnet test --filter TestCategory=...` against a large test suite and compare wall-clock time. With 10,000 tests, expect a small but measurable reduction in filter-evaluation overhead.

## Green Software Foundation Context

*Hardware Efficiency*: Eliminating unnecessary work makes better use of the available CPU cycles, reducing energy drawn per functional unit (test execution).

*SCI*: Reducing the instruction count per `dotnet test` run lowers the energy term of the SCI equation for CI/CD pipelines that run vstest millions of times per day across the .NET ecosystem.

## Trade-offs

None. The change is purely mechanical — no algorithmic change, no new dependencies, no readability degradation. Using `kvp.Key` / `kvp.Value` from a `foreach` over a dictionary is idiomatic C# and already used throughout the codebase (e.g. `JsoniteConvert.cs`).

## Test Status

- `Microsoft.TestPlatform.Common.UnitTests` (Filtering namespace): ✅ 108/108 passed
- `Microsoft.TestPlatform.Filter.Source.UnitTests`: ✅ 45/45 passed
- Build: ✅ 0 warnings, 0 errors (`net462` + `netstandard2.0`)




> Generated by [Efficiency Improver](https://github.com/microsoft/vstest/actions/runs/27839705239) · 1.6K AIC · ⌖ 25.9 AIC · ⊞ 45.5K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27839705239, workflow_id: efficiency-improver, run: https://github.com/microsoft/vstest/actions/runs/27839705239 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/vstest/efficiency-improver -->