### PR TITLE
Suggest Microsoft.NET.Test.Sdk when a managed test project brings no testhost

### DIFF
--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -383,6 +383,17 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
 #endif
                 if (_fileHelper.Exists(testHostNextToRunner))
                 {
+                    // The testhost shipped next to the runner (together with the package's testhost.deps.json and a
+                    // synthesized runtimeconfig) is the fallback for native (C++) runners that bring no managed testhost.
+                    // A managed (.NET) source reaching here did not resolve a testhost from its own deps.json, which means
+                    // the test project is missing the Microsoft.NET.Test.Sdk reference. Don't silently run it on the
+                    // built-in testhost (it would just discover no tests) - throw and point the user at Microsoft.NET.Test.Sdk.
+                    if (!IsNativeModule(sourcePath))
+                    {
+                        string message = string.Format(CultureInfo.CurrentCulture, Resources.CouldNotFindTesthost, sourcePath, sourceDirectory);
+                        throw new TestPlatformException(message);
+                    }
+
                     EqtTrace.Verbose("DotnetTestHostManager: Found testhost.dll next to runner executable: {0}.", testHostNextToRunner);
                     testHostPath = testHostNextToRunner;
 
@@ -700,23 +711,35 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
                    new Version(_targetFramework.Version).Major < 5 &&
                    !IsNativeModule(sourcePath);
         }
+    }
 
