### PR TITLE
Inject TestSessionPool into the CrossPlatEngine session proxies

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
@@ -29,6 +29,7 @@ public class ProxyDiscoveryManager : IProxyDiscoveryManager, IBaseProxy, ITestDi
 {
     private readonly TestSessionInfo? _testSessionInfo;
     private readonly Func<string, ProxyDiscoveryManager, ProxyOperationManager>? _proxyOperationManagerCreator;
+    private readonly TestSessionPool? _testSessionPool;
     private readonly DiscoveryDataAggregator _discoveryDataAggregator;
     private readonly IFileHelper _fileHelper;
     private readonly IDataSerializer _dataSerializer;
@@ -56,11 +57,13 @@ public class ProxyDiscoveryManager : IProxyDiscoveryManager, IBaseProxy, ITestDi
     internal ProxyDiscoveryManager(
         TestSessionInfo testSessionInfo,
         Func<string, ProxyDiscoveryManager, ProxyOperationManager> proxyOperationManagerCreator,
-        DiscoveryDataAggregator discoveryDataAggregator)
+        DiscoveryDataAggregator discoveryDataAggregator,
+        TestSessionPool? testSessionPool = null)
     {
         // Filling in test session info and proxy information.
         _testSessionInfo = testSessionInfo;
         _proxyOperationManagerCreator = proxyOperationManagerCreator;
+        _testSessionPool = testSessionPool;
         _discoveryDataAggregator = discoveryDataAggregator;
         _dataSerializer = JsonDataSerializer.Instance;
         _fileHelper = new FileHelper();
@@ -289,7 +292,7 @@ public class ProxyDiscoveryManager : IProxyDiscoveryManager, IBaseProxy, ITestDi
             return;
         }
 
-        TestSessionPool.Instance.ReturnProxy(_testSessionInfo, _proxyOperationManager.Id);
+        (_testSessionPool ?? TestSessionPool.Instance).ReturnProxy(_testSessionInfo, _proxyOperationManager.Id);
     }
 
     /// <inheritdoc/>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -34,6 +34,7 @@ internal class ProxyExecutionManager : IProxyExecutionManager, IBaseProxy, IInte
 {
     private readonly TestSessionInfo? _testSessionInfo;
     private readonly Func<string, ProxyExecutionManager, ProxyOperationManager>? _proxyOperationManagerCreator;
+    private readonly TestSessionPool? _testSessionPool;
     private readonly IFileHelper _fileHelper;
     private readonly IDataSerializer _dataSerializer;
     private readonly bool _debugEnabledForTestSession;
@@ -73,14 +74,20 @@ internal class ProxyExecutionManager : IProxyExecutionManager, IBaseProxy, IInte
     /// <param name="debugEnabledForTestSession">
     /// A flag indicating if debugging should be enabled or not.
     /// </param>
+    /// <param name="testSessionPool">
+    /// The test session pool to return proxies to, or <see langword="null"/> to use the shared
+    /// <see cref="TestSessionPool.Instance"/>.
+    /// </param>
     public ProxyExecutionManager(
         TestSessionInfo testSessionInfo,
         Func<string, ProxyExecutionManager, ProxyOperationManager> proxyOperationManagerCreator,
-        bool debugEnabledForTestSession)
+        bool debugEnabledForTestSession,
+        TestSessionPool? testSessionPool = null)
     {
         // Filling in test session info and proxy information.
         _testSessionInfo = testSessionInfo;
         _proxyOperationManagerCreator = proxyOperationManagerCreator;
+        _testSessionPool = testSessionPool;
 
         // This should be set to enable debugging when we have test session info available.
         _debugEnabledForTestSession = debugEnabledForTestSession;
@@ -391,7 +398,7 @@ internal class ProxyExecutionManager : IProxyExecutionManager, IBaseProxy, IInte
             return;
         }
 
-        TestSessionPool.Instance.ReturnProxy(_testSessionInfo, _proxyOperationManager.Id);
+        (_testSessionPool ?? TestSessionPool.Instance).ReturnProxy(_testSessionInfo, _proxyOperationManager.Id);
     }
 
     /// <inheritdoc/>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
