### PR TITLE
[efficiency-improver] perf: avoid string[1] allocation in Condition.Evaluate for single-string properties

### DIFF
--- a/src/Microsoft.TestPlatform.Filter.Source/Condition.cs
+++ b/src/Microsoft.TestPlatform.Filter.Source/Condition.cs
@@ -157,8 +157,32 @@ internal sealed class Condition
 #if IS_VSTEST_REPO
         ValidateArg.NotNull(propertyValueProvider, nameof(propertyValueProvider));
 #endif
-        var multiValue = GetPropertyValue(propertyValueProvider);
-        var result = Operation switch
+        var propertyValue = propertyValueProvider(Name);
+
+        // Fast path: single string value (most common case for FullyQualifiedName, DisplayName, etc.)
+        // Avoids allocating a string[1] wrapper that the general multi-value path would create.
+        if (propertyValue is string singleValue)
+        {
+            return Operation switch
+            {
+                Operation.Equal => string.Equals(singleValue, Value, StringComparison.OrdinalIgnoreCase),
+                Operation.NotEqual => !string.Equals(singleValue, Value, StringComparison.OrdinalIgnoreCase),
+                Operation.Contains => singleValue.IndexOf(Value, StringComparison.OrdinalIgnoreCase) != -1,
+                Operation.NotContains => singleValue.IndexOf(Value, StringComparison.OrdinalIgnoreCase) == -1,
+                _ => false,
+            };
+        }
+
+        // Null, string[], or other types: use multi-value evaluation.
+        // Other types are coerced via ToString() for backward compatibility.
+        string[]? multiValue = propertyValue switch
+        {
+            null => null,
+            string[] arr => arr,
+            _ => new[] { propertyValue.ToString()! },
+        };
+
+        return Operation switch
         {
             // if any value in multi-valued property matches 'this.Value', for Equal to evaluate true.
             Operation.Equal => EvaluateEqualOperation(multiValue),
@@ -170,8 +194,6 @@ internal sealed class Condition
             Operation.NotContains => !EvaluateContainsOperation(multiValue),
             _ => false,
         };
-
-        return result;
     }
 
     /// <summary>
@@ -290,25 +312,6 @@ internal sealed class Condition
             "!~" => Operation.NotContains,
             _ => throw new FormatException(string.Format(CultureInfo.CurrentCulture, TestCaseFilterFormatException, string.Format(CultureInfo.CurrentCulture, InvalidOperator, operationString))),
         };
-    }
-
-    /// <summary>
-    /// Returns property value for Property using propertValueProvider.
-    /// </summary>
-    private string[]? GetPropertyValue(Func<string, object?> propertyValueProvider)
-    {
-        var propertyValue = propertyValueProvider(Name);
-        if (null != propertyValue)
-        {
-            if (propertyValue is not string[] multiValue)
-            {
-                multiValue = new string[1];
-                multiValue[0] = propertyValue.ToString()!;
-            }
-            return multiValue;
-        }
-
-        return null;
     }
 
     internal static IEnumerable<string> TokenizeFilterConditionString(string str)


### PR DESCRIPTION
## Goal and Rationale

When a test property value is a plain `string` (the common case for `FullyQualifiedName`, `DisplayName`, `Source`, etc.), `Condition.Evaluate` previously wrapped it in a `new string[1]` array before dispatching to `EvaluateEqualOperation` / `EvaluateContainsOperation`. This allocation occurred on **every test-case evaluation in the slow filter path** — i.e., filters using `~` (Contains), `!~` (NotContains), or mixed boolean operators.

The `~` operator is the most commonly used developer filter (`--filter "FullyQualifiedName~MyTest"`), making this a high-frequency allocation.

## Focus Area

**Code-Level Efficiency** — unnecessary object creation per evaluated test case.

## Approach

Add a fast path in `Condition.Evaluate` that handles the `string` case directly, without wrapping:

```csharp
// Fast path: single string value (most common case)
if (propertyValue is string singleValue)
{
    return Operation switch
    {
        Operation.Equal    => string.Equals(singleValue, Value, StringComparison.OrdinalIgnoreCase),
        Operation.NotEqual => !string.Equals(singleValue, Value, StringComparison.OrdinalIgnoreCase),
        Operation.Contains => singleValue.IndexOf(Value, StringComparison.OrdinalIgnoreCase) != -1,
        Operation.NotContains => singleValue.IndexOf(Value, StringComparison.OrdinalIgnoreCase) == -1,
        _ => false,
    };
}
```

The `null` and `string[]` cases continue through `EvaluateEqualOperation` / `EvaluateContainsOperation` unchanged. Non-string/non-array types retain the `ToString()` fallback for backward compatibility. The now-unused private `GetPropertyValue` helper is removed.

This mirrors the approach already taken in `FastFilter.TryGetPropertyValue` (merged in #16160), which also avoids allocation for single-valued properties.

## Energy Efficiency Evidence

**Proxy metric**: heap allocation count in the slow filter path (less memory churn → less GC pressure → less CPU energy for collection).

**Before**: `GetPropertyValue` allocates `new string[1]` + assigns `[0]` for every non-`string[]` property value.

**After**: `string` properties go through the fast path with zero allocation.

**Estimated reduction**: ~1 `string[1]` (~24 bytes) per test case evaluated when a Contains/NotContains filter is active. For a 10 K-test run with `--filter "FullyQualifiedName~Test"`:
- ~10 000 allocations eliminated → ~240 KB of short-lived GC garbage removed per filter evaluation pass.
- For 100 K-test suites: ~2.4 MB per pass.

**Green Software Foundation context** — *Hardware Efficiency*: reducing allocations makes better use of DRAM bandwidth and CPU cache by reducing GC scan pressure proportional to the working set size.

## Trade-offs

- Slight increase in code complexity (two code paths instead of one); offset by the removal of `GetPropertyValue`.
- Readability is maintained: the fast path mirrors FastFilter's existing pattern and is clearly commented.

## Reproducibility

```bash
# Build
./build.sh --restore --nobl

# Run condition evaluation tests
DOTNET_ROOT=.dotnet .dotnet/dotnet run \
  --project test/Microsoft.TestPlatform.Common.UnitTests/Microsoft.TestPlatform.Common.UnitTests.csproj \
  --no-build --framework net11.0 -- --filter "FullyQualifiedName~Condition"

# Run filter source tests
DOTNET_ROOT=.dotnet .dotnet/dotnet run \
  --project test/Microsoft.TestPlatform.Filter.Source.UnitTests/Microsoft.TestPlatform.Filter.Source.UnitTests.csproj \
  --no-build --framework net11.0
```

## Test Status

- ✅ 73 / 73 Condition-related tests passed (`Microsoft.TestPlatform.Common.UnitTests`, `net11.0`)
- ✅ 45 / 45 Filter source tests passed (`Microsoft.TestPlatform.Filter.Source.UnitTests`, `net11.0`)




> Generated by [Efficiency Improver](https://github.com/microsoft/vstest/actions/runs/28295762495) · 4K AIC · ⌖ 25.9 AIC · ⊞ 45.6K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28295762495, workflow_id: efficiency-improver, run: https://github.com/microsoft/vstest/actions/runs/28295762495 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/vstest/efficiency-improver -->