### PR TITLE
[fix] Preserve the real exception (type + stack trace) when a test run aborts in BaseRunTests

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.TestPlatform.Common.ExtensionDecorators;
@@ -218,7 +219,14 @@ internal abstract class BaseRunTests
             {
                 EqtTrace.Error("BaseRunTests.RunTests: Failed to run the tests. Reason: {0}.", ex);
 
-                exception = new Exception(ex.Message, ex);
+                // RunTestsInternal can surface a TargetInvocationException when a test extension is
+                // instantiated via reflection and its constructor throws. Unwrap that wrapper to the
+                // real exception so callers don't see the reflection noise. Any other exception is
+                // preserved as-is so its concrete type and stack trace are not lost on the way out.
+                Exception realException = ex is TargetInvocationException tie && tie.InnerException is not null
+                    ? tie.InnerException
+                    : ex;
+                exception = new Exception(realException.Message, realException);
                 isAborted = true;
             }
             finally

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -218,7 +218,7 @@ internal abstract class BaseRunTests
             {
                 EqtTrace.Error("BaseRunTests.RunTests: Failed to run the tests. Reason: {0}.", ex);
 
-                exception = new Exception(ex.Message, ex.InnerException);
+                exception = new Exception(ex.Message, ex);
                 isAborted = true;
             }
             finally

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/BaseRunTestsTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/BaseRunTestsTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 
 using Microsoft.TestPlatform.TestUtilities;
 using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
@@ -188,6 +189,41 @@ public class BaseRunTestsTests
         Assert.IsNotNull(receivedCompleteArgs.Error);
         Assert.AreSame(originalException, receivedCompleteArgs.Error!.InnerException,
             "The original exception should be preserved as the inner exception of the wrapper.");
+    }
+
+    [TestMethod]
+    public void RunTestsShouldUnwrapTargetInvocationExceptionToTheRealException()
+    {
+        TestRunCompleteEventArgs? receivedCompleteArgs = null;
+        var realException = new NotImplementedException("real message");
+
+        // A TargetInvocationException is what reflection-based extension instantiation throws when
+        // a constructor fails; the wrapper itself is noise, the real exception is the inner one.
+        var reflectionWrapper = new TargetInvocationException(realException);
+
+        // Setup mocks.
+        _runTestsInstance.GetExecutorUriExtensionMapCallback = (fh, rc) => throw reflectionWrapper;
+        _mockTestRunEventsHandler.Setup(
+                treh =>
+                    treh.HandleTestRunComplete(
+                        It.IsAny<TestRunCompleteEventArgs>(),
+                        It.IsAny<TestRunChangedEventArgs>(),
+                        It.IsAny<ICollection<AttachmentSet>>(),
+                        It.IsAny<ICollection<string>>()))
+            .Callback(
+                (
+                    TestRunCompleteEventArgs complete,
+                    TestRunChangedEventArgs stats,
+                    ICollection<AttachmentSet> attachments,
+                    ICollection<string> executorUris) => receivedCompleteArgs = complete);
+
+        _runTestsInstance.RunTests();
+
+        Assert.IsNotNull(receivedCompleteArgs);
+        Assert.IsTrue(receivedCompleteArgs.IsAborted);
+        Assert.IsNotNull(receivedCompleteArgs.Error);
+        Assert.AreSame(realException, receivedCompleteArgs.Error!.InnerException,
+            "A TargetInvocationException should be unwrapped to its real inner exception, not surfaced as-is.");
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/BaseRunTestsTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Execution/BaseRunTestsTests.cs
@@ -160,6 +160,37 @@ public class BaseRunTestsTests
     }
 
     [TestMethod]
+    public void RunTestsShouldPreserveOriginalExceptionAsInnerException()
+    {
+        TestRunCompleteEventArgs? receivedCompleteArgs = null;
+        var originalException = new NotImplementedException("original message");
+
+        // Setup mocks.
+        _runTestsInstance.GetExecutorUriExtensionMapCallback = (fh, rc) => throw originalException;
+        _mockTestRunEventsHandler.Setup(
+                treh =>
+                    treh.HandleTestRunComplete(
+                        It.IsAny<TestRunCompleteEventArgs>(),
+                        It.IsAny<TestRunChangedEventArgs>(),
+                        It.IsAny<ICollection<AttachmentSet>>(),
+                        It.IsAny<ICollection<string>>()))
+            .Callback(
+                (
+                    TestRunCompleteEventArgs complete,
+                    TestRunChangedEventArgs stats,
+                    ICollection<AttachmentSet> attachments,
+                    ICollection<string> executorUris) => receivedCompleteArgs = complete);
+
+        _runTestsInstance.RunTests();
+
+        Assert.IsNotNull(receivedCompleteArgs);
+        Assert.IsTrue(receivedCompleteArgs.IsAborted);
+        Assert.IsNotNull(receivedCompleteArgs.Error);
+        Assert.AreSame(originalException, receivedCompleteArgs.Error!.InnerException,
+            "The original exception should be preserved as the inner exception of the wrapper.");
+    }
+
+    [TestMethod]
     public void RunTestsShouldNotThrowIfExceptionIsAFileNotFoundException()
     {
         TestRunCompleteEventArgs? receivedCompleteArgs = null;


### PR DESCRIPTION
When a test run aborts, `BaseRunTests.RunTests` caught the exception and rewrapped it as `new Exception(ex.Message, ex.InnerException)`. That threw away the original exception's **type** and **stack trace** — callers (translation layer, VS Test Explorer) saw a bare `Exception` with a broken (often `null`) inner chain.

The fix preserves the original exception as the inner exception. The one thing we deliberately unwrap is `TargetInvocationException` — the reflection wrapper you get when a test extension is instantiated via `Activator.CreateInstance` and its constructor throws. That wrapper is just noise, so we surface its inner (real) exception. Every other exception is kept as-is. This mirrors the unwrap logic we already use in `test/Intent/Runner.cs`.

Tests cover both paths: a plain exception is preserved as the inner exception, and a `TargetInvocationException` is unwrapped to its real inner exception.

Fixes #16161.

---

> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/28140571892)* — refined after review.

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 28140571892, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/28140571892 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->
