### PR TITLE
Fix null-safety annotation debt: NullPathConverter, DataCollectionContext, serialization ctors, PathConverter (#16186 tasks 1-3, 5)

### DIFF
--- a/src/Microsoft.TestPlatform.Common/DataCollection/AfterTestRunEndResult.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/AfterTestRunEndResult.cs
@@ -15,18 +15,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollection;
 [DataContract]
 public class AfterTestRunEndResult
 {
-    // We have more than one ctor for backward-compatibility reason. This non-public default
-    // constructor exists so the serializers can construct the instance when a parameterized
-    // constructor cannot be used; the real (de)serialization paths build via the parameterized
-    // constructor (see AfterTestRunEndResultConverter and JsoniteConvert), so we initialize the
-    // non-nullable collections to empty here to guarantee they are never null.
-    private AfterTestRunEndResult()
-    {
-        AttachmentSets = new Collection<AttachmentSet>();
-        InvokedDataCollectors = null;
-        Metrics = new Dictionary<string, object>();
-    }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="AfterTestRunEndResult"/> class.
     /// </summary>

--- a/src/Microsoft.TestPlatform.Common/DataCollection/AfterTestRunEndResult.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/AfterTestRunEndResult.cs
@@ -15,15 +15,16 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.DataCollection;
 [DataContract]
 public class AfterTestRunEndResult
 {
-    // We have more than one ctor for backward-compatibility reason but we don't want to add dependency on Newtosoft([JsonConstructor])
-    // We want to fallback to the non-public default constructor https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_ConstructorHandling.htm during deserialization
+    // We have more than one ctor for backward-compatibility reason. This non-public default
+    // constructor exists so the serializers can construct the instance when a parameterized
+    // constructor cannot be used; the real (de)serialization paths build via the parameterized
+    // constructor (see AfterTestRunEndResultConverter and JsoniteConvert), so we initialize the
+    // non-nullable collections to empty here to guarantee they are never null.
     private AfterTestRunEndResult()
     {
-        // Forcing nulls to the differnet properties as this is only serialization ctor but
-        // we can guarantee non-null for the other ctors.
-        AttachmentSets = null!;
-        InvokedDataCollectors = null!;
-        Metrics = null!;
+        AttachmentSets = new Collection<AttachmentSet>();
+        InvokedDataCollectors = null;
+        Metrics = new Dictionary<string, object>();
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/NullPathConverter.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/NullPathConverter.cs
@@ -21,7 +21,11 @@ internal class NullPathConverter : IPathConverter
 
     Collection<AttachmentSet> IPathConverter.UpdateAttachmentSets(Collection<AttachmentSet> attachmentSets, PathConversionDirection _) => attachmentSets;
 
-    ICollection<AttachmentSet> IPathConverter.UpdateAttachmentSets(ICollection<AttachmentSet>? attachmentSets, PathConversionDirection _) => attachmentSets!;
+    ICollection<AttachmentSet> IPathConverter.UpdateAttachmentSets(ICollection<AttachmentSet>? attachmentSets, PathConversionDirection _)
+    {
+        ValidateArg.NotNull(attachmentSets, nameof(attachmentSets));
+        return attachmentSets;
+    }
 
     DiscoveryCriteria IPathConverter.UpdateDiscoveryCriteria(DiscoveryCriteria discoveryCriteria, PathConversionDirection _) => discoveryCriteria;
 
@@ -31,9 +35,17 @@ internal class NullPathConverter : IPathConverter
 
     TestCase IPathConverter.UpdateTestCase(TestCase testCase, PathConversionDirection _) => testCase;
 
-    IEnumerable<TestCase> IPathConverter.UpdateTestCases(IEnumerable<TestCase>? testCases, PathConversionDirection _) => testCases!;
+    IEnumerable<TestCase> IPathConverter.UpdateTestCases(IEnumerable<TestCase>? testCases, PathConversionDirection _)
+    {
+        ValidateArg.NotNull(testCases, nameof(testCases));
+        return testCases;
+    }
 
-    TestRunChangedEventArgs IPathConverter.UpdateTestRunChangedEventArgs(TestRunChangedEventArgs? testRunChangedArgs, PathConversionDirection _) => testRunChangedArgs!;
+    TestRunChangedEventArgs IPathConverter.UpdateTestRunChangedEventArgs(TestRunChangedEventArgs? testRunChangedArgs, PathConversionDirection _)
+    {
+        ValidateArg.NotNull(testRunChangedArgs, nameof(testRunChangedArgs));
+        return testRunChangedArgs;
+    }
 
     TestRunCompleteEventArgs IPathConverter.UpdateTestRunCompleteEventArgs(TestRunCompleteEventArgs testRunCompleteEventArgs, PathConversionDirection _) => testRunCompleteEventArgs;
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/PathConverter.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/PathConverter.cs
@@ -86,8 +86,8 @@ internal class PathConverter : IPathConverter
     public IEnumerable<TestCase> UpdateTestCases(IEnumerable<TestCase>? testCases, PathConversionDirection updateDirection)
     {
         ValidateArg.NotNull(testCases, nameof(testCases));
-        testCases!.ToList().ForEach(tc => UpdateTestCase(tc, updateDirection));
-        return testCases!;
+        testCases.ToList().ForEach(tc => UpdateTestCase(tc, updateDirection));
+        return testCases;
     }
 
     public TestRunCompleteEventArgs UpdateTestRunCompleteEventArgs(TestRunCompleteEventArgs testRunCompleteEventArgs, PathConversionDirection updateDirection)
@@ -100,7 +100,7 @@ internal class PathConverter : IPathConverter
     public TestRunChangedEventArgs UpdateTestRunChangedEventArgs(TestRunChangedEventArgs? testRunChangedArgs, PathConversionDirection updateDirection)
     {
         ValidateArg.NotNull(testRunChangedArgs, nameof(testRunChangedArgs));
-        UpdateTestResults(testRunChangedArgs!.NewTestResults!, updateDirection);
+        UpdateTestResults(testRunChangedArgs.NewTestResults!, updateDirection);
         UpdateTestCases(testRunChangedArgs.ActiveTests, updateDirection);
         return testRunChangedArgs;
     }
@@ -115,8 +115,8 @@ internal class PathConverter : IPathConverter
     public ICollection<AttachmentSet> UpdateAttachmentSets(ICollection<AttachmentSet>? attachmentSets, PathConversionDirection updateDirection)
     {
         ValidateArg.NotNull(attachmentSets, nameof(attachmentSets));
-        attachmentSets!.ToList().ForEach(i => UpdateAttachmentSet(i, updateDirection));
-        return attachmentSets!;
+        attachmentSets.ToList().ForEach(i => UpdateAttachmentSet(i, updateDirection));
+        return attachmentSets;
     }
 
     private static AttachmentSet UpdateAttachmentSet(AttachmentSet attachmentSet, PathConversionDirection updateDirection)

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/CollectorDataEntry.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/CollectorDataEntry.cs
@@ -78,19 +78,6 @@ internal class CollectorDataEntry : IXmlTestStore
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="CollectorDataEntry"/> class.
-    /// </summary>
-    /// <remarks>
-    /// For XML persistence
-    /// </remarks>
-    internal CollectorDataEntry()
-    {
-        _agentName = null!;
-        _uri = null!;
-        _collectorDisplayName = null!;
-    }
-
-    /// <summary>
     /// Gets the read-only list of data attachments
     /// </summary>
     public IList<IDataAttachment> Attachments

--- a/src/Microsoft.TestPlatform.ObjectModel/DataCollector/DataCollectionContext.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/DataCollector/DataCollectionContext.cs
@@ -36,9 +36,12 @@ public class DataCollectionContext
     public DataCollectionContext(TestCase? testCase)
     {
         TestCase = testCase;
-        // TODO: Comment says this ctor should never have been made public but it was added.
-        // This leaves a path where SessionId is null but the rest of the class doesn't handle it.
-        SessionId = null!;
+        // There is no session associated with an in-process data collection context that is
+        // created from a test case alone, so we use the empty session id sentinel to signify
+        // that the session is irrelevant in this context (matching the convention used by the
+        // test case and session event args).
+        SessionId = SessionId.Empty;
+        _hashCode = ComputeHashCode();
     }
 
     /// <summary>

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/Serialization/AfterTestRunEndResultSerializationTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/Serialization/AfterTestRunEndResultSerializationTests.cs
@@ -205,6 +205,41 @@ public class AfterTestRunEndResultSerializationTests
         Assert.AreEqual("Code Coverage", result.InvokedDataCollectors[0].FriendlyName);
     }
 
+    // ── Missing collections ──────────────────────────────────────────────
+
+    [TestMethod]
+    [DataRow(1)]
+    [DataRow(7)]
+    public void DeserializePayloadWithMissingCollectionsReturnsNonNullEmptyCollections(int version)
+    {
+        // Regression test for https://github.com/microsoft/vstest/issues/16186 (Task 3).
+        // A payload that omits AttachmentSets/Metrics must still deserialize to non-null
+        // collections so consumers never observe null on these non-nullable properties.
+        var json = version == 1
+            ? """
+              {
+                "MessageType": "DataCollection.AfterTestRunEndResult",
+                "Payload": {}
+              }
+              """
+            : """
+              {
+                "Version": 7,
+                "MessageType": "DataCollection.AfterTestRunEndResult",
+                "Payload": {}
+              }
+              """;
+
+        var message = JsonDataSerializer.Instance.DeserializeMessage(Minify(json));
+        var result = JsonDataSerializer.Instance.DeserializePayload<AfterTestRunEndResult>(message);
+
+        Assert.IsNotNull(result);
+        Assert.IsNotNull(result.AttachmentSets);
+        Assert.IsEmpty(result.AttachmentSets);
+        Assert.IsNotNull(result.Metrics);
+        Assert.IsEmpty(result.Metrics);
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────
 
 }

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/EventHandlers/NullPathConverterRegressionTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/EventHandlers/NullPathConverterRegressionTests.cs
@@ -71,4 +71,35 @@ public class NullPathConverterRegressionTests
 
         Assert.AreSame(instance1, instance2, "NullPathConverter should be a singleton.");
     }
+
+    // Regression test for #16186 — these methods previously returned param! and silently
+    // passed null through, violating their non-nullable return contracts.
+    [TestMethod]
+    public void UpdateAttachmentSets_Null_ShouldThrowArgumentNullException()
+    {
+        IPathConverter converter = NullPathConverter.Instance;
+
+        Assert.ThrowsExactly<ArgumentNullException>(
+            () => converter.UpdateAttachmentSets((ICollection<AttachmentSet>?)null, PathConversionDirection.Receive));
+    }
+
+    // Regression test for #16186
+    [TestMethod]
+    public void UpdateTestCases_Null_ShouldThrowArgumentNullException()
+    {
+        IPathConverter converter = NullPathConverter.Instance;
+
+        Assert.ThrowsExactly<ArgumentNullException>(
+            () => converter.UpdateTestCases(null, PathConversionDirection.Receive));
+    }
+
+    // Regression test for #16186
+    [TestMethod]
+    public void UpdateTestRunChangedEventArgs_Null_ShouldThrowArgumentNullException()
+    {
+        IPathConverter converter = NullPathConverter.Instance;
+
+        Assert.ThrowsExactly<ArgumentNullException>(
+            () => converter.UpdateTestRunChangedEventArgs(null, PathConversionDirection.Receive));
+    }
 }

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/DataCollector/DataCollectionContextTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/DataCollector/DataCollectionContextTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.TestPlatform.ObjectModel.UnitTests;
+
+[TestClass]
+public class DataCollectionContextTests
+{
+    // Regression test for https://github.com/microsoft/vstest/issues/16186 (Task 2).
+    // The DataCollectionContext(TestCase?) constructor used to assign SessionId = null!,
+    // leaving a non-nullable property null and breaking Equals/GetHashCode. It must now
+    // use the SessionId.Empty sentinel to signify that the session is irrelevant.
+    [TestMethod]
+    public void ConstructorWithTestCaseShouldSetSessionIdToEmpty()
+    {
+        var testCase = new TestCase("Test1", new System.Uri("executor://test"), @"C:\Path\test.dll");
+
+        var context = new DataCollectionContext(testCase);
+
+        Assert.IsNotNull(context.SessionId);
+        Assert.AreEqual(SessionId.Empty, context.SessionId);
+    }
+
+    [TestMethod]
+    public void ConstructorWithNullTestCaseShouldSetSessionIdToEmpty()
+    {
+        var context = new DataCollectionContext((TestCase?)null);
+
+        Assert.IsNotNull(context.SessionId);
+        Assert.AreEqual(SessionId.Empty, context.SessionId);
+    }
+
+    [TestMethod]
+    public void ConstructorWithTestCaseShouldProduceWorkingEqualsAndGetHashCode()
+    {
+        var testCase = new TestCase("Test1", new System.Uri("executor://test"), @"C:\Path\test.dll");
+
+        var context1 = new DataCollectionContext(testCase);
+        var context2 = new DataCollectionContext(testCase);
+
+        // Equals dereferences SessionId, so this would throw if SessionId were null.
+        Assert.AreEqual(context1, context2);
+        Assert.AreEqual(context1.GetHashCode(), context2.GetHashCode());
+    }
+}


### PR DESCRIPTION
Addresses Tasks 1, 2, 3 and 5 of #16186. **Task 4 (removing CS8618 suppressions from public ObjectModel API types) was intentionally skipped for now** — it is the Large-effort item and touches the public serialization API surface, so it is left for a separate change.

## Task 1 — Fix `NullPathConverter` interface contract violations

Three `IPathConverter` methods in `NullPathConverter` accepted nullable parameters but returned `param!`, silently passing `null` through despite non-nullable return types (`UpdateAttachmentSets`, `UpdateTestCases`, `UpdateTestRunChangedEventArgs`). They now validate with `ValidateArg.NotNull` so `null` throws `ArgumentNullException`, matching the real `PathConverter`. Added regression tests.

## Task 2 — Resolve `DataCollectionContext(TestCase?)` known null `SessionId` bug

The `DataCollectionContext(TestCase?)` ctor assigned `SessionId = null!` (with a TODO), which would `NullReferenceException` in `Equals`/`GetHashCode`. A real session id cannot be derived from a `TestCase` alone, so per the codebase's documented convention (*"empty session signifies it is irrelevant in the current context"*) it now assigns `SessionId.Empty` and computes the hash code. Keeps the public non-null contract intact (no ObjectModel API change). Added regression tests.

## Task 3 — Replace `= null!` in serialization constructors

Both `= null!` assignments lived in constructors that the real (de)serialization paths never use, so the dead constructors were removed entirely:

- **`AfterTestRunEndResult`**: the private parameterless ctor assigned `= null!` to non-nullable collection properties. Its old comment referenced a Newtonsoft `ConstructorHandling` fallback, but Newtonsoft is no longer used — both the STJ `AfterTestRunEndResultConverter` and net462 `JsoniteConvert` build via the **parameterized** ctor with empty-collection fallbacks, and `findReferences` confirmed the private ctor had no callers. Removed it.
- **`CollectorDataEntry`**: the internal parameterless *"For XML persistence"* ctor assigned `= null!` to its readonly fields, but the TRX logger is write-only (no read/Load path) and the ctor had **zero references**. Removed it.
- Added a serialization regression test asserting a payload missing `AttachmentSets`/`Metrics` still deserializes to non-null empty collections (covered by the converters' fallbacks).

## Task 4 — Skipped (for now)

Removing the `#pragma warning disable CS8618` suppressions from the seven public `[DataContract]` ObjectModel types is deliberately **not** part of this PR. It is the Large-effort task and changes the public API (e.g. introducing `required` members or nullable annotations), which warrants its own focused change and review.

## Task 5 — Remove redundant `!` after `ValidateArg.NotNull` in `PathConverter`

`ValidateArg.NotNull<T>` is annotated with `[NotNull]`, so the compiler already treats the validated variable as non-null afterwards. The null-forgiving `!` operators that immediately followed these calls in `PathConverter` were noise and have been removed. (The `!` on the nullable `NewTestResults` property is kept, as it is unrelated.)

---

All builds pass with no new warnings; new and existing related tests pass locally (ObjectModel, CrossPlatEngine incl. PathConverter, CommunicationUtilities serialization, TrxLogger, datacollector).