### PR TITLE
Clear architecture-mismatched DOTNET_ROOT before launching testhost

### DIFF
--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -611,6 +611,22 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
                     }
                 }
             }
+
+            // Issue 16151: An inherited DOTNET_ROOT / DOTNET_ROOT(x86) that points at a .NET installation of a
+            // different architecture than the testhost we are about to launch makes the net8+ apphost fall back
+            // to it (DOTNET_ROOT_<ARCH> -> DOTNET_ROOT since .NET 6) and load a mismatched hostfxr.dll into the
+            // testhost process, failing with 0x800700C1. We don't control the apphost resolution, so we read the
+            // architecture of the testhost exe and scrub any incompatible DOTNET_ROOT* from its environment,
+            // letting the apphost fall back to the global/default installation like the netcoreapp3.1 testhost
+            // did before 17.14. This path is not covered by the dotnet/sdk#49436 fix, which only governs what
+            // 'dotnet test' itself forwards.
+            var testHostArchitecture = StringUtils.IsNullOrWhiteSpace(startInfo.FileName)
+                ? null
+                : TryGetPeArchitecture(startInfo.FileName);
+            if (testHostArchitecture is not null)
+            {
+                SanitizeIncompatibleDotnetRoot(startInfo, testHostArchitecture.Value);
+            }
         }
 
         startInfo.WorkingDirectory = sourceDirectory;
@@ -736,6 +752,111 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
             startInfo.EnvironmentVariables.Add(environmentVariableName, dotnetRootPath);
 
             EqtTrace.Verbose($"DotnetTestHostManager.SetDotnetRootForArchitecture: Adding {environmentVariableName}={dotnetRootPath} to testhost start info.");
