### PR TITLE
[efficiency-improver] perf: replace ManualResetEvent with ManualResetEventSlim in JobQueue

### DIFF
--- a/src/Microsoft.TestPlatform.CoreUtilities/Utilities/Job.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Utilities/Job.cs
@@ -63,7 +63,7 @@ internal class Job<TPayload>
     /// <summary>
     /// Gets the signal that this job is being processed.
     /// </summary>
-    public ManualResetEvent? WaitManualResetEvent { get; private set; }
+    public ManualResetEventSlim? WaitManualResetEvent { get; private set; }
 
     /// <summary>
     /// Gets the size of this job instance. This is used to manage the total size of Job Queue.
@@ -75,7 +75,7 @@ internal class Job<TPayload>
     /// </summary>
     /// <param name="waitEvent"> The wait Event. </param>
     /// <returns> The wait job. </returns>
-    public static Job<TPayload> CreateWaitJob(ManualResetEvent waitEvent)
+    public static Job<TPayload> CreateWaitJob(ManualResetEventSlim waitEvent)
     {
         ValidateArg.NotNull(waitEvent, nameof(waitEvent));
 

--- a/src/Microsoft.TestPlatform.CoreUtilities/Utilities/JobQueue.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Utilities/JobQueue.cs
@@ -38,7 +38,7 @@ public class JobQueue<T> : IDisposable
     /// <summary>
     /// Signaled when a job is added to the queue.  Used to wakeup the background thread.
     /// </summary>
-    private readonly ManualResetEvent _jobAdded;
+    private readonly ManualResetEventSlim _jobAdded;
 
     /// <summary>
     /// The maximum number of jobs the job queue may hold.
@@ -64,7 +64,7 @@ public class JobQueue<T> : IDisposable
     /// Used to pause and resume processing of the queue.  By default the manual reset event is
     /// set so the queue can continue processing.
     /// </summary>
-    private readonly ManualResetEvent _queueProcessing;
+    private readonly ManualResetEventSlim _queueProcessing;
 
     /// <summary>
     /// The background thread which is processing the jobs.  Used when disposing to wait
@@ -122,8 +122,8 @@ public class JobQueue<T> : IDisposable
 
         // Initialize defaults.
         _jobsQueue = new Queue<Job<T>>();
-        _jobAdded = new ManualResetEvent(false);
-        _queueProcessing = new ManualResetEvent(true);
+        _jobAdded = new ManualResetEventSlim(false);
+        _queueProcessing = new ManualResetEventSlim(true);
         _currentNumberOfBytesQueueIsHolding = 0;
         _isDisposed = false;
 
@@ -183,13 +183,13 @@ public class JobQueue<T> : IDisposable
         CheckDisposed();
 
         // Create the wait job.
-        using var waitEvent = new ManualResetEvent(false);
+        using var waitEvent = new ManualResetEventSlim(false);
         var waitJob = Job<T>.CreateWaitJob(waitEvent);
 
         // Queue the wait job and wait for it to be processed.
         InternalQueueJob(waitJob);
 
-        waitEvent.WaitOne();
+        waitEvent.Wait();
     }
 
     /// <summary>
@@ -210,7 +210,7 @@ public class JobQueue<T> : IDisposable
         }
 
         // If the queue is paused, then throw.
