### PR TITLE
Skip a single bad executor instead of failing all executor loading

### DIFF
--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestDiscoveryExtensionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestDiscoveryExtensionManager.cs
@@ -99,16 +99,11 @@ internal class TestDiscoveryExtensionManager
     /// <param name="throwOnError"> The throw On Error. </param>
     internal static void LoadAndInitializeAllExtensions(bool throwOnError)
     {
+        TestDiscoveryExtensionManager allDiscoverers;
+
         try
         {
-            var allDiscoverers = Create();
-
-            // Iterate throw the discoverers so that they are initialized
-            foreach (var discoverer in allDiscoverers.Discoverers)
-            {
-                // discoverer.value below is what initializes the extension types and hence is not under a EqtTrace.IsVerboseEnabled check.
-                EqtTrace.Verbose("TestDiscoveryManager: LoadExtensions: Created discoverer {0}", discoverer.Value);
-            }
+            allDiscoverers = Create();
         }
         catch (Exception ex)
         {
@@ -117,6 +112,28 @@ internal class TestDiscoveryExtensionManager
             if (throwOnError)
             {
                 throw;
+            }
+
+            return;
+        }
+
+        // Iterate through the discoverers so that they are initialized. One discoverer failing to
+        // initialize must not prevent the remaining discoverers from being loaded.
+        foreach (var discoverer in allDiscoverers.Discoverers)
+        {
+            try
+            {
+                // discoverer.value below is what initializes the extension types and hence is not under a EqtTrace.IsVerboseEnabled check.
+                EqtTrace.Verbose("TestDiscoveryManager: LoadExtensions: Created discoverer {0}", discoverer.Value);
+            }
+            catch (Exception ex)
+            {
+                EqtTrace.Error("TestDiscoveryManager: LoadExtensions: Exception occurred while loading extension {0}: {1}", discoverer.TestPluginInfo?.IdentifierData, ex);
+
+                if (throwOnError)
+                {
+                    throw;
+                }
             }
         }
     }

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestExecutorExtensionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestExecutorExtensionManager.cs
@@ -77,10 +77,28 @@ internal class TestExecutorExtensionManager : TestExtensionManager<ITestExecutor
         // we prefer the second extension to the first.
         foreach (var testExtension in testExtensions2)
         {
-            if (testExtension.TestPluginInfo?.IdentifierData is not null
-                && cache.ContainsKey(testExtension.TestPluginInfo.IdentifierData))
+            if (testExtension.TestPluginInfo?.IdentifierData is null
+                || !cache.ContainsKey(testExtension.TestPluginInfo.IdentifierData))
             {
+                continue;
+            }
+
+            try
+            {
+                // Accessing Value instantiates the extension. A rogue extension (for example one
+                // without a parameterless constructor) throws here. Instantiating one bad extension
+                // must not prevent the remaining extensions from being merged, otherwise the whole
+                // executor extension manager fails to build and every executor becomes unreachable.
+                // Skip the failing extension and keep the version already present in the cache from
+                // the first list.
                 cache[testExtension.TestPluginInfo.IdentifierData] = new(testExtension.Value, testExtension.Metadata);
+            }
+            catch (Exception ex)
+            {
+                EqtTrace.Error(
+                    "TestExecutorExtensionManager: MergeTestExtensionLists: Failed to instantiate extension '{0}'. Skipping it. {1}",
+                    testExtension.TestPluginInfo.IdentifierData,
+                    ex);
             }
         }
 
@@ -197,24 +215,27 @@ internal class TestExecutorExtensionManager : TestExtensionManager<ITestExecutor
     {
         var executorExtensionManager = Create();
 
-        try
+        foreach (var executor in executorExtensionManager.TestExtensions)
         {
-            foreach (var executor in executorExtensionManager.TestExtensions)
+            try
             {
                 // Note: - The below Verbose call should not be under IsVerboseEnabled check as we want to
                 // call executor.Value even if logging is not enabled.
                 EqtTrace.Verbose("TestExecutorExtensionManager: Loading executor {0}", executor.Value);
             }
-        }
-        catch (Exception ex)
-        {
-            EqtTrace.Error(
-                "TestExecutorExtensionManager: LoadAndInitialize: Exception occurred while loading extensions {0}",
-                ex);
-
-            if (shouldThrowOnError)
+            catch (Exception ex)
             {
-                throw;
+                // Instantiating one executor must not prevent the remaining executors from being
+                // loaded. Log and move on to the next executor unless the caller opted into failing.
+                EqtTrace.Error(
+                    "TestExecutorExtensionManager: LoadAndInitialize: Exception occurred while loading extension {0}: {1}",
+                    executor.TestPluginInfo?.IdentifierData,
+                    ex);
+
+                if (shouldThrowOnError)
+                {
+                    throw;
+                }
             }
         }
     }

