### PR TITLE
Inject IRunSettingsHelper instead of reading RunSettingsHelper.Instance

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/DataCollectorAttachmentsProcessorsFactory.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/DataCollectorAttachmentsProcessorsFactory.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
 using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 
 namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.TestRunAttachmentsProcessing;
 
@@ -22,6 +23,13 @@ internal class DataCollectorAttachmentsProcessorsFactory : IDataCollectorAttachm
 {
     private const string CoverageFriendlyName = "Code Coverage";
     private static readonly ConcurrentDictionary<string, DataCollectorExtensionManager> DataCollectorExtensionManagerCache = new();
+
+    private readonly IRunSettingsHelper _runSettingsHelper;
+
+    public DataCollectorAttachmentsProcessorsFactory(IRunSettingsHelper? runSettingsHelper = null)
+    {
+        _runSettingsHelper = runSettingsHelper ?? RunSettingsHelper.Instance;
+    }
 
     public DataCollectorAttachmentProcessor[] Create(InvokedDataCollector[]? invokedDataCollectors, IMessageLogger? logger)
     {
@@ -52,7 +60,7 @@ internal class DataCollectorAttachmentsProcessorsFactory : IDataCollectorAttachm
 #endif
 
                 // If we're in design mode we need to load the extension inside a different AppDomain to avoid to lock extension file containers.
-                if (canUseAppDomains && RunSettingsHelper.Instance.IsDesignMode)
+                if (canUseAppDomains && _runSettingsHelper.IsDesignMode)
                 {
 #if NETFRAMEWORK
                     try

--- a/src/vstest.console/CommandLine/Executor.cs
+++ b/src/vstest.console/CommandLine/Executor.cs
@@ -26,6 +26,8 @@ using Abstraction::Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
 using Abstraction::Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
 
 using Microsoft.VisualStudio.TestPlatform.Utilities;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 
 using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;
 
@@ -61,6 +63,7 @@ internal class Executor
     private readonly IProcessHelper _processHelper;
     private readonly IEnvironment _environment;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly IRunSettingsHelper _runSettingsHelper;
     private bool _showHelp;
 
     /// <summary>
@@ -91,11 +94,16 @@ internal class Executor
     }
 
     internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment)
-        : this(output, testPlatformEventSource, processHelper, environment, RunSettingsManager.Instance)
+        : this(output, testPlatformEventSource, processHelper, environment, RunSettingsManager.Instance, RunSettingsHelper.Instance)
     {
     }
 
     internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment, IRunSettingsProvider runSettingsProvider)
+        : this(output, testPlatformEventSource, processHelper, environment, runSettingsProvider, RunSettingsHelper.Instance)
+    {
+    }
+
+    internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment, IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper)
     {
         DebuggerBreakpoint.AttachVisualStudioDebugger(WellKnownDebugEnvironmentVariables.VSTEST_RUNNER_DEBUG_ATTACHVS);
         DebuggerBreakpoint.WaitForNativeDebugger(WellKnownDebugEnvironmentVariables.VSTEST_RUNNER_NATIVE_DEBUG);
@@ -107,6 +115,7 @@ internal class Executor
         _processHelper = processHelper;
         _environment = environment;
         _runSettingsProvider = runSettingsProvider;
+        _runSettingsHelper = runSettingsHelper;
     }
 
     /// <summary>
@@ -228,7 +237,7 @@ internal class Executor
     {
         processors = new List<IArgumentProcessor>();
         int result = 0;
-        var processorFactory = ArgumentProcessorFactory.Create(runSettingsProvider: _runSettingsProvider);
+        var processorFactory = ArgumentProcessorFactory.Create(runSettingsProvider: _runSettingsProvider, runSettingsHelper: _runSettingsHelper);
         for (var index = 0; index < args.Length; index++)
         {
             var arg = args[index];

--- a/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudio.TestPlatform.Common;
 using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 
 using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;
 
@@ -30,10 +30,12 @@ internal class CliRunSettingsArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly IRunSettingsHelper _runSettingsHelper;
 
-    public CliRunSettingsArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    public CliRunSettingsArgumentProcessor(IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper)
     {
         _runSettingsProvider = runSettingsProvider;
+        _runSettingsHelper = runSettingsHelper;
     }
 
     /// <summary>
@@ -49,7 +51,7 @@ internal class CliRunSettingsArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new CliRunSettingsArgumentExecutor(_runSettingsProvider, CommandLineOptions.Instance));
+            new CliRunSettingsArgumentExecutor(_runSettingsProvider, CommandLineOptions.Instance, _runSettingsHelper));
 
         set => _executor = value;
     }
