### PR TITLE
Inject DataCollectionManager into DataCollectionTestCaseEventHandler

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionRequestHandler.cs
@@ -142,12 +142,13 @@ internal class DataCollectionRequestHandler : IDataCollectionRequestHandler, IDi
                 {
                     var requestData = new RequestData();
                     var telemetryReporter = new TelemetryReporter(requestData, communicationManager, JsonDataSerializer.Instance);
+                    var dataCollectionManager = DataCollectionManager.Create(messageSink, requestData, telemetryReporter);
 
                     Instance = new DataCollectionRequestHandler(
                         communicationManager,
                         messageSink,
-                        DataCollectionManager.Create(messageSink, requestData, telemetryReporter),
-                        new DataCollectionTestCaseEventHandler(messageSink),
+                        dataCollectionManager,
+                        new DataCollectionTestCaseEventHandler(messageSink, dataCollectionManager),
                         JsonDataSerializer.Instance,
                         new FileHelper(),
                         requestData);

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionTestCaseEventHandler.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/DataCollectionTestCaseEventHandler.cs
@@ -29,7 +29,16 @@ internal class DataCollectionTestCaseEventHandler : IDataCollectionTestCaseEvent
     /// Initializes a new instance of the <see cref="DataCollectionTestCaseEventHandler"/> class.
     /// </summary>
     internal DataCollectionTestCaseEventHandler(IMessageSink messageSink)
-        : this(messageSink, new SocketCommunicationManager(), DataCollectionManager.Instance, JsonDataSerializer.Instance)
+        : this(messageSink, DataCollectionManager.Instance)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataCollectionTestCaseEventHandler"/> class.
+    /// </summary>
+    /// <param name="messageSink">Sink for messages</param>
+    /// <param name="dataCollectionManager">Data collection manager implementation.</param>
+    internal DataCollectionTestCaseEventHandler(IMessageSink messageSink, IDataCollectionManager? dataCollectionManager)
+        : this(messageSink, new SocketCommunicationManager(), dataCollectionManager, JsonDataSerializer.Instance)
     { }
 
     /// <summary>

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/DataCollectionTestCaseEventHandlerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/DataCollectionTestCaseEventHandlerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Net;
+using System.Reflection;
 
 using Microsoft.VisualStudio.TestPlatform.Common.DataCollector.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
@@ -215,5 +216,23 @@ public class DataCollectionTestCaseEventHandlerTests
         _mockCommunicationManager.Setup(x => x.ReceiveMessage()).Throws<Exception>();
 
         Assert.ThrowsExactly<Exception>(() => _requestHandler.ProcessRequests());
+    }
+
+    [TestMethod]
+    public void ConstructorShouldForwardTestCaseEventsToTheInjectedDataCollectionManager()
+    {
+        // DataCollectionRequestHandler.Create hands the DataCollectionManager it built to this handler
+        // through the (messageSink, dataCollectionManager) ctor. Guard that the handler keeps exactly that
+        // instance to forward test-case events to, instead of reaching back to DataCollectionManager.Instance.
+        // If a future edit reverted to the static, the writer (the datacollector-host root) and the reader
+        // (this handler) could drift onto two different managers with nothing turning red.
+        var injectedManager = new Mock<IDataCollectionManager>();
+
+        var requestHandler = new DataCollectionTestCaseEventHandler(_messageSink.Object, injectedManager.Object);
+
+        var managerField = typeof(DataCollectionTestCaseEventHandler)
+            .GetField("_dataCollectionManager", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(managerField);
+        Assert.AreSame(injectedManager.Object, managerField.GetValue(requestHandler));
     }
 }


### PR DESCRIPTION
## Problem

`DataCollectionTestCaseEventHandler` reaches the data collection manager through the mutable static `DataCollectionManager.Instance`. Its convenience constructor hard-codes that static, so in the datacollector host the writer (`DataCollectionRequestHandler.Create`, which builds the manager) and the reader (this handler, which forwards `TestCaseStarted`/`TestCaseEnded` to it) only agree on the same manager because both resolve the same static. That is process-wide state feeding a single host's request-scoped concern, and `DataCollectionManager.Instance` has a `private set`, so a test can never point it at a manager it controls.

## Change

`DataCollectionRequestHandler.Create` is the one place that constructs both objects, and it already holds the manager - it is the return value of `DataCollectionManager.Create(...)` that gets passed into the request handler. So I capture that instance into a local and thread it into a new `DataCollectionTestCaseEventHandler(IMessageSink, IDataCollectionManager?)` constructor, instead of letting the handler re-read the static.

- The existing 1-arg constructor stays and now delegates to the new one with `DataCollectionManager.Instance` as the default, so when nothing is injected the behavior is byte-for-byte identical. `DataCollectionManager.Instance` is untouched and keeps working for that path (no `[Obsolete]`).
- Every type involved (`DataCollectionTestCaseEventHandler`, `DataCollectionManager`, `IDataCollectionManager`) is `internal`, so there is no shipped public signature change and no `PublicAPI` edit.

This is the same "thread one instance from the composition root, default it to the existing static" shape as the earlier argument-processor and `TestSessionPool` changes.

The other three statics I looked at on this seam I left alone for now: `TestRuntimeProviderManager.Instance` is already injected into `TestEngine`/`TestPlatform` (the only reads left are their parameterless default constructors) and is the reflection-activation seam; `TestPluginManager.Instance` is stateless with no production reader; and `TestPluginCache.Instance` is shipped public API, read and written across the console, testhost and datacollector processes with no single composition root, so it needs its own careful pass.

## Verification

Added a test in `DataCollectionTestCaseEventHandlerTests` that builds the handler through the new constructor and checks it keeps exactly the injected `IDataCollectionManager` rather than reaching for `DataCollectionManager.Instance` - if a later edit reverted to the static, the writer and reader could drift onto two different managers with nothing turning red.

Locally on Windows:

- `build.cmd -c Release` - 0 errors, no `IDE0005` (only the pre-existing `CommunicationUtilities` IL trim warnings).
- `Microsoft.TestPlatform.CommunicationUtilities.UnitTests` (`net481`) - 608 passed, 0 failed.
- `build.cmd -c Release -pack` - DLL-target-framework and nupkg checks pass.
- `test.cmd -c Release -smokeTest` - `Acceptance.IntegrationTests` and `Library.IntegrationTests` (net11.0 and net481) all green.
