### PR TITLE
[efficiency-improver] perf: replace DateTime.Now with DateTime.UtcNow in test cache hot paths

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscoveryResultCache.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscoveryResultCache.cs
@@ -57,7 +57,7 @@ internal class DiscoveryResultCache
 
         _cacheSize = cacheSize;
         _onReportTestCases = onReportTestCases;
-        _lastUpdate = DateTime.Now;
+        _lastUpdate = DateTime.UtcNow;
         _cacheTimeout = discoveredTestEventTimeout;
 
         _tests = new List<TestCase>();
@@ -107,13 +107,13 @@ internal class DiscoveryResultCache
 
             // Send test cases when the specified cache size has been reached or
             // after the specified cache timeout has been hit.
-            var timeDelta = DateTime.Now - _lastUpdate;
+            var timeDelta = DateTime.UtcNow - _lastUpdate;
             if (_tests.Count >= _cacheSize || (timeDelta > _cacheTimeout && _tests.Count > 0))
             {
                 // Pass on the buffer to the listener and clear the old one
                 _onReportTestCases(_tests);
                 _tests = new List<TestCase>();
-                _lastUpdate = DateTime.Now;
+                _lastUpdate = DateTime.UtcNow;
 
                 EqtTrace.Verbose("DiscoveryResultCache.AddTest: Notified the onReportTestCases callback.");
             }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/TestRunCache.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/TestRunCache.cs
@@ -91,7 +91,7 @@ internal class TestRunCache : ITestRunCache
 
         _cacheSize = cacheSize;
         _onCacheHit = onCacheHit;
-        _lastUpdate = DateTime.Now;
+        _lastUpdate = DateTime.UtcNow;
         _cacheTimeout = cacheTimeout;
         _inProgressTests = new Collection<TestCase>();
         _testResults = new Collection<TestResult>();
@@ -311,7 +311,7 @@ internal class TestRunCache : ITestRunCache
         {
             // Send results when the specified cache size has been reached or
             // after the specified cache timeout has been hit.
-            var timeDelta = DateTime.Now - _lastUpdate;
+            var timeDelta = DateTime.UtcNow - _lastUpdate;
 
             var inProgressTestsCount = _inProgressTests.Count;
 
@@ -339,7 +339,7 @@ internal class TestRunCache : ITestRunCache
         _onCacheHit(TestRunStatistics, _testResults, _inProgressTests);
         _testResults = new Collection<TestResult>();
         _inProgressTests = new Collection<TestCase>();
-        _lastUpdate = DateTime.Now;
+        _lastUpdate = DateTime.UtcNow;
 
         // Reset the timer
         _timer.Change(_cacheTimeout, _cacheTimeout);


### PR DESCRIPTION
## Goal and Rationale

`DateTime.Now` internally calls `DateTime.UtcNow` and then applies the local timezone offset conversion. Since the cache classes only ever compute **time deltas** (elapsed time since last flush), the timezone component is irrelevant — and the conversion is pure overhead.

This PR replaces all `DateTime.Now` usages in the two test-pipeline cache classes with `DateTime.UtcNow`, eliminating unnecessary timezone conversions in hot paths called on every test case.

## Focus Area

**Code-Level Efficiency** — removing redundant computation from per-test-case hot paths.

## Affected Hot Paths

| Class | Method | Call Frequency |
|---|---|---|
| `TestRunCache` | `CheckForCacheHit` | Once per `OnTestStarted` + once per `OnNewTestResult` → **~2× per test case** |
| `TestRunCache` | `SendResults` | Each time the cache is flushed |
| `DiscoveryResultCache` | `AddTest` | Once per discovered test case |

## Approach

Replace `DateTime.Now` with `DateTime.UtcNow` in both `_lastUpdate` assignments and all time-delta computations. Both the baseline value (`_lastUpdate`) and the comparison value are now UTC, so all time deltas remain correct.

## Energy Efficiency Evidence

**Proxy metric:** CPU instruction count (fewer instructions = less power draw per test run).

`DateTime.Now` on .NET calls into `TimeZoneInfo.ConvertTime`, which involves:
1. A P/Invoke or cached DST table lookup to determine the current UTC offset
2. An addition of the offset to the UTC ticks

`DateTime.UtcNow` skips all of that — it reads the system clock tick counter directly.

For a 10,000-test suite this eliminates **~20,000+ unnecessary timezone-conversion operations** per `dotnet test` invocation. Given that vstest is used by millions of developers and CI pipelines across the .NET ecosystem, this compounds significantly at scale.

## Green Software Foundation Context

*Hardware Efficiency*: Eliminating unnecessary work makes better use of available CPU cycles, reducing energy drawn per functional unit (test discovery/execution).

*SCI (Software Carbon Intensity)*: Reducing CPU instructions per `dotnet test` run lowers the energy term of the SCI equation for the countless CI/CD pipelines running vstest daily.

## Trade-offs

None. The change is a pure mechanical substitution — no behavioural change, no new dependencies, no readability impact. Using UTC for time-delta calculations is actually more semantically correct (timezone is irrelevant when you only care about elapsed time).

## Test Status

- `Microsoft.TestPlatform.CrossPlatEngine.UnitTests` (TestRunCache + DiscoveryResultCache): ✅ 29/29 passed
- Build: ✅ 0 errors (`net11.0`)

## Reproducibility

```sh
# Run the relevant unit tests
.dotnet/dotnet run --project test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Microsoft.TestPlatform.CrossPlatEngine.UnitTests.csproj -f net11.0 -- --filter "TestRunCache|DiscoveryResultCache"
```




> Generated by [Efficiency Improver](https://github.com/microsoft/vstest/actions/runs/27878073130) · 1K AIC · ⌖ 25 AIC · ⊞ 45.6K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27878073130, workflow_id: efficiency-improver, run: https://github.com/microsoft/vstest/actions/runs/27878073130 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/vstest/efficiency-improver -->