-        bool IsNativeModule(string modulePath)
+    /// <summary>
+    /// Determines whether the given module is a native (unmanaged) binary, such as a C++ CppUnitTestFramework test dll.
+    /// </summary>
+    /// <remarks>
+    /// Native sources have no managed (CLI) metadata, or are not IL-only (mixed mode). They legitimately have no
+    /// deps.json and rely on the testhost shipped next to the runner, so callers treat them leniently. If the module
+    /// cannot be read we cannot prove it is native, so we assume managed.
+    /// </remarks>
+    internal virtual bool IsNativeModule(string modulePath)
+    {
+        // Scenario: dotnet test nativeArm64.dll for CppUnitTestFramework
+        try
         {
-            // Scenario: dotnet test nativeArm64.dll for CppUnitTestFramework
-            // If the dll is native and we're not running in process(vstest.console.exe)
-            // the expected target framework is ".NETCoreApp,Version=v1.0".
-            // In this case we don't want to force x64 architecture
-            using var assemblyStream = _fileHelper.GetStream(sourcePath, FileMode.Open, FileAccess.Read);
+            using var assemblyStream = _fileHelper.GetStream(modulePath, FileMode.Open, FileAccess.Read);
             using var peReader = new PEReader(assemblyStream);
             if (!peReader.HasMetadata || (peReader.PEHeaders.CorHeader?.Flags & CorFlags.ILOnly) == 0)
             {
-                EqtTrace.Verbose($"DotnetTestHostmanager.IsNativeModule: Source '{sourcePath}' is native.");
+                EqtTrace.Verbose($"DotnetTestHostManager.IsNativeModule: Source '{modulePath}' is native.");
                 return true;
             }
-
-            return false;
         }
+        catch (Exception ex)
+        {
+            EqtTrace.Verbose($"DotnetTestHostManager.IsNativeModule: Failed to read '{modulePath}', assuming managed. {ex}");
+        }
+
+        return false;
     }
 
     private void SetDotnetRootForArchitecture(TestProcessStartInfo startInfo, string dotnetRootPath, string dotnetRootArchitecture)

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/MissingTestSdkTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/MissingTestSdkTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+
+using Microsoft.TestPlatform.TestUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.TestPlatform.AcceptanceTests;
+
+[TestClass]
+public class MissingTestSdkTests : AcceptanceTestBase
+{
+    // A substring of the CouldNotFindTesthost guidance. We don't match the whole (localizable) message, just enough to
+    // make clear the failure is telling the user to reference the Microsoft.NET.Test.Sdk package.
+    private const string TestSdkGuidance = "references the 'Microsoft.NET.Test.Sdk' NuGet package";
+
+    // A managed test project that does not reference Microsoft.NET.Test.Sdk brings no testhost of its own. It must not
+    // silently run on the built-in testhost shipped next to the runner (that fallback is for native C++ runners) - the
+    // run should fail and tell the user to reference Microsoft.NET.Test.Sdk.
+    [TestMethod]
+    [NetCoreTargetFrameworkDataSource(useDesktopRunner: false, useCoreRunner: true)]
+    public void RunningManagedProjectWithoutTestSdkShouldFailAndSuggestTestSdk(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var assemblyPath = GetAssetFullPath("ProjectWithoutTestSdk.dll");
+        var arguments = PrepareArguments(assemblyPath, string.Empty, string.Empty, string.Empty, resultsDirectory: TempDirectory.Path);
+
+        InvokeVsTest(arguments);
+
+        // The run fails (the managed source is rejected, not run on the built-in testhost) and tells the user to
+        // reference Microsoft.NET.Test.Sdk.
+        ExitCodeEquals(1);
+        Assert.Contains(TestSdkGuidance, StdOut + StdErr);
+    }
+
+    // A native (C++) source has no managed testhost of its own, and that is exactly what the built-in testhost fallback
+    // is for. It keeps using the fallback (the testhost launches and discovery runs - here it finds no C++ adapter under
+    // .NET Core, like the [Ignore]'d CPPRunAllTestExecutionPlatformx64Net), and must NOT get the managed
+    // Microsoft.NET.Test.Sdk guidance. Uses the prebuilt Microsoft.TestPlatform.TestAsset.NativeCPP package so we don't
+    // build C++ locally. Windows-only (the asset is a Windows native dll).
+    [TestMethod]
+    [TestCategory("Windows-Review")]
+    [NetCoreTargetFrameworkDataSource(useDesktopRunner: false, useCoreRunner: true)]
+    public void RunningNativeCppProjectWithoutTestSdkShouldUseTheBuiltInTesthostFallback(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var assemblyPath = Path.Combine(
+            _testEnvironment.GlobalPackageDirectory,
+            "microsoft.testplatform.testasset.nativecpp", "2.0.0", "contentFiles", "any", "any", "x64",
+            "Microsoft.TestPlatform.TestAsset.NativeCPP.dll");
+        var arguments = PrepareArguments(assemblyPath, string.Empty, string.Empty, FrameworkArgValue, _testEnvironment.InIsolationValue, resultsDirectory: TempDirectory.Path);
+
+        InvokeVsTest(arguments);
+
+        // The fallback was used: the testhost launched and discovery ran (it just finds no C++ adapter under .NET Core).
+        // This also guards against the test passing vacuously if the asset path failed to resolve.
+        StdOutputContains("No test is available");
+        // ...and the native source was NOT rejected with the managed Microsoft.NET.Test.Sdk guidance.
+        Assert.DoesNotContain(TestSdkGuidance, StdOut + StdErr);
+    }
+}

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 #if NET
@@ -26,6 +27,8 @@ using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
+
+using HostProviderResources = Microsoft.TestPlatform.TestHostProvider.Resources.Resources;
 
 namespace TestPlatform.TestHostProvider.UnitTests.Hosting;
 
@@ -544,10 +547,15 @@ public class DotnetTestHostManagerTests
     }
 
     [TestMethod]
