### PR TITLE
[fix] Fix test output eaten by MSBuild terminal logger

### DIFF
--- a/test.cmd
+++ b/test.cmd
@@ -1,3 +1,4 @@
 @echo off
+if not defined MSBUILDTERMINALLOGGER set MSBUILDTERMINALLOGGER=off
 powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\Build.ps1""" -test %*"
 exit /b %ErrorLevel%

--- a/test.sh
+++ b/test.sh
@@ -16,4 +16,8 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 if [[ -z "${DOTNET_ROOT:-}" && -d "$scriptroot/.dotnet" ]]; then
   export DOTNET_ROOT="$scriptroot/.dotnet"
 fi
+# Disable MSBuild terminal logger so test output isn't buffered. TestCaptureOutput=false
+# means there are no log files to reference, so the terminal logger would show
+# misleading "See log file" messages with paths to files that don't exist.
+export MSBUILDTERMINALLOGGER=${MSBUILDTERMINALLOGGER:-off}
 "$scriptroot/eng/common/build.sh" --test "$@"


### PR DESCRIPTION
## Summary

Fixes #15509

> 🤖 This is an automated fix.

## Root Cause

When `TestCaptureOutput=false` is set in `Directory.Build.props` (to allow live test output in the console) and the MSBuild terminal logger is active (default in .NET 8+ SDK), the terminal logger buffers all output from MSBuild sub-tasks — including test output. When tests complete, the terminal logger shows "See log file: \(path\)" messages. Since `TestCaptureOutput=false` means no log files are created, those paths point to files that don't exist, leaving developers with no visible test output.

## Fix

Disable the MSBuild terminal logger in `test.sh` and `test.cmd` by setting `MSBUILDTERMINALLOGGER=off` before invoking the build scripts. This lets test output flow directly to the console as intended.

Developers who prefer the terminal logger UI can override the default by setting `MSBUILDTERMINALLOGGER=auto` before invoking the test scripts.

## Testing

This is a developer-tooling change affecting only the `test.sh` and `test.cmd` scripts. No production code is modified. The change is:

- `test.sh`: Exports `MSBUILDTERMINALLOGGER=${MSBUILDTERMINALLOGGER:-off}` so the default is off but can be overridden.
- `test.cmd`: Sets `MSBUILDTERMINALLOGGER=off` if not already defined.

CI runs (`azure-pipelines.yml` calls `./test.sh`) will also have the terminal logger disabled, which is harmless — CI output is captured by the Azure DevOps agent regardless.




> 🔍 *Triaged by [Issue Repro Triage & Auto-Fix 🔍](https://github.com/microsoft/vstest/actions/runs/28834207444)*

<!-- gh-aw-agentic-workflow: Issue Repro Triage & Auto-Fix 🔍, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 28834207444, workflow_id: issue-repro-triage, run: https://github.com/microsoft/vstest/actions/runs/28834207444 -->

<!-- gh-aw-workflow-id: issue-repro-triage -->