### PR TITLE
Inject CommandLineOptions into vstest.console argument processors

### DIFF
--- a/src/vstest.console/CommandLine/Executor.cs
+++ b/src/vstest.console/CommandLine/Executor.cs
@@ -64,6 +64,7 @@ internal class Executor
     private readonly IEnvironment _environment;
     private readonly IRunSettingsProvider _runSettingsProvider;
     private readonly IRunSettingsHelper _runSettingsHelper;
+    private readonly CommandLineOptions _commandLineOptions;
     private bool _showHelp;
 
     /// <summary>
@@ -94,16 +95,16 @@ internal class Executor
     }
 
     internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment)
-        : this(output, testPlatformEventSource, processHelper, environment, RunSettingsManager.Instance, RunSettingsHelper.Instance)
+        : this(output, testPlatformEventSource, processHelper, environment, RunSettingsManager.Instance, RunSettingsHelper.Instance, CommandLineOptions.Instance)
     {
     }
 
     internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment, IRunSettingsProvider runSettingsProvider)
-        : this(output, testPlatformEventSource, processHelper, environment, runSettingsProvider, RunSettingsHelper.Instance)
+        : this(output, testPlatformEventSource, processHelper, environment, runSettingsProvider, RunSettingsHelper.Instance, CommandLineOptions.Instance)
     {
     }
 
-    internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment, IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper)
+    internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment, IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper, CommandLineOptions commandLineOptions)
     {
         DebuggerBreakpoint.AttachVisualStudioDebugger(WellKnownDebugEnvironmentVariables.VSTEST_RUNNER_DEBUG_ATTACHVS);
         DebuggerBreakpoint.WaitForNativeDebugger(WellKnownDebugEnvironmentVariables.VSTEST_RUNNER_NATIVE_DEBUG);
@@ -116,6 +117,7 @@ internal class Executor
         _environment = environment;
         _runSettingsProvider = runSettingsProvider;
         _runSettingsHelper = runSettingsHelper;
+        _commandLineOptions = commandLineOptions;
     }
 
     /// <summary>
@@ -237,7 +239,7 @@ internal class Executor
     {
         processors = new List<IArgumentProcessor>();
         int result = 0;
-        var processorFactory = ArgumentProcessorFactory.Create(runSettingsProvider: _runSettingsProvider, runSettingsHelper: _runSettingsHelper);
+        var processorFactory = ArgumentProcessorFactory.Create(runSettingsProvider: _runSettingsProvider, runSettingsHelper: _runSettingsHelper, commandLineOptions: _commandLineOptions);
         for (var index = 0; index < args.Length; index++)
         {
             var arg = args[index];

--- a/src/vstest.console/Processors/ArtifactProcessingCollectModeProcessor.cs
+++ b/src/vstest.console/Processors/ArtifactProcessingCollectModeProcessor.cs
@@ -20,6 +20,12 @@ internal class ArtifactProcessingCollectModeProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
 
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly CommandLineOptions _commandLineOptions;
+
+    public ArtifactProcessingCollectModeProcessor(CommandLineOptions commandLineOptions)
+    {
+        _commandLineOptions = commandLineOptions;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -34,7 +40,7 @@ internal class ArtifactProcessingCollectModeProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new ArtifactProcessingCollectModeProcessorExecutor(CommandLineOptions.Instance));
+            new ArtifactProcessingCollectModeProcessorExecutor(_commandLineOptions));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/ArtifactProcessingPostProcessModeProcessor.cs
+++ b/src/vstest.console/Processors/ArtifactProcessingPostProcessModeProcessor.cs
@@ -24,6 +24,12 @@ internal class ArtifactProcessingPostProcessModeProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
 
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly CommandLineOptions _commandLineOptions;
+
+    public ArtifactProcessingPostProcessModeProcessor(CommandLineOptions commandLineOptions)
+    {
+        _commandLineOptions = commandLineOptions;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -38,8 +44,8 @@ internal class ArtifactProcessingPostProcessModeProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new ArtifactProcessingPostProcessModeProcessorExecutor(CommandLineOptions.Instance,
-                new ArtifactProcessingManager(CommandLineOptions.Instance.TestSessionCorrelationId)));
+            new ArtifactProcessingPostProcessModeProcessorExecutor(_commandLineOptions,
+                new ArtifactProcessingManager(_commandLineOptions.TestSessionCorrelationId)));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
@@ -30,10 +30,12 @@ internal class CliRunSettingsArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly CommandLineOptions _commandLineOptions;
     private readonly IRunSettingsHelper _runSettingsHelper;
 
-    public CliRunSettingsArgumentProcessor(IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper)
+    public CliRunSettingsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper)
     {
+        _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
         _runSettingsHelper = runSettingsHelper;
     }
@@ -51,7 +53,7 @@ internal class CliRunSettingsArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new CliRunSettingsArgumentExecutor(_runSettingsProvider, CommandLineOptions.Instance, _runSettingsHelper));
+            new CliRunSettingsArgumentExecutor(_runSettingsProvider, _commandLineOptions, _runSettingsHelper));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/DisableAutoFakesArgumentProcessor.cs
+++ b/src/vstest.console/Processors/DisableAutoFakesArgumentProcessor.cs
@@ -17,11 +17,17 @@ internal class DisableAutoFakesArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly CommandLineOptions _commandLineOptions;
+
+    public DisableAutoFakesArgumentProcessor(CommandLineOptions commandLineOptions)
+    {
+        _commandLineOptions = commandLineOptions;
+    }
 
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new DisableAutoFakesArgumentExecutor(CommandLineOptions.Instance));
+            new DisableAutoFakesArgumentExecutor(_commandLineOptions));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/EnableCodeCoverageArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnableCodeCoverageArgumentProcessor.cs
@@ -30,9 +30,11 @@ internal class EnableCodeCoverageArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly CommandLineOptions _commandLineOptions;
 
