### PR TITLE
Fix mixed synchronization for _runStartedClients in ParallelProxyExecutionManager

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelProxyExecutionManager.cs
@@ -404,7 +404,14 @@ internal sealed class ParallelProxyExecutionManager : IParallelProxyExecutionMan
                     proxyExecutionManager.Initialize(_skipDefaultAdapters);
                 }
 
-                Interlocked.Increment(ref _runStartedClients);
+                // Increment under the same lock that guards reads of this field in
+                // HandlePartialRunComplete, so the write is properly fenced against the
+                // concurrent read instead of relying on an unsynchronized Interlocked op.
+                lock (_executionStatusLockObject)
+                {
+                    _runStartedClients++;
+                }
+
                 EqtTrace.Verbose("ParallelProxyExecutionManager.StartTestRunOnConcurrentManager: Initializing test run. Started clients: " + _runStartedClients);
                 proxyExecutionManager.InitializeTestRun(testRunCriteria, eventHandler);
 


### PR DESCRIPTION
Addresses **task 4** of #16195.

### Problem
_runStartedClients in `ParallelProxyExecutionManager` was incremented via `Interlocked.Increment` from a `Task.Run` lambda **outside** any lock, but read inside `lock (_executionStatusLockObject)` in `HandlePartialRunComplete`. The lock does not fence the atomic write performed on a concurrent thread, so per the C# memory model this is formally a data race (an existing `// BUG` comment acknowledged the concern).

### Fix
Increment `_runStartedClients` under `_executionStatusLockObject`, matching how the sibling counter `_runCompletedClients` is already handled. This guards the write and read with the same lock.

### Validation
- `dotnet build src/Microsoft.TestPlatform.CrossPlatEngine -c Release` — 0 warnings, 0 errors.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>