### PR TITLE
[code-simplifier] refactor: use switch expression for TargetInvocationException unwrap in BaseRunTests

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -223,9 +223,11 @@ internal abstract class BaseRunTests
                 // instantiated via reflection and its constructor throws. Unwrap that wrapper to the
                 // real exception so callers don't see the reflection noise. Any other exception is
                 // preserved as-is so its concrete type and stack trace are not lost on the way out.
-                Exception realException = ex is TargetInvocationException tie && tie.InnerException is not null
-                    ? tie.InnerException
-                    : ex;
+                Exception realException = ex switch
+                {
+                    TargetInvocationException { InnerException: { } inner } => inner,
+                    _ => ex,
+                };
                 exception = new Exception(realException.Message, realException);
                 isAborted = true;
             }


### PR DESCRIPTION
## Code Simplification — 2026-06-28

This PR simplifies recently modified code to improve clarity and consistency while preserving all functionality.

### Files Simplified

- `src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs` — replaced conditional ternary with a switch expression for the `TargetInvocationException` unwrap logic

### Improvements Made

**Applied Project Standards**
- Replaced `is ... && ... ? ... : ...` ternary with a switch expression, per the project guideline: *"Use pattern matching and switch expressions wherever possible"*
- The property pattern `TargetInvocationException { InnerException: { } inner }` makes both the type check and the null guard explicit in one arm, removing the intermediate `tie` binding variable

Before:
```csharp
Exception realException = ex is TargetInvocationException tie && tie.InnerException is not null
    ? tie.InnerException
    : ex;
```

After:
```csharp
Exception realException = ex switch
{
    TargetInvocationException { InnerException: { } inner } => inner,
    _ => ex,
};
```

### Changes Based On

Recent changes from:
- #16167 — [fix] Preserve the real exception (type + stack trace) when a test run aborts in BaseRunTests

### Testing

- ✅ Build succeeds (0 errors)
- ✅ All 654 `Microsoft.TestPlatform.CrossPlatEngine.UnitTests` tests pass (net11.0|x64)
- ✅ All 630 `Microsoft.TestPlatform.CommunicationUtilities.UnitTests` tests pass (net11.0|x64)
- ✅ No functional changes — behavior is identical


<!-- gh-aw-tracker-id: code-simplifier -->




> Generated by [Code Simplifier](https://github.com/microsoft/vstest/actions/runs/28326645584) · 301.3 AIC · ⌖ 21.9 AIC · ⊞ 31.6K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
> - [x] expires <!-- gh-aw-expires: 2026-06-29T15:27:04.459Z --> on Jun 29, 2026, 3:27 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28326645584, workflow_id: code-simplifier, run: https://github.com/microsoft/vstest/actions/runs/28326645584 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->
<!-- gh-aw-workflow-call-id: microsoft/vstest/code-simplifier -->