-    public EnableCodeCoverageArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    public EnableCodeCoverageArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider)
     {
+        _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
     }
 
@@ -49,7 +51,7 @@ internal class EnableCodeCoverageArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new EnableCodeCoverageArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider, new FileHelper()));
+            new EnableCodeCoverageArgumentExecutor(_commandLineOptions, _runSettingsProvider, new FileHelper()));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/EnvironmentArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnvironmentArgumentProcessor.cs
@@ -29,16 +29,18 @@ internal class EnvironmentArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly CommandLineOptions _commandLineOptions;
 
-    public EnvironmentArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    public EnvironmentArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider)
     {
+        _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
     }
 
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new ArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider, ConsoleOutput.Instance));
+            new ArgumentExecutor(_commandLineOptions, _runSettingsProvider, ConsoleOutput.Instance));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/FrameworkArgumentProcessor.cs
+++ b/src/vstest.console/Processors/FrameworkArgumentProcessor.cs
@@ -28,9 +28,11 @@ internal class FrameworkArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly CommandLineOptions _commandLineOptions;
 
-    public FrameworkArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    public FrameworkArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider)
     {
+        _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
     }
 
@@ -47,7 +49,7 @@ internal class FrameworkArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new FrameworkArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider));
+            new FrameworkArgumentExecutor(_commandLineOptions, _runSettingsProvider));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/InIsolationArgumentProcessor.cs
+++ b/src/vstest.console/Processors/InIsolationArgumentProcessor.cs
@@ -24,9 +24,11 @@ internal class InIsolationArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly CommandLineOptions _commandLineOptions;
 
-    public InIsolationArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    public InIsolationArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider)
     {
+        _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
     }
 
@@ -43,7 +45,7 @@ internal class InIsolationArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new InIsolationArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider));
+            new InIsolationArgumentExecutor(_commandLineOptions, _runSettingsProvider));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/ListFullyQualifiedTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ListFullyQualifiedTestsArgumentProcessor.cs
@@ -33,9 +33,11 @@ internal class ListFullyQualifiedTestsArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly CommandLineOptions _commandLineOptions;
 
-    public ListFullyQualifiedTestsArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    public ListFullyQualifiedTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider)
     {
+        _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
     }
 
@@ -53,7 +55,7 @@ internal class ListFullyQualifiedTestsArgumentProcessor : IArgumentProcessor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
             new ListFullyQualifiedTestsArgumentExecutor(
-                CommandLineOptions.Instance,
+                _commandLineOptions,
                 _runSettingsProvider,
                 TestRequestManager.Instance));
 

--- a/src/vstest.console/Processors/ListTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ListTestsArgumentProcessor.cs
@@ -36,9 +36,11 @@ internal class ListTestsArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly CommandLineOptions _commandLineOptions;
 
-    public ListTestsArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    public ListTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider)
     {
+        _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
     }
 
@@ -56,7 +58,7 @@ internal class ListTestsArgumentProcessor : IArgumentProcessor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
             new ListTestsArgumentExecutor(
-                CommandLineOptions.Instance,
+                _commandLineOptions,
                 _runSettingsProvider,
                 TestRequestManager.Instance));
 

--- a/src/vstest.console/Processors/ListTestsTargetPathArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ListTestsTargetPathArgumentProcessor.cs
@@ -17,6 +17,12 @@ internal class ListTestsTargetPathArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly CommandLineOptions _commandLineOptions;
+
+    public ListTestsTargetPathArgumentProcessor(CommandLineOptions commandLineOptions)
+    {
+        _commandLineOptions = commandLineOptions;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -31,7 +37,7 @@ internal class ListTestsTargetPathArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new ListTestsTargetPathArgumentExecutor(CommandLineOptions.Instance));
+            new ListTestsTargetPathArgumentExecutor(_commandLineOptions));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/ParallelArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ParallelArgumentProcessor.cs
@@ -23,9 +23,11 @@ internal class ParallelArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly CommandLineOptions _commandLineOptions;
 
-    public ParallelArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    public ParallelArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider)
     {
+        _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
     }
 
@@ -42,7 +44,7 @@ internal class ParallelArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new ParallelArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider));
+            new ParallelArgumentExecutor(_commandLineOptions, _runSettingsProvider));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/ParentProcessIdArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ParentProcessIdArgumentProcessor.cs
@@ -21,6 +21,12 @@ internal class ParentProcessIdArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly CommandLineOptions _commandLineOptions;
+
+    public ParentProcessIdArgumentProcessor(CommandLineOptions commandLineOptions)
+    {
+        _commandLineOptions = commandLineOptions;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -35,7 +41,7 @@ internal class ParentProcessIdArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new ParentProcessIdArgumentExecutor(CommandLineOptions.Instance));
+            new ParentProcessIdArgumentExecutor(_commandLineOptions));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/PlatformArgumentProcessor.cs
+++ b/src/vstest.console/Processors/PlatformArgumentProcessor.cs
@@ -29,10 +29,12 @@ internal class PlatformArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly CommandLineOptions _commandLineOptions;
     private readonly IRunSettingsHelper _runSettingsHelper;
 
-    public PlatformArgumentProcessor(IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper)
+    public PlatformArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper)
     {
+        _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
         _runSettingsHelper = runSettingsHelper;
     }
@@ -50,7 +52,7 @@ internal class PlatformArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new PlatformArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider, _runSettingsHelper));
+            new PlatformArgumentExecutor(_commandLineOptions, _runSettingsProvider, _runSettingsHelper));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/PortArgumentProcessor.cs
+++ b/src/vstest.console/Processors/PortArgumentProcessor.cs
@@ -31,9 +31,11 @@ internal class PortArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsHelper _runSettingsHelper;
+    private readonly CommandLineOptions _commandLineOptions;
 
