### PR TITLE
Remove dead DotNet-VSTS-Infra-Access variable group reference

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -91,8 +91,6 @@ variables:
     - name: Codeql.Cadence 
       value: 0
 
-  # Group gives access to $dn-bot-devdiv-drop-rw-code-rw and dn-bot-dnceng-build-rw-code-rw
-  - group: DotNet-VSTS-Infra-Access
   # DevDiv drop access token is acquired via WIF service connection (dnceng-devdiv-drop-rw-code-rw-wif)
   - name: _DevDivDropAccessToken
     value: ''


### PR DESCRIPTION
The \DotNet-VSTS-Infra-Access\ variable group (VG 4 in dnceng/internal) only contained the \dn-bot-devdiv-drop-r-code-r\ PAT which has been fully migrated to WIF:

- **WIF service connection**: \dnceng-devdiv-drop-rw-code-rw-wif\ (already in use by this pipeline, as noted in the remaining comment)
- **PAT status**: Expired (May 31, 2026) and disabled in Key Vault
- **Secret manifest**: Removed from \.vault-config/product-builds-engkeyvault.yaml\

The variable group is empty/stale and its reference is dead code. The \_DevDivDropAccessToken\ is already set to \''\ with WIF handling the token acquisition.

Related: https://dev.azure.com/dnceng/internal/_workitems/edit/10147