### PR TITLE
Inject ITestRequestManager into vstest.console argument processors

### DIFF
--- a/src/vstest.console/CommandLine/Executor.cs
+++ b/src/vstest.console/CommandLine/Executor.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 
+using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
 using Microsoft.VisualStudio.TestPlatform.CommandLine.Internal;
 using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
 using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
@@ -65,6 +66,9 @@ internal class Executor
     private readonly IRunSettingsProvider _runSettingsProvider;
     private readonly IRunSettingsHelper _runSettingsHelper;
     private readonly CommandLineOptions _commandLineOptions;
+    // Left null in production so the argument processors resolve TestRequestManager.Instance lazily
+    // (only when a run/discovery command actually executes); tests inject a specific instance.
+    private readonly ITestRequestManager? _testRequestManager;
     private bool _showHelp;
 
     /// <summary>
@@ -104,7 +108,7 @@ internal class Executor
     {
     }
 
-    internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment, IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper, CommandLineOptions commandLineOptions)
+    internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment, IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper, CommandLineOptions commandLineOptions, ITestRequestManager? testRequestManager = null)
     {
         DebuggerBreakpoint.AttachVisualStudioDebugger(WellKnownDebugEnvironmentVariables.VSTEST_RUNNER_DEBUG_ATTACHVS);
         DebuggerBreakpoint.WaitForNativeDebugger(WellKnownDebugEnvironmentVariables.VSTEST_RUNNER_NATIVE_DEBUG);
@@ -118,6 +122,7 @@ internal class Executor
         _runSettingsProvider = runSettingsProvider;
         _runSettingsHelper = runSettingsHelper;
         _commandLineOptions = commandLineOptions;
+        _testRequestManager = testRequestManager;
     }
 
     /// <summary>
@@ -239,7 +244,7 @@ internal class Executor
     {
         processors = new List<IArgumentProcessor>();
         int result = 0;
-        var processorFactory = ArgumentProcessorFactory.Create(runSettingsProvider: _runSettingsProvider, runSettingsHelper: _runSettingsHelper, commandLineOptions: _commandLineOptions);
+        var processorFactory = ArgumentProcessorFactory.Create(runSettingsProvider: _runSettingsProvider, runSettingsHelper: _runSettingsHelper, commandLineOptions: _commandLineOptions, testRequestManager: _testRequestManager);
         for (var index = 0; index < args.Length; index++)
         {
             var arg = args[index];

--- a/src/vstest.console/Processors/ListFullyQualifiedTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ListFullyQualifiedTestsArgumentProcessor.cs
@@ -34,11 +34,13 @@ internal class ListFullyQualifiedTestsArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
     private readonly CommandLineOptions _commandLineOptions;
+    private readonly ITestRequestManager? _testRequestManager;
 
-    public ListFullyQualifiedTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider)
+    public ListFullyQualifiedTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider, ITestRequestManager? testRequestManager = null)
     {
         _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
+        _testRequestManager = testRequestManager;
     }
 
     /// <summary>
@@ -57,7 +59,7 @@ internal class ListFullyQualifiedTestsArgumentProcessor : IArgumentProcessor
             new ListFullyQualifiedTestsArgumentExecutor(
                 _commandLineOptions,
                 _runSettingsProvider,
-                TestRequestManager.Instance));
+                _testRequestManager ?? TestRequestManager.Instance));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/ListTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ListTestsArgumentProcessor.cs
@@ -37,11 +37,13 @@ internal class ListTestsArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
     private readonly CommandLineOptions _commandLineOptions;
+    private readonly ITestRequestManager? _testRequestManager;
 
-    public ListTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider)
+    public ListTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider, ITestRequestManager? testRequestManager = null)
     {
         _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
+        _testRequestManager = testRequestManager;
     }
 
     /// <summary>
