### PR TITLE
Forward per-test-case events to the datacollector for MTP runs

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpDataCollectionForwarder.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpDataCollectionForwarder.cs
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
+using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Helpers;
+using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection;
+using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.EventHandlers;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.MTP;
+
+/// <summary>
+/// Forwards per-test-case "started"/"ended" notifications from a Microsoft.Testing.Platform (MTP)
+/// application to the out-of-process datacollector, over the same socket sub-channel that testhost
+/// uses in the classic run path.
+///
+/// <para>
+/// In the classic path testhost owns this connection: the datacollector opens a socket, testhost
+/// dials in via <see cref="DataCollectionTestCaseEventSender"/> and pushes
+/// <c>TestCaseStart</c>/<c>TestCaseEnd</c> events so collectors such as Blame can track which test is
+/// currently running. Under MTP there is no testhost — vstest.console drives the MTP application
+/// directly and is the only party that observes per-test-case state — so nobody connects to that
+/// socket and the datacollector blocks for its full connection timeout (~90s) before giving up, and
+/// collectors never learn which test crashed.
+/// </para>
+///
+/// <para>
+/// This class closes that gap. It reuses the very same <see cref="DataCollectionTestCaseEventSender"/>,
+/// <see cref="ProxyOutOfProcDataCollectionManager"/> and <see cref="TestCaseEventsHandler"/> publisher
+/// that testhost uses, but is driven by MTP node updates instead of the adapter: as the run progresses
+/// it raises test-case start/end, test-result and session-end notifications through the publisher, which
+/// the out-of-proc manager relays to the datacollector.
+/// </para>
+/// </summary>
+internal sealed class MtpDataCollectionForwarder : IDisposable
+{
+    private readonly DataCollectionTestCaseEventSender _sender;
+    private readonly object _syncObject = new();
+    private readonly HashSet<Guid> _startedTests = new();
+
+    // The classic publisher used by testhost. ProxyOutOfProcDataCollectionManager subscribes to it in
+    // its constructor and forwards the events to the datacollector through _sender; we raise them by
+    // calling the publisher's Send* methods as MTP node updates arrive.
+    private readonly TestCaseEventsHandler _publisher;
+    private readonly ProxyOutOfProcDataCollectionManager _outOfProcManager;
+
+    private bool _connected;
+    private bool _disposed;
+
+    public MtpDataCollectionForwarder()
+    {
+        _sender = DataCollectionTestCaseEventSender.Create();
+        _publisher = new TestCaseEventsHandler();
+        _outOfProcManager = new ProxyOutOfProcDataCollectionManager(_sender, _publisher);
+    }
+
+    /// <summary>
+    /// Connects to the datacollector's test-case event socket on the given port. Returns
+    /// <see langword="true"/> on success. On failure the run continues without event forwarding
+    /// (data collectors that need per-test-case events, e.g. Blame, will not function, but the run
+    /// itself is not aborted).
+    /// </summary>
+    public bool Connect(int port)
+    {
+        try
+        {
+            _sender.InitializeCommunication(port);
+            var timeout = EnvironmentHelper.GetConnectionTimeout();
+            _connected = _sender.WaitForRequestSenderConnection(timeout * 1000);
+            if (!_connected)
+            {
+                EqtTrace.Error("MtpDataCollectionForwarder.Connect: timed out connecting to the datacollector on port {0}.", port);
+            }
+        }
+        catch (Exception ex)
+        {
+            EqtTrace.Error("MtpDataCollectionForwarder.Connect: failed to connect to the datacollector on port {0}: {1}", port, ex);
+            _connected = false;
+        }
+
+        return _connected;
+    }
+
+    /// <summary>
+    /// Notifies the datacollector that a test case has started. Idempotent per test id.
+    /// </summary>
+    public void NotifyTestCaseStart(TestCase testCase)
+    {
+        if (!_connected)
+        {
+            return;
+        }
+
+        lock (_syncObject)
+        {
+            if (!_startedTests.Add(testCase.Id))
+            {
+                return;
+            }
+        }
+
+        SafeInvoke(() => _publisher.SendTestCaseStart(testCase));
+    }
+
+    /// <summary>
+    /// Notifies the datacollector that a test case has ended. Ensures a matching start was sent first,
+    /// so collectors that key end events off a prior start (e.g. Blame) never see an orphan end.
+    /// </summary>
+    public void NotifyTestCaseEnd(TestResult result)
+    {
+        if (!_connected)
+        {
+            return;
+        }
+
+        NotifyTestCaseStart(result.TestCase);
+        SafeInvoke(() => _publisher.SendTestCaseEnd(result.TestCase, result.Outcome));
+
+        // Give the out-of-proc manager the result so any attachments produced by TestCaseEnd are
+        // merged into it, matching the classic path.
+        SafeInvoke(() => _publisher.SendTestResult(result));
+    }
+
+    /// <summary>
+    /// Notifies the datacollector that the session has ended, releasing its wait on the test-case
+    /// event channel so it can finalize without hitting the connection timeout.
+    /// </summary>
+    public void NotifySessionEnd()
+    {
+        if (!_connected)
+        {
+            return;
+        }
+
+        SafeInvoke(() => _publisher.SendSessionEnd());
+    }
+
+    private void SafeInvoke(Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception ex)
+        {
+            // A failure on the datacollector sub-channel must not take the whole run down. Stop
+            // forwarding and let the run finish; the datacollector's own timeout is the backstop.
+            EqtTrace.Error("MtpDataCollectionForwarder: error forwarding a test-case event, disabling forwarding: {0}", ex);
+            _connected = false;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        try
+        {
+            _sender.Close();
+        }
+        catch (Exception ex)
+        {
+            EqtTrace.Warning("MtpDataCollectionForwarder.Dispose: error closing the sender: {0}", ex);
+        }
+    }
+}

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpProxyExecutionManager.cs
@@ -37,6 +37,13 @@ internal sealed class MtpProxyExecutionManager : IProxyExecutionManager, IDispos
 
     private readonly DataCollectionRunEventsHandler? _dataCollectionEventsHandler;
 
