### PR TITLE
Drop Mono fallback, run .NET Framework tests on Windows only

### DIFF
--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -210,8 +210,7 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
         // longer supported. Fail with a clear message instead of launching Mono.
         if (!_environment.OperatingSystem.Equals(PlatformOperatingSystem.Windows))
         {
-            throw new TestPlatformException(
-                string.Format(CultureInfo.CurrentCulture, Resources.NetFrameworkTestsNotSupportedOnNonWindows));
+            throw new TestPlatformException(Resources.NetFrameworkTestsNotSupportedOnNonWindows);
         }
 
         var launcherPath = testhostProcessPath;

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -56,7 +56,6 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
     private readonly IProcessHelper _processHelper;
     private readonly IFileHelper _fileHelper;
     private readonly IEnvironment _environment;
-    private readonly IDotnetHostHelper _dotnetHostHelper;
     private readonly IEnvironmentVariableHelper _environmentVariableHelper;
     private bool _disableAppDomain;
     private Architecture _architecture;
@@ -78,7 +77,6 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
         : this(
             new ProcessHelper(),
             new FileHelper(),
-            new DotnetHostHelper(),
             new PlatformEnvironment(),
             new EnvironmentVariableHelper())
     {
@@ -91,17 +89,14 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
     /// <param name="fileHelper">File helper instance.</param>
     /// <param name="environment">Instance of platform environment.</param>
     /// <param name="environmentVariableHelper">The environment helper.</param>
-    /// <param name="dotnetHostHelper">Instance of dotnet host helper.</param>
     internal DefaultTestHostManager(
         IProcessHelper processHelper,
         IFileHelper fileHelper,
-        IDotnetHostHelper dotnetHostHelper,
         IEnvironment environment,
         IEnvironmentVariableHelper environmentVariableHelper)
     {
         _processHelper = processHelper;
         _fileHelper = fileHelper;
-        _dotnetHostHelper = dotnetHostHelper;
         _environment = environment;
         _environmentVariableHelper = environmentVariableHelper;
     }
@@ -210,28 +205,27 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
 
         EqtTrace.Verbose("DefaultTestHostmanager.GetTestHostProcessStartInfo: Trying to use {0} from {1}", originalTestHostProcessName, testhostProcessPath);
 
+        // .NET Framework tests run through testhost.exe, which can only run on Windows.
+        // Running them on other operating systems previously relied on Mono, which is no
+        // longer supported. Fail with a clear message instead of launching Mono.
+        if (!_environment.OperatingSystem.Equals(PlatformOperatingSystem.Windows))
+        {
+            throw new TestPlatformException(
+                string.Format(CultureInfo.CurrentCulture, Resources.NetFrameworkTestsNotSupportedOnNonWindows));
+        }
+
         var launcherPath = testhostProcessPath;
         var processName = _processHelper.GetCurrentProcessFileName();
         if (processName is not null)
         {
-            if (!_environment.OperatingSystem.Equals(PlatformOperatingSystem.Windows)
-                && !processName.EndsWith(DotnetHostHelper.MONOEXENAME, StringComparison.OrdinalIgnoreCase))
+            // Patching the relative path for IDE scenarios.
+            if (!(processName.EndsWith("dotnet", StringComparison.OrdinalIgnoreCase)
+                    || processName.EndsWith("dotnet.exe", StringComparison.OrdinalIgnoreCase))
+                && !File.Exists(testhostProcessPath))
             {
-                launcherPath = _dotnetHostHelper.GetMonoPath();
-                argumentsString = testhostProcessPath.AddDoubleQuote() + " " + argumentsString;
-            }
-            else
-            {
-                // Patching the relative path for IDE scenarios.
-                if (_environment.OperatingSystem.Equals(PlatformOperatingSystem.Windows)
-                    && !(processName.EndsWith("dotnet", StringComparison.OrdinalIgnoreCase)
-                        || processName.EndsWith("dotnet.exe", StringComparison.OrdinalIgnoreCase))
-                    && !File.Exists(testhostProcessPath))
-                {
-                    testhostProcessPath = Path.Combine(currentWorkingDirectory, "..", originalTestHostProcessName);
-                    EqtTrace.Verbose("DefaultTestHostmanager.GetTestHostProcessStartInfo: Could not find {0} in previous location, now using {1}", originalTestHostProcessName, testhostProcessPath);
-                    launcherPath = testhostProcessPath;
-                }
+                testhostProcessPath = Path.Combine(currentWorkingDirectory, "..", originalTestHostProcessName);
+                EqtTrace.Verbose("DefaultTestHostmanager.GetTestHostProcessStartInfo: Could not find {0} in previous location, now using {1}", originalTestHostProcessName, testhostProcessPath);
+                launcherPath = testhostProcessPath;
             }
         }
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.Designer.cs
@@ -111,5 +111,14 @@ namespace Microsoft.TestPlatform.TestHostProvider.Resources {
             }
         }
 