@@ -74,11 +76,13 @@ internal class CliRunSettingsArgumentExecutor : IArgumentsExecutor
 {
     private readonly IRunSettingsProvider _runSettingsManager;
     private readonly CommandLineOptions _commandLineOptions;
+    private readonly IRunSettingsHelper _runSettingsHelper;
 
-    internal CliRunSettingsArgumentExecutor(IRunSettingsProvider runSettingsManager, CommandLineOptions commandLineOptions)
+    internal CliRunSettingsArgumentExecutor(IRunSettingsProvider runSettingsManager, CommandLineOptions commandLineOptions, IRunSettingsHelper runSettingsHelper)
     {
         _runSettingsManager = runSettingsManager;
         _commandLineOptions = commandLineOptions;
+        _runSettingsHelper = runSettingsHelper;
     }
 
     public void Initialize(string? argument)
@@ -239,7 +243,7 @@ internal class CliRunSettingsArgumentExecutor : IArgumentsExecutor
             bool success = Enum.TryParse<Architecture>(value, true, out var architecture);
             if (success)
             {
-                RunSettingsHelper.Instance.IsDefaultTargetArchitecture = false;
+                _runSettingsHelper.IsDefaultTargetArchitecture = false;
                 _commandLineOptions.TargetArchitecture = architecture;
             }
         }

--- a/src/vstest.console/Processors/PlatformArgumentProcessor.cs
+++ b/src/vstest.console/Processors/PlatformArgumentProcessor.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.TestPlatform.Common;
 using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 
 using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;
 
@@ -29,10 +29,12 @@ internal class PlatformArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly IRunSettingsHelper _runSettingsHelper;
 
-    public PlatformArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    public PlatformArgumentProcessor(IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper)
     {
         _runSettingsProvider = runSettingsProvider;
+        _runSettingsHelper = runSettingsHelper;
     }
 
     /// <summary>
@@ -48,7 +50,7 @@ internal class PlatformArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new PlatformArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider));
+            new PlatformArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider, _runSettingsHelper));
 
         set => _executor = value;
     }
@@ -80,6 +82,8 @@ internal class PlatformArgumentExecutor : IArgumentExecutor
 
     private readonly IRunSettingsProvider _runSettingsManager;
 
+    private readonly IRunSettingsHelper _runSettingsHelper;
+
     public const string RunSettingsPath = "RunConfiguration.TargetPlatform";
 
     /// <summary>
@@ -87,12 +91,15 @@ internal class PlatformArgumentExecutor : IArgumentExecutor
     /// </summary>
     /// <param name="options"> The options. </param>
     /// <param name="runSettingsManager"> The runsettings manager. </param>
-    public PlatformArgumentExecutor(CommandLineOptions options, IRunSettingsProvider runSettingsManager)
+    /// <param name="runSettingsHelper"> The runsettings helper. </param>
+    public PlatformArgumentExecutor(CommandLineOptions options, IRunSettingsProvider runSettingsManager, IRunSettingsHelper runSettingsHelper)
     {
         ValidateArg.NotNull(options, nameof(options));
         ValidateArg.NotNull(runSettingsManager, nameof(runSettingsManager));
+        ValidateArg.NotNull(runSettingsHelper, nameof(runSettingsHelper));
         _commandLineOptions = options;
         _runSettingsManager = runSettingsManager;
+        _runSettingsHelper = runSettingsHelper;
     }
 
 
@@ -125,7 +132,7 @@ internal class PlatformArgumentExecutor : IArgumentExecutor
 
         if (validPlatform)
         {
-            RunSettingsHelper.Instance.IsDefaultTargetArchitecture = false;
+            _runSettingsHelper.IsDefaultTargetArchitecture = false;
             _commandLineOptions.TargetArchitecture = platform;
             _runSettingsManager.UpdateRunSettingsNode(RunSettingsPath, platform.ToString());
         }

--- a/src/vstest.console/Processors/PortArgumentProcessor.cs
+++ b/src/vstest.console/Processors/PortArgumentProcessor.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Abstraction::Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
 using Abstraction::Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
-using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 
 using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;
 
@@ -30,6 +30,12 @@ internal class PortArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly IRunSettingsHelper _runSettingsHelper;
+
+    public PortArgumentProcessor(IRunSettingsHelper runSettingsHelper)
+    {
+        _runSettingsHelper = runSettingsHelper;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -43,7 +49,7 @@ internal class PortArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new PortArgumentExecutor(CommandLineOptions.Instance, TestRequestManager.Instance));
+            new PortArgumentExecutor(CommandLineOptions.Instance, TestRequestManager.Instance, _runSettingsHelper));
 
         set => _executor = value;
     }
@@ -100,37 +106,43 @@ internal class PortArgumentExecutor : IArgumentExecutor
     private readonly IProcessHelper _processHelper;
 
     /// <summary>
+    /// Used to flag that the run was started from an Editor or IDE.
+    /// </summary>
+    private readonly IRunSettingsHelper _runSettingsHelper;
+
+    /// <summary>
     /// Default constructor.
     /// </summary>
     /// <param name="options">
     /// The options.
     /// </param>
     /// <param name="testRequestManager"> Test request manager</param>
