### PR TITLE
[fix] Use Assert.Inconclusive instead of [Ignore] for video recorder test in CI

### DIFF
--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/VideoRecorderTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/VideoRecorderTests.cs
@@ -13,11 +13,15 @@ namespace Microsoft.TestPlatform.AcceptanceTests;
 [TestCategory("Windows-Review")]
 public class VideoRecorderTests : AcceptanceTestBase
 {
-    [Ignore("Video recording is flaky in CI — screen recorder fails to establish communication. See #15586.")]
     [TestMethod]
     [NetFullTargetFrameworkDataSource(useCoreRunner: false, useVsixRunner: true)]
     public void VideoRecorderDataCollectorShouldRecordVideoWithRunSettings(RunnerInfo runnerInfo)
     {
+        if (IsCI)
+        {
+            Assert.Inconclusive("Video recording is flaky in CI — screen recorder fails to establish communication. See #15586.");
+        }
+
         SetTestEnvironment(_testEnvironment, runnerInfo);
         var assemblyPaths = GetAssetFullPath("SimpleTestProject.dll");
         var arguments = PrepareArguments(assemblyPaths, GetTestAdapterPath(), string.Empty, FrameworkArgValue,


### PR DESCRIPTION
🤖 This is an automated fix generated by GitHub Copilot.

Closes #15586

## Root Cause

The `VideoRecorderDataCollectorShouldRecordVideoWithRunSettings` test was suppressed with `[Ignore]`, which prevents the test from running **everywhere** — both in CI and locally. The maintainer's intent (documented in the issue) was to only skip the test on the official CI pipeline where the screen recorder cannot establish a communication channel (headless environment).

## Fix

Replace the blanket `[Ignore]` attribute with a conditional `Assert.Inconclusive` check at the start of the test method:

```csharp
if (IsCI)
{
    Assert.Inconclusive("Video recording is flaky in CI — screen recorder fails to establish communication. See #15586.");
}
```

`IsCI` is a property inherited from `IntegrationTestBase` that returns `true` when `TF_BUILD == "True"` (the Azure DevOps CI environment variable). This is the same pattern used by `BlameDataCollectorTests.BlameDataCollectorAeDebuggerShouldCollectDump` for similar conditional skips.

**Before**: Test skipped everywhere (locally and in CI)  
**After**: Test runs locally, marked `Inconclusive` in CI

## Why This Matters

The `[Ignore]` approach left the video recorder data collector completely untested. Developers running the suite locally would never see this test execute. With `Assert.Inconclusive`, local runs will attempt the test, and CI runs will report it as inconclusive rather than a failure.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/28377153057)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 28377153057, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/28377153057 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->