### PR TITLE
[code-simplifier] Simplify CLIRunSettings architecture check and remove misleading field comment

### DIFF
--- a/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
@@ -238,14 +238,10 @@ internal class CliRunSettingsArgumentExecutor : IArgumentsExecutor
             }
         }
 
-        if (key.Equals(PlatformArgumentExecutor.RunSettingsPath))
+        if (key.Equals(PlatformArgumentExecutor.RunSettingsPath) && Enum.TryParse<Architecture>(value, true, out var architecture))
         {
-            bool success = Enum.TryParse<Architecture>(value, true, out var architecture);
-            if (success)
-            {
-                _runSettingsHelper.IsDefaultTargetArchitecture = false;
-                _commandLineOptions.TargetArchitecture = architecture;
-            }
+            _runSettingsHelper.IsDefaultTargetArchitecture = false;
+            _commandLineOptions.TargetArchitecture = architecture;
         }
     }
 }

--- a/src/vstest.console/Processors/PortArgumentProcessor.cs
+++ b/src/vstest.console/Processors/PortArgumentProcessor.cs
@@ -105,9 +105,6 @@ internal class PortArgumentExecutor : IArgumentExecutor
     /// </summary>
     private readonly IProcessHelper _processHelper;
 
-    /// <summary>
-    /// Used to flag that the run was started from an Editor or IDE.
-    /// </summary>
     private readonly IRunSettingsHelper _runSettingsHelper;
 
     /// <summary>


### PR DESCRIPTION
## Code Simplification — 2026-07-03

This PR simplifies two small issues introduced in #16205 (IRunSettingsHelper injection), improving clarity and consistency without changing behavior.

### Files Simplified

- `src/vstest.console/Processors/PortArgumentProcessor.cs` — remove incorrect XML doc comment on `_runSettingsHelper`
- `src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs` — collapse intermediate `bool success` variable into compound condition

### Improvements Made

1. **Removed incorrect documentation**
   - `PortArgumentExecutor._runSettingsHelper` had `/// <summary>Used to flag that the run was started from an Editor or IDE.</summary>` — this describes what `IsDesignMode` *does*, not what the field *is*. The field is `IRunSettingsHelper`, which is self-describing; no doc comment is needed. The wrong comment would mislead future readers into thinking this is a boolean flag.

2. **Applied idiomatic C# pattern consistently**
   - `UpdateFrameworkAndPlatform` in `CLIRunSettingsArgumentExecutor` used an intermediate `bool success = Enum.TryParse(...); if (success)` pattern. Collapsed to `if (Enum.TryParse(...))`, which is the same pattern already used in `RunSettingsArgumentExecutor.ExtractFrameworkAndPlatform` doing the equivalent operation.

### Changes Based On

Recent changes from:
- #16205 — Inject IRunSettingsHelper instead of reading RunSettingsHelper.Instance

### Testing

- ✅ Build succeeds (`./build.sh`)
- ✅ All 60 relevant unit tests pass (`test/vstest.console.UnitTests` filtered to `PortArgumentProcessor` and `CLIRunSettings`)
- ✅ No functional changes — behavior is identical


<!-- gh-aw-tracker-id: code-simplifier -->




> Generated by [Code Simplifier](https://github.com/microsoft/vstest/actions/runs/28670001997) · 1.2K AIC · ⌖ 16.8 AIC · ⊞ 31.6K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
> - [x] expires <!-- gh-aw-expires: 2026-07-04T15:45:00.125Z --> on Jul 4, 2026, 3:45 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28670001997, workflow_id: code-simplifier, run: https://github.com/microsoft/vstest/actions/runs/28670001997 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->
<!-- gh-aw-workflow-call-id: microsoft/vstest/code-simplifier -->