-    public PortArgumentProcessor(IRunSettingsHelper runSettingsHelper)
+    public PortArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsHelper runSettingsHelper)
     {
+        _commandLineOptions = commandLineOptions;
         _runSettingsHelper = runSettingsHelper;
     }
 
@@ -49,7 +51,7 @@ internal class PortArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new PortArgumentExecutor(CommandLineOptions.Instance, TestRequestManager.Instance, _runSettingsHelper));
+            new PortArgumentExecutor(_commandLineOptions, TestRequestManager.Instance, _runSettingsHelper));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/ResultsDirectoryArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ResultsDirectoryArgumentProcessor.cs
@@ -28,9 +28,11 @@ internal class ResultsDirectoryArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly CommandLineOptions _commandLineOptions;
 
-    public ResultsDirectoryArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    public ResultsDirectoryArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider)
     {
+        _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
     }
 
@@ -47,7 +49,7 @@ internal class ResultsDirectoryArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new ResultsDirectoryArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider));
+            new ResultsDirectoryArgumentExecutor(_commandLineOptions, _runSettingsProvider));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/RunSettingsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunSettingsArgumentProcessor.cs
@@ -31,10 +31,12 @@ internal class RunSettingsArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly CommandLineOptions _commandLineOptions;
     private readonly IRunSettingsHelper _runSettingsHelper;
 
-    public RunSettingsArgumentProcessor(IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper)
+    public RunSettingsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper)
     {
+        _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
         _runSettingsHelper = runSettingsHelper;
     }
@@ -52,7 +54,7 @@ internal class RunSettingsArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new RunSettingsArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider, _runSettingsHelper));
+            new RunSettingsArgumentExecutor(_commandLineOptions, _runSettingsProvider, _runSettingsHelper));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/RunSpecificTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunSpecificTestsArgumentProcessor.cs
@@ -31,9 +31,11 @@ internal class RunSpecificTestsArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly CommandLineOptions _commandLineOptions;
 
-    public RunSpecificTestsArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    public RunSpecificTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider)
     {
+        _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
     }
 
@@ -45,10 +47,10 @@ internal class RunSpecificTestsArgumentProcessor : IArgumentProcessor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
             new RunSpecificTestsArgumentExecutor(
-                CommandLineOptions.Instance,
+                _commandLineOptions,
                 _runSettingsProvider,
                 TestRequestManager.Instance,
-                new ArtifactProcessingManager(CommandLineOptions.Instance.TestSessionCorrelationId),
+                new ArtifactProcessingManager(_commandLineOptions.TestSessionCorrelationId),
                 ConsoleOutput.Instance));
 
         set => _executor = value;
@@ -370,7 +372,7 @@ internal class RunSpecificTestsArgumentExecutor : IArgumentExecutor
                 var testsFoundInAnySource = e.TestRunStatistics != null && (e.TestRunStatistics.ExecutedTests > 0);
 
                 // Indicate the user to use testadapterpath command if there are no tests found
-                if (!testsFoundInAnySource && !CommandLineOptions.Instance.TestAdapterPathsSet && _commandLineOptions.TestCaseFilterValue == null)
+                if (!testsFoundInAnySource && !_commandLineOptions.TestAdapterPathsSet && _commandLineOptions.TestCaseFilterValue == null)
                 {
                     _output.Warning(false, CommandLineResources.SuggestTestAdapterPathIfNoTestsIsFound);
                 }

--- a/src/vstest.console/Processors/RunTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunTestsArgumentProcessor.cs
@@ -27,9 +27,11 @@ internal class RunTestsArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly CommandLineOptions _commandLineOptions;
 
-    public RunTestsArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    public RunTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider)
     {
+        _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
     }
 
@@ -41,10 +43,10 @@ internal class RunTestsArgumentProcessor : IArgumentProcessor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
             new RunTestsArgumentExecutor(
-                CommandLineOptions.Instance,
+                _commandLineOptions,
                 _runSettingsProvider,
                 TestRequestManager.Instance,
-                new ArtifactProcessingManager(CommandLineOptions.Instance.TestSessionCorrelationId),
+                new ArtifactProcessingManager(_commandLineOptions.TestSessionCorrelationId),
                 ConsoleOutput.Instance));
 
         set => _executor = value;
@@ -230,7 +232,7 @@ internal class RunTestsArgumentExecutor : IArgumentExecutor
                 s_numberOfExecutedTests = e.TestRunStatistics!.ExecutedTests;
 
                 // Indicate the user to use test adapter path command if there are no tests found
-                if (!testsFoundInAnySource && !CommandLineOptions.Instance.TestAdapterPathsSet && _commandLineOptions.TestCaseFilterValue == null)
+                if (!testsFoundInAnySource && !_commandLineOptions.TestAdapterPathsSet && _commandLineOptions.TestCaseFilterValue == null)
                 {
                     _output.Warning(false, CommandLineResources.SuggestTestAdapterPathIfNoTestsIsFound);
                 }

--- a/src/vstest.console/Processors/TestAdapterLoadingStrategyArgumentProcessor.cs
+++ b/src/vstest.console/Processors/TestAdapterLoadingStrategyArgumentProcessor.cs
@@ -30,9 +30,11 @@ internal class TestAdapterLoadingStrategyArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly CommandLineOptions _commandLineOptions;
 
-    public TestAdapterLoadingStrategyArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    public TestAdapterLoadingStrategyArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider)
     {
+        _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
     }
 