-    public PortArgumentExecutor(CommandLineOptions options, ITestRequestManager testRequestManager)
-        : this(options, testRequestManager, InitializeDesignMode, new ProcessHelper())
+    /// <param name="runSettingsHelper"> The runsettings helper. </param>
+    public PortArgumentExecutor(CommandLineOptions options, ITestRequestManager testRequestManager, IRunSettingsHelper runSettingsHelper)
+        : this(options, testRequestManager, InitializeDesignMode, new ProcessHelper(), runSettingsHelper)
     {
     }
 
     /// <summary>
     /// For Unit testing only
     /// </summary>
-    internal PortArgumentExecutor(CommandLineOptions options, ITestRequestManager testRequestManager, IProcessHelper processHelper)
-        : this(options, testRequestManager, InitializeDesignMode, processHelper)
+    internal PortArgumentExecutor(CommandLineOptions options, ITestRequestManager testRequestManager, IProcessHelper processHelper, IRunSettingsHelper runSettingsHelper)
+        : this(options, testRequestManager, InitializeDesignMode, processHelper, runSettingsHelper)
     {
     }
 
     /// <summary>
     /// For Unit testing only
     /// </summary>
-    internal PortArgumentExecutor(CommandLineOptions options, ITestRequestManager testRequestManager, Func<int, IProcessHelper, IDesignModeClient> designModeInitializer, IProcessHelper processHelper)
+    internal PortArgumentExecutor(CommandLineOptions options, ITestRequestManager testRequestManager, Func<int, IProcessHelper, IDesignModeClient> designModeInitializer, IProcessHelper processHelper, IRunSettingsHelper runSettingsHelper)
     {
         ValidateArg.NotNull(options, nameof(options));
         _commandLineOptions = options;
         _testRequestManager = testRequestManager;
         _designModeInitializer = designModeInitializer;
         _processHelper = processHelper;
+        _runSettingsHelper = runSettingsHelper;
     }
-
 
     #region IArgumentExecutor
 
@@ -148,7 +160,7 @@ internal class PortArgumentExecutor : IArgumentExecutor
         _port = portNumber;
         _commandLineOptions.Port = portNumber;
         _commandLineOptions.IsDesignMode = true;
-        RunSettingsHelper.Instance.IsDesignMode = true;
+        _runSettingsHelper.IsDesignMode = true;
         _designModeClient = _designModeInitializer?.Invoke(_commandLineOptions.ParentProcessId, _processHelper);
     }
 

--- a/src/vstest.console/Processors/RunSettingsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunSettingsArgumentProcessor.cs
@@ -31,10 +31,12 @@ internal class RunSettingsArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly IRunSettingsHelper _runSettingsHelper;
 
-    public RunSettingsArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    public RunSettingsArgumentProcessor(IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper)
     {
         _runSettingsProvider = runSettingsProvider;
+        _runSettingsHelper = runSettingsHelper;
     }
 
     /// <summary>
@@ -50,7 +52,7 @@ internal class RunSettingsArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new RunSettingsArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider));
+            new RunSettingsArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider, _runSettingsHelper));
 
         set => _executor = value;
     }
@@ -75,13 +77,15 @@ internal class RunSettingsArgumentExecutor : IArgumentExecutor
 {
     private readonly CommandLineOptions _commandLineOptions;
     private readonly IRunSettingsProvider _runSettingsManager;
+    private readonly IRunSettingsHelper _runSettingsHelper;
 
     internal IFileHelper FileHelper { get; set; }
 
-    internal RunSettingsArgumentExecutor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsManager)
+    internal RunSettingsArgumentExecutor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsManager, IRunSettingsHelper runSettingsHelper)
     {
         _commandLineOptions = commandLineOptions;
         _runSettingsManager = runSettingsManager;
+        _runSettingsHelper = runSettingsHelper;
         FileHelper = new FileHelper();
     }
 
@@ -150,7 +154,7 @@ internal class RunSettingsArgumentExecutor : IArgumentExecutor
         var platformStr = _runSettingsManager.QueryRunSettingsNode(PlatformArgumentExecutor.RunSettingsPath);
         if (Enum.TryParse<Architecture>(platformStr, true, out var architecture))
         {
-            RunSettingsHelper.Instance.IsDefaultTargetArchitecture = false;
+            _runSettingsHelper.IsDefaultTargetArchitecture = false;
             _commandLineOptions.TargetArchitecture = architecture;
         }
     }

--- a/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
+++ b/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
@@ -11,6 +11,8 @@ using Microsoft.VisualStudio.TestPlatform.Common;
 using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
 
@@ -51,11 +53,17 @@ internal class ArgumentProcessorFactory
     /// Defaults to the ambient <see cref="RunSettingsManager.Instance"/> when not provided, so that
     /// callers (and the composition root) can inject an isolated instance instead of sharing static state.
     /// </param>
+    /// <param name="runSettingsHelper">
+    /// The run settings helper that the created argument processors write request-scoped flags to.
+    /// Defaults to the ambient <see cref="RunSettingsHelper.Instance"/> when not provided, so that
+    /// callers (and the composition root) can inject an isolated instance instead of sharing static state.
+    /// </param>
     /// <returns>ArgumentProcessorFactory.</returns>