+    /// <summary>
+    /// Forwards per-test-case started/ended notifications (observed from the MTP application) to the
+    /// out-of-process datacollector. Created only when a data collector asks for test-case-level
+    /// events (e.g. Blame); left null for code coverage or when data collection is off.
+    /// </summary>
+    private MtpDataCollectionForwarder? _testCaseEventForwarder;
+
     private bool _isInitialized;
 
     public MtpProxyExecutionManager()
@@ -154,6 +161,24 @@ internal sealed class MtpProxyExecutionManager : IProxyExecutionManager, IDispos
             }
         }
 
+        // If a data collector needs per-test-case events (e.g. Blame tracks the currently running
+        // test to attribute crashes), it opens a socket and returns its port. In the classic path
+        // testhost connects to it; under MTP there is no testhost, so we connect from here and
+        // forward the started/ended notifications we observe from the MTP application. A port of 0
+        // means no collector needs these events (e.g. code coverage) and we do nothing.
+        if (parameters?.DataCollectionEventsPort > 0)
+        {
+            _testCaseEventForwarder = new MtpDataCollectionForwarder();
+            if (!_testCaseEventForwarder.Connect(parameters.DataCollectionEventsPort))
+            {
+                eventHandler.HandleLogMessage(
+                    ObjectModel.Logging.TestMessageLevel.Warning,
+                    "Could not connect to the data collector for per-test-case events; collectors that rely on them (such as Blame) may not function for this Microsoft.Testing.Platform run.");
+                _testCaseEventForwarder.Dispose();
+                _testCaseEventForwarder = null;
+            }
+        }
+
         // Surface any messages the data collector produced while starting up.
         foreach (Tuple<ObjectModel.Logging.TestMessageLevel, string?> message in _dataCollectionEventsHandler!.Messages)
         {
@@ -173,6 +198,10 @@ internal sealed class MtpProxyExecutionManager : IProxyExecutionManager, IDispos
         {
             return;
         }
+
+        // Signal end-of-stream on the test-case event channel so the datacollector's wait on it
+        // completes promptly instead of blocking until the connection timeout (~90s).
+        _testCaseEventForwarder?.NotifySessionEnd();
 
         DataCollectionResult result = _dataCollectionManager.AfterTestRunEnd(
             _cancellationTokenSource.IsCancellationRequested,
@@ -200,6 +229,15 @@ internal sealed class MtpProxyExecutionManager : IProxyExecutionManager, IDispos
 
     public void Dispose()
     {
+        try
+        {
+            _testCaseEventForwarder?.Dispose();
+        }
+        catch
+        {
+            // ignore
+        }
+
         try
         {
             _dataCollectionManager?.Dispose();
@@ -247,12 +285,30 @@ internal sealed class MtpProxyExecutionManager : IProxyExecutionManager, IDispos
                     continue;
                 }
 
-                if (!MtpTestNodeConverter.IsTerminalState(MtpTestNodeConverter.GetExecutionState(node)))
+                string? state = MtpTestNodeConverter.GetExecutionState(node);
+
+                if (EqtTrace.IsVerboseEnabled)
+                {
+                    EqtTrace.Verbose("MtpProxyExecutionManager: node update uid={0} state={1}", MtpJson.GetString(node, MtpConstants.Uid), state ?? "(none)");
+                }
+
+                // A test entering the in-progress state is our "test started" signal. Forwarding it
+                // lets per-test-case collectors (e.g. Blame) know which test is in flight, which is
+                // what makes crash attribution work when the test never reaches a terminal state.
+                if (_testCaseEventForwarder is { } forwarder && state == MtpConstants.StateInProgress)
+                {
+                    forwarder.NotifyTestCaseStart(MtpTestNodeConverter.ToTestCase(node, source));
+                    continue;
+                }
+
+                if (!MtpTestNodeConverter.IsTerminalState(state))
                 {
                     continue;
                 }
 
-                results.Add(MtpTestNodeConverter.ToTestResult(node, source));
+                TestResult result = MtpTestNodeConverter.ToTestResult(node, source);
+                _testCaseEventForwarder?.NotifyTestCaseEnd(result);
+                results.Add(result);
             }
 
             if (results.Count == 0)

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/MtpUnderVstestTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/MtpUnderVstestTests.cs
@@ -96,4 +96,30 @@ public class MtpUnderVstestTests : AcceptanceTestBase
         var trxPath = Path.Combine(TempDirectory.Path, trxFileName);
         Assert.IsTrue(File.Exists(trxPath), "Expected a single TRX to be written for the mixed run at '{0}'.", trxPath);
     }
+
+    [TestMethod]
+    // Blame runs the datacollector out of process; in the classic path testhost dials into it and reports
+    // which test is currently running so collectors can track it. An MTP app has no testhost, so
+    // vstest.console forwards those per-test-case started/ended notifications itself (see
+    // MtpDataCollectionForwarder). Before that forwarding existed the datacollector waited on an event
+    // channel nobody connected to and blocked until its connection timeout. This guards that enabling
+    // /Blame on an MTP app connects the datacollector and completes the run with the expected results.
+    [TestMatrix(testHost: Target.Net)]
+    public void RunMtpApplicationWithBlameCompletesRun(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var arguments = PrepareArguments(
+            GetAssetFullPath(MtpApp),
+            testAdapterPath: null,
+            runSettings: string.Empty,
+            FrameworkArgValue,
+            runnerInfo.InIsolationValue,
+            resultsDirectory: TempDirectory.Path);
+        arguments = string.Concat(arguments, " /Blame");
+
+        InvokeVsTest(arguments);
+
+        ValidateSummaryStatus(2, 1, 1);
+    }
 }


