### PR TITLE
[code-simplifier] style: use collection expression in Condition.Evaluate

### DIFF
--- a/src/Microsoft.TestPlatform.Filter.Source/Condition.cs
+++ b/src/Microsoft.TestPlatform.Filter.Source/Condition.cs
@@ -179,7 +179,7 @@ internal sealed class Condition
         {
             null => null,
             string[] arr => arr,
-            _ => new[] { propertyValue.ToString()! },
+            _ => [propertyValue.ToString()!],
         };
 
         return Operation switch


### PR DESCRIPTION
## Code Simplification — 2026-06-29

This PR applies a one-line style consistency fix to code modified in the last 24 hours, aligning it with the established codebase pattern.

### Files Simplified

- `src/Microsoft.TestPlatform.Filter.Source/Condition.cs` — use collection expression `[...]` instead of `new[] { ... }`

### Improvement Made

In #16179, the `Condition.Evaluate` method was refactored to inline `GetPropertyValue` and add a fast path for single-string properties. The inlined fallback array creation used `new[] { propertyValue.ToString()! }`. The rest of the codebase (e.g. `CrossPlatEngine`, `vstest.console`, `ObjectModel`) consistently uses collection expression syntax `[...]` for this pattern. This PR aligns the new code with that convention.

```diff
-            _ => new[] { propertyValue.ToString()! },
+            _ => [propertyValue.ToString()!],
```

Collection expressions are a C# 12 language feature (syntactic sugar) and compile to equivalent IL for any target framework, including `netstandard2.0`.

### Changes Based On

Recent changes from:
- #16179 — perf: avoid string[1] allocation in Condition.Evaluate for single-string properties

### Testing

- ✅ Build succeeds (`./build.sh -c Debug` — 0 errors, 4 pre-existing warnings)
- ✅ No functional changes — behaviour is identical


<!-- gh-aw-tracker-id: code-simplifier -->




> Generated by [Code Simplifier](https://github.com/microsoft/vstest/actions/runs/28385947618) · 399.1 AIC · ⌖ 14.9 AIC · ⊞ 31.6K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
> - [x] expires <!-- gh-aw-expires: 2026-06-30T16:23:17.108Z --> on Jun 30, 2026, 4:23 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28385947618, workflow_id: code-simplifier, run: https://github.com/microsoft/vstest/actions/runs/28385947618 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->
<!-- gh-aw-workflow-call-id: microsoft/vstest/code-simplifier -->