-    internal static ArgumentProcessorFactory Create(IFeatureFlag? featureFlag = null, IRunSettingsProvider? runSettingsProvider = null)
+    internal static ArgumentProcessorFactory Create(IFeatureFlag? featureFlag = null, IRunSettingsProvider? runSettingsProvider = null, IRunSettingsHelper? runSettingsHelper = null)
     {
         runSettingsProvider ??= RunSettingsManager.Instance;
-        var defaultArgumentProcessor = GetDefaultArgumentProcessors(runSettingsProvider);
+        runSettingsHelper ??= RunSettingsHelper.Instance;
+        var defaultArgumentProcessor = GetDefaultArgumentProcessors(runSettingsProvider, runSettingsHelper);
 
         if (!(featureFlag ?? FeatureFlag.Instance).IsSet(FeatureFlag.VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING))
         {
@@ -189,7 +197,7 @@ internal class ArgumentProcessorFactory
             .Where(lazyProcessor => lazyProcessor.Metadata.Value.IsSpecialCommand && lazyProcessor.Metadata.Value.AlwaysExecute);
     }
 
-    private static IList<IArgumentProcessor> GetDefaultArgumentProcessors(IRunSettingsProvider runSettingsProvider) => new List<IArgumentProcessor> {
+    private static IList<IArgumentProcessor> GetDefaultArgumentProcessors(IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper) => new List<IArgumentProcessor> {
         new HelpArgumentProcessor(),
         new TestSourceArgumentProcessor(),
         new ListTestsArgumentProcessor(runSettingsProvider),
@@ -199,14 +207,14 @@ internal class ArgumentProcessorFactory
         new TestAdapterLoadingStrategyArgumentProcessor(runSettingsProvider),
         new TestCaseFilterArgumentProcessor(),
         new ParentProcessIdArgumentProcessor(),
-        new PortArgumentProcessor(),
-        new RunSettingsArgumentProcessor(runSettingsProvider),
-        new PlatformArgumentProcessor(runSettingsProvider),
+        new PortArgumentProcessor(runSettingsHelper),
+        new RunSettingsArgumentProcessor(runSettingsProvider, runSettingsHelper),
+        new PlatformArgumentProcessor(runSettingsProvider, runSettingsHelper),
         new FrameworkArgumentProcessor(runSettingsProvider),
         new EnableLoggerArgumentProcessor(runSettingsProvider),
         new ParallelArgumentProcessor(runSettingsProvider),
         new EnableDiagArgumentProcessor(),
-        new CliRunSettingsArgumentProcessor(runSettingsProvider),
+        new CliRunSettingsArgumentProcessor(runSettingsProvider, runSettingsHelper),
         new ResultsDirectoryArgumentProcessor(runSettingsProvider),
         new InIsolationArgumentProcessor(runSettingsProvider),
         new CollectArgumentProcessor(runSettingsProvider),

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -66,6 +66,7 @@ internal class TestRequestManager : ITestRequestManager
     private readonly ITestRunAttachmentsProcessingManager _attachmentsProcessingManager;
     private readonly IEnvironment _environment;
     private readonly IEnvironmentVariableHelper _environmentVariableHelper;
+    private readonly IRunSettingsHelper _runSettingsHelper;
 
     /// <summary>
     /// Maintains the current active execution request.
@@ -108,7 +109,8 @@ internal class TestRequestManager : ITestRequestManager
             new ProcessHelper(),
             new TestRunAttachmentsProcessingManager(TestPlatformEventSource.Instance, new DataCollectorAttachmentsProcessorsFactory()),
             new PlatformEnvironment(),
-            new EnvironmentVariableHelper())
+            new EnvironmentVariableHelper(),
+            RunSettingsHelper.Instance)
     {
     }
 
@@ -123,6 +125,33 @@ internal class TestRequestManager : ITestRequestManager
         ITestRunAttachmentsProcessingManager attachmentsProcessingManager,
         IEnvironment environment,
         IEnvironmentVariableHelper environmentVariableHelper)
+        : this(
+            commandLineOptions,
+            testPlatform,
+            testRunResultAggregator,
+            testPlatformEventSource,
+            inferHelper,
+            metricsPublisher,
+            processHelper,
+            attachmentsProcessingManager,
+            environment,
+            environmentVariableHelper,
+            RunSettingsHelper.Instance)
+    {
+    }
+
+    internal TestRequestManager(
+        CommandLineOptions commandLineOptions,
+        ITestPlatform testPlatform,
+        TestRunResultAggregator testRunResultAggregator,
+        ITestPlatformEventSource testPlatformEventSource,
+        InferHelper inferHelper,
+        Task<IMetricsPublisher> metricsPublisher,
+        IProcessHelper processHelper,
+        ITestRunAttachmentsProcessingManager attachmentsProcessingManager,
+        IEnvironment environment,
+        IEnvironmentVariableHelper environmentVariableHelper,
+        IRunSettingsHelper runSettingsHelper)
     {
         _testPlatform = testPlatform;
         _commandLineOptions = commandLineOptions;
@@ -134,6 +163,7 @@ internal class TestRequestManager : ITestRequestManager
         _attachmentsProcessingManager = attachmentsProcessingManager;
         _environment = environment;
         _environmentVariableHelper = environmentVariableHelper;
+        _runSettingsHelper = runSettingsHelper;
     }
 
     /// <summary>
