### PR TITLE
[efficiency-improver] perf: eliminate GetRawText() string allocation in STJ deserializer converters

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/AfterTestRunEndResultConverter.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/AfterTestRunEndResultConverter.cs
@@ -52,7 +52,7 @@ internal class AfterTestRunEndResultConverter : JsonConverter<AfterTestRunEndRes
     {
         if (element.TryGetProperty(name, out var prop) && prop.ValueKind != JsonValueKind.Null)
         {
-            return StjSafe.Deserialize<T>(prop.GetRawText(), options);
+            return StjSafe.Deserialize<T>(prop, options);
         }
 
         return default;

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/AttachmentConverters.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/AttachmentConverters.cs
@@ -32,7 +32,7 @@ internal class AttachmentSetConverter : JsonConverter<AttachmentSet>
             {
                 if (attachment.ValueKind != JsonValueKind.Null)
                 {
-                    attachmentSet.Attachments.Add(StjSafe.Deserialize<UriDataAttachment>(attachment.GetRawText(), options)!);
+                    attachmentSet.Attachments.Add(StjSafe.Deserialize<UriDataAttachment>(attachment, options)!);
                 }
             }
         }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/DiscoveryCriteriaConverter.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/DiscoveryCriteriaConverter.cs
@@ -75,7 +75,7 @@ internal class DiscoveryCriteriaConverter : JsonConverter<DiscoveryCriteria>
     {
         if (element.TryGetProperty(name, out var prop) && prop.ValueKind != JsonValueKind.Null)
         {
-            return StjSafe.Deserialize<T>(prop.GetRawText(), options);
+            return StjSafe.Deserialize<T>(prop, options);
         }
 
         return default;

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/ExceptionConverter.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/ExceptionConverter.cs
@@ -49,7 +49,7 @@ internal class ExceptionConverter : JsonConverter<Exception>
         Exception? innerException = null;
         if (root.TryGetProperty("InnerException", out var innerProp) && innerProp.ValueKind != JsonValueKind.Null)
         {
-            innerException = StjSafe.Deserialize<Exception>(innerProp.GetRawText(), options);
+            innerException = StjSafe.Deserialize<Exception>(innerProp, options);
         }
 
         var exception = new RemoteException(className, message, stackTrace, innerException);

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestCaseConverter.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestCaseConverter.cs
@@ -39,7 +39,7 @@ internal class TestCaseConverter : JsonConverter<TestCase>
                 return null;
             }
 
-            var testProperty = StjSafe.Deserialize<TestProperty>(keyElement.GetRawText(), options);
+            var testProperty = StjSafe.Deserialize<TestProperty>(keyElement, options);
 
             if (testProperty is null)
             {

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestExecutionContextConverter.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestExecutionContextConverter.cs
@@ -40,7 +40,7 @@ internal class TestExecutionContextConverter : JsonConverter<TestExecutionContex
         if (data.TryGetProperty("TestCaseFilter", out var filter) && filter.ValueKind != JsonValueKind.Null)
             context.TestCaseFilter = filter.GetString();
         if (data.TryGetProperty("FilterOptions", out var filterOptions) && filterOptions.ValueKind != JsonValueKind.Null)
-            context.FilterOptions = StjSafe.Deserialize<FilterOptions>(filterOptions.GetRawText(), options);
+            context.FilterOptions = StjSafe.Deserialize<FilterOptions>(filterOptions, options);
 
         return context;
     }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestObjectBaseConverter.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestObjectBaseConverter.cs
@@ -70,7 +70,7 @@ internal class TestObjectBaseConverter : JsonConverter<TestObject>
             if (!prop.TryGetProperty("Key", out var keyElement))
                 continue;
 
