### PR TITLE
[code-simplifier] Introduce SessionPool property to eliminate repeated null-coalescing pattern

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs
@@ -41,6 +41,8 @@ public class ProxyDiscoveryManager : IProxyDiscoveryManager, IBaseProxy, ITestDi
     private bool _skipDefaultAdapters;
     private string? _previousSource;
 
+    private TestSessionPool SessionPool => _testSessionPool ?? TestSessionPool.Instance;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ProxyDiscoveryManager"/> class.
     /// </summary>
@@ -292,7 +294,7 @@ public class ProxyDiscoveryManager : IProxyDiscoveryManager, IBaseProxy, ITestDi
             return;
         }
 
-        (_testSessionPool ?? TestSessionPool.Instance).ReturnProxy(_testSessionInfo, _proxyOperationManager.Id);
+        SessionPool.ReturnProxy(_testSessionInfo, _proxyOperationManager.Id);
     }
 
     /// <inheritdoc/>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs
@@ -49,6 +49,8 @@ internal class ProxyExecutionManager : IProxyExecutionManager, IBaseProxy, IInte
     /// <inheritdoc/>
     public bool IsInitialized { get; private set; }
 
+    private TestSessionPool SessionPool => _testSessionPool ?? TestSessionPool.Instance;
+
     /// <summary>
     /// Gets or sets the cancellation token source.
     /// </summary>
@@ -398,7 +400,7 @@ internal class ProxyExecutionManager : IProxyExecutionManager, IBaseProxy, IInte
             return;
         }
 
-        (_testSessionPool ?? TestSessionPool.Instance).ReturnProxy(_testSessionInfo, _proxyOperationManager.Id);
+        SessionPool.ReturnProxy(_testSessionInfo, _proxyOperationManager.Id);
     }
 
     /// <inheritdoc/>

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
@@ -40,6 +40,8 @@ public class TestEngine : ITestEngine
 
     private ITestExtensionManager? _testExtensionManager;
 
+    private TestSessionPool SessionPool => _testSessionPool ?? TestSessionPool.Instance;
+
     public TestEngine()
         : this(TestRuntimeProviderManager.Instance, new ProcessHelper())
     {
@@ -153,7 +155,7 @@ public class TestEngine : ITestEngine
 
                     // In case we have an active test session, we always prefer the already
                     // created proxies instead of the ones that need to be created on the spot.
-                    var proxyOperationManager = (_testSessionPool ?? TestSessionPool.Instance).TryTakeProxy(
+                    var proxyOperationManager = SessionPool.TryTakeProxy(
                         discoveryCriteria.TestSessionInfo,
                         source,
                         runtimeProviderInfo.RunSettings,
@@ -317,7 +319,7 @@ public class TestEngine : ITestEngine
                     string source,
                     ProxyExecutionManager proxyExecutionManager) =>
                 {
-                    var proxyOperationManager = (_testSessionPool ?? TestSessionPool.Instance).TryTakeProxy(
+                    var proxyOperationManager = SessionPool.TryTakeProxy(
                         testRunCriteria.TestSessionInfo,
                         source,
                         runtimeProviderInfo.RunSettings,

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/TestSession/ProxyTestSessionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/TestSession/ProxyTestSessionManager.cs
@@ -56,6 +56,8 @@ public class ProxyTestSessionManager : IProxyTestSessionManager
 
     internal ProxyDisposalOnCreationFailPolicy DisposalPolicy { get; set; } = ProxyDisposalOnCreationFailPolicy.DisposeAllOnFailure;
 
+    private TestSessionPool SessionPool => _testSessionPool ?? TestSessionPool.Instance;
+
     private IDictionary<string, string?> TestSessionEnvironmentVariables
     {
         get
@@ -192,7 +194,7 @@ public class ProxyTestSessionManager : IProxyTestSessionManager
         }
 
         // Make the session available.
-        if (!(_testSessionPool ?? TestSessionPool.Instance).AddSession(_testSessionInfo, this))
+        if (!SessionPool.AddSession(_testSessionInfo, this))
         {
             requestData?.MetricsCollection.Add(
                 TelemetryDataConstants.TestSessionState,


### PR DESCRIPTION
## Code Simplification — 2026-07-07

This PR eliminates a repeated null-coalescing expression introduced by [#16225](https://github.com/microsoft/vstest/pull/16225) across the CrossPlatEngine session proxy classes.

### Files Simplified

- `src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyDiscoveryManager.cs`
- `src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyExecutionManager.cs`
- `src/Microsoft.TestPlatform.CrossPlatEngine/TestSession/ProxyTestSessionManager.cs`
- `src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs`

### Improvement

PR #16225 injected `TestSessionPool?` into each class and used the pattern `(_testSessionPool ?? TestSessionPool.Instance)` at every call site. The pattern appeared **5 times** across 4 files.

Each class now exposes a private expression-bodied property that encapsulates the fallback logic once:

```csharp
private TestSessionPool SessionPool => _testSessionPool ?? TestSessionPool.Instance;
```

Call sites become:

```csharp
// before
(_testSessionPool ?? TestSessionPool.Instance).ReturnProxy(_testSessionInfo, _proxyOperationManager.Id);

// after
SessionPool.ReturnProxy(_testSessionInfo, _proxyOperationManager.Id);
```

### Changes Based On

- #16225 — _Inject TestSessionPool into the CrossPlatEngine session proxies_

### Testing

- ✅ All 657 CrossPlatEngine unit tests pass
- ✅ Build succeeds (Debug configuration)
- ✅ No functional changes — behavior is identical

### Review Focus

Please verify:
- The `SessionPool` property faithfully reproduces the `_testSessionPool ?? TestSessionPool.Instance` fallback
- No call sites were missed or altered unintentionally


<!-- gh-aw-tracker-id: code-simplifier -->




> Generated by [Code Simplifier](https://github.com/microsoft/vstest/actions/runs/28879229478) · 158.7 AIC · ⌖ 12.4 AIC · ⊞ 8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
> - [x] expires <!-- gh-aw-expires: 2026-07-08T15:56:15.961Z --> on Jul 8, 2026, 3:56 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.65, model: claude-sonnet-4.6, id: 28879229478, workflow_id: code-simplifier, run: https://github.com/microsoft/vstest/actions/runs/28879229478 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->
<!-- gh-aw-workflow-call-id: microsoft/vstest/code-simplifier -->