@@ -779,7 +809,7 @@ internal class TestRequestManager : ITestRequestManager
             // Other scenarios, most notably .NET Framework with MultiTFM disabled, will use the old default X86 architecture.
         }
 
-        EqtTrace.Verbose($"TestRequestManager.UpdateRunSettingsIfRequired: Default architecture: {defaultArchitecture} IsDefaultTargetArchitecture: {RunSettingsHelper.Instance.IsDefaultTargetArchitecture}, Current process architecture: {_processHelper.GetCurrentProcessArchitecture()} OperatingSystem: {_environment.OperatingSystem}.");
+        EqtTrace.Verbose($"TestRequestManager.UpdateRunSettingsIfRequired: Default architecture: {defaultArchitecture} IsDefaultTargetArchitecture: {_runSettingsHelper.IsDefaultTargetArchitecture}, Current process architecture: {_processHelper.GetCurrentProcessArchitecture()} OperatingSystem: {_environment.OperatingSystem}.");
 
         // True when runsettings don't set platforml. False when runsettings force platform
         // in both cases the sourceToArchitectureMap is populated with the real architecture as we inferred it
@@ -856,7 +886,7 @@ internal class TestRequestManager : ITestRequestManager
 
         Architecture GetDefaultArchitecture(RunConfiguration runConfiguration)
         {
-            if (!RunSettingsHelper.Instance.IsDefaultTargetArchitecture)
+            if (!_runSettingsHelper.IsDefaultTargetArchitecture)
             {
                 return runConfiguration.TargetPlatform;
             }

--- a/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
@@ -9,6 +9,8 @@ using Microsoft.VisualStudio.TestPlatform.CommandLine;
 using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
 using Microsoft.VisualStudio.TestPlatform.Common;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -22,6 +24,7 @@ public class CliRunSettingsArgumentProcessorTests
     private readonly TestableRunSettingsProvider _settingsProvider;
     private readonly CliRunSettingsArgumentExecutor _executor;
     private readonly CommandLineOptions _commandLineOptions;
+    private readonly IRunSettingsHelper _runSettingsHelper;
     private readonly string _defaultRunSettings = string.Join(Environment.NewLine,
         "<?xml version=\"1.0\" encoding=\"utf-16\"?>",
         "<RunSettings>",
@@ -56,7 +59,8 @@ public class CliRunSettingsArgumentProcessorTests
     {
         _commandLineOptions = CommandLineOptions.Instance;
         _settingsProvider = new TestableRunSettingsProvider();
-        _executor = new CliRunSettingsArgumentExecutor(_settingsProvider, _commandLineOptions);
+        _runSettingsHelper = new RunSettingsHelper();
+        _executor = new CliRunSettingsArgumentExecutor(_settingsProvider, _commandLineOptions, _runSettingsHelper);
     }
 
     [TestCleanup]
@@ -68,14 +72,14 @@ public class CliRunSettingsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnRunSettingsArgumentProcessorCapabilities()
     {
-        var processor = new CliRunSettingsArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new CliRunSettingsArgumentProcessor(new TestableRunSettingsProvider(), _runSettingsHelper);
         Assert.IsTrue(processor.Metadata.Value is CliRunSettingsArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnRunSettingsArgumentProcessorCapabilities()
     {
-        var processor = new CliRunSettingsArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new CliRunSettingsArgumentProcessor(new TestableRunSettingsProvider(), _runSettingsHelper);
         Assert.IsTrue(processor.Executor!.Value is CliRunSettingsArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
@@ -5,6 +5,8 @@ using System.Globalization;
 
 using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
 using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using vstest.console.UnitTests.Processors;
@@ -16,11 +18,13 @@ public class PlatformArgumentProcessorTests
 {
     private readonly PlatformArgumentExecutor _executor;
     private readonly TestableRunSettingsProvider _runSettingsProvider;
+    private readonly IRunSettingsHelper _runSettingsHelper;
 
     public PlatformArgumentProcessorTests()
     {
         _runSettingsProvider = new TestableRunSettingsProvider();
-        _executor = new PlatformArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider);
+        _runSettingsHelper = new RunSettingsHelper();
+        _executor = new PlatformArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider, _runSettingsHelper);
     }
 
     [TestCleanup]
@@ -32,14 +36,14 @@ public class PlatformArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnPlatformArgumentProcessorCapabilities()
     {
-        var processor = new PlatformArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new PlatformArgumentProcessor(new TestableRunSettingsProvider(), _runSettingsHelper);
         Assert.IsTrue(processor.Metadata.Value is PlatformArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnPlatformArgumentExecutor()
     {
-        var processor = new PlatformArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new PlatformArgumentProcessor(new TestableRunSettingsProvider(), _runSettingsHelper);
         Assert.IsTrue(processor.Executor!.Value is PlatformArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
@@ -11,6 +11,8 @@ using Microsoft.VisualStudio.TestPlatform.Client.DesignMode;
 using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
 using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -23,6 +25,7 @@ public class PortArgumentProcessorTests
     private readonly Mock<IProcessHelper> _mockProcessHelper;
     private readonly Mock<IDesignModeClient> _testDesignModeClient;
     private readonly Mock<ITestRequestManager> _testRequestManager;
+    private readonly IRunSettingsHelper _runSettingsHelper;
     private PortArgumentExecutor _executor;
 
     public PortArgumentProcessorTests()
@@ -30,20 +33,21 @@ public class PortArgumentProcessorTests
         _mockProcessHelper = new Mock<IProcessHelper>();
         _testDesignModeClient = new Mock<IDesignModeClient>();
         _testRequestManager = new Mock<ITestRequestManager>();
-        _executor = new PortArgumentExecutor(CommandLineOptions.Instance, _testRequestManager.Object);
+        _runSettingsHelper = new RunSettingsHelper();
+        _executor = new PortArgumentExecutor(CommandLineOptions.Instance, _testRequestManager.Object, _runSettingsHelper);
     }
 
     [TestMethod]
     public void GetMetadataShouldReturnPortArgumentProcessorCapabilities()
     {
-        var processor = new PortArgumentProcessor();
+        var processor = new PortArgumentProcessor(_runSettingsHelper);
         Assert.IsTrue(processor.Metadata.Value is PortArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecutorShouldReturnPortArgumentProcessorCapabilities()
     {
-        var processor = new PortArgumentProcessor();
+        var processor = new PortArgumentProcessor(_runSettingsHelper);
         Assert.IsTrue(processor.Executor!.Value is PortArgumentExecutor);
     }
 
@@ -102,12 +106,13 @@ public class PortArgumentProcessorTests
         _executor.Initialize(port.ToString(CultureInfo.InvariantCulture));
 
         Assert.IsTrue(CommandLineOptions.Instance.IsDesignMode);
+        Assert.IsTrue(_runSettingsHelper.IsDesignMode);
     }
 
     [TestMethod]
     public void ExecutorInitializeShouldSetProcessExitCallback()
     {
-        _executor = new PortArgumentExecutor(CommandLineOptions.Instance, _testRequestManager.Object, _mockProcessHelper.Object);
+        _executor = new PortArgumentExecutor(CommandLineOptions.Instance, _testRequestManager.Object, _mockProcessHelper.Object, _runSettingsHelper);
         int port = 2345;
 #if NET5_0_OR_GREATER
         var pid = Environment.ProcessId;
@@ -127,7 +132,7 @@ public class PortArgumentProcessorTests
     public void ExecutorExecuteForValidConnectionReturnsArgumentProcessorResultSuccess()
     {
         _executor = new PortArgumentExecutor(CommandLineOptions.Instance, _testRequestManager.Object,
-            (parentProcessId, ph) => _testDesignModeClient.Object, _mockProcessHelper.Object);
+            (parentProcessId, ph) => _testDesignModeClient.Object, _mockProcessHelper.Object, _runSettingsHelper);
 
         int port = 2345;
         _executor.Initialize(port.ToString(CultureInfo.InvariantCulture));
@@ -143,7 +148,7 @@ public class PortArgumentProcessorTests
     public void ExecutorExecuteForFailedConnectionShouldThrowCommandLineException()
     {
         _executor = new PortArgumentExecutor(CommandLineOptions.Instance, _testRequestManager.Object,
-            (parentProcessId, ph) => _testDesignModeClient.Object, _mockProcessHelper.Object);
+            (parentProcessId, ph) => _testDesignModeClient.Object, _mockProcessHelper.Object, _runSettingsHelper);
 
         _testDesignModeClient.Setup(td => td.ConnectToClientAndProcessRequests(It.IsAny<int>(),
             It.IsAny<ITestRequestManager>())).Callback(() => throw new TimeoutException());
@@ -171,7 +176,8 @@ public class PortArgumentProcessorTests
                 actualParentProcessId = ppid;
                 return _testDesignModeClient.Object;
             },
-            _mockProcessHelper.Object
+            _mockProcessHelper.Object,
+            _runSettingsHelper
         );
 
         int port = 2345;

--- a/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
 using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -40,14 +41,14 @@ public class RunSettingsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnRunSettingsArgumentProcessorCapabilities()
     {
-        var processor = new RunSettingsArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new RunSettingsArgumentProcessor(new TestableRunSettingsProvider(), new RunSettingsHelper());
         Assert.IsTrue(processor.Metadata.Value is RunSettingsArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnRunSettingsArgumentExecutor()
     {
-        var processor = new RunSettingsArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new RunSettingsArgumentProcessor(new TestableRunSettingsProvider(), new RunSettingsHelper());
         Assert.IsTrue(processor.Executor!.Value is RunSettingsArgumentExecutor);
     }
 
@@ -77,14 +78,14 @@ public class RunSettingsArgumentProcessorTests
     [TestMethod]
     public void InitializeShouldThrowExceptionIfArgumentIsNull()
     {
-        var ex = Assert.ThrowsExactly<CommandLineException>(() => new RunSettingsArgumentExecutor(CommandLineOptions.Instance, null!).Initialize(null));
+        var ex = Assert.ThrowsExactly<CommandLineException>(() => new RunSettingsArgumentExecutor(CommandLineOptions.Instance, null!, new RunSettingsHelper()).Initialize(null));
         Assert.Contains("The /Settings parameter requires a settings file to be provided.", ex.Message);
     }
 
     [TestMethod]
     public void InitializeShouldThrowExceptionIfArgumentIsWhiteSpace()
     {
-        var ex = Assert.ThrowsExactly<CommandLineException>(() => new RunSettingsArgumentExecutor(CommandLineOptions.Instance, null!).Initialize("  "));
+        var ex = Assert.ThrowsExactly<CommandLineException>(() => new RunSettingsArgumentExecutor(CommandLineOptions.Instance, null!, new RunSettingsHelper()).Initialize("  "));
         Assert.Contains("The /Settings parameter requires a settings file to be provided.", ex.Message);
     }
 
@@ -93,7 +94,7 @@ public class RunSettingsArgumentProcessorTests
     {
         var fileName = "C:\\Imaginary\\nonExistentFile.txt";
 
-        var executor = new RunSettingsArgumentExecutor(CommandLineOptions.Instance, null!);
+        var executor = new RunSettingsArgumentExecutor(CommandLineOptions.Instance, null!, new RunSettingsHelper());
         var mockFileHelper = new Mock<IFileHelper>();
         mockFileHelper.Setup(fh => fh.Exists(It.IsAny<string>())).Returns(false);
 
@@ -407,7 +408,7 @@ public class RunSettingsArgumentProcessorTests
             CommandLineOptions commandLineOptions,
             IRunSettingsProvider runSettingsManager,
             string? runSettings)
-            : base(commandLineOptions, runSettingsManager)
+            : base(commandLineOptions, runSettingsManager, new RunSettingsHelper())
 
         {
             _runSettingsString = runSettings;

--- a/test/vstest.console.UnitTests/Processors/Utilities/ArgumentProcessorFactoryTests.cs
+++ b/test/vstest.console.UnitTests/Processors/Utilities/ArgumentProcessorFactoryTests.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
 using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers.Interfaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -167,11 +169,18 @@ public class ArgumentProcessorFactoryTests
 
         foreach (var processor in allProcessors)
         {
-            // Some processors require an IRunSettingsProvider via constructor injection; the rest are parameterless.
-            var runSettingsCtor = processor.GetConstructor([typeof(IRunSettingsProvider)]);
-            var instance = (runSettingsCtor is not null
-                ? runSettingsCtor.Invoke([new TestableRunSettingsProvider()])
-                : Activator.CreateInstance(processor)) as IArgumentProcessor;
+            // Processors declare different constructor shapes: some take an IRunSettingsProvider, some take
+            // an IRunSettingsHelper, some take both, and the rest are parameterless. Pick the matching one.
+            var runSettingsProvider = new TestableRunSettingsProvider();
+            var runSettingsHelper = new RunSettingsHelper();
+
+            var instance = (processor.GetConstructor([typeof(IRunSettingsProvider), typeof(IRunSettingsHelper)]) is { } providerAndHelperCtor
+                ? providerAndHelperCtor.Invoke([runSettingsProvider, runSettingsHelper])
+                : processor.GetConstructor([typeof(IRunSettingsProvider)]) is { } providerCtor
+                    ? providerCtor.Invoke([runSettingsProvider])
+                    : processor.GetConstructor([typeof(IRunSettingsHelper)]) is { } helperCtor
+                        ? helperCtor.Invoke([runSettingsHelper])
+                        : Activator.CreateInstance(processor)) as IArgumentProcessor;
             Assert.IsNotNull(instance, $"Unable to instantiate processor: {processor}");
 
             var specialProcessor = instance.Metadata.Value.IsSpecialCommand;

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -63,6 +63,7 @@ public class TestRequestManagerTests
     private readonly Mock<ITestRunAttachmentsProcessingManager> _mockAttachmentsProcessingManager;
     private readonly Mock<IEnvironment> _mockEnvironment;
     private readonly Mock<IEnvironmentVariableHelper> _mockEnvironmentVariableHelper;
+    private readonly IRunSettingsHelper _runSettingsHelper;
 
     private const string DefaultRunsettings = @"<?xml version=""1.0"" encoding=""utf-8""?>
                 <RunSettings>
@@ -85,6 +86,7 @@ public class TestRequestManagerTests
         _mockProcessHelper = new Mock<IProcessHelper>();
         _mockEnvironment = new Mock<IEnvironment>();
         _mockEnvironmentVariableHelper = new Mock<IEnvironmentVariableHelper>();
+        _runSettingsHelper = new RunSettingsHelper();
 
         _mockMetricsPublisher = new Mock<IMetricsPublisher>();
         _mockMetricsPublisherTask = Task.FromResult(_mockMetricsPublisher.Object);
@@ -99,7 +101,8 @@ public class TestRequestManagerTests
             _mockProcessHelper.Object,
             _mockAttachmentsProcessingManager.Object,
             _mockEnvironment.Object,
-            _mockEnvironmentVariableHelper.Object);
+            _mockEnvironmentVariableHelper.Object,
+            _runSettingsHelper);
         _mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>()))
             .Returns(_mockDiscoveryRequest.Object);
         _mockTestPlatform.Setup(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>()))
@@ -2842,14 +2845,13 @@ public class TestRequestManagerTests
     [DataRow("x86")]
     [DataRow("x64")]
     [DataRow("arm64")]
-    // Don't parallelize because we can run into conflict with GetDefaultArchitecture -> RunSettingsHelper.Instance.IsDefaultTargetArchitecture
-    // which is set by some other test.
-    [DoNotParallelize]
     public void SettingDefaultPlatformUsesItForAnyCPUSourceButNotForNonAnyCPUSource(string defaultPlatform)
     {
         // -- Arrange
 
-        RunSettingsHelper.Instance.IsDefaultTargetArchitecture = true;
+        // GetDefaultArchitecture reads IsDefaultTargetArchitecture from the injected IRunSettingsHelper, so we set it
+        // on that per-test instance rather than the shared RunSettingsHelper.Instance static. That keeps the test isolated.
+        _runSettingsHelper.IsDefaultTargetArchitecture = true;
         var payload = new DiscoveryRequestPayload()
         {
             Sources = new List<string>() { "AnyCPU.dll", "x64.dll" },


### PR DESCRIPTION
`RunSettingsHelper.Instance` is a settable public static that holds two request-scoped flags — `IsDefaultTargetArchitecture` and `IsDesignMode`. The argument processors set them while parsing the command line, and the engine, attachment processing, and test host provider read them back deeper in the pipeline. So they're shared, process-wide static state: in design mode (VS / a long-running host) requests reuse the process, and tests have to poke and reset the singleton to isolate cases. This is the second step of pulling that state out into constructor injection, after #16200 did the same for `IRunSettingsProvider`.

The tricky part is that the writers and the readers have to end up on the *same* instance, or design-mode propagation silently breaks. I kept that safe by threading one `IRunSettingsHelper` from each composition root and defaulting it to `RunSettingsHelper.Instance` everywhere, so writers and readers still share the same object and runtime behavior is unchanged.

## Change
- `ArgumentProcessorFactory.Create(...)` now takes an optional `IRunSettingsHelper`, defaulting to `RunSettingsHelper.Instance`, and threads it into the four processors that write the flags: `RunSettingsArgumentProcessor`, `PlatformArgumentProcessor`, `CliRunSettingsArgumentProcessor`, and `PortArgumentProcessor`. Those take the helper through a required constructor instead of reaching for `.Instance`. `PortArgumentProcessor` picks up injection for the first time (it wasn't one of the phase-1 processors).
- `Executor` (the composition root for the writers) owns the helper and passes it to the factory, defaulting to `RunSettingsHelper.Instance`.
- On the reader side, `TestRequestManager` takes `IRunSettingsHelper` through its DI constructor (the parameterless ctor still defaults to `.Instance`) and reads the injected instance in `GetDefaultArchitecture` and the verbose log. `DataCollectorAttachmentsProcessorsFactory` takes the helper through an optional constructor (default `.Instance`) and reads it in `Create`.
- `TestRequestManager` keeps a thin delegating constructor that defaults the helper to `.Instance` so the existing test construction sites compile unchanged.

`DotnetTestHostManager` also reads `RunSettingsHelper.Instance`, but it's activated by reflection through `Activator.CreateInstance` in the extension framework, not constructed by the engine, so there's no constructor to inject through without reworking activation. I left it on the `.Instance` fallback — it's the same shared instance, so it stays correct. A later phase can take it if we rework extension activation.

I did not `[Obsolete]` `RunSettingsHelper.Instance` — later phases and other consumers still read it. The only `.Instance` references left are the composition-root defaults (and the deliberate `DotnetTestHostManager` one), so this is behavior-preserving.

One small testability win falls out of this: `SettingDefaultPlatformUsesItForAnyCPUSourceButNotForNonAnyCPUSource` used to need `[DoNotParallelize]` because it wrote `RunSettingsHelper.Instance.IsDefaultTargetArchitecture` and raced other tests. With the helper injected per-test, I removed that attribute.

## Verification
- `vstest.console.UnitTests` — 635 pass on `net481` (2 pre-existing skips).
- `Microsoft.TestPlatform.CrossPlatEngine.UnitTests` — 670 pass on `net481` (1 pre-existing skip).
- `build.cmd -pack` (Debug) — clean; binding redirects and DLL frameworks verified.
- Debug and Release both build clean (no IDE0005).
- Smoke tests green (`test.cmd -smokeTest`): Acceptance 5/5 `net11.0`-x64, Library 4/4 `net11.0`-x64 + 4/4 `net481`-x86.