+        }
+    }
+
+    /// <summary>
+    /// Clears any inherited <c>DOTNET_ROOT*</c> variable that points at a .NET installation whose architecture
+    /// does not match the testhost we are about to launch, so that the apphost does not load a mismatched
+    /// <c>hostfxr.dll</c> (<c>0x800700C1</c>).
+    /// </summary>
+    /// <remarks>
+    /// Since .NET 6 the apphost falls back from the architecture specific <c>DOTNET_ROOT_&lt;ARCH&gt;</c> to the
+    /// architecture-less <c>DOTNET_ROOT</c> (dotnet/runtime#53763). Combined with the net8 testhost apphost
+    /// shipped since 17.14, a <c>DOTNET_ROOT</c> pointing at e.g. an x64 install gets picked up by the x86
+    /// testhost, which then loads the x64 <c>hostfxr.dll</c> and aborts the run. We don't control the apphost
+    /// resolution, so we remove the offending variable from the testhost environment and let the apphost fall
+    /// back to the global/default installation, like the netcoreapp3.1 testhost did before 17.14.
+    /// See https://github.com/microsoft/vstest/issues/16151.
+    /// </remarks>
+    private void SanitizeIncompatibleDotnetRoot(TestProcessStartInfo startInfo, PlatformArchitecture testHostArchitecture)
+    {
+        // The DOTNET_ROOT* variables the apphost consults for this architecture, most specific first.
+        var candidateNames = new List<string>
+        {
+            $"DOTNET_ROOT_{testHostArchitecture.ToString().ToUpperInvariant()}",
+        };
+        if (testHostArchitecture == PlatformArchitecture.X86)
+        {
+            candidateNames.Add("DOTNET_ROOT(x86)");
+        }
+
+        candidateNames.Add("DOTNET_ROOT");
+
+        // Walk the candidates in the order the apphost consults them and stop at the first one that is usable.
+        // - If it is compatible (or we cannot read its architecture) the apphost will resolve the runtime from
+        //   there, so we leave it and every lower priority variable untouched. This is how an explicitly provided
+        //   DOTNET_ROOT_<ARCH> / DOTNET_ROOT(x86) keeps being used even when DOTNET_ROOT points elsewhere.
+        // - If it targets a different architecture, we blank it so the apphost moves on to the next candidate,
+        //   and ultimately to the global/default installation, instead of loading a mismatched hostfxr.dll.
+        foreach (var name in candidateNames)
+        {
+            // Prefer a value we are about to pass to the testhost, otherwise look at the inherited environment.
+            var value = startInfo.EnvironmentVariables is not null && startInfo.EnvironmentVariables.TryGetValue(name, out var explicitValue)
+                ? explicitValue
+                : _environmentVariableHelper.GetEnvironmentVariable(name);
+
+            if (StringUtils.IsNullOrWhiteSpace(value) || !_fileHelper.DirectoryExists(value))
+            {
+                // Not usable: the apphost skips it, so do we.
+                continue;
+            }
+
+            var dotnetRootArchitecture = TryGetDotnetRootArchitecture(value);
+            if (dotnetRootArchitecture is null || dotnetRootArchitecture == testHostArchitecture)
+            {
+                // The apphost will resolve the runtime from here (compatible, or we cannot tell and must not
+                // break a potentially valid private install). Leave this and every lower priority variable
+                // (including a possibly mismatched DOTNET_ROOT) untouched.
+                break;
+            }
+
+            // Incompatible: blank it out for the testhost so the apphost ignores it and moves on. An empty value
+            // is treated the same as 'not set' by the apphost runtime resolver.
+            startInfo.EnvironmentVariables ??= new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+            startInfo.EnvironmentVariables[name] = string.Empty;
+            EqtTrace.Warning(
+                $"DotnetTestHostManager.SanitizeIncompatibleDotnetRoot: '{name}' points at a '{dotnetRootArchitecture}' .NET installation ('{value}'), " +
+                $"but the testhost is '{testHostArchitecture}'. Clearing '{name}' for the testhost to avoid loading a mismatched hostfxr.dll " +
+                "(https://github.com/microsoft/vstest/issues/16151).");
+        }
+    }
+
+    /// <summary>
+    /// Gets the architecture of a .NET installation, which is the architecture of its <c>dotnet.exe</c> muxer,
+    /// or <see langword="null"/> when it cannot be determined.
+    /// </summary>
+    private PlatformArchitecture? TryGetDotnetRootArchitecture(string dotnetRoot)
+    {
+        // This is only reached on the Windows apphost path, so the muxer is always dotnet.exe.
+        var muxerPath = Path.Combine(dotnetRoot, "dotnet.exe");
+        return _fileHelper.Exists(muxerPath) ? TryGetPeArchitecture(muxerPath) : null;
+    }
+
+    /// <summary>
+    /// Reads the processor architecture from the PE header of a Windows executable, or <see langword="null"/>
+    /// when it cannot be determined.
+    /// </summary>
+    private PlatformArchitecture? TryGetPeArchitecture(string filePath)
+    {
+        try
+        {
+            using Stream stream = _fileHelper.GetStream(filePath, FileMode.Open, FileAccess.Read);
+            using PEReader peReader = new(stream);
+            return peReader.PEHeaders.CoffHeader.Machine switch
+            {
+                Machine.I386 => PlatformArchitecture.X86,
+                Machine.Amd64 => PlatformArchitecture.X64,
+                Machine.IA64 => PlatformArchitecture.X64,
+                Machine.Arm64 => PlatformArchitecture.ARM64,
+                Machine.Arm => PlatformArchitecture.ARM,
+                _ => (PlatformArchitecture?)null,
+            };
+        }
+        catch (Exception ex)
+        {
+            EqtTrace.Verbose($"DotnetTestHostManager.TryGetPeArchitecture: Failed to read PE architecture of '{filePath}'.\n{ex}");
+            return null;
         }
     }
 

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetArchitectureSwitchTests.Windows.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetArchitectureSwitchTests.Windows.cs
@@ -102,6 +102,59 @@ public class UnitTest1
         Assert.AreEqual(0, exitCode, stdOut);
     }
 