@@ -36,6 +36,7 @@ public class TestEngine : ITestEngine
     private readonly ITestRuntimeProviderManager _testHostProviderManager;
     private readonly IProcessHelper _processHelper;
     private readonly IEnvironment _environment;
+    private readonly TestSessionPool? _testSessionPool;
 
     private ITestExtensionManager? _testExtensionManager;
 
@@ -54,11 +55,13 @@ public class TestEngine : ITestEngine
     internal TestEngine(
         ITestRuntimeProviderManager testHostProviderManager,
         IProcessHelper processHelper,
-        IEnvironment environment)
+        IEnvironment environment,
+        TestSessionPool? testSessionPool = null)
     {
         _testHostProviderManager = testHostProviderManager;
         _processHelper = processHelper;
         _environment = environment;
+        _testSessionPool = testSessionPool;
     }
 
     #region ITestEngine implementation
@@ -150,7 +153,7 @@ public class TestEngine : ITestEngine
 
                     // In case we have an active test session, we always prefer the already
                     // created proxies instead of the ones that need to be created on the spot.
-                    var proxyOperationManager = TestSessionPool.Instance.TryTakeProxy(
+                    var proxyOperationManager = (_testSessionPool ?? TestSessionPool.Instance).TryTakeProxy(
                         discoveryCriteria.TestSessionInfo,
                         source,
                         runtimeProviderInfo.RunSettings,
@@ -184,7 +187,8 @@ public class TestEngine : ITestEngine
                 ? new ProxyDiscoveryManager(
                     discoveryCriteria.TestSessionInfo,
                     proxyOperationManagerCreator,
-                    discoveryDataAggregator)
+                    discoveryDataAggregator,
+                    _testSessionPool)
                 : new ProxyDiscoveryManager(
                     requestData,
                     new TestRequestSender(requestData.ProtocolConfig!, hostManager),
@@ -313,7 +317,7 @@ public class TestEngine : ITestEngine
                     string source,
                     ProxyExecutionManager proxyExecutionManager) =>
                 {
-                    var proxyOperationManager = TestSessionPool.Instance.TryTakeProxy(
+                    var proxyOperationManager = (_testSessionPool ?? TestSessionPool.Instance).TryTakeProxy(
                         testRunCriteria.TestSessionInfo,
                         source,
                         runtimeProviderInfo.RunSettings,
@@ -348,7 +352,8 @@ public class TestEngine : ITestEngine
             return new ProxyExecutionManager(
                 testRunCriteria.TestSessionInfo,
                 proxyOperationManagerCreator,
-                testRunCriteria.DebugEnabledForTestSession);
+                testRunCriteria.DebugEnabledForTestSession,
+                _testSessionPool);
         }
 
         return isDataCollectorEnabled
@@ -457,7 +462,7 @@ public class TestEngine : ITestEngine
         // can be smaller than the number of sources to run.
         var maxTesthostCount = isParallelRun ? testSessionCriteria.Sources.Count : 1;
 
-        return new ProxyTestSessionManager(testSessionCriteria, maxTesthostCount, proxyCreator, testRuntimeProviders)
+        return new ProxyTestSessionManager(testSessionCriteria, maxTesthostCount, proxyCreator, testRuntimeProviders, _testSessionPool)
         {
             // Individual proxy setup failures are tolerated since SetupChannel may fail if the
             // testhost it tries to start is not compatible with the test session feature.

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/TestSession/ProxyTestSessionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/TestSession/ProxyTestSessionManager.cs
@@ -51,6 +51,7 @@ public class ProxyTestSessionManager : IProxyTestSessionManager
     private readonly IDictionary<string, int> _proxyMap;
     private readonly Stopwatch _testSessionStopwatch;
     private readonly Dictionary<string, TestRuntimeProviderInfo> _sourceToRuntimeProviderInfoMap;
+    private readonly TestSessionPool? _testSessionPool;
     private Dictionary<string, string?> _testSessionEnvironmentVariables = new();
 
     internal ProxyDisposalOnCreationFailPolicy DisposalPolicy { get; set; } = ProxyDisposalOnCreationFailPolicy.DisposeAllOnFailure;
@@ -82,11 +83,22 @@ public class ProxyTestSessionManager : IProxyTestSessionManager
         int maxTesthostCount,
         Func<TestRuntimeProviderInfo, ProxyOperationManager?> proxyCreator,
         List<TestRuntimeProviderInfo> runtimeProviders)
+        : this(criteria, maxTesthostCount, proxyCreator, runtimeProviders, testSessionPool: null)
+    {
+    }
+
+    internal ProxyTestSessionManager(
+        StartTestSessionCriteria criteria,
+        int maxTesthostCount,
+        Func<TestRuntimeProviderInfo, ProxyOperationManager?> proxyCreator,
+        List<TestRuntimeProviderInfo> runtimeProviders,
+        TestSessionPool? testSessionPool)
     {
         _testSessionCriteria = criteria;
         _maxTesthostCount = maxTesthostCount;
         _proxyCreator = proxyCreator;
         _runtimeProviders = runtimeProviders;
+        _testSessionPool = testSessionPool;
         _proxyContainerList = new List<ProxyOperationManagerContainer>();
         _proxyMap = new Dictionary<string, int>();
         _testSessionStopwatch = new Stopwatch();
@@ -180,7 +192,7 @@ public class ProxyTestSessionManager : IProxyTestSessionManager
         }
 
         // Make the session available.
-        if (!TestSessionPool.Instance.AddSession(_testSessionInfo, this))
+        if (!(_testSessionPool ?? TestSessionPool.Instance).AddSession(_testSessionInfo, this))
         {
             requestData?.MetricsCollection.Add(
                 TelemetryDataConstants.TestSessionState,

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyTestSessionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyTestSessionManagerTests.cs
@@ -313,6 +313,52 @@ public class ProxyTestSessionManagerTests
     }
 
     [TestMethod]
+    public void StartSessionWritesToTheInjectedTestSessionPoolWhichTheReadSideObservesThroughTheSameInstance()
+    {
+        // Point the static default at a separate pool. If the write side wrongly used the static
+        // instead of the injected instance (i.e. the writer and reader ended up on different
+        // instances), the read side below would observe nothing.
+        var staticPool = new TestSessionPool();
+        TestSessionPool.Instance = staticPool;
+
+        // The single pool instance shared by the write side (StartSession -> AddSession) and the
+        // read side (TryTakeProxy) in this test.
+        var injectedPool = new TestSessionPool();
+
+        var mockProxyOperationManager = new Mock<ProxyOperationManager>(null, null, null, null);
+        mockProxyOperationManager.Setup(pom => pom.SetupChannel(It.IsAny<IEnumerable<string>>(), It.IsAny<string>()))
+            .Returns(true);
+
+        TestSessionInfo? sessionInfo = null;
+        _mockEventsHandler
+            .Setup(eh => eh.HandleStartTestSessionComplete(It.IsAny<StartTestSessionCompleteEventArgs>()))
+            .Callback((StartTestSessionCompleteEventArgs args) => sessionInfo = args.TestSessionInfo);
+
+        var testSessionCriteria = CreateTestSession(_fakeTestSources, _runSettingsNoEnvVars);
+        var proxyManager = CreateProxy(testSessionCriteria, mockProxyOperationManager.Object, injectedPool);
+
+        // Write side: StartSession adds the session (and its proxy) to the injected pool.
+        Assert.IsTrue(proxyManager.StartSession(_mockEventsHandler.Object, _mockRequestData.Object));
+        Assert.IsNotNull(sessionInfo);
+
+        // Read side: taking a proxy from the SAME injected instance observes what the writer added.
+        var proxy = injectedPool.TryTakeProxy(
+            sessionInfo,
+            testSessionCriteria.Sources![0],
+            testSessionCriteria.RunSettings,
+            _mockRequestData.Object);
+        Assert.AreSame(mockProxyOperationManager.Object, proxy);
+
+        // The separate static default never received the session, proving the writer and reader
+        // shared the injected instance rather than silently falling back to the static.
+        Assert.IsNull(staticPool.TryTakeProxy(
+            sessionInfo,
+            testSessionCriteria.Sources[0],
+            testSessionCriteria.RunSettings,
+            _mockRequestData.Object));
+    }
+
+    [TestMethod]
     public void StopSessionShouldSucceedIfCalledOnlyOnce()
     {
         var mockProxyOperationManager = new Mock<ProxyOperationManager>(null, null, null, null);
@@ -578,7 +624,8 @@ public class ProxyTestSessionManagerTests
 
     private ProxyTestSessionManager CreateProxy(
         StartTestSessionCriteria testSessionCriteria,
-        ProxyOperationManager proxyOperationManager)
+        ProxyOperationManager proxyOperationManager,
+        TestSessionPool? testSessionPool = null)
     {
         var runSettings = testSessionCriteria.RunSettings ?? _fakeRunSettings;
         var runtimeProviderInfo = new TestRuntimeProviderInfo
@@ -599,7 +646,8 @@ public class ProxyTestSessionManagerTests
             testSessionCriteria,
             testSessionCriteria.Sources!.Count,
             _ => proxyOperationManager,
-            runtimeProviders
+            runtimeProviders,
+            testSessionPool
             );
     }
 


### PR DESCRIPTION
## Problem

`TestSessionPool` is reached everywhere through the mutable public static `TestSessionPool.Instance`. The sites that coordinate a test session - the writer `ProxyTestSessionManager.AddSession` and the readers `TestEngine.TryTakeProxy`, `ProxyDiscoveryManager.ReturnProxy` and `ProxyExecutionManager.ReturnProxy` - only agree on the same pool because they all resolve the same static. That is process-wide state feeding a request-scoped concern, and it makes the session proxies awkward to exercise in isolation.

## Change

`TestEngine` is the single place that constructs the session-mode proxies, so I thread one `TestSessionPool?` from there into `ProxyTestSessionManager`, `ProxyDiscoveryManager` and `ProxyExecutionManager`. Each stores it in a nullable field and reads `(_testSessionPool ?? TestSessionPool.Instance)` at the call site.

- When nothing is injected the field is `null` and every site reads `TestSessionPool.Instance`, exactly as before - runtime behavior is byte-for-byte identical.
- The new parameters live on internal constructors/overloads only, so there is no change to any shipped public signature and no `PublicAPI` edit. `TestSessionPool.Instance` is untouched and keeps working for the callers that still use it (no `[Obsolete]`).
- `TestRequestManager.KillSession` in `vstest.console` is intentionally left on the static. It is not one of the objects `TestEngine` builds, so wiring it would be a separate seam; in production it resolves the same static instance, so it is already correct.

This follows the same "inject one instance from the composition root, default it to the existing static" shape as the earlier argument-processor changes.

## Verification

Added a `ProxyTestSessionManagerTests` case that injects one pool as the shared instance and puts a *different* pool behind the static default. `StartSession` writes to the injected pool, and a `TryTakeProxy` off that same injected instance observes the proxy the writer added, while the static default never sees the session. If a writer and a reader ever ended up on different instances, that read side would come back empty - so the test guards the same-instance contract the refactor depends on.

Locally on Windows:

- `build.cmd -c Release` - 0 errors, no `IDE0005` (only the pre-existing `CommunicationUtilities` IL trim warnings).
- `Microsoft.TestPlatform.CrossPlatEngine.UnitTests` (`net481`) - 675 total, 674 passed, 1 skipped, 0 failed.
- `build.cmd -pack` - binding-redirect and DLL-target-framework checks pass.
- `test.cmd -smokeTest` - `Library.IntegrationTests` and `Acceptance.IntegrationTests` all green.
