### PR TITLE
[efficiency-improver] perf: eliminate Duration.ToString() and Guid.ToString() allocations in IPC serializers

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestCaseConverter.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestCaseConverter.cs
@@ -142,7 +142,7 @@ internal class TestCaseConverter : JsonConverter<TestCase>
         // TestCase.Id
         writer.WriteStartObject();
         WriteProperty(writer, TestCaseProperties.Id, options);
-        writer.WriteStringValue(value.Id.ToString());
+        writer.WriteStringValue(value.Id);
         writer.WriteEndObject();
 
         // TestCase.LineNumber

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestResultConverter.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestResultConverter.cs
@@ -161,7 +161,9 @@ internal class TestResultConverter : JsonConverter<TestResult>
         // TestResult.Duration
         writer.WriteStartObject();
         WriteProperty(writer, TestResultProperties.Duration, options);
-        writer.WriteStringValue(value.Duration.ToString());
+        Span<char> durationBuf = stackalloc char[32];
+        value.Duration.TryFormat(durationBuf, out int durationChars, default, CultureInfo.InvariantCulture);
+        writer.WriteStringValue(durationBuf[..durationChars]);
         writer.WriteEndObject();
 
         // TestResult.StartTime

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestResultConverterV2.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestResultConverterV2.cs
@@ -125,7 +125,9 @@ internal class TestResultConverterV2 : JsonConverter<TestResult>
         StjSafe.Serialize(writer, value.Messages, options);
 
         writer.WriteString("ComputerName", value.ComputerName);
-        writer.WriteString("Duration", value.Duration.ToString());
+        Span<char> durationBuf = stackalloc char[32];
+        value.Duration.TryFormat(durationBuf, out int durationChars, default, CultureInfo.InvariantCulture);
+        writer.WriteString("Duration", durationBuf[..durationChars]);
         writer.WriteString("StartTime", value.StartTime);
         writer.WriteString("EndTime", value.EndTime);
 


### PR DESCRIPTION
## Goal and Rationale

Eliminate two categories of heap allocation on the IPC serialization hot path — called for every `TestResult` and `TestCase` crossing the vstest.console ↔ testhost process boundary.

**Focus area:** Network & I/O Efficiency (IPC serialization write path)

## Problem

### 1. `Duration.ToString()` — `TestResultConverterV2` and `TestResultConverter`

```csharp
// Before — allocates a heap string per TestResult
writer.WriteString("Duration", value.Duration.ToString());
writer.WriteStringValue(value.Duration.ToString());
```

`TimeSpan.ToString()` always allocates a heap string (typically 7–26 bytes UTF-16 encoded). This string is immediately consumed by `WriteString`/`WriteStringValue` and then eligible for GC. It serves no purpose beyond bridging the absence of a `WriteString(string, TimeSpan)` overload.

### 2. `Guid.ToString()` — `TestCaseConverter` (v1 protocol)

```csharp
// Before — allocates a heap string per TestCase
writer.WriteStringValue(value.Id.ToString());
```

`Guid.ToString()` allocates a 72–88 byte heap string (36-char UUID). `Utf8JsonWriter` already has a `WriteStringValue(Guid)` overload that writes the UUID directly from the struct, without any heap allocation. The **V2** converter (`TestCaseConverterV2`) already uses this overload (line 79); the V1 converter was overlooked.

## Approach

**Duration fix (both converters):** allocate a 32-char stack buffer, format in-place with `TryFormat`, write directly via `WriteString(string, ReadOnlySpan<char>)` / `WriteStringValue(ReadOnlySpan<char>)`:

```csharp
Span<char> durationBuf = stackalloc char[32];
value.Duration.TryFormat(durationBuf, out int durationChars, default, CultureInfo.InvariantCulture);
writer.WriteString("Duration", durationBuf[..durationChars]);
```

**Guid fix (`TestCaseConverter`):** use the existing zero-allocation overload:

```csharp
writer.WriteStringValue(value.Id);   // Guid overload — no ToString(), no heap alloc
```

## Energy Efficiency Evidence

**Proxy metric:** Memory allocation (GC pressure on the IPC write thread)

| Site | Before | After |
|------|--------|-------|
| `TestResultConverterV2.Write` — Duration | 1 heap string (~7–26 chars) per result | 0 heap allocs — stack buffer |
| `TestResultConverter.Write` — Duration | 1 heap string (~7–26 chars) per result | 0 heap allocs — stack buffer |
| `TestCaseConverter.Write` — Guid | 1 heap string (36 chars / ~72 bytes) per case | 0 heap allocs — Guid overload |

For a run with 10,000 tests:
- **Duration**: eliminates ~10,000 short-lived Gen0 strings on the write thread across both converter paths
- **Guid (V1 protocol)**: eliminates ~10,000 36-char heap strings per run when using the V1 wire protocol

**Green Software Foundation context:**
- *Hardware Efficiency*: fewer Gen0 objects → fewer minor GC collections → more CPU cycles on useful serialization work
- *SCI (Software Carbon Intensity)*: reduced CPU energy per `dotnet test` invocation, proportional to test count and run frequency

## Trade-offs

None. `TimeSpan.TryFormat` produces byte-for-byte identical output to `TimeSpan.ToString()` (same "G" general format). `WriteStringValue(Guid)` produces byte-for-byte identical JSON UUID string output. All existing round-trip tests pass.

The `stackalloc char[32]` is safe: `TimeSpan.MaxValue` formats to 26 chars (`-10675199.02:48:05.4775807`); 32 gives ample headroom.

## Reproducibility

```bash
# Verify no Duration.ToString() remains on the write path:
grep -n "Duration\.ToString\|\.ToString()" \
  src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestResult*.cs \
  src/Microsoft.TestPlatform.CommunicationUtilities/Serialization/TestCase*.cs

# Run the full serializer test suite:
.dotnet/dotnet run --project test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/ \
  -c Release -f net11.0
```

## Test Status

- ✅ Build: 0 errors (4 pre-existing IL-trimming warnings, unrelated)
- ✅ `Microsoft.TestPlatform.CommunicationUtilities.UnitTests`: **632/632 passed**, 0 failures




> Generated by [Efficiency Improver](https://github.com/microsoft/vstest/actions/runs/28748142713) · 1.3K AIC · ⌖ 28.2 AIC · ⊞ 45.6K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28748142713, workflow_id: efficiency-improver, run: https://github.com/microsoft/vstest/actions/runs/28748142713 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/vstest/efficiency-improver -->