### PR TITLE
[code-simplifier] simplify: apply project standards to recently modified files

### DIFF
--- a/src/Microsoft.TestPlatform.CoreUtilities/Utilities/Job.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Utilities/Job.cs
@@ -33,7 +33,6 @@ internal class Job<TPayload>
     /// </summary>
     private Job()
     {
-        Size = 0;
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscoveryResultCache.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscoveryResultCache.cs
@@ -61,7 +61,6 @@ internal class DiscoveryResultCache
         _cacheTimeout = discoveredTestEventTimeout;
 
         _tests = new List<TestCase>();
-        TotalDiscoveredTests = 0;
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/TestRunCache.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/TestRunCache.cs
@@ -205,16 +205,8 @@ internal class TestRunCache : ITestRunCache
             _testResults.Add(testResult);
             MsTestV1TelemetryHelper.AddTelemetry(testResult, AdapterTelemetry);
 
-            if (_runStats.TryGetValue(testResult.Outcome, out long count))
-            {
-                count++;
-            }
-            else
-            {
-                count = 1;
-            }
-
-            _runStats[testResult.Outcome] = count;
+            _runStats.TryGetValue(testResult.Outcome, out long count);
+            _runStats[testResult.Outcome] = count + 1;
 
             RemoveInProgress(testResult);
 
@@ -292,10 +284,7 @@ internal class TestRunCache : ITestRunCache
         // operations, as well as in your methods that use the resource.
         if (disposing && !_isDisposed)
         {
-            if (_timer != null)
-            {
-                _timer.Dispose();
-            }
+            _timer.Dispose();
 
             // Indicate that the instance has been disposed.
             _isDisposed = true;

--- a/src/Microsoft.TestPlatform.Filter.Source/FastFilter.cs
+++ b/src/Microsoft.TestPlatform.Filter.Source/FastFilter.cs
@@ -177,7 +177,7 @@ internal sealed class FastFilter
     private static bool TryGetPropertyValue(string name, Func<string, object?> propertyValueProvider, out string? singleValue, out string[]? multiValues)
     {
         var propertyValue = propertyValueProvider(name);
-        if (null != propertyValue)
+        if (propertyValue is not null)
         {
             multiValues = propertyValue as string[];
             singleValue = multiValues == null ? propertyValue.ToString() : null;


### PR DESCRIPTION
## Code Simplification — 2026-06-24

This PR applies project-standard refinements to files modified in the last 24 hours (PRs #16160, #16159, #16150, #16147, #16144), preserving all functionality.

### Files Simplified

- `src/Microsoft.TestPlatform.Filter.Source/FastFilter.cs` — use `is not null` instead of `null !=` (project standard)
- `src/Microsoft.TestPlatform.CoreUtilities/Utilities/Job.cs` — remove redundant `Size = 0` default assignment
- `src/Microsoft.TestPlatform.CrossPlatEngine/Discovery/DiscoveryResultCache.cs` — remove redundant `TotalDiscoveredTests = 0` default assignment
- `src/Microsoft.TestPlatform.CrossPlatEngine/Execution/TestRunCache.cs` — simplify `_runStats` increment; remove null check on non-nullable `_timer`

### Improvements Made

1. **Applied Project Standards**
   - `null != propertyValue` → `propertyValue is not null` in `FastFilter.TryGetPropertyValue` (`.editorconfig` / custom instructions require `is null` / `is not null`)

2. **Removed Redundant Default Assignments** (consistent with what PR #16159 already did for `JobQueue.cs`)
   - `Size = 0` in `Job<TPayload>` private constructor — `int` fields default to `0`
   - `TotalDiscoveredTests = 0` in `DiscoveryResultCache` constructor — auto-property `long` defaults to `0`

3. **Reduced Complexity**
   - `_runStats` increment in `TestRunCache.OnNewTestResult` collapsed from 8 lines (if/else + assignment) to 2 lines by relying on `TryGetValue`'s out-param defaulting to `0`:
     ```csharp
     // before
     if (_runStats.TryGetValue(testResult.Outcome, out long count)) { count++; }
     else { count = 1; }
     _runStats[testResult.Outcome] = count;

     // after
     _runStats.TryGetValue(testResult.Outcome, out long count);
     _runStats[testResult.Outcome] = count + 1;
     ```
   - Removed `if (_timer != null)` guard in `TestRunCache.Dispose` — `_timer` is `private readonly Timer` (non-nullable), always initialized in the constructor

### Changes Based On

Recent merged PRs:
- #16160 — `FastFilter.cs` hot-loop refactor
- #16159 — `Job.cs` / `JobQueue.cs` object initializer simplification
- #16150 — `Job.cs` / `JobQueue.cs` `ManualResetEventSlim` migration
- #16147 — `LengthPrefixCommunicationChannel.cs` / `TcpClientExtensions.cs` `Task.CompletedTask`
- #16144 — `DiscoveryResultCache.cs` / `TestRunCache.cs` `DateTime.UtcNow`

### Testing

- ✅ Build succeeds (`./build.sh`, Debug config, 0 errors)
- ✅ No functional changes — behavior is identical
- ✅ Aligns with project conventions (`.editorconfig`, custom instructions)


<!-- gh-aw-tracker-id: code-simplifier -->




> Generated by [Code Simplifier](https://github.com/microsoft/vstest/actions/runs/28110484730) · 493.2 AIC · ⌖ 22.9 AIC · ⊞ 31.6K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
> - [x] expires <!-- gh-aw-expires: 2026-06-25T15:51:04.331Z --> on Jun 25, 2026, 3:51 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28110484730, workflow_id: code-simplifier, run: https://github.com/microsoft/vstest/actions/runs/28110484730 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->
<!-- gh-aw-workflow-call-id: microsoft/vstest/code-simplifier -->