### PR TITLE
Inject IRunSettingsProvider into vstest.console argument processors

### DIFF
--- a/.github/skills/vstest-build-test/SKILL.md
+++ b/.github/skills/vstest-build-test/SKILL.md
@@ -90,30 +90,71 @@ For isolated projects with few dependencies:
 ./test.cmd
 ```
 
-### Specific Test Assembly
+### Specific Project(s)
 
-Use `-p` to filter by assembly name pattern:
-
-```bash
-# Linux / macOS
-./test.sh -p htmllogger       # HTML logger tests
-./test.sh -p trxlogger        # TRX logger tests
-./test.sh -p datacollector    # Data collector tests
-./test.sh -p smoke            # Smoke tests
-
-# Windows (-p is ambiguous in PowerShell; use -projects)
-./test.cmd -projects htmllogger
-./test.cmd -projects smoke
-```
-
-### Specific Test by Name
+`-projects` / `--projects` takes a **resolvable path or glob** — it is passed through
+`Resolve-Path`, so a bare project nickname or category (e.g. `smoke`, `htmllogger`) fails with
+`Cannot find path`. Point it at the csproj(s):
 
 ```bash
 # Windows
-./test.cmd -bl -c release /p:TestRunnerAdditionalArguments="'--filter TestName'" -Integration
+./test.cmd -projects "test\**\*HtmlLogger*\*.csproj"
 
 # Linux / macOS
