### PR TITLE
Fix playground running 0 tests

### DIFF
--- a/playground/TestPlatform.Playground/TestPlatform.Playground.csproj
+++ b/playground/TestPlatform.Playground/TestPlatform.Playground.csproj
@@ -65,7 +65,13 @@
     <ItemGroup>
       <!-- .NET Framework console -->
       <FileToCopy Include="$(SourcePath)bin\vstest.console\$(Configuration)\$(NetFrameworkRunnerTargetFramework)\win7-x64\**\*.*" SubFolder="netfx" />
-      <FileToCopy Include="$(SourcePath)bin\Microsoft.TestPlatform.TestHostProvider\$(Configuration)\$(NetFrameworkRunnerTargetFramework)\**\*.*" SubFolder="netfx\Extensions\" />
+      <!-- Copy only the runtime provider assembly (and its satellites), NOT the whole build output folder.
+           The provider's build output carries its full dependency closure (Common.dll, ObjectModel.dll, ...),
+           and Common.dll contains SerialTestRunDecorator, an ITestExecutor without a parameterless constructor.
+           If that closure lands in Extensions\, vstest.console discovers the decorator as a rogue executor and
+           instantiating it throws, which tears down the whole executor manager -> "Could not find test executor".
+           The provider's dependencies resolve from the netfx root (copied above) at runtime. -->
+      <FileToCopy Include="$(SourcePath)bin\Microsoft.TestPlatform.TestHostProvider\$(Configuration)\$(NetFrameworkRunnerTargetFramework)\**\Microsoft.TestPlatform.TestHostRuntimeProvider*" SubFolder="netfx\Extensions\" />
 
       <!-- copy net462, net47, net471, net472, net48 and net481 testhosts -->
       <FileToCopy Include="$(SourcePath)bin\testhost.x86\$(Configuration)\$(NetFrameworkMinimum)\win-x86\**\*.*" SubFolder="netfx\TestHostNetFramework\" />
@@ -95,7 +101,8 @@
 
       <!-- .NET console -->
       <FileToCopy Include="$(SourcePath)bin\vstest.console\$(Configuration)\$(NetCoreAppMinimum)\**\*.*" SubFolder="net" />
-      <FileToCopy Include="$(SourcePath)bin\Microsoft.TestPlatform.TestHostProvider\$(Configuration)\netstandard2.0\**\*.*" SubFolder="net\Extensions\" />
+      <!-- Copy only the runtime provider assembly (see the netfx note above for why the whole folder must not be copied). -->
+      <FileToCopy Include="$(SourcePath)bin\Microsoft.TestPlatform.TestHostProvider\$(Configuration)\netstandard2.0\**\Microsoft.TestPlatform.TestHostRuntimeProvider*" SubFolder="net\Extensions\" />
 
       <!-- copy testhost -->
       <FileToCopy Include="$(SourcePath)bin\testhost\$(Configuration)\$(NetCoreAppMinimum)\**\*.*" SubFolder="net" />


### PR DESCRIPTION
The playground discovers tests but runs none of them. The run completes with 0 results and vstest.console logs `Could not find test executor with URI 'executor://mstestadapter/v2'`, while discovery finds all 14 tests. It looks like it works, but it never actually executes anything.

The cause is the playground PostBuild copy, not the product. It copies the whole `Microsoft.TestPlatform.TestHostProvider` output folder into `vstest.console\...\Extensions`:

```
TestHostProvider\$(Configuration)\net48\**\*.*  ->  netfx\Extensions\
```

That folder carries the provider's full dependency closure, including `Common.dll`. `Common.dll` contains `SerialTestRunDecorator`, an internal `ITestExecutor` with no parameterless constructor and no `[ExtensionUri]`. vstest.console scans `Extensions` for adapters, discovers the decorator as an executor, and instantiating it throws `MissingMethodException`, which tears down the whole executor manager. No executor is registered after that, so nothing runs. Discovery uses the discoverer path, so it was not affected and hid the failure.

The fix copies only the provider assembly into `Extensions`, the same way the loggers copy only their own dll. The provider dependencies still resolve from the netfx root at runtime.

This is a playground layout problem only. The shipped `Microsoft.TestPlatform` package never routes `Common.dll` into `Extensions`, so `dotnet test` and VS are not affected. It is also unrelated to the recent packing changes (#16206, #16236), the playground copies raw `artifacts\bin` output and never touches the packages.

Verified locally on net48: after the fix `Extensions` contains only the provider and the Trx logger, `Common.dll` sits at the netfx root, and running the playground executes all 14 tests with no executor warnings and no `MissingMethodException` in the testhost log.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
