### PR TITLE
[efficiency-improver] perf: eliminate closure allocations and redundant dict lookups in FastFilter.Evaluate

### DIFF
--- a/src/Microsoft.TestPlatform.Filter.Source/FastFilter.cs
+++ b/src/Microsoft.TestPlatform.Filter.Source/FastFilter.cs
@@ -80,13 +80,15 @@ internal sealed class FastFilter
 #endif
 
         bool matched = false;
-        foreach (var name in FilterProperties.Keys)
+        foreach (var kvp in FilterProperties)
         {
+            var filterValues = kvp.Value;
+
             // Reserved keyword: "None" matches tests with no value for this property (uncategorized).
-            bool hasNoneFilter = FilterProperties[name].Contains(Condition.NoneFilterValue);
+            bool hasNoneFilter = filterValues.Contains(Condition.NoneFilterValue);
 
             // If there is no value corresponding to given name, treat it as unmatched unless filtering for "None".
-            if (!TryGetPropertyValue(name, propertyValueProvider, out var singleValue, out var multiValues))
+            if (!TryGetPropertyValue(kvp.Key, propertyValueProvider, out var singleValue, out var multiValues))
             {
                 if (hasNoneFilter)
                 {
@@ -100,12 +102,33 @@ internal sealed class FastFilter
             if (singleValue != null)
             {
                 var value = PropertyValueRegex == null ? singleValue : ApplyRegex(singleValue);
-                matched = value != null && FilterProperties[name].Contains(value);
+                matched = value != null && filterValues.Contains(value);
             }
             else if (multiValues is { Length: > 0 })
             {
-                var values = PropertyValueRegex == null ? multiValues : multiValues?.Select(value => ApplyRegex(value));
-                matched = values?.Any(result => result != null && FilterProperties[name].Contains(result)) == true;
+                if (PropertyValueRegex == null)
+                {
+                    foreach (var result in multiValues)
+                    {
+                        if (result != null && filterValues.Contains(result))
+                        {
+                            matched = true;
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    foreach (var result in multiValues)
+                    {
+                        var transformed = ApplyRegex(result);
+                        if (transformed != null && filterValues.Contains(transformed))
+                        {
+                            matched = true;
+                            break;
+                        }
+                    }
+                }
             }
             else if (hasNoneFilter)
             {


### PR DESCRIPTION
## Goal and Rationale

`FastFilter.Evaluate` is called **once per test case** whenever a test filter is active. The previous implementation had two independent inefficiencies in the hot loop:

1. **Redundant dictionary lookups**: iterating over `FilterProperties.Keys` required 1–3 additional `FilterProperties[name]` hash-and-compare lookups per property per call (for `hasNoneFilter`, `singleValue`, and the multi-value branch).

2. **Closure allocation in multi-value path**: the `Select().Any(lambda)` pattern allocated a `Func<string,bool>` delegate, a captured-variable closure object (capturing `FilterProperties` + `name`), and (in the regex path) an intermediate `Select` iterator — all per invocation.

This PR addresses both issues with no behaviour change. `ValidForProperties` is intentionally left unchanged.

## Focus Area

**Code-Level Efficiency** — eliminating per-test-case allocations and redundant computation in the filter evaluation hot path.

## Approach

**Change 1 – cache the filter value set:**
```csharp
// Before: iterates .Keys, then looks up FilterProperties[name] up to 3 times
foreach (var name in FilterProperties.Keys)
{
    bool hasNoneFilter = FilterProperties[name].Contains(Condition.NoneFilterValue);
    ...
    matched = value != null && FilterProperties[name].Contains(value);
    ...
    matched = values?.Any(result => ... && FilterProperties[name].Contains(result)) == true;
}

// After: obtains both key and value once from the iterator
foreach (var kvp in FilterProperties)
{
    var filterValues = kvp.Value;  // cached — no further dict lookups
    bool hasNoneFilter = filterValues.Contains(Condition.NoneFilterValue);
    ...
    matched = value != null && filterValues.Contains(value);
}
```

**Change 2 – replace `Select().Any(lambda)` with `foreach`:**
```csharp
// Before: allocates delegate + closure + (in regex path) Select iterator
var values = PropertyValueRegex == null ? multiValues : multiValues?.Select(value => ApplyRegex(value));
matched = values?.Any(result => result != null && FilterProperties[name].Contains(result)) == true;

// After: zero allocations, early exit on first match
foreach (var result in multiValues)
{
    if (result != null && filterValues.Contains(result))
    {
        matched = true;
        break;
    }
}
```

The `foreach`-based replacement was suggested by the maintainer in review comments on PR #16139.

## Energy Efficiency Evidence

**Proxy metric:** heap allocation count → GC pressure → CPU energy; instruction count → CPU energy.

Per `Evaluate()` call, the savings are:

| Path | Before | After | Saving |
|---|---|---|---|
| `singleValue` (common) | 2 dict lookups | 0 dict lookups | 2 × hash+compare |
| `multiValues`, no regex | 1 closure + delegate + 3 dict lookups | 0 allocs, 0 extra lookups | ~2 heap allocs + lookups |
| `multiValues`, with regex | 2 closures + iterator + 3 lookups | 0 allocs, 0 extra lookups | ~3 heap allocs + lookups |
| `hasNoneFilter` | 1 dict lookup | 0 (reuses `filterValues`) | 1 × hash+compare |

For a 10,000-test run with a single-property filter: up to **20,000 fewer dictionary lookups** and — for runs with multi-category filters — **up to 20,000 fewer heap allocations**, reducing GC pause time and CPU energy.

## Green Software Foundation Context

*Hardware Efficiency*: Eliminating allocation-per-call noise makes better use of CPU cache lines for actual test evaluation work.

*SCI (Software Carbon Intensity)*: `dotnet test` is invoked millions of times daily across .NET CI/CD pipelines. Reducing per-invocation work lowers the energy term in the SCI equation at ecosystem scale.

## Trade-offs

The multi-value branch is slightly more verbose (explicit `foreach` instead of LINQ one-liner). This is offset by:
- Zero allocation cost vs. two heap allocations per call
- The `foreach` pattern is idiomatic C# and consistent with the rest of the codebase

## Test Status

- `Microsoft.TestPlatform.Common.UnitTests` (Filtering namespace): ✅ 108/108 passed
- `Microsoft.TestPlatform.Filter.Source.UnitTests`: ✅ 45/45 passed
- Build: ✅ 0 errors (Debug, net11.0)

## Reproducibility

```sh
.dotnet/dotnet run --project test/Microsoft.TestPlatform.Common.UnitTests/Microsoft.TestPlatform.Common.UnitTests.csproj -f net11.0 -- --filter "Filtering"
.dotnet/dotnet run --project test/Microsoft.TestPlatform.Filter.Source.UnitTests/Microsoft.TestPlatform.Filter.Source.UnitTests.csproj -f net11.0
```




> Generated by [Efficiency Improver](https://github.com/microsoft/vstest/actions/runs/28043985451) · 2K AIC · ⌖ 27.3 AIC · ⊞ 45.6K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28043985451, workflow_id: efficiency-improver, run: https://github.com/microsoft/vstest/actions/runs/28043985451 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/vstest/efficiency-improver -->