### PR TITLE
[efficiency-improver] perf: eliminate redundant ContainsKey in IPC deserialization hot path

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/JsoniteConvert.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/JsoniteConvert.cs
@@ -246,10 +246,10 @@ internal static class JsoniteConvert
     {
         if (value is not IDictionary<string, object> dict) return null;
         var tc = new TestCase();
-        bool flat = dict.ContainsKey("FullyQualifiedName");
+        bool flat = dict.TryGetValue("FullyQualifiedName", out var fqnFlat);
         if (flat)
         {
-            if (dict.TryGetValue("FullyQualifiedName", out var fqn) && fqn != null) tc.FullyQualifiedName = fqn.ToString()!;
+            if (fqnFlat != null) tc.FullyQualifiedName = fqnFlat.ToString()!;
             if (dict.TryGetValue("ExecutorUri", out var uri) && uri != null) tc.ExecutorUri = new Uri(uri.ToString()!);
             if (dict.TryGetValue("Source", out var src) && src != null) tc.Source = src.ToString()!;
             if (dict.TryGetValue("Id", out var id) && id != null) tc.Id = Guid.Parse(id.ToString()!);
@@ -288,10 +288,10 @@ internal static class JsoniteConvert
         var tr = new TestResult(tc);
         if (dict.TryGetValue("Attachments", out var ao) && ao is IList al) foreach (var i in al) if (i != null && DeserializeAttachmentSet(i) is AttachmentSet a) tr.Attachments.Add(a);
         if (dict.TryGetValue("Messages", out var mo) && mo is IList ml) foreach (var i in ml) if (i != null && ConvertTo(i, typeof(TestResultMessage)) is TestResultMessage m) tr.Messages.Add(m);
-        bool flat = dict.ContainsKey("Outcome");
+        bool flat = dict.TryGetValue("Outcome", out var ocFlat);
         if (flat)
         {
-            if (dict.TryGetValue("Outcome", out var oc)) tr.Outcome = (TestOutcome)Convert.ToInt32(oc, CultureInfo.InvariantCulture);
+            tr.Outcome = (TestOutcome)Convert.ToInt32(ocFlat, CultureInfo.InvariantCulture);
             if (dict.TryGetValue("ErrorMessage", out var em) && em != null) tr.ErrorMessage = em.ToString();
             if (dict.TryGetValue("ErrorStackTrace", out var es) && es != null) tr.ErrorStackTrace = es.ToString();
             if (dict.TryGetValue("DisplayName", out var dn) && dn != null) tr.DisplayName = dn.ToString();


### PR DESCRIPTION
## Goal and Rationale

Eliminate redundant dictionary hash lookups in the IPC deserialization hot path (`JsoniteConvert`). Both `DeserializeTestCase` and `DeserializeTestResult` used `ContainsKey` to detect the wire-format version ("flat" vs "nested"), then immediately repeated the same key lookup with `TryGetValue` — hashing the same key twice per test case/result received over IPC.

**Focus area:** Network & I/O Efficiency (IPC receive path)

---

## Approach

1. **`DeserializeTestCase`** — replaced `dict.ContainsKey("FullyQualifiedName")` with `dict.TryGetValue("FullyQualifiedName", out var fqnFlat)`, reusing `fqnFlat` directly instead of a second `TryGetValue` call on the same key.

2. **`DeserializeTestResult`** — replaced `dict.ContainsKey("Outcome")` with `dict.TryGetValue("Outcome", out var ocFlat)`, and removed the now-redundant inner `if (dict.TryGetValue("Outcome", ...))` guard.

Both changes are semantics-preserving: the `flat` boolean has the same value, and the extracted value is used identically.

---

## Energy Efficiency Evidence

**Proxy metric used: CPU instruction count / hash operations** → fewer redundant dictionary hash computations = fewer CPU cycles per test case/result received.

| Location | Before | After |
|---|---|---|
| `DeserializeTestCase` | 2 hash lookups for `"FullyQualifiedName"` per deserialized test case | 1 hash lookup |
| `DeserializeTestResult` | 2 hash lookups for `"Outcome"` per deserialized test result | 1 hash lookup |

For a **10 000-test run** (discovery + execution):
- **~20 000 redundant dictionary hash lookups eliminated** — 10K in discovery (test cases) + 10K in execution (test results)
- These are called in the IPC receive loop — every test case discovered and every test result received takes this path

---

## Green Software Foundation Context

- **Hardware Efficiency**: fewer CPU instructions per test case received over IPC reduces overall CPU energy per `dotnet test` invocation. At ecosystem scale (millions of CI runs daily), even small per-invocation reductions accumulate.
- **SCI (Software Carbon Intensity)**: reduces CPU work per functional unit (test run), lowering the energy term in the SCI equation.

---

## Trade-offs

None. This is a pure refactoring that preserves identical behaviour. The change is a 4-line diff with no added complexity.

---

## Reproducibility

```bash
./build.sh
./test.sh -p CommunicationUtilities
```

## Test Status

✅ Build succeeded (0 errors, 0 new warnings from this change)
✅ All 630 `Microsoft.TestPlatform.CommunicationUtilities.UnitTests` tests passed (net11.0|x64)




> Generated by [Efficiency Improver](https://github.com/microsoft/vstest/actions/runs/28188098090) · 1.1K AIC · ⌖ 26.4 AIC · ⊞ 45.6K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28188098090, workflow_id: efficiency-improver, run: https://github.com/microsoft/vstest/actions/runs/28188098090 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/vstest/efficiency-improver -->