### PR TITLE
[efficiency-improver] perf: eliminate redundant ConcurrentDictionary updates in DiscoveryDataAggregator hot path

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/DiscoveryDataAggregator.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/DiscoveryDataAggregator.cs
@@ -186,39 +186,44 @@ internal sealed class DiscoveryDataAggregator
 
         foreach (var source in sources)
         {
-            if (source is null)
-            {
-                continue;
-            }
-
-            _sourcesWithDiscoveryStatus.AddOrUpdate(source,
-                _ =>
-                {
-                    if (status != DiscoveryStatus.NotDiscovered)
-                    {
-                        EqtTrace.Warning($"DiscoveryDataAggregator.MarkSourcesWithStatus: Undiscovered {source} added with status: '{status}'.");
-                    }
-                    else
-                    {
-                        EqtTrace.Verbose($"DiscoveryDataAggregator.MarkSourcesWithStatus: Adding {source} with status: '{status}'.");
-                    }
-
-                    return status;
-                },
-                (_, previousStatus) =>
-                {
-                    if (previousStatus == DiscoveryStatus.FullyDiscovered && status != DiscoveryStatus.FullyDiscovered
-                        || previousStatus == DiscoveryStatus.PartiallyDiscovered && (status == DiscoveryStatus.NotDiscovered || status == DiscoveryStatus.SkippedDiscovery))
-                    {
-                        EqtTrace.Warning($"DiscoveryDataAggregator.MarkSourcesWithStatus: Downgrading source {source} status from '{previousStatus}' to '{status}'.");
-                    }
-                    else if (previousStatus != status)
-                    {
-                        EqtTrace.Verbose($"DiscoveryDataAggregator.MarkSourcesWithStatus: Upgrading {source} status from '{previousStatus}' to '{status}'.");
-                    }
-                    return status;
-                });
+            MarkSourceWithStatus(source, status);
         }
+    }
+
+    private void MarkSourceWithStatus(string? source, DiscoveryStatus status)
+    {
+        if (source is null)
+        {
+            return;
+        }
+
+        _sourcesWithDiscoveryStatus.AddOrUpdate(source,
+            _ =>
+            {
+                if (status != DiscoveryStatus.NotDiscovered)
+                {
+                    EqtTrace.Warning($"DiscoveryDataAggregator.MarkSourcesWithStatus: Undiscovered {source} added with status: '{status}'.");
+                }
+                else
+                {
+                    EqtTrace.Verbose($"DiscoveryDataAggregator.MarkSourcesWithStatus: Adding {source} with status: '{status}'.");
+                }
+
+                return status;
+            },
+            (_, previousStatus) =>
+            {
+                if (previousStatus == DiscoveryStatus.FullyDiscovered && status != DiscoveryStatus.FullyDiscovered
+                    || previousStatus == DiscoveryStatus.PartiallyDiscovered && (status == DiscoveryStatus.NotDiscovered || status == DiscoveryStatus.SkippedDiscovery))
+                {
+                    EqtTrace.Warning($"DiscoveryDataAggregator.MarkSourcesWithStatus: Downgrading source {source} status from '{previousStatus}' to '{status}'.");
+                }
+                else if (previousStatus != status)
+                {
+                    EqtTrace.Verbose($"DiscoveryDataAggregator.MarkSourcesWithStatus: Upgrading {source} status from '{previousStatus}' to '{status}'.");
+                }
+                return status;
+            });
     }
 
     /// <summary>
@@ -247,19 +252,19 @@ internal sealed class DiscoveryDataAggregator
         {
             var currentSource = testCase.Source;
 
-            // We rely on the fact that sources are processed in a sequential way, which
-            // means that when we receive a different source than the previous, we can
-            // assume that the previous source was fully discovered.
-            if (previousSource is null || previousSource == currentSource)
+            // Sources arrive sequentially; when source changes the previous one is fully discovered.
+            if (previousSource is null)
             {
-                MarkSourcesWithStatus(new[] { currentSource }, DiscoveryStatus.PartiallyDiscovered);
+                // First test case seen: mark this source as partially discovered.
+                MarkSourceWithStatus(currentSource, DiscoveryStatus.PartiallyDiscovered);
             }
             else if (currentSource != previousSource)
             {
                 EqtTrace.Verbose($"DiscoveryDataAggregator.MarkSourcesBasedOnDiscoveredTestCases: Discovered test source changed from {previousSource} to {currentSource}.");
-                MarkSourcesWithStatus(new[] { previousSource }, DiscoveryStatus.FullyDiscovered);
-                MarkSourcesWithStatus(new[] { currentSource }, DiscoveryStatus.PartiallyDiscovered);
+                MarkSourceWithStatus(previousSource, DiscoveryStatus.FullyDiscovered);
+                MarkSourceWithStatus(currentSource, DiscoveryStatus.PartiallyDiscovered);
             }
+            // When currentSource == previousSource: status already PartiallyDiscovered; skip.
 
             previousSource = currentSource;
         }