--- a/src/Microsoft.TestPlatform.Common/SettingsProvider/SettingsProviderExtensionManager.cs
+++ b/src/Microsoft.TestPlatform.Common/SettingsProvider/SettingsProviderExtensionManager.cs
@@ -139,22 +139,24 @@ public class SettingsProviderExtensionManager
     {
         var extensionManager = Create();
 
-        try
+        foreach (var settingsProvider in extensionManager.SettingsProvidersMap)
         {
-            foreach (var settingsProvider in extensionManager.SettingsProvidersMap)
+            try
             {
                 // Note: - The below Verbose call should not be under IsVerboseEnabled check as we want to
                 // call executor.Value even if logging is not enabled.
                 EqtTrace.Verbose("SettingsProviderExtensionManager: Loading settings provider {0}", settingsProvider.Value.Value);
             }
-        }
-        catch (Exception ex)
-        {
-            EqtTrace.Error("SettingsProviderExtensionManager: LoadAndInitialize: Exception occurred while loading extensions {0}", ex);
-
-            if (shouldThrowOnError)
+            catch (Exception ex)
             {
-                throw;
+                // Instantiating one settings provider must not prevent the remaining providers from
+                // being loaded. Log and move on unless the caller opted into failing.
+                EqtTrace.Error("SettingsProviderExtensionManager: LoadAndInitialize: Exception occurred while loading extension {0}: {1}", settingsProvider.Key, ex);
+
+                if (shouldThrowOnError)
+                {
+                    throw;
+                }
             }
         }
     }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -411,21 +411,33 @@ internal abstract class BaseRunTests
             // host by default.
             // Same goes if all adapters implement the new test executor interface but at
             // least one of them needs the test platform to attach to the default test host.
-            if (executor.Value is not ITestExecutor2
-                || ShouldAttachDebuggerToTestHost(executor, executorUriExtensionTuple, RunContext))
+            try
             {
-                EqtTrace.Verbose("Attaching to default test host.");
-
-                attachedToTestHost = true;
-#if NET
-                var pid = Environment.ProcessId;
-#else
-                var pid = Process.GetCurrentProcess().Id;
-#endif
-                if (!FrameworkHandle.AttachDebuggerToProcess(pid))
+                if (executor.Value is not ITestExecutor2
+                    || ShouldAttachDebuggerToTestHost(executor, executorUriExtensionTuple, RunContext))
                 {
-                    EqtTrace.Warning(string.Format(CultureInfo.CurrentCulture, CrossPlatEngineResources.AttachDebuggerToDefaultTestHostFailure, pid));
+                    EqtTrace.Verbose("Attaching to default test host.");
+
+                    attachedToTestHost = true;
+#if NET
+                    var pid = Environment.ProcessId;
+#else
+                    var pid = Process.GetCurrentProcess().Id;
+#endif
+                    if (!FrameworkHandle.AttachDebuggerToProcess(pid))
+                    {
+                        EqtTrace.Warning(string.Format(CultureInfo.CurrentCulture, CrossPlatEngineResources.AttachDebuggerToDefaultTestHostFailure, pid));
+                    }
                 }
+            }
+            catch (Exception ex)
+            {
+                // Accessing executor.Value instantiates the executor, which can throw for a rogue
+                // extension (for example one without a parameterless constructor). A failure to
+                // evaluate the debugger-attach condition for one executor must not abort processing
+                // of the remaining executors; the failure is surfaced per-executor in the execution
+                // loop below.
+                EqtTrace.Error("BaseRunTests.RunTestInternalWithExecutors: Failed to evaluate debugger attach for executor {0}: {1}", executorUriExtensionTuple.Item1.AbsoluteUri, ex);
             }
         }
 

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestExecutorExtensionManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestExecutorExtensionManagerTests.cs
@@ -52,6 +52,26 @@ public class TestExecutorExtensionManagerTests
         Assert.IsTrue(extensionManager.TestExtensions.Any());
     }
 