-            var testProperty = StjSafe.Deserialize<TestProperty>(keyElement.GetRawText(), options);
+            var testProperty = StjSafe.Deserialize<TestProperty>(keyElement, options);
             if (testProperty is null)
                 continue;
 

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestRunChangedEventArgsConverter.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestRunChangedEventArgsConverter.cs
@@ -51,7 +51,7 @@ internal class TestRunChangedEventArgsConverter : JsonConverter<TestRunChangedEv
     {
         if (element.TryGetProperty(name, out var prop) && prop.ValueKind != JsonValueKind.Null)
         {
-            return StjSafe.Deserialize<T>(prop.GetRawText(), options);
+            return StjSafe.Deserialize<T>(prop, options);
         }
 
         return default;

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestRunCompleteEventArgsConverter.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestRunCompleteEventArgsConverter.cs
@@ -66,7 +66,7 @@ internal class TestRunCompleteEventArgsConverter : JsonConverter<TestRunComplete
     {
         if (element.TryGetProperty(name, out var prop) && prop.ValueKind != JsonValueKind.Null)
         {
-            return StjSafe.Deserialize<T>(prop.GetRawText(), options);
+            return StjSafe.Deserialize<T>(prop, options);
         }
 
         return default;


### PR DESCRIPTION
## Goal and Rationale

Eliminate redundant string allocation and re-parse on the IPC deserialization path by replacing `StjSafe.Deserialize<T>(element.GetRawText(), options)` with `StjSafe.Deserialize<T>(element, options)` across 9 STJ converter classes.

**Focus area:** Network & I/O Efficiency (IPC deserialization path)

## Problem

`JsonElement.GetRawText()` allocates a new heap string containing the raw JSON fragment. Passing this string to `JsonSerializer.Deserialize<T>(string, ...)` then causes a **second parse** — the serializer must re-tokenize the string from scratch.

`JsonSerializer.Deserialize<T>(JsonElement, ...)` reads directly from the already-parsed `JsonElement`, skipping both the string allocation and the re-parse entirely. `StjSafe` already exposes this overload.

## Approach

Single-line substitution in 9 converters (all inside `#if NETCOREAPP`):

| Converter | Variable |
|---|---|
| `AttachmentConverters.cs` | `attachment` |
| `TestObjectBaseConverter.cs` | `keyElement` |
| `ExceptionConverter.cs` | `innerProp` |
| `TestRunChangedEventArgsConverter.cs` | `prop` |
| `TestCaseConverter.cs` | `keyElement` |
| `TestRunCompleteEventArgsConverter.cs` | `prop` |
| `TestExecutionContextConverter.cs` | `filterOptions` |
| `AfterTestRunEndResultConverter.cs` | `prop` |
| `DiscoveryCriteriaConverter.cs` | `prop` |

The shared `DeserializeProperty<T>` helper pattern (used by 4 converters) makes each replacement a one-line change.

## Energy Efficiency Evidence

**Proxy metric:** Memory allocation (GC pressure on the IPC deserialization path)

Each `GetRawText()` call allocates a heap string proportional to the JSON fragment size. Typical fragment sizes for the affected types:
- `TestProperty` key object: ~60–150 bytes of JSON → ~120–300 bytes UTF-16 string
- `UriDataAttachment`: ~80–200 bytes → ~160–400 bytes
- `FilterOptions` / `TestExecutionContext` sub-objects: ~20–100 bytes

These allocations occur on every `TestCase` and `TestResult` deserialization, and on every `DiscoveryCriteria` / execution context message receive. Eliminating all 9 sites reduces Gen0 heap pressure on the IPC receive thread.

**Green Software Foundation context:**
- *Hardware Efficiency*: fewer GC pauses → more CPU cycles on useful work instead of heap management
- *SCI (Software Carbon Intensity)*: less CPU energy per `dotnet test` invocation, proportional to test count and run frequency

## Trade-offs

None. `Deserialize<T>(JsonElement, ...)` produces identical output for every case — it reads the same token tree that `GetRawText()` serialises back to a string. Change is fully covered by existing round-trip tests.

## Reproducibility

```bash
# Verify no Deserialize+GetRawText calls remain:
grep -rn "Deserialize.*GetRawText" --include="*.cs" src/Microsoft.TestPlatform.CommunicationUtilities/

# Run affected tests:
./test.sh -p CommunicationUtilities -c Release
```

## Test Status

- ✅ Build: 0 errors (4 pre-existing IL-trimming warnings, unrelated)
- ✅ `Microsoft.TestPlatform.CommunicationUtilities.UnitTests`: **632/632 passed**, 0 failures




> Generated by [Efficiency Improver](https://github.com/microsoft/vstest/actions/runs/28674132575) · 747 AIC · ⌖ 15.9 AIC · ⊞ 45.6K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28674132575, workflow_id: efficiency-improver, run: https://github.com/microsoft/vstest/actions/runs/28674132575 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/vstest/efficiency-improver -->