### PR DESCRIPTION
## Goal and Rationale

Eliminate O(N) redundant `ConcurrentDictionary.AddOrUpdate` calls and single-element array allocations on the discovery hot path in `DiscoveryDataAggregator.MarkSourcesBasedOnDiscoveredTestCases`.

**Focus area:** Code-Level Efficiency

## Problem

The original inner loop called:

```csharp
if (previousSource is null || previousSource == currentSource)
{
    MarkSourcesWithStatus(new[] { currentSource }, DiscoveryStatus.PartiallyDiscovered);
}
```

This fires for **every test case** when consecutive tests share a source assembly (the common case). For a project with N tests in one assembly it means:

- N `new[] { currentSource }` array allocations (~32 bytes each on 64-bit)
- N `ConcurrentDictionary.AddOrUpdate` calls with lock acquisition
- N update-factory invocations that return `PartiallyDiscovered` unchanged

After the first call, the status is already `PartiallyDiscovered`; all subsequent calls with the same source are pure no-ops.

## Approach

1. **Skip redundant updates**: change the condition from `previousSource is null || previousSource == currentSource` to just `previousSource is null`. When the source matches the previous one, the status is already set — skip entirely.

2. **Extract `MarkSourceWithStatus(string?, DiscoveryStatus)`**: private single-source helper that calls `AddOrUpdate` directly, eliminating the `new[]` array, the `IEnumerable` overhead, and the null guard on `sources` for the three remaining single-source call sites in the loop.

3. **Refactor `MarkSourcesWithStatus`** to delegate to the new helper, removing the duplicated `AddOrUpdate` logic.

## Energy Efficiency Evidence

**Proxy metric:** Memory allocation (GC pressure) and CPU cycles (lock contention) on the discovery path

| Metric | Before | After |
|--------|--------|-------|
| Array allocations | O(N) per source — one `string[1]` per test case | O(1) per source — zero after first encounter |
| `ConcurrentDictionary.AddOrUpdate` calls | O(N) per source | O(1) per source |

For a solution with 10,000 tests in a single assembly, this eliminates ~10,000 heap allocations and ~10,000 lock acquisitions from the discovery path per `dotnet test` run.

**Green Software Foundation context:**
- *Hardware Efficiency*: fewer lock acquisitions → less bus traffic and cache-line contention; fewer GC pauses → more CPU cycles spent on useful work
- *SCI (Software Carbon Intensity)*: reduced CPU energy per `dotnet test` invocation, proportional to test count

## Trade-offs

None. The semantics are identical: `AddOrUpdate` with a value that already matches the stored value is a pure no-op. All 45 `DiscoveryDataAggregator` unit tests (including source-tracking regression tests) pass without modification.

## Reproducibility

```bash
# Run the specific test suite:
.dotnet/dotnet run --project test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/ \
  -c Release -f net11.0 -- --filter "DiscoveryDataAggregator"

# Verify no new[] single-element calls remain in the loop:
grep -n "new\[\]" src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/DiscoveryDataAggregator.cs
```

## Test Status

- ✅ Build: 0 errors (4 pre-existing IL-trimming warnings, unrelated)
- ✅ `DiscoveryDataAggregator` tests: **45/45 passed**, 0 failures
- i️ 8 pre-existing failures in CrossPlatEngine suite (Windows-path tests, fail on Linux on both `main` and this branch)




> Generated by [Efficiency Improver](https://github.com/microsoft/vstest/actions/runs/28713232251) · 1.3K AIC · ⌖ 25.6 AIC · ⊞ 45.6K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28713232251, workflow_id: efficiency-improver, run: https://github.com/microsoft/vstest/actions/runs/28713232251 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/vstest/efficiency-improver -->