+    // Regression test for https://github.com/microsoft/vstest/issues/16151
+    //
+    // When the architecture specific roots (DOTNET_ROOT_X86 / DOTNET_ROOT(x86)) are not set and only the
+    // architecture-less DOTNET_ROOT is set, pointing at an x64 installation, the net8 testhost.x86.exe apphost
+    // falls back to DOTNET_ROOT (DOTNET_ROOT_X86 -> DOTNET_ROOT since .NET 6) and loads the x64 hostfxr.dll
+    // into the 32-bit process, aborting the run with HRESULT 0x800700C1 (ERROR_BAD_EXE_FORMAT). vstest.console
+    // must detect that DOTNET_ROOT points at a different architecture than the testhost and scrub it before
+    // launching the testhost, so the apphost never loads the mismatched hostfxr.dll.
+    [TestMethod]
+    public void X86Testhost_DoesNotLoadMismatchedHostfxr_WhenOnlyArchlessDotnetRootIsSetToX64()
+    {
+        SetTestEnvironment(_testEnvironment, new RunnerInfo { RunnerFramework = RUNNER_NET });
+        string dotnetX64 = GetDownloadedDotnetMuxerFromTools("X64");
+        var vstestConsolePath = GetDotnetRunnerPath();
+        var dotnetRunnerPath = TempDirectory.CreateDirectory("dotnetrunner");
+        TempDirectory.CopyDirectory(new DirectoryInfo(Path.GetDirectoryName(vstestConsolePath)!), dotnetRunnerPath);
+
+        // Patch the runner to run on the x64 runtime we resolved above.
+        string sdkVersion = GetLatestSdkVersion(dotnetX64);
+        string runtimeConfigFile = Path.Combine(dotnetRunnerPath.FullName, "vstest.console.runtimeconfig.json");
+        var patchRuntimeConfig = JsonNode.Parse(File.ReadAllText(runtimeConfigFile))!;
+        patchRuntimeConfig["runtimeOptions"]!["framework"]!["version"] = sdkVersion;
+        File.WriteAllText(runtimeConfigFile, patchRuntimeConfig.ToJsonString());
+
+        ExecuteApplication(dotnetX64, "new mstest", out _, out _, out _, new Dictionary<string, string?>(), TempDirectory.Path);
+
+        // Only the architecture-less DOTNET_ROOT is set, and it points at the x64 installation. The architecture
+        // specific overrides are cleared (the test runner sets DOTNET_ROOT(x86) in the surrounding environment),
+        // so without the fix the x86 testhost would fall back to the x64 DOTNET_ROOT and load the x64 hostfxr.dll.
+        var environmentVariables = new Dictionary<string, string?>
+        {
+            ["DOTNET_ROOT"] = Path.GetDirectoryName(dotnetX64),
+            ["DOTNET_ROOT(x86)"] = string.Empty,
+            ["DOTNET_ROOT_X86"] = string.Empty,
+        };
+
+        ExecuteApplication(
+            dotnetX64,
+            $"test -p:VsTestConsolePath=\"{Path.Combine(dotnetRunnerPath.FullName, Path.GetFileName(vstestConsolePath))}\" --arch x86 --diag:log.txt",
+            out string stdOut,
+            out string stdError,
+            out _,
+            environmentVariables,
+            TempDirectory.Path);
+
+        // The x86 testhost must not try to load the x64 hostfxr.dll. Per the issue, an honest "runtime not found"
+        // diagnostic is acceptable; loading the wrong-architecture hostfxr.dll (0x800700C1) is the bug.
+        Assert.DoesNotContain(
+            "0x800700C1",
+            stdOut + stdError,
+            $"x86 testhost loaded the x64 hostfxr.dll (issue 16151).\nStdOut:\n{stdOut}\nStdError:\n{stdError}");
+    }
+
     private static string GetLatestSdkVersion(string dotnetPath)
     {
         var folders = Directory.GetDirectories(Path.Combine(Path.GetDirectoryName(dotnetPath)!, @"shared/Microsoft.NETCore.App")).Select(f => new


### PR DESCRIPTION
An x86 test run through `vstest.console.exe` aborts with `0x800700C1` (`ERROR_BAD_EXE_FORMAT`) when `DOTNET_ROOT` points at an x64 install. The net8 testhost apphost (17.14+) falls back from `DOTNET_ROOT_<ARCH>` to the architecture-less `DOTNET_ROOT` (dotnet/runtime#53763), so `testhost.x86.exe` loads the x64 `hostfxr.dll` into the 32-bit process. The dotnet/sdk#49436 fix only governs what `dotnet test` forwards; a user-set `DOTNET_ROOT` on the `vstest.console.exe` path was never sanitized.

When launching `testhost.<arch>.exe`, read the architecture of the testhost (PE header) and of each `DOTNET_ROOT*` the apphost would consult. Stop at the first compatible root — so an explicit `DOTNET_ROOT_X86` / `DOTNET_ROOT(x86)` keeps being used — and clear an architecture-less `DOTNET_ROOT` only when it targets a different architecture and nothing compatible is set, letting the apphost fall back to the global/default install like the netcoreapp3.1 testhost did before 17.14.

Verified against `Microsoft.NET.Test.Sdk` 18.9.0-preview-26319-02:

| Environment (x86 testhost) | before | after |
| --- | --- | --- |
| `DOTNET_ROOT`=x64 only | aborts `0x800700C1` | passes, x86 from global install |
| `DOTNET_ROOT`=x64 + `DOTNET_ROOT_X86`=x86 | passes | passes, `DOTNET_ROOT_X86` used, `DOTNET_ROOT` untouched |
| `DOTNET_ROOT`=x64 + `DOTNET_ROOT(x86)`=x86 | passes | passes, `DOTNET_ROOT(x86)` used |
| x64 testhost, `DOTNET_ROOT`=x64 | passes | passes, untouched |

Added an acceptance test (`DotnetArchitectureSwitchTests.Windows.cs`); existing `DotnetTestHostManagerTests` (100) still pass.

Fixes #16151