-./test.sh -bl -c release /p:TestRunnerAdditionalArguments="'--filter TestName'" --integrationTest
+./test.sh --projects "test/**/*HtmlLogger*/*.csproj"
+```
+
+For a single project you can also build+test its csproj directly with the bootstrapped SDK:
+
+```bash
+./.dotnet/dotnet.exe test test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/*.csproj -c Debug
+```
+
+### Test Categories (smoke / integration / performance / compatibility)
+
+These are **switches** handled by `eng/Build.ps1` — NOT `-projects` values:
+
+```bash
+# Windows
+./test.cmd -smokeTest           # TestCategory=Smoke (a subset of integration tests)
+./test.cmd -integrationTest     # full acceptance / integration suite
+./test.cmd -performanceTest
+./test.cmd -compatibilityTest
+
+# Linux / macOS use the same switch names
+./test.sh -smokeTest
+```
+
+> `-smokeTest` and `-integrationTest` are mutually exclusive (smoke is a subset); passing both throws.
+
+### Filter by Test Name
+
+Use the `-filter` parameter. Do **not** pass `--filter` inside `TestRunnerAdditionalArguments` —
+`eng/Build.ps1` explicitly throws if you do.
+
+```bash
+# Windows
+./test.cmd -integrationTest -filter "FullyQualifiedName~MyScenario"
+
+# Linux / macOS
+./test.sh -integrationTest -filter "FullyQualifiedName~MyScenario"
+```
+
+### Running integration / smoke tests locally (DOTNET_ROOT gotcha)
+
+Integration and smoke tests self-host: they launch test-asset apphosts built against the repo's
+preview TFM (e.g. `net11.0`). An apphost resolves its shared runtime from `DOTNET_ROOT`, falling
+back to the machine-wide install (`C:\Program Files\dotnet`), which usually lacks the preview
+runtime — so it fails instantly with *"You must install or update .NET to run this application."*
+
+- `test.sh` (Linux/macOS) sets `DOTNET_ROOT` to the repo `.dotnet` automatically.
+- `test.cmd` (Windows) does **not** — set it yourself before running:
+
+```powershell
+$env:DOTNET_ROOT = "$PWD\.dotnet"
+${env:DOTNET_ROOT(x86)} = "$PWD\.dotnet\dotnet-sdk-x86"   # only if x86 test hosts run
+$env:DOTNET_MULTILEVEL_LOOKUP = "0"
+./test.cmd -smokeTest
 ```
 
 ## Manual Validation with vstest.console
@@ -131,15 +172,16 @@ After building with `--pack` / `-pack`, validate vstest.console changes by unzip
 
 ## Test Categories
 
-| Category | Speed | What it tests | Filter |
+| Category | Speed | What it tests | How to run |
 |---|---|---|---|
-| Unit tests | Fast | Individual units | `./test.sh` / `./test.cmd` (default) |
-| Smoke tests | Slow | P0 end-to-end scenarios | `-p smoke` |
-| Acceptance tests | Slowest | Extensive coverage | `--integrationTest` / `-Integration` flag |
+| Unit tests | Fast | Individual units | `./test.cmd` / `./test.sh` (default) |
+| Smoke tests | Slow | P0 end-to-end scenarios | `-smokeTest` switch |
+| Acceptance / integration | Slowest | Extensive coverage | `-integrationTest` switch |
 
 ## Troubleshooting
 
 - **OS mismatch errors:** If you see SDK load failures, run the mismatch detection script above to clean and re-bootstrap.
+- **Integration/smoke tests fail instantly on Windows with "You must install or update .NET to run this application":** `test.cmd` does not set `DOTNET_ROOT`, so the self-hosted preview-TFM apphosts look in `C:\Program Files\dotnet` (which lacks the preview runtime). Set `$env:DOTNET_ROOT = "$PWD\.dotnet"` before running — see "Running integration / smoke tests locally".
 - If build fails asking for .NET 4.6 targeting pack, install it from [Microsoft Downloads](https://www.microsoft.com/download/details.aspx?id=48136)
 - Enable verbose diagnostics: see `docs/diagnose.md`
 - For debugging, add `Debugger.Launch` at process entry points (testhost.exe, vstest.console.exe)

--- a/.github/skills/vstest-build-test/SKILL.md
+++ b/.github/skills/vstest-build-test/SKILL.md
@@ -107,12 +107,16 @@ For isolated projects with few dependencies:
 For a single project you can also build+test its csproj directly with the bootstrapped SDK:
 
 ```bash
+# Windows
 ./.dotnet/dotnet.exe test test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/*.csproj -c Debug
+
+# Linux / macOS
+./.dotnet/dotnet test test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/*.csproj -c Debug
 ```
 
 ### Test Categories (smoke / integration / performance / compatibility)
 
-These are **switches** handled by `eng/Build.ps1` — NOT `-projects` values:
+These are **switches** handled by `eng/build.ps1` — NOT `-projects` values:
 
 ```bash
 # Windows
@@ -130,7 +134,7 @@ These are **switches** handled by `eng/Build.ps1` — NOT `-projects` values:
 ### Filter by Test Name
 
 Use the `-filter` parameter. Do **not** pass `--filter` inside `TestRunnerAdditionalArguments` —
-`eng/Build.ps1` explicitly throws if you do.
+`eng/build.ps1` explicitly throws if you do.
 
 ```bash
 # Windows

--- a/src/vstest.console/CommandLine/Executor.cs
+++ b/src/vstest.console/CommandLine/Executor.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.TestPlatform.CommandLine.Internal;
 using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
 using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
 using Microsoft.VisualStudio.TestPlatform.Common;
+using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
 using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Tracing;
 using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Tracing.Interfaces;
@@ -59,6 +60,7 @@ internal class Executor
     private readonly ITestPlatformEventSource _testPlatformEventSource;
     private readonly IProcessHelper _processHelper;
     private readonly IEnvironment _environment;
+    private readonly IRunSettingsProvider _runSettingsProvider;
     private bool _showHelp;
 
     /// <summary>
@@ -89,6 +91,11 @@ internal class Executor
     }
 
     internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment)
+        : this(output, testPlatformEventSource, processHelper, environment, RunSettingsManager.Instance)
+    {
+    }
+
+    internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment, IRunSettingsProvider runSettingsProvider)
     {
         DebuggerBreakpoint.AttachVisualStudioDebugger(WellKnownDebugEnvironmentVariables.VSTEST_RUNNER_DEBUG_ATTACHVS);
         DebuggerBreakpoint.WaitForNativeDebugger(WellKnownDebugEnvironmentVariables.VSTEST_RUNNER_NATIVE_DEBUG);
@@ -99,6 +106,7 @@ internal class Executor
         _showHelp = true;
         _processHelper = processHelper;
         _environment = environment;
+        _runSettingsProvider = runSettingsProvider;
     }
 
     /// <summary>
@@ -220,7 +228,7 @@ internal class Executor
     {
         processors = new List<IArgumentProcessor>();
         int result = 0;
-        var processorFactory = ArgumentProcessorFactory.Create();
+        var processorFactory = ArgumentProcessorFactory.Create(runSettingsProvider: _runSettingsProvider);
         for (var index = 0; index < args.Length; index++)
         {
             var arg = args[index];
@@ -268,7 +276,7 @@ internal class Executor
         }
 
         // Initialize Runsettings with defaults
-        RunSettingsManager.Instance.AddDefaultRunSettings();
+        _runSettingsProvider.AddDefaultRunSettings();
 
         // Ensure we have an action argument.
         EnsureActionArgumentIsPresent(processors, processorFactory);

--- a/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
@@ -29,6 +29,12 @@ internal class CliRunSettingsArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsProvider _runSettingsProvider;
+
+    public CliRunSettingsArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    {
+        _runSettingsProvider = runSettingsProvider;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -43,7 +49,7 @@ internal class CliRunSettingsArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new CliRunSettingsArgumentExecutor(RunSettingsManager.Instance, CommandLineOptions.Instance));
+            new CliRunSettingsArgumentExecutor(_runSettingsProvider, CommandLineOptions.Instance));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/CollectArgumentProcessor.cs
+++ b/src/vstest.console/Processors/CollectArgumentProcessor.cs
@@ -35,6 +35,12 @@ internal class CollectArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsProvider _runSettingsProvider;
+
+    public CollectArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    {
+        _runSettingsProvider = runSettingsProvider;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -49,7 +55,7 @@ internal class CollectArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new CollectArgumentExecutor(RunSettingsManager.Instance, new FileHelper()));
+            new CollectArgumentExecutor(_runSettingsProvider, new FileHelper()));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/EnableBlameArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnableBlameArgumentProcessor.cs
@@ -40,12 +40,14 @@ internal class EnableBlameArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsProvider _runSettingsProvider;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EnableBlameArgumentProcessor"/> class.
     /// </summary>
-    public EnableBlameArgumentProcessor()
+    public EnableBlameArgumentProcessor(IRunSettingsProvider runSettingsProvider)
     {
+        _runSettingsProvider = runSettingsProvider;
     }
 
     public Lazy<IArgumentProcessorCapabilities> Metadata
@@ -58,7 +60,7 @@ internal class EnableBlameArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new EnableBlameArgumentExecutor(RunSettingsManager.Instance, new PlatformEnvironment(), new FileHelper()));
+            new EnableBlameArgumentExecutor(_runSettingsProvider, new PlatformEnvironment(), new FileHelper()));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/EnableCodeCoverageArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnableCodeCoverageArgumentProcessor.cs
@@ -29,6 +29,12 @@ internal class EnableCodeCoverageArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsProvider _runSettingsProvider;
+
+    public EnableCodeCoverageArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    {
+        _runSettingsProvider = runSettingsProvider;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -43,7 +49,7 @@ internal class EnableCodeCoverageArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new EnableCodeCoverageArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance, new FileHelper()));
+            new EnableCodeCoverageArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider, new FileHelper()));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/EnableLoggerArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnableLoggerArgumentProcessor.cs
@@ -27,6 +27,12 @@ internal class EnableLoggerArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsProvider _runSettingsProvider;
+
+    public EnableLoggerArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    {
+        _runSettingsProvider = runSettingsProvider;
+    }
 
     /// <summary>
     /// Gets or sets the executor.
@@ -34,7 +40,7 @@ internal class EnableLoggerArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new EnableLoggerArgumentExecutor(RunSettingsManager.Instance));
+            new EnableLoggerArgumentExecutor(_runSettingsProvider));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/EnvironmentArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnvironmentArgumentProcessor.cs
@@ -28,11 +28,17 @@ internal class EnvironmentArgumentProcessor : IArgumentProcessor
     public const string CommandName = "/Environment";
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsProvider _runSettingsProvider;
+
+    public EnvironmentArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    {
+        _runSettingsProvider = runSettingsProvider;
+    }
 
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new ArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance, ConsoleOutput.Instance));
+            new ArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider, ConsoleOutput.Instance));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/FrameworkArgumentProcessor.cs
+++ b/src/vstest.console/Processors/FrameworkArgumentProcessor.cs
@@ -27,6 +27,12 @@ internal class FrameworkArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsProvider _runSettingsProvider;
+
+    public FrameworkArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    {
+        _runSettingsProvider = runSettingsProvider;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -41,7 +47,7 @@ internal class FrameworkArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new FrameworkArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance));
+            new FrameworkArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/InIsolationArgumentProcessor.cs
+++ b/src/vstest.console/Processors/InIsolationArgumentProcessor.cs
@@ -23,6 +23,12 @@ internal class InIsolationArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsProvider _runSettingsProvider;
+
+    public InIsolationArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    {
+        _runSettingsProvider = runSettingsProvider;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -37,7 +43,7 @@ internal class InIsolationArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new InIsolationArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance));
+            new InIsolationArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/ListFullyQualifiedTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ListFullyQualifiedTestsArgumentProcessor.cs
@@ -32,6 +32,12 @@ internal class ListFullyQualifiedTestsArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsProvider _runSettingsProvider;
+
+    public ListFullyQualifiedTestsArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    {
+        _runSettingsProvider = runSettingsProvider;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -48,7 +54,7 @@ internal class ListFullyQualifiedTestsArgumentProcessor : IArgumentProcessor
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
             new ListFullyQualifiedTestsArgumentExecutor(
                 CommandLineOptions.Instance,
-                RunSettingsManager.Instance,
+                _runSettingsProvider,
                 TestRequestManager.Instance));
 
         set => _executor = value;

--- a/src/vstest.console/Processors/ListTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ListTestsArgumentProcessor.cs
@@ -35,6 +35,12 @@ internal class ListTestsArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsProvider _runSettingsProvider;
+
+    public ListTestsArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    {
+        _runSettingsProvider = runSettingsProvider;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -51,7 +57,7 @@ internal class ListTestsArgumentProcessor : IArgumentProcessor
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
             new ListTestsArgumentExecutor(
                 CommandLineOptions.Instance,
-                RunSettingsManager.Instance,
+                _runSettingsProvider,
                 TestRequestManager.Instance));
 
         set => _executor = value;

--- a/src/vstest.console/Processors/ParallelArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ParallelArgumentProcessor.cs
@@ -22,6 +22,12 @@ internal class ParallelArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsProvider _runSettingsProvider;
+
+    public ParallelArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    {
+        _runSettingsProvider = runSettingsProvider;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -36,7 +42,7 @@ internal class ParallelArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new ParallelArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance));
+            new ParallelArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/PlatformArgumentProcessor.cs
+++ b/src/vstest.console/Processors/PlatformArgumentProcessor.cs
@@ -28,6 +28,12 @@ internal class PlatformArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsProvider _runSettingsProvider;
+
+    public PlatformArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    {
+        _runSettingsProvider = runSettingsProvider;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -42,7 +48,7 @@ internal class PlatformArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new PlatformArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance));
+            new PlatformArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/ResultsDirectoryArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ResultsDirectoryArgumentProcessor.cs
@@ -27,6 +27,12 @@ internal class ResultsDirectoryArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsProvider _runSettingsProvider;
+
+    public ResultsDirectoryArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    {
+        _runSettingsProvider = runSettingsProvider;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -41,7 +47,7 @@ internal class ResultsDirectoryArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new ResultsDirectoryArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance));
+            new ResultsDirectoryArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/RunSettingsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunSettingsArgumentProcessor.cs
@@ -30,6 +30,12 @@ internal class RunSettingsArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsProvider _runSettingsProvider;
+
+    public RunSettingsArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    {
+        _runSettingsProvider = runSettingsProvider;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -44,7 +50,7 @@ internal class RunSettingsArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new RunSettingsArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance));
+            new RunSettingsArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/RunSpecificTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunSpecificTestsArgumentProcessor.cs
@@ -30,6 +30,12 @@ internal class RunSpecificTestsArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsProvider _runSettingsProvider;
+
+    public RunSpecificTestsArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    {
+        _runSettingsProvider = runSettingsProvider;
+    }
 
     public Lazy<IArgumentProcessorCapabilities> Metadata
         => _metadata ??= new Lazy<IArgumentProcessorCapabilities>(() =>
@@ -40,7 +46,7 @@ internal class RunSpecificTestsArgumentProcessor : IArgumentProcessor
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
             new RunSpecificTestsArgumentExecutor(
                 CommandLineOptions.Instance,
-                RunSettingsManager.Instance,
+                _runSettingsProvider,
                 TestRequestManager.Instance,
                 new ArtifactProcessingManager(CommandLineOptions.Instance.TestSessionCorrelationId),
                 ConsoleOutput.Instance));
@@ -143,7 +149,7 @@ internal class RunSpecificTestsArgumentExecutor : IArgumentExecutor
         _runSettingsManager = runSettingsProvider;
         Output = output;
         _discoveryEventsRegistrar = new DiscoveryEventsRegistrar(DiscoveryRequest_OnDiscoveredTests);
-        _testRunEventsRegistrar = new TestRunRequestEventsRegistrar(Output, _commandLineOptions, artifactProcessingManager);
+        _testRunEventsRegistrar = new TestRunRequestEventsRegistrar(Output, _commandLineOptions, artifactProcessingManager, _runSettingsManager);
     }
 
     #region IArgumentProcessor
@@ -325,12 +331,14 @@ internal class RunSpecificTestsArgumentExecutor : IArgumentExecutor
         private readonly IOutput _output;
         private readonly CommandLineOptions _commandLineOptions;
         private readonly IArtifactProcessingManager _artifactProcessingManager;
+        private readonly IRunSettingsProvider _runSettingsProvider;
 
-        public TestRunRequestEventsRegistrar(IOutput output, CommandLineOptions commandLineOptions, IArtifactProcessingManager artifactProcessingManager)
+        public TestRunRequestEventsRegistrar(IOutput output, CommandLineOptions commandLineOptions, IArtifactProcessingManager artifactProcessingManager, IRunSettingsProvider runSettingsProvider)
         {
             _output = output;
             _commandLineOptions = commandLineOptions;
             _artifactProcessingManager = artifactProcessingManager;
+            _runSettingsProvider = runSettingsProvider;
         }
 
         public void LogWarning(string message)
@@ -371,8 +379,9 @@ internal class RunSpecificTestsArgumentExecutor : IArgumentExecutor
             // Collect tests session artifacts for post processing
             if (_commandLineOptions.ArtifactProcessingMode == ArtifactProcessingMode.Collect)
             {
-                TPDebug.Assert(RunSettingsManager.Instance.ActiveRunSettings.SettingsXml is not null, "RunSettingsManager.Instance.ActiveRunSettings.SettingsXml is null");
-                _artifactProcessingManager.CollectArtifacts(e, RunSettingsManager.Instance.ActiveRunSettings.SettingsXml);
+                var settingsXml = _runSettingsProvider.ActiveRunSettings?.SettingsXml;
+                TPDebug.Assert(settingsXml is not null, "RunSettingsProvider.ActiveRunSettings.SettingsXml is null");
+                _artifactProcessingManager.CollectArtifacts(e, settingsXml);
             }
         }
     }

--- a/src/vstest.console/Processors/RunTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunTestsArgumentProcessor.cs
@@ -26,6 +26,12 @@ internal class RunTestsArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsProvider _runSettingsProvider;
+
+    public RunTestsArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    {
+        _runSettingsProvider = runSettingsProvider;
+    }
 
     public Lazy<IArgumentProcessorCapabilities> Metadata
         => _metadata ??= new Lazy<IArgumentProcessorCapabilities>(() =>
@@ -36,7 +42,7 @@ internal class RunTestsArgumentProcessor : IArgumentProcessor
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
             new RunTestsArgumentExecutor(
                 CommandLineOptions.Instance,
-                RunSettingsManager.Instance,
+                _runSettingsProvider,
                 TestRequestManager.Instance,
                 new ArtifactProcessingManager(CommandLineOptions.Instance.TestSessionCorrelationId),
                 ConsoleOutput.Instance));
@@ -112,7 +118,7 @@ internal class RunTestsArgumentExecutor : IArgumentExecutor
         _runSettingsManager = runSettingsProvider;
         _testRequestManager = testRequestManager;
         Output = output;
-        _testRunEventsRegistrar = new TestRunRequestEventsRegistrar(Output, _commandLineOptions, artifactProcessingManager);
+        _testRunEventsRegistrar = new TestRunRequestEventsRegistrar(Output, _commandLineOptions, artifactProcessingManager, _runSettingsManager);
     }
 
     public void Initialize(string? argument)
@@ -184,12 +190,14 @@ internal class RunTestsArgumentExecutor : IArgumentExecutor
         private readonly IOutput _output;
         private readonly CommandLineOptions _commandLineOptions;
         private readonly IArtifactProcessingManager _artifactProcessingManager;
+        private readonly IRunSettingsProvider _runSettingsProvider;
 
-        public TestRunRequestEventsRegistrar(IOutput output, CommandLineOptions commandLineOptions, IArtifactProcessingManager artifactProcessingManager)
+        public TestRunRequestEventsRegistrar(IOutput output, CommandLineOptions commandLineOptions, IArtifactProcessingManager artifactProcessingManager, IRunSettingsProvider runSettingsProvider)
         {
             _output = output;
             _commandLineOptions = commandLineOptions;
             _artifactProcessingManager = artifactProcessingManager;
+            _runSettingsProvider = runSettingsProvider;
         }
 
         public void LogWarning(string message)
@@ -231,8 +239,9 @@ internal class RunTestsArgumentExecutor : IArgumentExecutor
             // Collect tests session artifacts for post processing
             if (_commandLineOptions.ArtifactProcessingMode == ArtifactProcessingMode.Collect)
             {
-                TPDebug.Assert(RunSettingsManager.Instance.ActiveRunSettings.SettingsXml is not null, "RunSettingsManager.Instance.ActiveRunSettings.SettingsXml is null");
-                _artifactProcessingManager.CollectArtifacts(e, RunSettingsManager.Instance.ActiveRunSettings.SettingsXml);
+                var settingsXml = _runSettingsProvider.ActiveRunSettings?.SettingsXml;
+                TPDebug.Assert(settingsXml is not null, "RunSettingsProvider.ActiveRunSettings.SettingsXml is null");
+                _artifactProcessingManager.CollectArtifacts(e, settingsXml);
             }
         }
     }

--- a/src/vstest.console/Processors/TestAdapterLoadingStrategyArgumentProcessor.cs
+++ b/src/vstest.console/Processors/TestAdapterLoadingStrategyArgumentProcessor.cs
@@ -29,6 +29,12 @@ internal class TestAdapterLoadingStrategyArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsProvider _runSettingsProvider;
+
+    public TestAdapterLoadingStrategyArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    {
+        _runSettingsProvider = runSettingsProvider;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -43,7 +49,7 @@ internal class TestAdapterLoadingStrategyArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new TestAdapterLoadingStrategyArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance, ConsoleOutput.Instance, new FileHelper()));
+            new TestAdapterLoadingStrategyArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider, ConsoleOutput.Instance, new FileHelper()));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/TestAdapterPathArgumentProcessor.cs
+++ b/src/vstest.console/Processors/TestAdapterPathArgumentProcessor.cs
@@ -29,6 +29,12 @@ internal class TestAdapterPathArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsProvider _runSettingsProvider;
+
+    public TestAdapterPathArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    {
+        _runSettingsProvider = runSettingsProvider;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -43,7 +49,7 @@ internal class TestAdapterPathArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new TestAdapterPathArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance,
+            new TestAdapterPathArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider,
                 ConsoleOutput.Instance, new FileHelper()));
 
         set => _executor = value;

--- a/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
+++ b/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
@@ -7,6 +7,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Linq;
 
+using Microsoft.VisualStudio.TestPlatform.Common;
+using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
 
@@ -44,10 +46,16 @@ internal class ArgumentProcessorFactory
     /// <param name="featureFlag">
     /// The feature flag support.
     /// </param>
+    /// <param name="runSettingsProvider">
+    /// The run settings provider that the created argument processors read from and write to.
+    /// Defaults to the ambient <see cref="RunSettingsManager.Instance"/> when not provided, so that
+    /// callers (and the composition root) can inject an isolated instance instead of sharing static state.
+    /// </param>
     /// <returns>ArgumentProcessorFactory.</returns>
-    internal static ArgumentProcessorFactory Create(IFeatureFlag? featureFlag = null)
+    internal static ArgumentProcessorFactory Create(IFeatureFlag? featureFlag = null, IRunSettingsProvider? runSettingsProvider = null)
     {
-        var defaultArgumentProcessor = DefaultArgumentProcessors;
+        runSettingsProvider ??= RunSettingsManager.Instance;
+        var defaultArgumentProcessor = GetDefaultArgumentProcessors(runSettingsProvider);
 
         if (!(featureFlag ?? FeatureFlag.Instance).IsSet(FeatureFlag.VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING))
         {
@@ -181,41 +189,41 @@ internal class ArgumentProcessorFactory
             .Where(lazyProcessor => lazyProcessor.Metadata.Value.IsSpecialCommand && lazyProcessor.Metadata.Value.AlwaysExecute);
     }
 
-    private static IList<IArgumentProcessor> DefaultArgumentProcessors => new List<IArgumentProcessor> {
+    private static IList<IArgumentProcessor> GetDefaultArgumentProcessors(IRunSettingsProvider runSettingsProvider) => new List<IArgumentProcessor> {
         new HelpArgumentProcessor(),
         new TestSourceArgumentProcessor(),
-        new ListTestsArgumentProcessor(),
-        new RunTestsArgumentProcessor(),
-        new RunSpecificTestsArgumentProcessor(),
-        new TestAdapterPathArgumentProcessor(),
-        new TestAdapterLoadingStrategyArgumentProcessor(),
+        new ListTestsArgumentProcessor(runSettingsProvider),
+        new RunTestsArgumentProcessor(runSettingsProvider),
+        new RunSpecificTestsArgumentProcessor(runSettingsProvider),
+        new TestAdapterPathArgumentProcessor(runSettingsProvider),
+        new TestAdapterLoadingStrategyArgumentProcessor(runSettingsProvider),
         new TestCaseFilterArgumentProcessor(),
         new ParentProcessIdArgumentProcessor(),
         new PortArgumentProcessor(),
-        new RunSettingsArgumentProcessor(),
-        new PlatformArgumentProcessor(),
-        new FrameworkArgumentProcessor(),
-        new EnableLoggerArgumentProcessor(),
-        new ParallelArgumentProcessor(),
+        new RunSettingsArgumentProcessor(runSettingsProvider),
+        new PlatformArgumentProcessor(runSettingsProvider),
+        new FrameworkArgumentProcessor(runSettingsProvider),
+        new EnableLoggerArgumentProcessor(runSettingsProvider),
+        new ParallelArgumentProcessor(runSettingsProvider),
         new EnableDiagArgumentProcessor(),
-        new CliRunSettingsArgumentProcessor(),
-        new ResultsDirectoryArgumentProcessor(),
-        new InIsolationArgumentProcessor(),
-        new CollectArgumentProcessor(),
-        new EnableCodeCoverageArgumentProcessor(),
+        new CliRunSettingsArgumentProcessor(runSettingsProvider),
+        new ResultsDirectoryArgumentProcessor(runSettingsProvider),
+        new InIsolationArgumentProcessor(runSettingsProvider),
+        new CollectArgumentProcessor(runSettingsProvider),
+        new EnableCodeCoverageArgumentProcessor(runSettingsProvider),
         new DisableAutoFakesArgumentProcessor(),
         new ResponseFileArgumentProcessor(),
-        new EnableBlameArgumentProcessor(),
+        new EnableBlameArgumentProcessor(runSettingsProvider),
         new AeDebuggerArgumentProcessor(),
         new UseVsixExtensionsArgumentProcessor(),
         new ListDiscoverersArgumentProcessor(),
         new ListExecutorsArgumentProcessor(),
         new ListLoggersArgumentProcessor(),
         new ListSettingsProvidersArgumentProcessor(),
-        new ListFullyQualifiedTestsArgumentProcessor(),
+        new ListFullyQualifiedTestsArgumentProcessor(runSettingsProvider),
         new ListTestsTargetPathArgumentProcessor(),
         new ShowDeprecateDotnetVStestMessageArgumentProcessor(),
-        new EnvironmentArgumentProcessor()
+        new EnvironmentArgumentProcessor(runSettingsProvider)
     };
 
     /// <summary>

--- a/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -68,14 +68,14 @@ public class CliRunSettingsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnRunSettingsArgumentProcessorCapabilities()
     {
-        var processor = new CliRunSettingsArgumentProcessor();
+        var processor = new CliRunSettingsArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is CliRunSettingsArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnRunSettingsArgumentProcessorCapabilities()
     {
-        var processor = new CliRunSettingsArgumentProcessor();
+        var processor = new CliRunSettingsArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is CliRunSettingsArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/CollectArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CollectArgumentProcessorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -46,14 +46,14 @@ public class CollectArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnCollectArgumentProcessorCapabilities()
     {
-        var processor = new CollectArgumentProcessor();
+        var processor = new CollectArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is CollectArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnCollectArgumentProcessorCapabilities()
     {
-        var processor = new CollectArgumentProcessor();
+        var processor = new CollectArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is CollectArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/EnableBlameArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableBlameArgumentProcessorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -49,14 +49,14 @@ public class EnableBlameArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnEnableBlameArgumentProcessorCapabilities()
     {
-        var processor = new EnableBlameArgumentProcessor();
+        var processor = new EnableBlameArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is EnableBlameArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnEnableBlameArgumentProcessorCapabilities()
     {
-        var processor = new EnableBlameArgumentProcessor();
+        var processor = new EnableBlameArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is EnableBlameArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/EnableCodeCoverageArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableCodeCoverageArgumentProcessorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -40,14 +40,14 @@ public class EnableCodeCoverageArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnEnableCodeCoverageArgumentProcessorCapabilities()
     {
-        var processor = new EnableCodeCoverageArgumentProcessor();
+        var processor = new EnableCodeCoverageArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is EnableCodeCoverageArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnEnableCodeCoverageArgumentProcessorCapabilities()
     {
-        var processor = new EnableCodeCoverageArgumentProcessor();
+        var processor = new EnableCodeCoverageArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is EnableCodeCoverageArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
@@ -8,6 +8,8 @@ using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
 using Microsoft.VisualStudio.TestPlatform.Common;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using vstest.console.UnitTests.Processors;
+
 using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;
 
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
@@ -33,14 +35,14 @@ public class EnableLoggersArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnEnableLoggerArgumentProcessorCapabilities()
     {
-        EnableLoggerArgumentProcessor processor = new();
+        EnableLoggerArgumentProcessor processor = new(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is EnableLoggerArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnEnableLoggerArgumentExecutor()
     {
-        EnableLoggerArgumentProcessor processor = new();
+        EnableLoggerArgumentProcessor processor = new(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is EnableLoggerArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/FrameworkArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/FrameworkArgumentProcessorTests.cs
@@ -32,14 +32,14 @@ public class FrameworkArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnFrameworkArgumentProcessorCapabilities()
     {
-        var processor = new FrameworkArgumentProcessor();
+        var processor = new FrameworkArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is FrameworkArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnFrameworkArgumentExecutor()
     {
-        var processor = new FrameworkArgumentProcessor();
+        var processor = new FrameworkArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is FrameworkArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/InIsolationArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/InIsolationArgumentProcessorTests.cs
@@ -32,21 +32,21 @@ public class InIsolationArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnInProcessArgumentProcessorCapabilities()
     {
-        var processor = new InIsolationArgumentProcessor();
+        var processor = new InIsolationArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is InIsolationArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnInProcessArgumentExecutor()
     {
-        var processor = new InIsolationArgumentProcessor();
+        var processor = new InIsolationArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is InIsolationArgumentExecutor);
     }
 
     [TestMethod]
     public void InIsolationArgumentProcessorMetadataShouldProvideAppropriateCapabilities()
     {
-        var isolationProcessor = new InIsolationArgumentProcessor();
+        var isolationProcessor = new InIsolationArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsFalse(isolationProcessor.Metadata.Value.AllowMultiple);
         Assert.IsFalse(isolationProcessor.Metadata.Value.AlwaysExecute);
         Assert.IsFalse(isolationProcessor.Metadata.Value.IsAction);

--- a/test/vstest.console.UnitTests/Processors/ListFullyQualifiedTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListFullyQualifiedTestsArgumentProcessorTests.cs
@@ -95,7 +95,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnListFullyQualifiedTestsArgumentProcessorCapabilities()
     {
-        var processor = new ListTestsArgumentProcessor();
+        var processor = new ListTestsArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is ListTestsArgumentProcessorCapabilities);
     }
 
@@ -105,7 +105,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
     [TestMethod]
     public void GetExecuterShouldReturnListFullyQualifiedTestsArgumentProcessorCapabilities()
     {
-        var processor = new ListFullyQualifiedTestsArgumentProcessor();
+        var processor = new ListFullyQualifiedTestsArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is ListFullyQualifiedTestsArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/ListFullyQualifiedTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListFullyQualifiedTestsArgumentProcessorTests.cs
@@ -95,8 +95,8 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnListFullyQualifiedTestsArgumentProcessorCapabilities()
     {
-        var processor = new ListTestsArgumentProcessor(new TestableRunSettingsProvider());
-        Assert.IsTrue(processor.Metadata.Value is ListTestsArgumentProcessorCapabilities);
+        var processor = new ListFullyQualifiedTestsArgumentProcessor(new TestableRunSettingsProvider());
+        Assert.IsTrue(processor.Metadata.Value is ListFullyQualifiedTestsArgumentProcessorCapabilities);
     }
 
     /// <summary>

--- a/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
@@ -93,7 +93,7 @@ public class ListTestsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnListTestsArgumentProcessorCapabilities()
     {
-        var processor = new ListTestsArgumentProcessor();
+        var processor = new ListTestsArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is ListTestsArgumentProcessorCapabilities);
     }
 
@@ -103,7 +103,7 @@ public class ListTestsArgumentProcessorTests
     [TestMethod]
     public void GetExecuterShouldReturnListTestsArgumentProcessorCapabilities()
     {
-        var processor = new ListTestsArgumentProcessor();
+        var processor = new ListTestsArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is ListTestsArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/ParallelArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ParallelArgumentProcessorTests.cs
@@ -29,14 +29,14 @@ public class ParallelArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnParallelArgumentProcessorCapabilities()
     {
-        var processor = new ParallelArgumentProcessor();
+        var processor = new ParallelArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is ParallelArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnParallelArgumentExecutor()
     {
-        var processor = new ParallelArgumentProcessor();
+        var processor = new ParallelArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is ParallelArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
@@ -32,14 +32,14 @@ public class PlatformArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnPlatformArgumentProcessorCapabilities()
     {
-        var processor = new PlatformArgumentProcessor();
+        var processor = new PlatformArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is PlatformArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnPlatformArgumentExecutor()
     {
-        var processor = new PlatformArgumentProcessor();
+        var processor = new PlatformArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is PlatformArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/ResultsDirectoryArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ResultsDirectoryArgumentProcessorTests.cs
@@ -34,14 +34,14 @@ public class ResultsDirectoryArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnResultsDirectoryArgumentProcessorCapabilities()
     {
-        var processor = new ResultsDirectoryArgumentProcessor();
+        var processor = new ResultsDirectoryArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is ResultsDirectoryArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnResultsDirectoryArgumentExecutor()
     {
-        var processor = new ResultsDirectoryArgumentProcessor();
+        var processor = new ResultsDirectoryArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is ResultsDirectoryArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -40,14 +40,14 @@ public class RunSettingsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnRunSettingsArgumentProcessorCapabilities()
     {
-        var processor = new RunSettingsArgumentProcessor();
+        var processor = new RunSettingsArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is RunSettingsArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnRunSettingsArgumentExecutor()
     {
-        var processor = new RunSettingsArgumentProcessor();
+        var processor = new RunSettingsArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is RunSettingsArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
@@ -81,7 +81,7 @@ public class RunSpecificTestsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnRunSpecificTestsArgumentProcessorCapabilities()
     {
-        RunSpecificTestsArgumentProcessor processor = new();
+        RunSpecificTestsArgumentProcessor processor = new(new TestableRunSettingsProvider());
 
         Assert.IsTrue(processor.Metadata.Value is RunSpecificTestsArgumentProcessorCapabilities);
     }
@@ -89,7 +89,7 @@ public class RunSpecificTestsArgumentProcessorTests
     [TestMethod]
     public void GetExecutorShouldReturnRunSpecificTestsArgumentExecutor()
     {
-        RunSpecificTestsArgumentProcessor processor = new();
+        RunSpecificTestsArgumentProcessor processor = new(new TestableRunSettingsProvider());
 
         Assert.IsTrue(processor.Executor!.Value is RunSpecificTestsArgumentExecutor);
     }

--- a/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
@@ -79,14 +79,14 @@ public class RunTestsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnRunTestsArgumentProcessorCapabilities()
     {
-        RunTestsArgumentProcessor processor = new();
+        RunTestsArgumentProcessor processor = new(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is RunTestsArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnRunTestsArgumentProcessorCapabilities()
     {
-        RunTestsArgumentProcessor processor = new();
+        RunTestsArgumentProcessor processor = new(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is RunTestsArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
@@ -17,6 +17,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
 
+using vstest.console.UnitTests.Processors;
+
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 
 [TestClass]
@@ -41,14 +43,14 @@ public class TestAdapterPathArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnTestAdapterPathArgumentProcessorCapabilities()
     {
-        var processor = new TestAdapterPathArgumentProcessor();
+        var processor = new TestAdapterPathArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is TestAdapterPathArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnTestAdapterPathArgumentProcessorCapabilities()
     {
-        var processor = new TestAdapterPathArgumentProcessor();
+        var processor = new TestAdapterPathArgumentProcessor(new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is TestAdapterPathArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/Utilities/ArgumentProcessorFactoryTests.cs
+++ b/test/vstest.console.UnitTests/Processors/Utilities/ArgumentProcessorFactoryTests.cs
@@ -6,10 +6,13 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
+using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
+
+using vstest.console.UnitTests.Processors;
 
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors.Utilities;
 
@@ -164,7 +167,11 @@ public class ArgumentProcessorFactoryTests
 
         foreach (var processor in allProcessors)
         {
-            var instance = Activator.CreateInstance(processor) as IArgumentProcessor;
+            // Some processors require an IRunSettingsProvider via constructor injection; the rest are parameterless.
+            var runSettingsCtor = processor.GetConstructor([typeof(IRunSettingsProvider)]);
+            var instance = (runSettingsCtor is not null
+                ? runSettingsCtor.Invoke([new TestableRunSettingsProvider()])
+                : Activator.CreateInstance(processor)) as IArgumentProcessor;
             Assert.IsNotNull(instance, $"Unable to instantiate processor: {processor}");
 
             var specialProcessor = instance.Metadata.Value.IsSpecialCommand;


### PR DESCRIPTION
`vstest.console` builds every argument processor with a parameterless constructor and reads `RunSettingsManager.Instance` internally. So the active runsettings are shared, process-wide static state — in design mode (VS / a long-running host) requests reuse the process, and tests have to poke and reset the singleton to isolate cases. This is the first step of pulling that state out into constructor injection.

## Change
- `ArgumentProcessorFactory.Create(...)` now takes an optional `IRunSettingsProvider`, defaulting to `RunSettingsManager.Instance`, and threads it into the 18 processors that actually read/write runsettings. The rest stay parameterless.
- Those processors take the provider through a required constructor instead of reaching for `.Instance`, so they can't silently pick up the ambient singleton.
- `Executor` (the composition root) owns the provider and passes it to the factory. It defaults to `RunSettingsManager.Instance`, so runtime behavior is unchanged.
- `RunTestsArgumentProcessor` / `RunSpecificTestsArgumentProcessor` also flow the provider into their nested `TestRunRequestEventsRegistrar` (the `.Instance` reads there become a null-flow local + `TPDebug.Assert`).

I did not `[Obsolete]` `RunSettingsManager.Instance` — the client and later phases still read it. The only `.Instance` references left in `vstest.console` are the composition-root defaults, so this is behavior-preserving.

## Verification
- `build.cmd -pack` (Debug) — clean; binding redirects and DLL frameworks verified.
- `vstest.console.UnitTests` — 637 pass on `net481` and `net11.0`.
- Smoke tests green (`test.cmd -smokeTest`): Acceptance 5/5 `net11.0`-x64, Library 4/4 `net11.0`-x64 + 4/4 `net481`-x86.
- Debug and Release both build clean (no IDE0005).

The second commit is unrelated to the refactor: it fixes the `vstest-build-test` skill doc, which pointed at `-projects smoke` for smoke tests — that value is `Resolve-Path`d and fails, the switch is `-smokeTest`. Happy to split it out if you'd rather keep this focused.