@@ -60,7 +62,7 @@ internal class ListTestsArgumentProcessor : IArgumentProcessor
             new ListTestsArgumentExecutor(
                 _commandLineOptions,
                 _runSettingsProvider,
-                TestRequestManager.Instance));
+                _testRequestManager ?? TestRequestManager.Instance));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/PortArgumentProcessor.cs
+++ b/src/vstest.console/Processors/PortArgumentProcessor.cs
@@ -32,11 +32,13 @@ internal class PortArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsHelper _runSettingsHelper;
     private readonly CommandLineOptions _commandLineOptions;
+    private readonly ITestRequestManager? _testRequestManager;
 
-    public PortArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsHelper runSettingsHelper)
+    public PortArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsHelper runSettingsHelper, ITestRequestManager? testRequestManager = null)
     {
         _commandLineOptions = commandLineOptions;
         _runSettingsHelper = runSettingsHelper;
+        _testRequestManager = testRequestManager;
     }
 
     /// <summary>
@@ -51,7 +53,7 @@ internal class PortArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new PortArgumentExecutor(_commandLineOptions, TestRequestManager.Instance, _runSettingsHelper));
+            new PortArgumentExecutor(_commandLineOptions, _testRequestManager ?? TestRequestManager.Instance, _runSettingsHelper));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/RunSpecificTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunSpecificTestsArgumentProcessor.cs
@@ -32,11 +32,13 @@ internal class RunSpecificTestsArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
     private readonly CommandLineOptions _commandLineOptions;
+    private readonly ITestRequestManager? _testRequestManager;
 
-    public RunSpecificTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider)
+    public RunSpecificTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider, ITestRequestManager? testRequestManager = null)
     {
         _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
+        _testRequestManager = testRequestManager;
     }
 
     public Lazy<IArgumentProcessorCapabilities> Metadata
@@ -49,7 +51,7 @@ internal class RunSpecificTestsArgumentProcessor : IArgumentProcessor
             new RunSpecificTestsArgumentExecutor(
                 _commandLineOptions,
                 _runSettingsProvider,
-                TestRequestManager.Instance,
+                _testRequestManager ?? TestRequestManager.Instance,
                 new ArtifactProcessingManager(_commandLineOptions.TestSessionCorrelationId),
                 ConsoleOutput.Instance));
 

--- a/src/vstest.console/Processors/RunTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunTestsArgumentProcessor.cs
@@ -28,11 +28,13 @@ internal class RunTestsArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
     private readonly CommandLineOptions _commandLineOptions;
+    private readonly ITestRequestManager? _testRequestManager;
 
-    public RunTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider)
+    public RunTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider, ITestRequestManager? testRequestManager = null)
     {
         _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
+        _testRequestManager = testRequestManager;
     }
 
     public Lazy<IArgumentProcessorCapabilities> Metadata
@@ -45,7 +47,7 @@ internal class RunTestsArgumentProcessor : IArgumentProcessor
             new RunTestsArgumentExecutor(
                 _commandLineOptions,
                 _runSettingsProvider,
-                TestRequestManager.Instance,
+                _testRequestManager ?? TestRequestManager.Instance,
                 new ArtifactProcessingManager(_commandLineOptions.TestSessionCorrelationId),
                 ConsoleOutput.Instance));
 

--- a/src/vstest.console/Processors/UseVsixExtensionsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/UseVsixExtensionsArgumentProcessor.cs
@@ -27,10 +27,12 @@ internal class UseVsixExtensionsArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly CommandLineOptions _commandLineOptions;
+    private readonly ITestRequestManager? _testRequestManager;
 
-    public UseVsixExtensionsArgumentProcessor(CommandLineOptions commandLineOptions)
+    public UseVsixExtensionsArgumentProcessor(CommandLineOptions commandLineOptions, ITestRequestManager? testRequestManager = null)
     {
         _commandLineOptions = commandLineOptions;
+        _testRequestManager = testRequestManager;
     }
 
     /// <summary>
@@ -46,7 +48,7 @@ internal class UseVsixExtensionsArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new UseVsixExtensionsArgumentExecutor(_commandLineOptions, TestRequestManager.Instance, new VSExtensionManager(), ConsoleOutput.Instance));
+            new UseVsixExtensionsArgumentExecutor(_commandLineOptions, _testRequestManager ?? TestRequestManager.Instance, new VSExtensionManager(), ConsoleOutput.Instance));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
+++ b/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Linq;
 