-    public void GetTestHostProcessStartInfoShouldIncludeSourcePathInExceptionMessageWhenTesthostNotFound()
+    public void GetTestHostProcessStartInfoShouldIncludeSourcePathInExceptionMessageWhenTesthostNotFoundForNativeSource()
     {
         var sourcePath = Path.Combine(_temp, "mytest.dll");
         var sourceDirectory = Path.GetDirectoryName(sourcePath)!;
+
+        // Native source with no testhost anywhere falls through to the final throw. It gets the same generic
+        // CouldNotFindTesthost message as any other source (which lists referencing Microsoft.NET.Test.Sdk among the
+        // possible causes); the managed-only rejection is exercised in the test below.
+        _dotnetHostManager.IsNativeModuleResult = true;
 
         // Ensure no testhost.dll exists anywhere
         _mockFileHelper.Setup(fh => fh.Exists(It.IsAny<string>())).Returns(false);
@@ -555,8 +563,33 @@ public class DotnetTestHostManagerTests
         Action action = () => _dotnetHostManager.GetTestHostProcessStartInfo(new[] { sourcePath }, null, _defaultConnectionInfo);
 
         var exception = Assert.ThrowsExactly<TestPlatformException>(action);
-        Assert.Contains(sourcePath, exception.Message);
-        Assert.Contains(sourceDirectory, exception.Message);
+        var expectedMessage = string.Format(CultureInfo.CurrentCulture, HostProviderResources.CouldNotFindTesthost, sourcePath, sourceDirectory);
+        Assert.AreEqual(expectedMessage, exception.Message);
+    }
+
+    [TestMethod]
+    public void GetTestHostProcessStartInfoShouldThrowTestSdkGuidanceWhenManagedSourceFallsBackToBuiltInTesthost()
+    {
+        // A managed .NET source whose own testhost cannot be resolved (the test project does not reference
+        // Microsoft.NET.Test.Sdk) would otherwise silently fall back to the testhost shipped next to the runner.
+        // That fallback is for native (C++) runners only, so for a managed source we throw and point the user at
+        // the missing Microsoft.NET.Test.Sdk reference.
+        var sourcePath = Path.Combine(_temp, "test.dll");
+        _dotnetHostManager.IsNativeModuleResult = false;
+
+        // No testhost next to the test dll, so resolution from the project fails...
+        _mockFileHelper.Setup(ph => ph.Exists(Path.Combine(_temp, "testhost.dll"))).Returns(false);
+        // ...but the built-in testhost exists next to the runner (the C++ fallback).
+        var here = Path.GetDirectoryName(System.Reflection.Assembly.GetEntryAssembly()!.Location)!;
+        _mockFileHelper.Setup(ph => ph.Exists(Path.Combine(here, "testhost.dll"))).Returns(true);
+
+        Action action = () => _dotnetHostManager.GetTestHostProcessStartInfo(new[] { sourcePath }, null, _defaultConnectionInfo);
+
+        // A managed source must be rejected (not run on the built-in testhost) with the CouldNotFindTesthost message,
+        // which tells the user to reference Microsoft.NET.Test.Sdk.
+        var exception = Assert.ThrowsExactly<TestPlatformException>(action);
+        var expectedMessage = string.Format(CultureInfo.CurrentCulture, HostProviderResources.CouldNotFindTesthost, sourcePath, Path.GetDirectoryName(sourcePath));
+        Assert.AreEqual(expectedMessage, exception.Message);
     }
 
 
@@ -667,6 +700,10 @@ public class DotnetTestHostManagerTests
     {
         // Absolute path to the source directory
         var sourcePath = Path.Combine(_temp, "test.dll");
+
+        // The testhost-next-to-runner fallback is the native (C++) runner path; a managed source would instead be told to reference Microsoft.NET.Test.Sdk.
+        _dotnetHostManager.IsNativeModuleResult = true;
+
         string testhostNextToTestDll = Path.Combine(_temp, "testhost.dll");
         _mockFileHelper.Setup(ph => ph.Exists(testhostNextToTestDll)).Returns(false);
 
@@ -707,6 +744,10 @@ public class DotnetTestHostManagerTests
     {
         // Absolute path to the source directory
         var sourcePath = Path.Combine(_temp, "test.dll");
+
+        // The testhost-next-to-runner fallback is the native (C++) runner path; a managed source would instead be told to reference Microsoft.NET.Test.Sdk.
+        _dotnetHostManager.IsNativeModuleResult = true;
+
         string testhostNextToTestDll = Path.Combine(_temp, "testhost.dll");
         _mockFileHelper.Setup(ph => ph.Exists(testhostNextToTestDll)).Returns(false);
 
@@ -1140,5 +1181,14 @@ public class DotnetTestHostManagerTests
             : base(processHelper, fileHelper, dotnetTestHostHelper, environment, runsettingsHelper, windowsRegistryHelper, environmentVariableHelper)
         {
         }
+
+        /// <summary>
+        /// When set, overrides native-module detection so tests can simulate native vs managed sources without
+        /// providing real PE bytes. When null, the real <see cref="DotnetTestHostManager.IsNativeModule"/> runs.
+        /// </summary>
+        public bool? IsNativeModuleResult { get; set; }
+
+        internal override bool IsNativeModule(string modulePath)
+            => IsNativeModuleResult ?? base.IsNativeModule(modulePath);
     }
 }

