### PR TITLE
Exclude NuGet audit warnings from compatibility test assets

### DIFF
--- a/test/TestAssets/Directory.Build.props
+++ b/test/TestAssets/Directory.Build.props
@@ -19,6 +19,12 @@
 
     <!-- Use Environment.ProcessId instead of Process.GetCurrentProcess().Id, api is not available on all targetted frameworks. -->
     CA1837;
+
+    <!-- These test assets (in particular the generated compatibility matrix) intentionally reference old, pinned
+    versions of Microsoft.NET.Test.Sdk and MSTest that transitively pull vulnerable Newtonsoft.Json versions.
+    Upgrading them defeats the purpose of the compatibility tests, so exclude NuGet audit warnings (NU1901-NU1904)
+    from failing the build. -->
+    NU1901;NU1902;NU1903;NU1904;
     </NoWarn>
   </PropertyGroup>
 

--- a/test/TestAssets/Directory.Build.props
+++ b/test/TestAssets/Directory.Build.props
@@ -17,7 +17,7 @@
     <!-- Suppress warning about using a preview of NETSDK -->
     NETSDK1057;
 
-    <!-- Use Environment.ProcessId instead of Process.GetCurrentProcess().Id, api is not available on all targetted frameworks. -->
+    <!-- Use Environment.ProcessId instead of Process.GetCurrentProcess().Id, API is not available on all targeted frameworks. -->
     CA1837;
 
     <!-- These test assets (in particular the generated compatibility matrix) intentionally reference old, pinned


### PR DESCRIPTION
Main restore is failing with ~12k `NU1903` errors. A newly published advisory ([GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr)) made NuGetAudit flag `Newtonsoft.Json` 9.0.1/10.0.3 (and a couple of other old transitives like `System.Net.Http` 4.3.0) that the generated compatibility matrix pulls in through the old `Microsoft.NET.Test.Sdk`/MSTest versions it pins on purpose. With `TreatWarningsAsErrors` that turns into a restore failure.

Those versions are old by design — that's the whole point of the compat tests — so `NoWarn` the audit range `NU1901`–`NU1904` in `test/TestAssets/Directory.Build.props` (which is inherited by the generated matrix via the copied props).

Verified locally: restoring an old `Microsoft.NET.Test.Sdk` 15.9.2 project reproduces `NU1903` and passes with the `NoWarn` in place.

Not a network/isolation problem — 1ES network isolation was compliant and there were no auth/feed-unreachable errors in the logs.