@@ -49,7 +51,7 @@ internal class TestAdapterLoadingStrategyArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new TestAdapterLoadingStrategyArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider, ConsoleOutput.Instance, new FileHelper()));
+            new TestAdapterLoadingStrategyArgumentExecutor(_commandLineOptions, _runSettingsProvider, ConsoleOutput.Instance, new FileHelper()));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/TestAdapterPathArgumentProcessor.cs
+++ b/src/vstest.console/Processors/TestAdapterPathArgumentProcessor.cs
@@ -30,9 +30,11 @@ internal class TestAdapterPathArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
+    private readonly CommandLineOptions _commandLineOptions;
 
-    public TestAdapterPathArgumentProcessor(IRunSettingsProvider runSettingsProvider)
+    public TestAdapterPathArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider)
     {
+        _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
     }
 
@@ -49,7 +51,7 @@ internal class TestAdapterPathArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new TestAdapterPathArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider,
+            new TestAdapterPathArgumentExecutor(_commandLineOptions, _runSettingsProvider,
                 ConsoleOutput.Instance, new FileHelper()));
 
         set => _executor = value;

--- a/src/vstest.console/Processors/TestCaseFilterArgumentProcessor.cs
+++ b/src/vstest.console/Processors/TestCaseFilterArgumentProcessor.cs
@@ -22,6 +22,12 @@ internal class TestCaseFilterArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly CommandLineOptions _commandLineOptions;
+
+    public TestCaseFilterArgumentProcessor(CommandLineOptions commandLineOptions)
+    {
+        _commandLineOptions = commandLineOptions;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -36,7 +42,7 @@ internal class TestCaseFilterArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new TestCaseFilterArgumentExecutor(CommandLineOptions.Instance));
+            new TestCaseFilterArgumentExecutor(_commandLineOptions));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/TestSessionCorrelationIdProcessor.cs
+++ b/src/vstest.console/Processors/TestSessionCorrelationIdProcessor.cs
@@ -22,6 +22,12 @@ internal class TestSessionCorrelationIdProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
 
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly CommandLineOptions _commandLineOptions;
+
+    public TestSessionCorrelationIdProcessor(CommandLineOptions commandLineOptions)
+    {
+        _commandLineOptions = commandLineOptions;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -36,7 +42,7 @@ internal class TestSessionCorrelationIdProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new TestSessionCorrelationIdProcessorModeProcessorExecutor(CommandLineOptions.Instance));
+            new TestSessionCorrelationIdProcessorModeProcessorExecutor(_commandLineOptions));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/TestSourceArgumentProcessor.cs
+++ b/src/vstest.console/Processors/TestSourceArgumentProcessor.cs
@@ -19,6 +19,12 @@ internal class TestSourceArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly CommandLineOptions _commandLineOptions;
+
+    public TestSourceArgumentProcessor(CommandLineOptions commandLineOptions)
+    {
+        _commandLineOptions = commandLineOptions;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -33,7 +39,7 @@ internal class TestSourceArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new TestSourceArgumentExecutor(CommandLineOptions.Instance));
+            new TestSourceArgumentExecutor(_commandLineOptions));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/UseVsixExtensionsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/UseVsixExtensionsArgumentProcessor.cs
@@ -26,6 +26,12 @@ internal class UseVsixExtensionsArgumentProcessor : IArgumentProcessor
 
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
+    private readonly CommandLineOptions _commandLineOptions;
+
+    public UseVsixExtensionsArgumentProcessor(CommandLineOptions commandLineOptions)
+    {
+        _commandLineOptions = commandLineOptions;
+    }
 
     /// <summary>
     /// Gets the metadata.
@@ -40,7 +46,7 @@ internal class UseVsixExtensionsArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new UseVsixExtensionsArgumentExecutor(CommandLineOptions.Instance, TestRequestManager.Instance, new VSExtensionManager(), ConsoleOutput.Instance));
+            new UseVsixExtensionsArgumentExecutor(_commandLineOptions, TestRequestManager.Instance, new VSExtensionManager(), ConsoleOutput.Instance));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
+++ b/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
@@ -58,18 +58,24 @@ internal class ArgumentProcessorFactory
     /// Defaults to the ambient <see cref="RunSettingsHelper.Instance"/> when not provided, so that
     /// callers (and the composition root) can inject an isolated instance instead of sharing static state.
     /// </param>
+    /// <param name="commandLineOptions">
+    /// The command line options that the created argument processors read from and write to.
+    /// Defaults to the ambient <see cref="CommandLineOptions.Instance"/> when not provided, so that
+    /// callers (and the composition root) can inject an isolated instance instead of sharing static state.
+    /// </param>
     /// <returns>ArgumentProcessorFactory.</returns>
-    internal static ArgumentProcessorFactory Create(IFeatureFlag? featureFlag = null, IRunSettingsProvider? runSettingsProvider = null, IRunSettingsHelper? runSettingsHelper = null)
+    internal static ArgumentProcessorFactory Create(IFeatureFlag? featureFlag = null, IRunSettingsProvider? runSettingsProvider = null, IRunSettingsHelper? runSettingsHelper = null, CommandLineOptions? commandLineOptions = null)
     {
         runSettingsProvider ??= RunSettingsManager.Instance;
         runSettingsHelper ??= RunSettingsHelper.Instance;
-        var defaultArgumentProcessor = GetDefaultArgumentProcessors(runSettingsProvider, runSettingsHelper);
+        commandLineOptions ??= CommandLineOptions.Instance;
+        var defaultArgumentProcessor = GetDefaultArgumentProcessors(runSettingsProvider, runSettingsHelper, commandLineOptions);
 
         if (!(featureFlag ?? FeatureFlag.Instance).IsSet(FeatureFlag.VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING))
         {
-            defaultArgumentProcessor.Add(new ArtifactProcessingCollectModeProcessor());
-            defaultArgumentProcessor.Add(new ArtifactProcessingPostProcessModeProcessor());
-            defaultArgumentProcessor.Add(new TestSessionCorrelationIdProcessor());
+            defaultArgumentProcessor.Add(new ArtifactProcessingCollectModeProcessor(commandLineOptions));
+            defaultArgumentProcessor.Add(new ArtifactProcessingPostProcessModeProcessor(commandLineOptions));
+            defaultArgumentProcessor.Add(new TestSessionCorrelationIdProcessor(commandLineOptions));
         }
 
         // Get the ArgumentProcessorFactory
@@ -197,41 +203,41 @@ internal class ArgumentProcessorFactory
             .Where(lazyProcessor => lazyProcessor.Metadata.Value.IsSpecialCommand && lazyProcessor.Metadata.Value.AlwaysExecute);
     }
 