--- a/test/TestAssets/ProjectWithoutTestSdk/ProjectWithoutTestSdk.csproj
+++ b/test/TestAssets/ProjectWithoutTestSdk/ProjectWithoutTestSdk.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(NetCoreAppMinimum)</TargetFrameworks>
+    <!--
+      Deliberately NO Microsoft.NET.Test.Sdk reference. This repros a managed test project that forgot the
+      Microsoft.NET.Test.Sdk package: it brings no testhost of its own, so without the fix vstest silently falls back
+      to the built-in (C++ runner) testhost next to the runner and discovers nothing.
+    -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestFrameworkVersion)" />
+    <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestTestAdapterVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/test/TestAssets/ProjectWithoutTestSdk/UnitTest.cs
+++ b/test/TestAssets/ProjectWithoutTestSdk/UnitTest.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ProjectWithoutTestSdk;
+
+[TestClass]
+public class UnitTest
+{
+    [TestMethod]
+    public void PassingTest()
+    {
+    }
+}

--- a/test/TestAssets/TestAssets.slnx
+++ b/test/TestAssets/TestAssets.slnx
@@ -60,6 +60,7 @@
   <Project Path="ParametrizedTestProject/ParametrizedTestProject.csproj" />
   <Project Path="problematic-child/problematic-child.csproj" />
   <Project Path="ProjectFileRunSettingsTestProject/ProjectFileRunSettingsTestProject.csproj" />
+  <Project Path="ProjectWithoutTestSdk/ProjectWithoutTestSdk.csproj" />
   <Project Path="RecursiveResourceLookupCrash/RecursiveResourceLookupCrash.csproj" />
   <Project Path="SelfContainedAppTestProject/SelfContainedAppTestProject.csproj" />
   <Project Path="SerializeTestRunTestProject/SerializeTestRunTestProject.csproj" />


### PR DESCRIPTION
The `Microsoft.TestPlatform` package ships a .NET Core testhost right next to the runner. So when a managed test project brings no testhost of its own — i.e. it does not reference `Microsoft.NET.Test.Sdk` — `DotnetTestHostManager` quietly falls back to that built-in testhost, plus the package's `testhost.deps.json` and a synthesized `runtimeconfig`. That fallback is meant for native (C++) runners only. A managed project landing there just spins up a testhost that discovers nothing, and the user gets a confusing "no tests" instead of "you forgot `Microsoft.NET.Test.Sdk`".

I confirmed it — a plain managed `net8.0` project without Test.Sdk goes straight into the fallback:

```
ManagedNoTestSdk.runtimeconfig.json, does not exist
Found testhost.dll next to runner executable: ...\testhost.dll
  --additional-deps "...\testhost.deps.json"
  --runtimeconfig  "...\testhost-8.0.runtimeconfig.json"
```

So the fix throws at that point: when we are about to use the testhost-next-to-runner fallback and the source is managed (not native), fail and tell the user to reference `Microsoft.NET.Test.Sdk` (the `CouldNotFindTesthost` message already lists it). Native (C++) sources keep the fallback, that is what it is for. `IsNativeModule` (the `PEReader` check already used for x64 forcing) is promoted to a method so both paths share it.

Tests: unit tests for both branches (managed -> throws, native -> uses the fallback), and an acceptance test that runs a managed project without Test.Sdk (`ProjectWithoutTestSdk`) through the real package runner and asserts the guidance.

Verified: `Microsoft.TestPlatform.TestHostProvider.UnitTests` green on `net481` (49/49). The `net11.0` unit legs and the acceptance test I could not run locally (no pinned .NET 11 preview runtime here), so CI covers those. 🤞