+using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
 using Microsoft.VisualStudio.TestPlatform.Common;
 using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -63,13 +64,19 @@ internal class ArgumentProcessorFactory
     /// Defaults to the ambient <see cref="CommandLineOptions.Instance"/> when not provided, so that
     /// callers (and the composition root) can inject an isolated instance instead of sharing static state.
     /// </param>
+    /// <param name="testRequestManager">
+    /// The test request manager that the run/discovery argument processors hand to their executors.
+    /// When not provided the processors fall back to the ambient <see cref="Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers.TestRequestManager.Instance"/>
+    /// lazily, at the point the executor is built, so that commands that never touch it (for example
+    /// <c>--Help</c>) do not force its (relatively heavy) construction.
+    /// </param>
     /// <returns>ArgumentProcessorFactory.</returns>
-    internal static ArgumentProcessorFactory Create(IFeatureFlag? featureFlag = null, IRunSettingsProvider? runSettingsProvider = null, IRunSettingsHelper? runSettingsHelper = null, CommandLineOptions? commandLineOptions = null)
+    internal static ArgumentProcessorFactory Create(IFeatureFlag? featureFlag = null, IRunSettingsProvider? runSettingsProvider = null, IRunSettingsHelper? runSettingsHelper = null, CommandLineOptions? commandLineOptions = null, ITestRequestManager? testRequestManager = null)
     {
         runSettingsProvider ??= RunSettingsManager.Instance;
         runSettingsHelper ??= RunSettingsHelper.Instance;
         commandLineOptions ??= CommandLineOptions.Instance;
-        var defaultArgumentProcessor = GetDefaultArgumentProcessors(runSettingsProvider, runSettingsHelper, commandLineOptions);
+        var defaultArgumentProcessor = GetDefaultArgumentProcessors(runSettingsProvider, runSettingsHelper, commandLineOptions, testRequestManager);
 
         if (!(featureFlag ?? FeatureFlag.Instance).IsSet(FeatureFlag.VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING))
         {
@@ -203,17 +210,17 @@ internal class ArgumentProcessorFactory
             .Where(lazyProcessor => lazyProcessor.Metadata.Value.IsSpecialCommand && lazyProcessor.Metadata.Value.AlwaysExecute);
     }
 
-    private static IList<IArgumentProcessor> GetDefaultArgumentProcessors(IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper, CommandLineOptions commandLineOptions) => new List<IArgumentProcessor> {
+    private static IList<IArgumentProcessor> GetDefaultArgumentProcessors(IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper, CommandLineOptions commandLineOptions, ITestRequestManager? testRequestManager) => new List<IArgumentProcessor> {
         new HelpArgumentProcessor(),
         new TestSourceArgumentProcessor(commandLineOptions),
-        new ListTestsArgumentProcessor(commandLineOptions, runSettingsProvider),
-        new RunTestsArgumentProcessor(commandLineOptions, runSettingsProvider),
-        new RunSpecificTestsArgumentProcessor(commandLineOptions, runSettingsProvider),
+        new ListTestsArgumentProcessor(commandLineOptions, runSettingsProvider, testRequestManager),
+        new RunTestsArgumentProcessor(commandLineOptions, runSettingsProvider, testRequestManager),
+        new RunSpecificTestsArgumentProcessor(commandLineOptions, runSettingsProvider, testRequestManager),
         new TestAdapterPathArgumentProcessor(commandLineOptions, runSettingsProvider),
         new TestAdapterLoadingStrategyArgumentProcessor(commandLineOptions, runSettingsProvider),
         new TestCaseFilterArgumentProcessor(commandLineOptions),
         new ParentProcessIdArgumentProcessor(commandLineOptions),
-        new PortArgumentProcessor(commandLineOptions, runSettingsHelper),
+        new PortArgumentProcessor(commandLineOptions, runSettingsHelper, testRequestManager),
         new RunSettingsArgumentProcessor(commandLineOptions, runSettingsProvider, runSettingsHelper),
         new PlatformArgumentProcessor(commandLineOptions, runSettingsProvider, runSettingsHelper),
         new FrameworkArgumentProcessor(commandLineOptions, runSettingsProvider),
@@ -229,12 +236,12 @@ internal class ArgumentProcessorFactory
         new ResponseFileArgumentProcessor(),
         new EnableBlameArgumentProcessor(runSettingsProvider),
         new AeDebuggerArgumentProcessor(),
-        new UseVsixExtensionsArgumentProcessor(commandLineOptions),
+        new UseVsixExtensionsArgumentProcessor(commandLineOptions, testRequestManager),
         new ListDiscoverersArgumentProcessor(),
         new ListExecutorsArgumentProcessor(),
         new ListLoggersArgumentProcessor(),
         new ListSettingsProvidersArgumentProcessor(),
-        new ListFullyQualifiedTestsArgumentProcessor(commandLineOptions, runSettingsProvider),
+        new ListFullyQualifiedTestsArgumentProcessor(commandLineOptions, runSettingsProvider, testRequestManager),
         new ListTestsTargetPathArgumentProcessor(commandLineOptions),
         new ShowDeprecateDotnetVStestMessageArgumentProcessor(),
         new EnvironmentArgumentProcessor(commandLineOptions, runSettingsProvider)

--- a/test/vstest.console.UnitTests/Processors/Utilities/ArgumentProcessorFactoryTests.cs
+++ b/test/vstest.console.UnitTests/Processors/Utilities/ArgumentProcessorFactoryTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
 using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
 using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
@@ -170,27 +171,39 @@ public class ArgumentProcessorFactoryTests
         foreach (var processor in allProcessors)
         {
             // Processors declare different constructor shapes: most now take a CommandLineOptions first,
-            // optionally followed by an IRunSettingsProvider and/or IRunSettingsHelper; a few legacy ones take
-            // only a run settings dependency, and the rest are parameterless. Pick the matching one.
+            // optionally followed by an IRunSettingsProvider and/or IRunSettingsHelper, and the run/discovery
+            // ones also take an ITestRequestManager; a few legacy ones take only a run settings dependency, and
+            // the rest are parameterless. Try the known shapes from most to least specific.
             var commandLineOptions = CommandLineOptions.Instance;
             var runSettingsProvider = new TestableRunSettingsProvider();
             var runSettingsHelper = new RunSettingsHelper();
+            var testRequestManager = new Mock<ITestRequestManager>().Object;
 
-            var instance = (processor.GetConstructor([typeof(CommandLineOptions), typeof(IRunSettingsProvider), typeof(IRunSettingsHelper)]) is { } optionsProviderHelperCtor
-                ? optionsProviderHelperCtor.Invoke([commandLineOptions, runSettingsProvider, runSettingsHelper])
-                : processor.GetConstructor([typeof(CommandLineOptions), typeof(IRunSettingsProvider)]) is { } optionsProviderCtor
-                    ? optionsProviderCtor.Invoke([commandLineOptions, runSettingsProvider])
-                    : processor.GetConstructor([typeof(CommandLineOptions), typeof(IRunSettingsHelper)]) is { } optionsHelperCtor
-                        ? optionsHelperCtor.Invoke([commandLineOptions, runSettingsHelper])
-                        : processor.GetConstructor([typeof(CommandLineOptions)]) is { } optionsCtor
-                            ? optionsCtor.Invoke([commandLineOptions])
-                            : processor.GetConstructor([typeof(IRunSettingsProvider), typeof(IRunSettingsHelper)]) is { } providerAndHelperCtor
-                                ? providerAndHelperCtor.Invoke([runSettingsProvider, runSettingsHelper])
-                                : processor.GetConstructor([typeof(IRunSettingsProvider)]) is { } providerCtor
-                                    ? providerCtor.Invoke([runSettingsProvider])
-                                    : processor.GetConstructor([typeof(IRunSettingsHelper)]) is { } helperCtor
-                                        ? helperCtor.Invoke([runSettingsHelper])
-                                        : Activator.CreateInstance(processor)) as IArgumentProcessor;
+            (Type[] ParameterTypes, object[] Arguments)[] candidateConstructors =
+            [
+                ([typeof(CommandLineOptions), typeof(IRunSettingsProvider), typeof(ITestRequestManager)], [commandLineOptions, runSettingsProvider, testRequestManager]),
+                ([typeof(CommandLineOptions), typeof(IRunSettingsHelper), typeof(ITestRequestManager)], [commandLineOptions, runSettingsHelper, testRequestManager]),
+                ([typeof(CommandLineOptions), typeof(ITestRequestManager)], [commandLineOptions, testRequestManager]),
+                ([typeof(CommandLineOptions), typeof(IRunSettingsProvider), typeof(IRunSettingsHelper)], [commandLineOptions, runSettingsProvider, runSettingsHelper]),
+                ([typeof(CommandLineOptions), typeof(IRunSettingsProvider)], [commandLineOptions, runSettingsProvider]),
+                ([typeof(CommandLineOptions), typeof(IRunSettingsHelper)], [commandLineOptions, runSettingsHelper]),
+                ([typeof(CommandLineOptions)], [commandLineOptions]),
+                ([typeof(IRunSettingsProvider), typeof(IRunSettingsHelper)], [runSettingsProvider, runSettingsHelper]),
+                ([typeof(IRunSettingsProvider)], [runSettingsProvider]),
+                ([typeof(IRunSettingsHelper)], [runSettingsHelper]),
+            ];
+
+            object? created = null;
+            foreach (var (parameterTypes, arguments) in candidateConstructors)
+            {
+                if (processor.GetConstructor(parameterTypes) is { } constructor)
+                {
+                    created = constructor.Invoke(arguments);
+                    break;
+                }
+            }
+
+            var instance = (created ?? Activator.CreateInstance(processor)) as IArgumentProcessor;
             Assert.IsNotNull(instance, $"Unable to instantiate processor: {processor}");
 
             var specialProcessor = instance.Metadata.Value.IsSpecialCommand;


### PR DESCRIPTION
This continues #16200 (`IRunSettingsProvider`), #16205 (`IRunSettingsHelper`), and #16208 (`CommandLineOptions`) of getting the vstest.console argument processors off process-wide mutable statics.

The run and discovery argument processors reach for `TestRequestManager.Instance` when they build their executors, so the request orchestrator is shared static state that is reused across requests in design mode. This threads `ITestRequestManager` through the composition root the same way as the previous three, defaulting to `TestRequestManager.Instance` so behavior is unchanged.

`TestRequestManager.Instance` is heavier than the earlier statics: its parameterless constructor builds a `TestPlatform`, a metrics publisher, and reads the design-mode flag. Today it is resolved lazily, inside each processor's `Lazy<IArgumentExecutor>`, so it is only constructed when a run or discovery command actually executes — not for commands like `--Help`. To keep that timing byte-for-byte identical the injected instance is nullable and the processors fall back to `TestRequestManager.Instance` inside the lambda; the factory passes the parameter straight through without forcing it, so production still constructs nothing up front.

- `ArgumentProcessorFactory.Create(...)` takes an optional `ITestRequestManager` and hands it to the six processors that build a request-manager-backed executor (`ListTests`, `RunTests`, `RunSpecificTests`, `Port`, `UseVsixExtensions`, and `ListFullyQualifiedTests`); `Executor` owns it and leaves it null in production so the lazy `.Instance` fallback keeps running.
- Each of those processors holds an injected `ITestRequestManager?` field and uses `_testRequestManager ?? TestRequestManager.Instance` when it constructs its executor.
- `ArgumentProcessorFactoryTests` builds each processor by reflection; its constructor-shape probe now covers the request-manager-bearing shapes.

`TestRequestManager.Instance` is not obsoleted; the remaining references are the composition-root default and the lazy fallback.

### Verification
- `vstest.console.UnitTests` on `net481`: 636 passed, 0 failed, 2 skipped (638 total).
- Debug and Release builds clean, no `IDE0005`.
- `build.cmd -pack` green.