+        /// <summary>
+        ///   Looks up a localized string similar to Running .NET Framework tests is supported on Windows only..
+        /// </summary>
+        internal static string NetFrameworkTestsNotSupportedOnNonWindows {
+            get {
+                return ResourceManager.GetString("NetFrameworkTestsNotSupportedOnNonWindows", resourceCulture);
+            }
+        }
+
     }
 }

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/Resources.resx
@@ -147,4 +147,9 @@ The specified framework can be found at:
 </value>
     <comment>'{0}' is the placeholder for 'dotnet.exe' or 'dotnet' value and depends on platform Windows/Unix, '{1}' is the placeholder for the architeture name like ARM64, X64 etc...</comment>
   </data>
+  <data name="NetFrameworkTestsNotSupportedOnNonWindows" xml:space="preserve">
+    <value>Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</value>
+  </data>
 </root>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.cs.xlf
@@ -26,6 +26,15 @@ Ověřte, že:
 {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetFrameworkTestsNotSupportedOnNonWindows">
+        <source>Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</source>
+        <target state="new">Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindDepsFile">
         <source>Unable to find {0}. Make sure test project has a nuget reference of package "Microsoft.NET.Test.Sdk".</source>
         <target state="translated">Nejde najít {0}. Ujistěte se, že testovací projekt má odkaz na balíček nuget Microsoft.NET.Test.Sdk.</target>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.de.xlf
@@ -26,6 +26,15 @@ Bestätigen Sie, dass:
 {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetFrameworkTestsNotSupportedOnNonWindows">
+        <source>Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</source>
+        <target state="new">Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindDepsFile">
         <source>Unable to find {0}. Make sure test project has a nuget reference of package "Microsoft.NET.Test.Sdk".</source>
         <target state="translated">"{0}" wurde nicht gefunden. Stellen Sie sicher, dass das Testprojekt einen NuGet-Verweis des Pakets "Microsoft.NET.Test.Sdk" aufweist.</target>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.es.xlf
@@ -26,6 +26,15 @@ Compruebe que:
 {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetFrameworkTestsNotSupportedOnNonWindows">
+        <source>Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</source>
+        <target state="new">Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindDepsFile">
         <source>Unable to find {0}. Make sure test project has a nuget reference of package "Microsoft.NET.Test.Sdk".</source>
         <target state="translated">No se encuentra {0}. Asegúrese de que el proyecto de prueba tenga una referencia NuGet del paquete "Microsoft.NET.Test.Sdk".</target>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.fr.xlf
@@ -26,6 +26,15 @@ Vérifiez ce qui suit :
 {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetFrameworkTestsNotSupportedOnNonWindows">
+        <source>Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</source>
+        <target state="new">Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindDepsFile">
         <source>Unable to find {0}. Make sure test project has a nuget reference of package "Microsoft.NET.Test.Sdk".</source>
         <target state="translated">{0} est introuvable. Vérifiez que le projet de test a une référence nuget du package "Microsoft.NET.Test.Sdk".</target>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.it.xlf
@@ -26,6 +26,15 @@ Verificare che:
 {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetFrameworkTestsNotSupportedOnNonWindows">
+        <source>Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</source>
+        <target state="new">Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindDepsFile">
         <source>Unable to find {0}. Make sure test project has a nuget reference of package "Microsoft.NET.Test.Sdk".</source>
         <target state="translated">Non è possibile trovare {0}. Assicurarsi che il progetto di test includa un riferimento NuGet del pacchetto "Microsoft.NET.Test.Sdk".</target>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ja.xlf
@@ -26,6 +26,15 @@ Verify that:
 {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetFrameworkTestsNotSupportedOnNonWindows">
+        <source>Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</source>
+        <target state="new">Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindDepsFile">
         <source>Unable to find {0}. Make sure test project has a nuget reference of package "Microsoft.NET.Test.Sdk".</source>
         <target state="translated">{0} を見つけることができません。テスト プロジェクトにパッケージ "Microsoft.NET.Test.Sdk" の NuGet 参照があることを確認してください。</target>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ko.xlf
@@ -26,6 +26,15 @@ Verify that:
 {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetFrameworkTestsNotSupportedOnNonWindows">
+        <source>Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</source>
+        <target state="new">Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindDepsFile">
         <source>Unable to find {0}. Make sure test project has a nuget reference of package "Microsoft.NET.Test.Sdk".</source>
         <target state="translated">{0}을(를) 찾을 수 없습니다. 테스트 프로젝트에 "Microsoft.NET.Test.Sdk" 패키지의 nuget 참조가 포함되어 있는지 확인하세요.</target>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pl.xlf
@@ -26,6 +26,15 @@ Sprawdź, czy:
 {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetFrameworkTestsNotSupportedOnNonWindows">
+        <source>Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</source>
+        <target state="new">Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindDepsFile">
         <source>Unable to find {0}. Make sure test project has a nuget reference of package "Microsoft.NET.Test.Sdk".</source>
         <target state="translated">Nie można znaleźć elementu {0}. Upewnij się, że projekt testowy ma odwołanie nuget do pakietu „Microsoft.NET.Test.Sdk”.</target>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.pt-BR.xlf
@@ -26,6 +26,15 @@ Verifique se:
 {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetFrameworkTestsNotSupportedOnNonWindows">
+        <source>Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</source>
+        <target state="new">Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindDepsFile">
         <source>Unable to find {0}. Make sure test project has a nuget reference of package "Microsoft.NET.Test.Sdk".</source>
         <target state="translated">Não foi possível localizar {0}. Certifique-se de que o projeto de teste tem uma referência nuget do pacote "Microsoft.NET.Test.Sdk".</target>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.ru.xlf
@@ -26,6 +26,15 @@ Verify that:
 {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetFrameworkTestsNotSupportedOnNonWindows">
+        <source>Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</source>
+        <target state="new">Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindDepsFile">
         <source>Unable to find {0}. Make sure test project has a nuget reference of package "Microsoft.NET.Test.Sdk".</source>
         <target state="translated">Не удается найти {0}. Убедитесь, что в тестовом проекте есть ссылка NuGet на пакет "Microsoft.NET.Test.Sdk".</target>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.tr.xlf
@@ -26,6 +26,15 @@ Verify that:
 {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetFrameworkTestsNotSupportedOnNonWindows">
+        <source>Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</source>
+        <target state="new">Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindDepsFile">
         <source>Unable to find {0}. Make sure test project has a nuget reference of package "Microsoft.NET.Test.Sdk".</source>
         <target state="translated">{0} bulunamıyor. Test projesinin "Microsoft.NET.Test.Sdk" paketinde nuget başvurusu olduğundan emin olun.</target>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hans.xlf
@@ -26,6 +26,15 @@ Verify that:
 {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetFrameworkTestsNotSupportedOnNonWindows">
+        <source>Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</source>
+        <target state="new">Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindDepsFile">
         <source>Unable to find {0}. Make sure test project has a nuget reference of package "Microsoft.NET.Test.Sdk".</source>
         <target state="translated">无法找到 {0}。确保测试项目具有包 "Microsoft.NET.Test.Sdk" 的 nuget 引用。</target>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Resources/xlf/Resources.zh-Hant.xlf
@@ -27,6 +27,15 @@ Verify that:
 {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NetFrameworkTestsNotSupportedOnNonWindows">
+        <source>Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</source>
+        <target state="new">Running .NET Framework tests is supported on Windows only.
+
+Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnableToFindDepsFile">
         <source>Unable to find {0}. Make sure test project has a nuget reference of package "Microsoft.NET.Test.Sdk".</source>
         <target state="translated">找不到 {0}。請確認測試專案有 "Microsoft.NET.Test.Sdk "套件的 nuget 參考。</target>

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/FrameworkTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/FrameworkTests.cs
@@ -87,10 +87,14 @@ public class FrameworkTests : AcceptanceTestBase
         // but the settings requested .NET Framework 4.0. The test will still run because .NET Framework is compatible, and in reality
         // the system has .NET Framework 481 or newer installed, which runs even if we ask for .NET Framework 4.0 testhost.
         //
-        // On Linux and Mac we execute only net11.0 tests, and even though we force .NET Framework, we end up running on mono
-        // which is suprisingly able to run the .NET CoreApp dll, so we still just see a warning and 1 completed test.
+        // This test is Windows-Review only, so it does not run on Linux or Mac in CI. If it is run there manually,
+        // forcing .NET Framework now fails fast, because the .NET Framework test host is no longer launched through Mono.
         var isWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win");
-        if (runnerInfo.TargetFramework.Contains("net11") && isWindows)
+        if (!isWindows)
+        {
+            StdErrorContains("Running .NET Framework tests is supported on Windows only");
+        }
+        else if (runnerInfo.TargetFramework.Contains("net11"))
         {
             StdOutputContains("No test is available");
         }
@@ -98,6 +102,32 @@ public class FrameworkTests : AcceptanceTestBase
         {
             StdOutputContains("Following DLL(s) do not match current settings, which are .NETFramework,Version=v4.0 framework and X64 platform.");
             ValidateSummaryStatus(1, 0, 0);
+        }
+    }
+
+    [TestMethod]
+    [NetCoreTargetFrameworkDataSource]
+    public void RunningNetFrameworkTestsOnNonWindowsShouldFailWithClearError(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        // Force the run to use the .NET Framework test host (testhost.exe). That host exists only on
+        // Windows. On other operating systems we used to fall back to Mono, which is no longer supported,
+        // so the run should fail fast with a clear, actionable message instead of an opaque Mono error.
+        var arguments = PrepareArguments(GetSampleTestAssembly(), string.Empty, string.Empty, string.Empty, resultsDirectory: TempDirectory.Path);
+        arguments = string.Concat(arguments, " ", "/Framework:Framework40");
+
+        InvokeVsTest(arguments);
+
+        var isWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win");
+        if (isWindows)
+        {
+            // On Windows the .NET Framework test host is available, so the "Windows only" error must not appear.
+            StdErrorDoesNotContains("Running .NET Framework tests is supported on Windows only");
+        }
+        else
+        {
+            StdErrorContains("Running .NET Framework tests is supported on Windows only");
         }
     }
 }

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/FrameworkTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/FrameworkTests.cs
@@ -127,7 +127,9 @@ public class FrameworkTests : AcceptanceTestBase
         }
         else
         {
+            // The run must fail fast with a clear message, not merely log a warning.
             StdErrorContains("Running .NET Framework tests is supported on Windows only");
+            ExitCodeEquals(1);
         }
     }
 }

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -190,7 +190,7 @@ public class DefaultTestHostManagerTests
         var exception = Assert.ThrowsExactly<TestPlatformException>(
             () => _testHostManager.GetTestHostProcessStartInfo(new List<string>() { source }, null, default));
 
-        Assert.Contains("Windows", exception.Message);
+        Assert.Contains("Running .NET Framework tests is supported on Windows only", exception.Message);
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DefaultTestHostManagerTests.cs
@@ -37,7 +37,6 @@ public class DefaultTestHostManagerTests
     private readonly Mock<IMessageLogger> _mockMessageLogger;
     private readonly Mock<IProcessHelper> _mockProcessHelper;
     private readonly Mock<IFileHelper> _mockFileHelper;
-    private readonly Mock<IDotnetHostHelper> _mockDotnetHostHelper;
     private readonly Mock<IEnvironment> _mockEnvironment;
     private readonly Mock<IEnvironmentVariableHelper> _mockEnvironmentVariable;
     private readonly DefaultTestHostManager _testHostManager;
@@ -54,13 +53,12 @@ public class DefaultTestHostManagerTests
         _mockProcessHelper = new Mock<IProcessHelper>();
         _mockFileHelper = new Mock<IFileHelper>();
         _mockProcessHelper.Setup(ph => ph.GetCurrentProcessFileName()).Returns("vstest.console.exe");
-        _mockDotnetHostHelper = new Mock<IDotnetHostHelper>();
         _mockEnvironment = new Mock<IEnvironment>();
         _mockEnvironmentVariable = new Mock<IEnvironmentVariableHelper>();
 
         _mockMessageLogger = new Mock<IMessageLogger>();
 
-        _testHostManager = new DefaultTestHostManager(_mockProcessHelper.Object, _mockFileHelper.Object, _mockDotnetHostHelper.Object, _mockEnvironment.Object, _mockEnvironmentVariable.Object);
+        _testHostManager = new DefaultTestHostManager(_mockProcessHelper.Object, _mockFileHelper.Object, _mockEnvironment.Object, _mockEnvironmentVariable.Object);
         _testHostManager.Initialize(_mockMessageLogger.Object, $"<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings> <RunConfiguration> <TargetPlatform>{Architecture.X64}</TargetPlatform> <TargetFrameworkVersion>{Framework.DefaultFramework}</TargetFrameworkVersion> <DisableAppDomain>{false}</DisableAppDomain> </RunConfiguration> </RunSettings>");
         _startInfo = _testHostManager.GetTestHostProcessStartInfo([], null, default);
     }
@@ -177,38 +175,22 @@ public class DefaultTestHostManagerTests
     }
 
     [TestMethod]
-    public void GetTestHostProcessStartInfoShouldUseMonoAsHostOnNonWindowsIfNotStartedWithMono()
+    [DataRow(PlatformOperatingSystem.Unix, "/usr/bin/dotnet")]
+    [DataRow(PlatformOperatingSystem.Unix, "/usr/bin/mono")]
+    [DataRow(PlatformOperatingSystem.OSX, "/usr/local/share/dotnet/dotnet")]
+    [DataRow(PlatformOperatingSystem.OSX, "/usr/local/bin/mono")]
+    public void GetTestHostProcessStartInfoShouldThrowWhenRunningNetFrameworkTestsOnNonWindows(PlatformOperatingSystem operatingSystem, string currentProcessFileName)
     {
-        _mockProcessHelper.Setup(p => p.GetCurrentProcessFileName()).Returns("/usr/bin/dotnet");
-        _mockEnvironment.Setup(e => e.OperatingSystem).Returns(PlatformOperatingSystem.Unix);
-        _mockDotnetHostHelper.Setup(d => d.GetMonoPath()).Returns("/usr/bin/mono");
-        var source = @"C:\temp\a.dll";
+        // .NET Framework tests can only run on Windows. On other operating systems we no longer
+        // fall back to Mono and instead fail with a clear, actionable message.
+        _mockProcessHelper.Setup(p => p.GetCurrentProcessFileName()).Returns(currentProcessFileName);
+        _mockEnvironment.Setup(e => e.OperatingSystem).Returns(operatingSystem);
+        var source = "/tmp/a.dll";
 
-        var info = _testHostManager.GetTestHostProcessStartInfo(
-            new List<string>() { source },
-            null,
-            default);
+        var exception = Assert.ThrowsExactly<TestPlatformException>(
+            () => _testHostManager.GetTestHostProcessStartInfo(new List<string>() { source }, null, default));
 
-        Assert.AreEqual("/usr/bin/mono", info.FileName);
-        Assert.Contains(Path.Combine("TestHostNetFramework", "testhost.exe"), info.Arguments!);
-    }
-
-    [TestMethod]
-    public void GetTestHostProcessStartInfoShouldNotUseMonoAsHostOnNonWindowsIfStartedWithMono()
-    {
-        _mockProcessHelper.Setup(p => p.GetCurrentProcessFileName()).Returns("/usr/bin/mono");
-        _mockEnvironment.Setup(e => e.OperatingSystem).Returns(PlatformOperatingSystem.Unix);
-        _mockDotnetHostHelper.Setup(d => d.GetMonoPath()).Returns("/usr/bin/mono");
-        var source = @"C:\temp\a.dll";
-
-        var info = _testHostManager.GetTestHostProcessStartInfo(
-            new List<string>() { source },
-            null,
-            default);
-
-        var testHostPath = Path.Combine("TestHostNetFramework", "testhost.exe");
-        Assert.EndsWith(testHostPath, info.FileName);
-        Assert.DoesNotContain(testHostPath, info.Arguments!);
+        Assert.Contains("Windows", exception.Message);
     }
 
     [TestMethod]
@@ -656,7 +638,7 @@ public class DefaultTestHostManagerTests
             IProcessHelper processHelper,
             bool shared,
             IMessageLogger logger)
-            : base(processHelper, new FileHelper(), new DotnetHostHelper(), new PlatformEnvironment(), new EnvironmentVariableHelper())
+            : base(processHelper, new FileHelper(), new PlatformEnvironment(), new EnvironmentVariableHelper())
         {
             Initialize(logger, $"<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings> <RunConfiguration> <TargetPlatform>{architecture}</TargetPlatform> <TargetFrameworkVersion>{framework}</TargetFrameworkVersion> <DisableAppDomain>{!shared}</DisableAppDomain> </RunConfiguration> </RunSettings>");
         }


### PR DESCRIPTION
Fixes #15340.

The .NET Framework test host (`testhost.exe`) only runs on Windows. On Linux and macOS vstest launched it through Mono, but Mono is no longer supported, and the .NET SDK on Linux no longer ships the `TestHostNetFramework` folder — so `dotnet test` on a `net462` project failed with an opaque Mono error:

```
Cannot open assembly '.../TestHostNetFramework/testhost.exe': No such file or directory.
```

`DefaultTestHostManager` (the .NET Framework host) now throws a clear error when it is about to run on a non-Windows OS, instead of falling back to Mono:

```
Running .NET Framework tests is supported on Windows only.

Running .NET Framework tests on this operating system relied on Mono, which is no longer supported. To run these tests, run them on Windows, or change the test project to target .NET instead of .NET Framework.
```

.NET tests are unaffected — they go through `DotnetTestHostManager`.

Breaking change: running .NET Framework tests on Linux or macOS is no longer supported. As discussed in the issue, anyone running them there also has a Windows leg, so the Mono path is not worth keeping.

Verified: full Debug build green, `DefaultTestHostManagerTests` pass on net481 and net11.0. Added an acceptance test that forces the .NET Framework host and asserts the clear error on non-Windows.

Replaces #16130, which only improved the error message but still ran Mono when the host happened to be present.
