### PR TITLE
[efficiency-improver] perf: short-circuit FilterExpression.Evaluate for single-condition leaf nodes

### DIFF
--- a/src/Microsoft.TestPlatform.Filter.Source/FilterExpression.cs
+++ b/src/Microsoft.TestPlatform.Filter.Source/FilterExpression.cs
@@ -387,7 +387,7 @@ internal sealed class FilterExpression
         // Fast path: leaf node (single condition, no sub-expressions).
         // Avoids allocating two Stack<T> objects and a lambda for the common
         // single-condition filter case (e.g. "FullyQualifiedName~Test").
-        if (_condition != null)
+        if (_condition is not null)
         {
             return _condition.Evaluate(propertyValueProvider);
         }

--- a/src/Microsoft.TestPlatform.Filter.Source/FilterExpression.cs
+++ b/src/Microsoft.TestPlatform.Filter.Source/FilterExpression.cs
@@ -384,6 +384,14 @@ internal sealed class FilterExpression
         ValidateArg.NotNull(propertyValueProvider, nameof(propertyValueProvider));
 #endif
 
+        // Fast path: leaf node (single condition, no sub-expressions).
+        // Avoids allocating two Stack<T> objects and a lambda for the common
+        // single-condition filter case (e.g. "FullyQualifiedName~Test").
+        if (_condition != null)
+        {
+            return _condition.Evaluate(propertyValueProvider);
+        }
+
         return IterateFilterExpression<bool>((current, result) =>
         {
             // Only the leaves have a condition value.


### PR DESCRIPTION
## Goal and Rationale

When a test filter uses a `Contains` or `NotContains` operator (e.g. `--filter "FullyQualifiedName~Test"`), `FilterExpressionWrapper.Evaluate` falls through to the `FilterExpression.Evaluate` slow path because `FastFilter` [explicitly does not support `~` operations](https://github.com/microsoft/vstest/blob/main/src/Microsoft.TestPlatform.Filter.Source/FastFilter.cs#L264). In the common case of a single-condition filter, the `FilterExpression` is a leaf node — but `Evaluate` always went through `IterateFilterExpression<bool>`, which allocates two `Stack<T>` objects and a lambda/closure for every evaluated test case.

**Focus area**: Code-Level Efficiency — unnecessary object allocation per evaluated test case.

## Problem

For a single-condition filter like `FullyQualifiedName~Test`, the `FilterExpression` tree is just one leaf node. `IterateFilterExpression<bool>` allocated:

- `Stack<FilterExpression>` — heap object, ~48 bytes
- `Stack<bool>` — heap object, ~48 bytes
- Lambda/closure capturing `propertyValueProvider` — heap object, ~32 bytes

Total: ~128 bytes of Gen0 garbage per evaluated test case, even though the traversal logic is trivially simple for a single node.

## Approach

Add a fast path at the start of `FilterExpression.Evaluate`: if `_condition != null` (i.e. this is a leaf node), call `_condition.Evaluate(propertyValueProvider)` directly, bypassing `IterateFilterExpression` entirely.

This is safe because:
- Leaf nodes have `_condition != null` and `_left == null`, `_right == null` by construction (the two constructors are mutually exclusive).
- The result is identical — `IterateFilterExpression` for a leaf node does exactly one thing: call `current._condition.Evaluate(...)` and push the result.
- The `ValidateArg.NotNull` guard runs before the fast path, so null argument validation is preserved.

```csharp
// Fast path: leaf node (single condition, no sub-expressions).
if (_condition != null)
{
    return _condition.Evaluate(propertyValueProvider);
}

return IterateFilterExpression<bool>(...);  // compound expressions unchanged
```

## Energy Efficiency Evidence

**Proxy metric**: heap allocation count in the slow filter path (less GC pressure → fewer GC pauses → less CPU energy).

| Scenario | Allocations eliminated per test case |
|---|---|
| `FullyQualifiedName~Test` (single Contains) | 2× `Stack<T>` + 1 lambda ≈ 128 bytes |
| `DisplayName~Foo` | same |

For a 10K-test run with `--filter "FullyQualifiedName~Test"`:
- ~10 000 × 128 bytes ≈ **~1.25 MB of Gen0 GC garbage eliminated** per filter pass.

These are short-lived Gen0 allocations, but at volume they increase minor GC frequency and cause coordinated managed-thread pauses, burning CPU cycles on heap management instead of useful work.

**Green Software Foundation context** — *Hardware Efficiency*: fewer allocations reduce GC pause frequency, making better use of the hardware for actual test work vs. memory management overhead.

## Trade-offs

- Minimal readability impact: the fast path is a 3-line guard with a clear comment.
- Compound filter expressions (`A~x&B~y`, `A~x|B~y`) are unaffected — they fall through to `IterateFilterExpression` as before.
- No behaviour change: semantically equivalent in all cases.

## Reproducibility

```bash
# Build
./build.sh --restore --nobl

# Run filter expression tests
DOTNET_ROOT=.dotnet .dotnet/dotnet run \
  --project test/Microsoft.TestPlatform.Common.UnitTests/Microsoft.TestPlatform.Common.UnitTests.csproj \
  --no-build --framework net11.0 -- --filter "FullyQualifiedName~Filter"

# Run filter source tests
DOTNET_ROOT=.dotnet .dotnet/dotnet run \
  --project test/Microsoft.TestPlatform.Filter.Source.UnitTests/Microsoft.TestPlatform.Filter.Source.UnitTests.csproj \
  --no-build --framework net11.0
```

## Test Status

Infrastructure: the .NET 11 SDK is not pre-installed in this runner environment. CI will validate on Azure DevOps.

The change is a pure short-circuit for the leaf-node case — semantically identical to the existing stack-traversal path — and all existing filter evaluation tests cover this path via `FilterExpressionWrapperTests.EvaluateShouldSupportContainsOperator` and related tests.




> Generated by [Efficiency Improver](https://github.com/microsoft/vstest/actions/runs/28329440536) · 3.3K AIC · ⌖ 16.5 AIC · ⊞ 45.6K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28329440536, workflow_id: efficiency-improver, run: https://github.com/microsoft/vstest/actions/runs/28329440536 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/vstest/efficiency-improver -->