### PR TITLE
[code-simplifier] refactor: simplify TestRunCache.OnTestCompletion null checks

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/TestRunCache.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/TestRunCache.cs
@@ -232,15 +232,15 @@ internal class TestRunCache : ITestRunCache
     {
         lock (_syncObject)
         {
-            if (completedTest == null)
+            if (completedTest is null)
             {
                 EqtTrace.Warning("TestRunCache: completedTest is null");
                 return false;
             }
 
-            if (_inProgressTests == null || _inProgressTests.Count == 0)
+            if (_inProgressTests.Count == 0)
             {
-                EqtTrace.Warning("TestRunCache: InProgressTests is null");
+                EqtTrace.Warning("TestRunCache: InProgressTests is empty");
                 return false;
             }
 
@@ -252,7 +252,7 @@ internal class TestRunCache : ITestRunCache
 
             // Try finding/removing a matching test corresponding to the completed test
             var inProgressTest = _inProgressTests.FirstOrDefault(inProgress => inProgress.Id == completedTest.Id);
-            if (inProgressTest != null)
+            if (inProgressTest is not null)
             {
                 removed = _inProgressTests.Remove(inProgressTest);
             }


### PR DESCRIPTION
## Code Simplification — 2026-06-26

This PR simplifies `OnTestCompletion` in `TestRunCache` to improve clarity and correctness following recent changes in #16165.

### Files Simplified

- `src/Microsoft.TestPlatform.CrossPlatEngine/Execution/TestRunCache.cs` — removed dead null check and applied project null-check conventions

### Improvements Made

1. **Removed dead-code null check**
   - PR #16165 changed `_inProgressTests` from `ICollection<TestCase>` to `List<TestCase>` (non-nullable). The guard `_inProgressTests == null` became unreachable after that change.
   - Per project coding standards: *"Trust the C# null annotations and don't add null checks when the type system says a value cannot be null."*

2. **Applied `is null` / `is not null` conventions**
   - `completedTest == null` → `completedTest is null`
   - `inProgressTest != null` → `inProgressTest is not null`
   - Per project coding standards: *"Always use `is null` or `is not null` instead of `== null` or `!= null`."*

3. **Fixed misleading warning message**
   - `"TestRunCache: InProgressTests is null"` → `"TestRunCache: InProgressTests is empty"`
   - The condition was always checking `Count == 0`; the message now accurately describes what was detected.

### Changes Based On

Recent changes from:
- #16165 — `[efficiency-improver] perf: pre-allocate List(T) capacity in DiscoveryResultCache and TestRunCache`

### Testing

- ✅ Build succeeds (0 errors, same pre-existing IL-trimming warnings)
- ✅ No functional changes — behaviour is identical; only unreachable code paths removed and log messages corrected

### Review Focus

Please verify:
- The `_inProgressTests == null` branch was indeed unreachable (the field is always initialised to a `new List<TestCase>(...)` in the constructor and only ever replaced with another non-null list)
- Null-pattern syntax (`is null` / `is not null`) is consistent with the rest of the codebase
- Warning message text reflects the actual condition


<!-- gh-aw-tracker-id: code-simplifier -->




> Generated by [Code Simplifier](https://github.com/microsoft/vstest/actions/runs/28248164075) · 1.1K AIC · ⌖ 31.6 AIC · ⊞ 31.6K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
> - [x] expires <!-- gh-aw-expires: 2026-06-27T15:54:22.603Z --> on Jun 27, 2026, 3:54 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28248164075, workflow_id: code-simplifier, run: https://github.com/microsoft/vstest/actions/runs/28248164075 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->
<!-- gh-aw-workflow-call-id: microsoft/vstest/code-simplifier -->