+    [TestMethod]
+    public void GetExecutorExtensionManagerShouldBeResilientToExecutorThatCannotBeInstantiated()
+    {
+        // The TestUtilities assembly contains a good ITestExecutor2 and a rogue ITestExecutor2 that
+        // has no parameterless constructor and therefore throws when instantiated. Building the
+        // extension manager must not fail because of the rogue executor, and the good executor must
+        // remain resolvable.
+        var extensionManager =
+            TestExecutorExtensionManager.GetExecutionExtensionManager(
+                typeof(GoodResilientTestExecutor).Assembly.Location);
+
+        Assert.IsNotNull(extensionManager.TestExtensions);
+
+        var discoveredUris = extensionManager.TestExtensions.Select(e => e.Metadata.ExtensionUri).ToList();
+        Assert.Contains(
+            GoodResilientTestExecutor.ExecutorUri,
+            discoveredUris,
+            "The good executor should be discovered and merged even though a sibling executor cannot be instantiated.");
+    }
+
     #region LoadAndInitialize tests
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.TestUtilities/ResilientExecutorFixtures.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/ResilientExecutorFixtures.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+namespace Microsoft.TestPlatform.TestUtilities;
+
+/// <summary>
+/// Test executors used to verify that the extension managers stay resilient when a single
+/// <see cref="ITestExecutor2"/> cannot be instantiated.
+///
+/// <para>
+/// These types intentionally live in this non test assembly so that they are only discovered when a
+/// test explicitly points discovery at this assembly (via
+/// <c>GetExecutionExtensionManager(&lt;this assembly&gt;)</c>). They are not named
+/// <c>*TestAdapter.dll</c> so the default extension discovery does not pick them up, and the unit
+/// tests that assert every discovered executor is created point at their own assemblies, so hosting
+/// a deliberately broken executor here does not break them.
+/// </para>
+/// </summary>
+[ExtensionUri(GoodResilientTestExecutor.ExecutorUri)]
+public class GoodResilientTestExecutor : ITestExecutor2
+{
+    /// <summary>
+    /// The extension URI of this executor.
+    /// </summary>
+    public const string ExecutorUri = "executor://resilient.good";
+
+    public void Cancel()
+    {
+    }
+
+    public void RunTests(IEnumerable<TestCase>? tests, IRunContext? runContext, IFrameworkHandle? frameworkHandle)
+    {
+    }
+
+    public void RunTests(IEnumerable<string>? sources, IRunContext? runContext, IFrameworkHandle? frameworkHandle)
+    {
+    }
+
+    public bool ShouldAttachToTestHost(IEnumerable<string>? sources, IRunContext runContext)
+    {
+        return false;
+    }
+
+    public bool ShouldAttachToTestHost(IEnumerable<TestCase>? tests, IRunContext runContext)
+    {
+        return false;
+    }
+}
+
+/// <summary>
+/// An <see cref="ITestExecutor2"/> that cannot be instantiated because it has no parameterless
+/// constructor. Discovery finds this type (discovery does not require a parameterless constructor),
+/// but instantiating it throws <see cref="MissingMethodException"/>. This reproduces the "rogue
+/// executor" scenario that used to tear down the whole executor extension manager.
+/// </summary>
+[ExtensionUri(RogueResilientTestExecutor.ExecutorUri)]
+public class RogueResilientTestExecutor : ITestExecutor2
+{
+    /// <summary>
+    /// The extension URI of this executor.
+    /// </summary>
+    public const string ExecutorUri = "executor://resilient.rogue";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RogueResilientTestExecutor"/> class.
+    /// The required parameter means there is no parameterless constructor, so the extension
+    /// framework cannot activate this type.
+    /// </summary>
+    /// <param name="required">A required parameter that prevents parameterless activation.</param>
+    public RogueResilientTestExecutor(string required)
+    {
+        _ = required;
+    }
+
+    public void Cancel()
+    {
+    }
+
+    public void RunTests(IEnumerable<TestCase>? tests, IRunContext? runContext, IFrameworkHandle? frameworkHandle)
+    {
+    }
+
+    public void RunTests(IEnumerable<string>? sources, IRunContext? runContext, IFrameworkHandle? frameworkHandle)
+    {
+    }
+
+    public bool ShouldAttachToTestHost(IEnumerable<string>? sources, IRunContext runContext)
+    {
+        return false;
+    }
+
+    public bool ShouldAttachToTestHost(IEnumerable<TestCase>? tests, IRunContext runContext)
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
An `ITestExecutor2` that can't be instantiated (for example one without a parameterless constructor) throws while merging the `ITestExecutor` and `ITestExecutor2` lists in `MergeTestExtensionLists`. That throw tears down the whole executor extension manager: `GetExecutorExtensionManager` catches it and returns `null` for the entire assembly, so every executor in that assembly — including the real one — becomes unreachable. The run ends with `Could not find test executor 'executor://mstestadapter/v2'` and 0 tests run. Discovery survives because it doesn't force instantiation.

The fix skips the one bad executor instead of failing the whole merge, and applies the same per-item resilience to the other loops that eagerly instantiate extensions:

- `MergeTestExtensionLists` — the root cause. Wrap `.Value` per extension and keep the already-cached good version on failure.
- `LoadAndInitializeAllExtensions` for executors, discoverers, and settings providers — move the try/catch inside the loop so one bad extension doesn't stop the rest. It still rethrows when the caller asked to fail on error.
- `BaseRunTests` debugger-attach loop — a rogue `.Value` there no longer aborts before the already-resilient execution loop.

The regression test lives in `TestExecutorExtensionManagerTests`, with a good and a rogue `ITestExecutor2` hosted in `TestUtilities` so it stays isolated from the tests that assert every discovered executor is created. It throws `MissingMethodException` without the merge fix and passes with it.