-    private static IList<IArgumentProcessor> GetDefaultArgumentProcessors(IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper) => new List<IArgumentProcessor> {
+    private static IList<IArgumentProcessor> GetDefaultArgumentProcessors(IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper, CommandLineOptions commandLineOptions) => new List<IArgumentProcessor> {
         new HelpArgumentProcessor(),
-        new TestSourceArgumentProcessor(),
-        new ListTestsArgumentProcessor(runSettingsProvider),
-        new RunTestsArgumentProcessor(runSettingsProvider),
-        new RunSpecificTestsArgumentProcessor(runSettingsProvider),
-        new TestAdapterPathArgumentProcessor(runSettingsProvider),
-        new TestAdapterLoadingStrategyArgumentProcessor(runSettingsProvider),
-        new TestCaseFilterArgumentProcessor(),
-        new ParentProcessIdArgumentProcessor(),
-        new PortArgumentProcessor(runSettingsHelper),
-        new RunSettingsArgumentProcessor(runSettingsProvider, runSettingsHelper),
-        new PlatformArgumentProcessor(runSettingsProvider, runSettingsHelper),
-        new FrameworkArgumentProcessor(runSettingsProvider),
+        new TestSourceArgumentProcessor(commandLineOptions),
+        new ListTestsArgumentProcessor(commandLineOptions, runSettingsProvider),
+        new RunTestsArgumentProcessor(commandLineOptions, runSettingsProvider),
+        new RunSpecificTestsArgumentProcessor(commandLineOptions, runSettingsProvider),
+        new TestAdapterPathArgumentProcessor(commandLineOptions, runSettingsProvider),
+        new TestAdapterLoadingStrategyArgumentProcessor(commandLineOptions, runSettingsProvider),
+        new TestCaseFilterArgumentProcessor(commandLineOptions),
+        new ParentProcessIdArgumentProcessor(commandLineOptions),
+        new PortArgumentProcessor(commandLineOptions, runSettingsHelper),
+        new RunSettingsArgumentProcessor(commandLineOptions, runSettingsProvider, runSettingsHelper),
+        new PlatformArgumentProcessor(commandLineOptions, runSettingsProvider, runSettingsHelper),
+        new FrameworkArgumentProcessor(commandLineOptions, runSettingsProvider),
         new EnableLoggerArgumentProcessor(runSettingsProvider),
-        new ParallelArgumentProcessor(runSettingsProvider),
+        new ParallelArgumentProcessor(commandLineOptions, runSettingsProvider),
         new EnableDiagArgumentProcessor(),
-        new CliRunSettingsArgumentProcessor(runSettingsProvider, runSettingsHelper),
-        new ResultsDirectoryArgumentProcessor(runSettingsProvider),
-        new InIsolationArgumentProcessor(runSettingsProvider),
+        new CliRunSettingsArgumentProcessor(commandLineOptions, runSettingsProvider, runSettingsHelper),
+        new ResultsDirectoryArgumentProcessor(commandLineOptions, runSettingsProvider),
+        new InIsolationArgumentProcessor(commandLineOptions, runSettingsProvider),
         new CollectArgumentProcessor(runSettingsProvider),
-        new EnableCodeCoverageArgumentProcessor(runSettingsProvider),
-        new DisableAutoFakesArgumentProcessor(),
+        new EnableCodeCoverageArgumentProcessor(commandLineOptions, runSettingsProvider),
+        new DisableAutoFakesArgumentProcessor(commandLineOptions),
         new ResponseFileArgumentProcessor(),
         new EnableBlameArgumentProcessor(runSettingsProvider),
         new AeDebuggerArgumentProcessor(),
-        new UseVsixExtensionsArgumentProcessor(),
+        new UseVsixExtensionsArgumentProcessor(commandLineOptions),
         new ListDiscoverersArgumentProcessor(),
         new ListExecutorsArgumentProcessor(),
         new ListLoggersArgumentProcessor(),
         new ListSettingsProvidersArgumentProcessor(),
-        new ListFullyQualifiedTestsArgumentProcessor(runSettingsProvider),
-        new ListTestsTargetPathArgumentProcessor(),
+        new ListFullyQualifiedTestsArgumentProcessor(commandLineOptions, runSettingsProvider),
+        new ListTestsTargetPathArgumentProcessor(commandLineOptions),
         new ShowDeprecateDotnetVStestMessageArgumentProcessor(),
-        new EnvironmentArgumentProcessor(runSettingsProvider)
+        new EnvironmentArgumentProcessor(commandLineOptions, runSettingsProvider)
     };
 
     /// <summary>

--- a/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
@@ -72,14 +72,14 @@ public class CliRunSettingsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnRunSettingsArgumentProcessorCapabilities()
     {
-        var processor = new CliRunSettingsArgumentProcessor(new TestableRunSettingsProvider(), _runSettingsHelper);
+        var processor = new CliRunSettingsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), _runSettingsHelper);
         Assert.IsTrue(processor.Metadata.Value is CliRunSettingsArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnRunSettingsArgumentProcessorCapabilities()
     {
-        var processor = new CliRunSettingsArgumentProcessor(new TestableRunSettingsProvider(), _runSettingsHelper);
+        var processor = new CliRunSettingsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), _runSettingsHelper);
         Assert.IsTrue(processor.Executor!.Value is CliRunSettingsArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/DisableAutoFakesArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/DisableAutoFakesArgumentProcessorTests.cs
@@ -14,7 +14,7 @@ public class DisableAutoFakesArgumentProcessorTests
 
     public DisableAutoFakesArgumentProcessorTests()
     {
-        _disableAutoFakesArgumentProcessor = new DisableAutoFakesArgumentProcessor();
+        _disableAutoFakesArgumentProcessor = new DisableAutoFakesArgumentProcessor(CommandLineOptions.Instance);
     }
 
     [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/EnableCodeCoverageArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableCodeCoverageArgumentProcessorTests.cs
@@ -40,14 +40,14 @@ public class EnableCodeCoverageArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnEnableCodeCoverageArgumentProcessorCapabilities()
     {
-        var processor = new EnableCodeCoverageArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new EnableCodeCoverageArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is EnableCodeCoverageArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnEnableCodeCoverageArgumentProcessorCapabilities()
     {
-        var processor = new EnableCodeCoverageArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new EnableCodeCoverageArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is EnableCodeCoverageArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/FrameworkArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/FrameworkArgumentProcessorTests.cs
@@ -32,14 +32,14 @@ public class FrameworkArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnFrameworkArgumentProcessorCapabilities()
     {
-        var processor = new FrameworkArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new FrameworkArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is FrameworkArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnFrameworkArgumentExecutor()
     {
-        var processor = new FrameworkArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new FrameworkArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is FrameworkArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/InIsolationArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/InIsolationArgumentProcessorTests.cs
@@ -32,21 +32,21 @@ public class InIsolationArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnInProcessArgumentProcessorCapabilities()
     {
-        var processor = new InIsolationArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new InIsolationArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is InIsolationArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnInProcessArgumentExecutor()
     {
-        var processor = new InIsolationArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new InIsolationArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is InIsolationArgumentExecutor);
     }
 
     [TestMethod]
     public void InIsolationArgumentProcessorMetadataShouldProvideAppropriateCapabilities()
     {
-        var isolationProcessor = new InIsolationArgumentProcessor(new TestableRunSettingsProvider());
+        var isolationProcessor = new InIsolationArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsFalse(isolationProcessor.Metadata.Value.AllowMultiple);
         Assert.IsFalse(isolationProcessor.Metadata.Value.AlwaysExecute);
         Assert.IsFalse(isolationProcessor.Metadata.Value.IsAction);

--- a/test/vstest.console.UnitTests/Processors/ListFullyQualifiedTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListFullyQualifiedTestsArgumentProcessorTests.cs
@@ -95,7 +95,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnListFullyQualifiedTestsArgumentProcessorCapabilities()
     {
-        var processor = new ListFullyQualifiedTestsArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new ListFullyQualifiedTestsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is ListFullyQualifiedTestsArgumentProcessorCapabilities);
     }
 
@@ -105,7 +105,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
     [TestMethod]
     public void GetExecuterShouldReturnListFullyQualifiedTestsArgumentProcessorCapabilities()
     {
-        var processor = new ListFullyQualifiedTestsArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new ListFullyQualifiedTestsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is ListFullyQualifiedTestsArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
@@ -93,7 +93,7 @@ public class ListTestsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnListTestsArgumentProcessorCapabilities()
     {
-        var processor = new ListTestsArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new ListTestsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is ListTestsArgumentProcessorCapabilities);
     }
 
@@ -103,7 +103,7 @@ public class ListTestsArgumentProcessorTests
     [TestMethod]
     public void GetExecuterShouldReturnListTestsArgumentProcessorCapabilities()
     {
-        var processor = new ListTestsArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new ListTestsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is ListTestsArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/ListTestsTargetPathArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListTestsTargetPathArgumentProcessorTests.cs
@@ -14,14 +14,14 @@ public class ListTestsTargetPathArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnListTestsTargetPathArgumentProcessorCapabilities()
     {
-        ListTestsTargetPathArgumentProcessor processor = new();
+        ListTestsTargetPathArgumentProcessor processor = new(CommandLineOptions.Instance);
         Assert.IsTrue(processor.Metadata.Value is ListTestsTargetPathArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecutorShouldReturnListTestsTargetPathArgumentProcessorCapabilities()
     {
-        ListTestsTargetPathArgumentProcessor processor = new();
+        ListTestsTargetPathArgumentProcessor processor = new(CommandLineOptions.Instance);
         Assert.IsTrue(processor.Executor!.Value is ListTestsTargetPathArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/ParallelArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ParallelArgumentProcessorTests.cs
@@ -29,14 +29,14 @@ public class ParallelArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnParallelArgumentProcessorCapabilities()
     {
-        var processor = new ParallelArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new ParallelArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is ParallelArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnParallelArgumentExecutor()
     {
-        var processor = new ParallelArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new ParallelArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is ParallelArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/ParentProcessIdArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ParentProcessIdArgumentProcessorTests.cs
@@ -15,14 +15,14 @@ public class ParentProcessIdArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnParentProcessIdArgumentProcessorCapabilities()
     {
-        var processor = new ParentProcessIdArgumentProcessor();
+        var processor = new ParentProcessIdArgumentProcessor(CommandLineOptions.Instance);
         Assert.IsTrue(processor.Metadata.Value is ParentProcessIdArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecutorShouldReturnParentProcessIdArgumentProcessorCapabilities()
     {
-        var processor = new ParentProcessIdArgumentProcessor();
+        var processor = new ParentProcessIdArgumentProcessor(CommandLineOptions.Instance);
         Assert.IsTrue(processor.Executor!.Value is ParentProcessIdArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
@@ -36,14 +36,14 @@ public class PlatformArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnPlatformArgumentProcessorCapabilities()
     {
-        var processor = new PlatformArgumentProcessor(new TestableRunSettingsProvider(), _runSettingsHelper);
+        var processor = new PlatformArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), _runSettingsHelper);
         Assert.IsTrue(processor.Metadata.Value is PlatformArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnPlatformArgumentExecutor()
     {
-        var processor = new PlatformArgumentProcessor(new TestableRunSettingsProvider(), _runSettingsHelper);
+        var processor = new PlatformArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), _runSettingsHelper);
         Assert.IsTrue(processor.Executor!.Value is PlatformArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
@@ -40,14 +40,14 @@ public class PortArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnPortArgumentProcessorCapabilities()
     {
-        var processor = new PortArgumentProcessor(_runSettingsHelper);
+        var processor = new PortArgumentProcessor(CommandLineOptions.Instance, _runSettingsHelper);
         Assert.IsTrue(processor.Metadata.Value is PortArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecutorShouldReturnPortArgumentProcessorCapabilities()
     {
-        var processor = new PortArgumentProcessor(_runSettingsHelper);
+        var processor = new PortArgumentProcessor(CommandLineOptions.Instance, _runSettingsHelper);
         Assert.IsTrue(processor.Executor!.Value is PortArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/ResultsDirectoryArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ResultsDirectoryArgumentProcessorTests.cs
@@ -34,14 +34,14 @@ public class ResultsDirectoryArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnResultsDirectoryArgumentProcessorCapabilities()
     {
-        var processor = new ResultsDirectoryArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new ResultsDirectoryArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is ResultsDirectoryArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnResultsDirectoryArgumentExecutor()
     {
-        var processor = new ResultsDirectoryArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new ResultsDirectoryArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is ResultsDirectoryArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
@@ -41,14 +41,14 @@ public class RunSettingsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnRunSettingsArgumentProcessorCapabilities()
     {
-        var processor = new RunSettingsArgumentProcessor(new TestableRunSettingsProvider(), new RunSettingsHelper());
+        var processor = new RunSettingsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new RunSettingsHelper());
         Assert.IsTrue(processor.Metadata.Value is RunSettingsArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnRunSettingsArgumentExecutor()
     {
-        var processor = new RunSettingsArgumentProcessor(new TestableRunSettingsProvider(), new RunSettingsHelper());
+        var processor = new RunSettingsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new RunSettingsHelper());
         Assert.IsTrue(processor.Executor!.Value is RunSettingsArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
@@ -81,7 +81,7 @@ public class RunSpecificTestsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnRunSpecificTestsArgumentProcessorCapabilities()
     {
-        RunSpecificTestsArgumentProcessor processor = new(new TestableRunSettingsProvider());
+        RunSpecificTestsArgumentProcessor processor = new(CommandLineOptions.Instance, new TestableRunSettingsProvider());
 
         Assert.IsTrue(processor.Metadata.Value is RunSpecificTestsArgumentProcessorCapabilities);
     }
@@ -89,7 +89,7 @@ public class RunSpecificTestsArgumentProcessorTests
     [TestMethod]
     public void GetExecutorShouldReturnRunSpecificTestsArgumentExecutor()
     {
-        RunSpecificTestsArgumentProcessor processor = new(new TestableRunSettingsProvider());
+        RunSpecificTestsArgumentProcessor processor = new(CommandLineOptions.Instance, new TestableRunSettingsProvider());
 
         Assert.IsTrue(processor.Executor!.Value is RunSpecificTestsArgumentExecutor);
     }

--- a/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
@@ -79,14 +79,14 @@ public class RunTestsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnRunTestsArgumentProcessorCapabilities()
     {
-        RunTestsArgumentProcessor processor = new(new TestableRunSettingsProvider());
+        RunTestsArgumentProcessor processor = new(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is RunTestsArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnRunTestsArgumentProcessorCapabilities()
     {
-        RunTestsArgumentProcessor processor = new(new TestableRunSettingsProvider());
+        RunTestsArgumentProcessor processor = new(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is RunTestsArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
@@ -43,14 +43,14 @@ public class TestAdapterPathArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnTestAdapterPathArgumentProcessorCapabilities()
     {
-        var processor = new TestAdapterPathArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new TestAdapterPathArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is TestAdapterPathArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnTestAdapterPathArgumentProcessorCapabilities()
     {
-        var processor = new TestAdapterPathArgumentProcessor(new TestableRunSettingsProvider());
+        var processor = new TestAdapterPathArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is TestAdapterPathArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/TestCaseFilterArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestCaseFilterArgumentProcessorTests.cs
@@ -14,14 +14,14 @@ public class TestCaseFilterArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnTestCaseFilterArgumentProcessorCapabilities()
     {
-        TestCaseFilterArgumentProcessor processor = new();
+        TestCaseFilterArgumentProcessor processor = new(CommandLineOptions.Instance);
         Assert.IsTrue(processor.Metadata.Value is TestCaseFilterArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecutorShouldReturnTestCaseFilterArgumentProcessorCapabilities()
     {
-        TestCaseFilterArgumentProcessor processor = new();
+        TestCaseFilterArgumentProcessor processor = new(CommandLineOptions.Instance);
         Assert.IsTrue(processor.Executor!.Value is TestCaseFilterArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/TestSourceArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestSourceArgumentProcessorTests.cs
@@ -26,7 +26,7 @@ public class TestSourceArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnTestSourceArgumentProcessorCapabilities()
     {
-        TestSourceArgumentProcessor processor = new();
+        TestSourceArgumentProcessor processor = new(CommandLineOptions.Instance);
         Assert.IsTrue(processor.Metadata.Value is TestSourceArgumentProcessorCapabilities);
     }
 
@@ -36,7 +36,7 @@ public class TestSourceArgumentProcessorTests
     [TestMethod]
     public void GetExecuterShouldReturnTestSourceArgumentProcessorCapabilities()
     {
-        TestSourceArgumentProcessor processor = new();
+        TestSourceArgumentProcessor processor = new(CommandLineOptions.Instance);
         Assert.IsTrue(processor.Executor!.Value is TestSourceArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/UseVsixExtensionsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/UseVsixExtensionsArgumentProcessorTests.cs
@@ -34,14 +34,14 @@ public class UseVsixExtensionsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnUseVsixExtensionsArgumentProcessorCapabilities()
     {
-        var processor = new UseVsixExtensionsArgumentProcessor();
+        var processor = new UseVsixExtensionsArgumentProcessor(CommandLineOptions.Instance);
         Assert.IsTrue(processor.Metadata.Value is UseVsixExtensionsArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnUseVsixExtensionsArgumentProcessorCapabilities()
     {
-        var processor = new UseVsixExtensionsArgumentProcessor();
+        var processor = new UseVsixExtensionsArgumentProcessor(CommandLineOptions.Instance);
         Assert.IsTrue(processor.Executor!.Value is UseVsixExtensionsArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/Utilities/ArgumentProcessorFactoryTests.cs
+++ b/test/vstest.console.UnitTests/Processors/Utilities/ArgumentProcessorFactoryTests.cs
@@ -169,18 +169,28 @@ public class ArgumentProcessorFactoryTests
 
         foreach (var processor in allProcessors)
         {
-            // Processors declare different constructor shapes: some take an IRunSettingsProvider, some take
-            // an IRunSettingsHelper, some take both, and the rest are parameterless. Pick the matching one.
+            // Processors declare different constructor shapes: most now take a CommandLineOptions first,
+            // optionally followed by an IRunSettingsProvider and/or IRunSettingsHelper; a few legacy ones take
+            // only a run settings dependency, and the rest are parameterless. Pick the matching one.
+            var commandLineOptions = CommandLineOptions.Instance;
             var runSettingsProvider = new TestableRunSettingsProvider();
             var runSettingsHelper = new RunSettingsHelper();
 
-            var instance = (processor.GetConstructor([typeof(IRunSettingsProvider), typeof(IRunSettingsHelper)]) is { } providerAndHelperCtor
-                ? providerAndHelperCtor.Invoke([runSettingsProvider, runSettingsHelper])
-                : processor.GetConstructor([typeof(IRunSettingsProvider)]) is { } providerCtor
-                    ? providerCtor.Invoke([runSettingsProvider])
-                    : processor.GetConstructor([typeof(IRunSettingsHelper)]) is { } helperCtor
-                        ? helperCtor.Invoke([runSettingsHelper])
-                        : Activator.CreateInstance(processor)) as IArgumentProcessor;
+            var instance = (processor.GetConstructor([typeof(CommandLineOptions), typeof(IRunSettingsProvider), typeof(IRunSettingsHelper)]) is { } optionsProviderHelperCtor
+                ? optionsProviderHelperCtor.Invoke([commandLineOptions, runSettingsProvider, runSettingsHelper])
+                : processor.GetConstructor([typeof(CommandLineOptions), typeof(IRunSettingsProvider)]) is { } optionsProviderCtor
+                    ? optionsProviderCtor.Invoke([commandLineOptions, runSettingsProvider])
+                    : processor.GetConstructor([typeof(CommandLineOptions), typeof(IRunSettingsHelper)]) is { } optionsHelperCtor
+                        ? optionsHelperCtor.Invoke([commandLineOptions, runSettingsHelper])
+                        : processor.GetConstructor([typeof(CommandLineOptions)]) is { } optionsCtor
+                            ? optionsCtor.Invoke([commandLineOptions])
+                            : processor.GetConstructor([typeof(IRunSettingsProvider), typeof(IRunSettingsHelper)]) is { } providerAndHelperCtor
+                                ? providerAndHelperCtor.Invoke([runSettingsProvider, runSettingsHelper])
+                                : processor.GetConstructor([typeof(IRunSettingsProvider)]) is { } providerCtor
+                                    ? providerCtor.Invoke([runSettingsProvider])
+                                    : processor.GetConstructor([typeof(IRunSettingsHelper)]) is { } helperCtor
+                                        ? helperCtor.Invoke([runSettingsHelper])
+                                        : Activator.CreateInstance(processor)) as IArgumentProcessor;
             Assert.IsNotNull(instance, $"Unable to instantiate processor: {processor}");
 
             var specialProcessor = instance.Metadata.Value.IsSpecialCommand;


### PR DESCRIPTION
This continues #16200 (`IRunSettingsProvider`) and #16205 (`IRunSettingsHelper`) of getting the vstest.console argument processors off process-wide mutable statics.

The argument processors reach for `CommandLineOptions.Instance` when they construct their executors, so the request-scoped command-line state — target framework, platform, test adapter paths, and the rest — is shared static state that leaks across requests in design mode. This threads `CommandLineOptions` through the composition root the same way the previous two went in, defaulting to `CommandLineOptions.Instance` so behavior is unchanged.

- `ArgumentProcessorFactory.Create(...)` takes an optional `CommandLineOptions` and passes it into every default processor as the first constructor argument; `Executor` owns it and passes it in, defaulting to `CommandLineOptions.Instance`.
- Each processor now holds an injected `CommandLineOptions` field instead of reading the static, and hands it to the executor it builds.
- `TestRequestManager` and `ConsoleLogger` construct or read `CommandLineOptions` outside the processor path, so they stay on the `.Instance` fallback — the same shared instance — for now. Converting those readers is a later phase.

`CommandLineOptions.Instance` is not obsoleted; the remaining references are the composition-root defaults, so anything still reading the static keeps working. Because both the writers (the processors) and the deferred readers resolve to that one static field by default, a flag written while parsing arguments is still read back through the same object in production.

### Verification
- `vstest.console.UnitTests` on `net481`: 635 passed, 0 failed, 2 skipped (637 total).
- Debug and Release builds clean, no `IDE0005`.
- `build.cmd -pack` green.