### PR DESCRIPTION
MTP applications running under vstest.console (#16201) had a broken Blame experience: every blame run hung for about 90s, and when the app crashed the crash was never attributed to the test that caused it.

The reason is the datacollector's per-test-case event channel. In the classic path testhost dials into it and reports which test is starting and ending, so collectors like Blame can track the in-flight test. An MTP app has no testhost, vstest.console drives it directly, so nobody connected to that socket. The datacollector waited for its full connection timeout (about 90s) on every run and never received a single test-case event.

vstest.console already sees every test-case start and end in the MTP node updates, it just kept them to itself. This connects to the datacollector from the console and forwards those started/ended notifications, reusing the same classic pieces (`DataCollectionTestCaseEventSender`, `ProxyOutOfProcDataCollectionManager`, `TestCaseEventsHandler`) driven by MTP node updates instead of testhost's adapter.

## What I tested

Preview vstest from aka.ms/vstest/preview (has #16201, without this fix, includes the Blame collector) as the "before", the same layout with this build's `CrossPlatEngine.dll` overlaid as the "after". The same MSTest 4.x apps built two ways, run with `/Blame`:

| scenario | before | after | culprit named |
| --- | --- | --- | --- |
| clean MTP, blame | 91.7s | 2.3s | n/a (no crash) |
| MTP test crashes after running a few seconds | 91.8s, no sequence | 5.7s | yes, names the crashing test |
| MTP test self-kills instantly | 91.6s, no sequence | 2.7s, no sequence | no (see below) |
| classic vstest, blame (regression check) | 2.5s | 2.5s | unchanged |
| classic crash, blame (regression check) | names test | names test | unchanged |

## What works

- The ~90s hang is gone. Blame under MTP finishes in about the same time as classic.
- Per-test-case start/end reach the datacollector for every test that completes.
- Crash attribution works when the test runs long enough for MTP to emit and flush its `in-progress` node update before dying. The Sequence file correctly marks the crashing test `Completed="False"`.
- Classic runs are unchanged.

## What does not work yet

- A test that hard-kills the process the instant it starts (`Environment.FailFast` or `Process.Kill` with no work before it) is not attributed. MTP sends the `in-progress` update asynchronously, and an instant self-kill wins the race before that update is flushed to the console, so the console has nothing to forward. Classic testhost sends the start synchronously before invoking the test, so it does not have this gap. Closing it fully needs MTP/MSTest to emit and flush `in-progress` before running each test, which is a runner-side change out of scope here.

## Test

Added an acceptance test that runs an MTP app with `/Blame` and asserts the run completes with the expected results. I did not add a crash-attribution acceptance test on purpose: the deterministic crash asset in the repo uses `Environment.FailFast` (instant), which hits the race above, and a "sleep then crash" test would rely on timing, which the acceptance test guidelines forbid.