-        if (!_queueProcessing.WaitOne(0))
+        if (!_queueProcessing.IsSet)
         {
             throw new InvalidOperationException(
                 string.Format(CultureInfo.CurrentCulture, Resources.QueuePausedDisposeError, _displayName));
@@ -297,7 +297,7 @@ public class JobQueue<T> : IDisposable
 
         do
         {
-            _jobAdded.WaitOne();
+            _jobAdded.Wait();
 
             // Pull all of the current jobs out of the queue.
             List<Job<T>> jobs = new();
@@ -332,7 +332,7 @@ public class JobQueue<T> : IDisposable
             foreach (var job in jobs)
             {
                 // Wait for the queue to be open (not paused) and process the job.
-                _queueProcessing.WaitOne();
+                _queueProcessing.Wait();
 
                 // If this is a wait job, signal the manual reset event and continue.
                 if (job.WaitManualResetEvent != null)


### PR DESCRIPTION
## Goal and Rationale

`ManualResetEvent` is a kernel object — even when it is already signaled, `WaitOne()` incurs a system call to check the kernel semaphore state. `ManualResetEventSlim` first does a cheap volatile `IsSet` read and spins briefly before ever touching the kernel, eliminating kernel transitions in the common (non-waiting) case.

## Focus Area

**Code-Level Efficiency** — eliminating kernel transitions from per-job-processed hot paths.

## Affected Call Sites

| Field | Location | Call Frequency |
|---|---|---|
| `_queueProcessing.Wait()` | `BackgroundJobProcessor` foreach loop | **Once per job processed** |
| `_jobAdded.Wait()` | `BackgroundJobProcessor` drain loop | Once per drain cycle |
| `Flush()` wait event | `Flush()` | Once per flush call |

The most impactful change is `_queueProcessing.Wait()`: this is called once for every job dequeued. When the queue is running (not paused — the common case), the event is already signaled. With `ManualResetEvent`, this still costs a kernel transition per job. With `ManualResetEventSlim`, it returns immediately via a volatile `IsSet` read — **zero system calls per job** in the happy path.

## Approach

1. Changed `_jobAdded` and `_queueProcessing` from `ManualResetEvent` to `ManualResetEventSlim`.
2. Updated `Flush()` to use `ManualResetEventSlim` for its per-call wait event (avoids allocating a kernel semaphore for short-lived flush waits).
3. Updated `Job<T>.WaitManualResetEvent` and `CreateWaitJob` to use `ManualResetEventSlim` consistently.
4. API differences handled: `WaitOne()` → `Wait()`, `WaitOne(0)` → `IsSet`.

## Energy Efficiency Evidence

**Proxy metric:** CPU instruction count / kernel transition count → CPU energy.

`ManualResetEvent.WaitOne()` when signaled calls into `WaitHandle.WaitOneWithTimeoutWorker(-1)` which ultimately calls the OS `WaitForSingleObject` / `futex_wait` kernel API — a full user-to-kernel mode transition (~100–1000 ns each, plus TLB/cache effects from the ring switch).

`ManualResetEventSlim.Wait()` when already set does:
```csharp
if (IsSet) return;   // volatile read — stays entirely in user space
```

For a test suite with 10,000 tests processed through a `JobQueue`, this eliminates **~10,000 unnecessary kernel transitions** per `dotnet test` run. Given vstest is used across millions of CI/CD pipelines daily, the aggregate energy savings compound significantly.

## Green Software Foundation Context

*Hardware Efficiency*: Eliminating kernel transitions reduces ring-switch overhead, making better use of available CPU cycles per test-pipeline invocation.

*SCI (Software Carbon Intensity)*: Fewer system calls per test run lowers the energy term of the SCI equation for every CI/CD pipeline running `dotnet test`.

## Trade-offs

`ManualResetEventSlim` is designed for intra-process synchronization — exactly the use case here. It is NOT suitable for cross-process waits, but `JobQueue` is a single-process internal utility. The spin-before-block behaviour is beneficial in high-throughput scenarios and gracefully falls back to kernel blocking for long waits (e.g., a paused queue).

No readability impact — `Wait()` / `IsSet` are the idiomatic `ManualResetEventSlim` API and map cleanly to the replaced `WaitOne()` / `WaitOne(0)` calls.

## Test Status

- `Microsoft.TestPlatform.CoreUtilities.UnitTests` (JobQueue tests): ✅ 17/17 passed
- Build: ✅ 0 errors (Debug, all TFMs)

## Reproducibility

```sh
# Run JobQueue tests
.dotnet/dotnet run --project test/Microsoft.TestPlatform.CoreUtilities.UnitTests/Microsoft.TestPlatform.CoreUtilities.UnitTests.csproj -f net11.0 -- --filter "JobQueue"
```




> Generated by [Efficiency Improver](https://github.com/microsoft/vstest/actions/runs/27973673361) · 1.3K AIC · ⌖ 25.7 AIC · ⊞ 45.6K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27973673361, workflow_id: efficiency-improver, run: https://github.com/microsoft/vstest/actions/runs/27973673361 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/vstest/efficiency-improver -->