### PR TITLE
[efficiency-improver] perf: replace Task.FromResult(0) with Task.CompletedTask in IPC channel hot paths

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/LengthPrefixCommunicationChannel.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/LengthPrefixCommunicationChannel.cs
@@ -67,7 +67,7 @@ public class LengthPrefixCommunicationChannel : ICommunicationChannel
             throw new CommunicationException("Unable to send data over channel.", ex);
         }
 
-        return Task.FromResult(0);
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc />
@@ -101,7 +101,7 @@ public class LengthPrefixCommunicationChannel : ICommunicationChannel
             EqtTrace.Verbose("LengthPrefixCommunicationChannel.Send: BaseStream was disposed. {0}", ex);
         }
 
-        return Task.FromResult(0);
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc />

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TcpClientExtensions.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TcpClientExtensions.cs
@@ -110,7 +110,7 @@ internal static class TcpClientExtensions
 
         EqtTrace.Verbose("TcpClientExtensions.MessageLoopAsync: exiting MessageLoopAsync remoteEndPoint: {0} localEndPoint: {1}", remoteEndPoint, localEndPoint);
 
-        return Task.FromResult(0);
+        return Task.CompletedTask;
     }
 
     /// <summary>


### PR DESCRIPTION
## Goal and Rationale

`Task.FromResult(0)` allocates a new `Task<int>` object on the managed heap every time it is called. `Task.CompletedTask` is a pre-allocated, cached singleton — it costs **zero allocations**. This PR replaces all three `Task.FromResult(0)` occurrences in the IPC communication layer with `Task.CompletedTask`.

## Focus Area

**Code-Level Efficiency** — eliminating per-message heap allocations from the IPC hot path.

## Affected Call Sites

| File | Method | Call Frequency |
|---|---|---|
| `LengthPrefixCommunicationChannel.Send` | Returns after each message write | Once per IPC message sent (every test result, discovery result, etc.) |
| `LengthPrefixCommunicationChannel.NotifyDataAvailable` | Returns after each receive iteration | Called in a tight read loop by the message pump |
| `TcpClientExtensions.MessageLoopAsync` | Returns when the loop exits | Once per connection lifetime |

## Approach

Mechanical substitution: `return Task.FromResult(0)` → `return Task.CompletedTask`. Both are already-completed tasks; any caller that `await`s them will continue synchronously. The change has no behavioural impact.

## Energy Efficiency Evidence

**Proxy metric:** Memory allocation (GC pressure) → CPU energy.

Every `Task.FromResult(0)` call allocates a `Task<int>` on the heap (~40 bytes). In a typical vstest run:

- `Send` is invoked for every test result, version handshake, test case, and log message over the IPC socket — easily **thousands of calls** per test run.
- `NotifyDataAvailable` runs in the message-pump tight loop — one call per received frame.

Each unnecessary allocation adds GC pressure: more objects to mark, sweep, and compact, which translates directly to additional CPU cycles and therefore energy. `Task.CompletedTask` is a static singleton: zero allocation per call.

## Green Software Foundation Context

*Hardware Efficiency*: Eliminating unnecessary allocations reduces GC work, making better use of available CPU cycles per test run.

*SCI (Software Carbon Intensity)*: Since vstest is invoked millions of times daily across CI/CD pipelines, reducing per-run allocations lowers the aggregate energy term of the SCI equation at ecosystem scale.

## Trade-offs

None. `Task.CompletedTask` is the idiomatic .NET pattern for synchronously-completing async methods. There is no readability impact; the change is purely a correctness + efficiency improvement.

## Test Status

- `Microsoft.TestPlatform.CommunicationUtilities.UnitTests` (LengthPrefix tests): ✅ 12/12 passed
- Build: ✅ 0 errors (Debug, all TFMs)

## Reproducibility

```sh
# Run the relevant unit tests
.dotnet/dotnet run --project test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/Microsoft.TestPlatform.CommunicationUtilities.UnitTests.csproj -f net11.0 -- --filter "LengthPrefix"
```




> Generated by [Efficiency Improver](https://github.com/microsoft/vstest/actions/runs/27911536690) · 1.2K AIC · ⌖ 25.1 AIC · ⊞ 45.6K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27911536690, workflow_id: efficiency-improver, run: https://github.com/microsoft/vstest/actions/runs/27911536690 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/vstest/efficiency-improver -->