### PR TITLE
Inject CommandLineOptions into vstest.console readers

### DIFF
--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -121,11 +121,12 @@ internal class ConsoleLogger : ITestLoggerWithParameters
     /// <summary>
     /// Constructor added for testing purpose
     /// </summary>
-    internal ConsoleLogger(IOutput output, IProgressIndicator progressIndicator, IFeatureFlag featureFlag)
+    internal ConsoleLogger(IOutput output, IProgressIndicator progressIndicator, IFeatureFlag featureFlag, CommandLineOptions? commandLineOptions = null)
     {
         Output = output;
         _progressIndicator = progressIndicator;
         _featureFlag = featureFlag;
+        _commandLineOptions = commandLineOptions;
     }
 
     /// <summary>
@@ -141,6 +142,8 @@ internal class ConsoleLogger : ITestLoggerWithParameters
     private IProgressIndicator? _progressIndicator;
 
     private readonly IFeatureFlag _featureFlag = FeatureFlag.Instance;
+
+    private readonly CommandLineOptions? _commandLineOptions;
 
     /// <summary>
     /// Get the verbosity level for the console logger
@@ -415,10 +418,11 @@ internal class ConsoleLogger : ITestLoggerWithParameters
         TPDebug.Assert(Output != null, "Initialize should have been called");
 
         // Print all test containers.
-        Output.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestSourcesDiscovered, CommandLineOptions.Instance.Sources.Count()), OutputLevel.Information);
+        var commandLineOptions = _commandLineOptions ?? CommandLineOptions.Instance;
+        Output.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestSourcesDiscovered, commandLineOptions.Sources.Count()), OutputLevel.Information);
         if (VerbosityLevel == Verbosity.Detailed)
         {
-            foreach (var source in CommandLineOptions.Instance.Sources)
+            foreach (var source in commandLineOptions.Sources)
             {
                 Output.WriteLine(source, OutputLevel.Information);
             }
@@ -684,7 +688,7 @@ internal class ConsoleLogger : ITestLoggerWithParameters
                 // DISABLE_ARTIFACTS_POSTPROCESSING_NEW_SDK_UX(new UX) is disabled
                 _featureFlag.IsSet(FeatureFlag.VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING_NEW_SDK_UX) ||
                 // TestSessionCorrelationId is null(we're not running through the dotnet SDK).
-                CommandLineOptions.Instance.TestSessionCorrelationId is null)
+                (_commandLineOptions ?? CommandLineOptions.Instance).TestSessionCorrelationId is null)
             {
                 Output.Information(false, CommandLineResources.AttachmentsBanner);
                 TPDebug.Assert(e.AttachmentSets != null, "e.AttachmentSets should not be null when runLevelAttachmentsCount > 0.");

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -96,15 +96,20 @@ internal class TestRequestManager : ITestRequestManager
     /// Initializes a new instance of the <see cref="TestRequestManager"/> class.
     /// </summary>
     public TestRequestManager()
+        : this(CommandLineOptions.Instance)
+    {
+    }
+
+    internal TestRequestManager(CommandLineOptions commandLineOptions)
         : this(
-            CommandLineOptions.Instance,
+            commandLineOptions,
             TestPlatformFactory.GetTestPlatform(),
             TestRunResultAggregator.Instance,
             TestPlatformEventSource.Instance,
             new InferHelper(AssemblyMetadataProvider.Instance),
             MetricsPublisherFactory.GetMetricsPublisher(
                 IsTelemetryOptedIn(),
-                CommandLineOptions.Instance.IsDesignMode),
+                commandLineOptions.IsDesignMode),
             new ProcessHelper(),
             new TestRunAttachmentsProcessingManager(TestPlatformEventSource.Instance, new DataCollectorAttachmentsProcessorsFactory()),
             new PlatformEnvironment(),

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -1002,6 +1002,44 @@ public class ConsoleLoggerTests
     }
 
     [TestMethod]
+    public void TestRunStartHandlerShouldUseInjectedCommandLineOptionsSourcesRatherThanTheStaticDefault()
+    {
+        // The console logger reads the discovered sources from the CommandLineOptions it was given. Injecting a distinct
+        // instance (with its own source) while the static default stays empty proves the reader resolves to the injected
+        // instance rather than to CommandLineOptions.Instance.
+        CommandLineOptions.Reset();
+
+        var fileHelper = new Mock<IFileHelper>();
+        var injectedOptions = new CommandLineOptions
+        {
+            FileHelper = fileHelper.Object,
+            FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, fileHelper.Object)
+        };
+        string testFilePath = Path.Combine(Path.GetTempPath(), "InjectedTestFile.dll");
+        fileHelper.Setup(fh => fh.Exists(testFilePath)).Returns(true);
+        injectedOptions.AddSource(testFilePath);
+
+        // The static default carries no sources, so a discovered count of 1 can only come from the injected instance.
+        Assert.AreEqual(0, CommandLineOptions.Instance.Sources.Count());
+
+        var consoleLogger = new ConsoleLogger(_mockOutput.Object, _mockProgressIndicator.Object, _mockFeatureFlag.Object, injectedOptions);
+
+        var loggerEvents = new InternalTestLoggerEvents(TestSessionMessageLogger.Instance);
+        loggerEvents.EnableEvents();
+        var parameters = new Dictionary<string, string?>
+        {
+            { "verbosity", "normal" }
+        };
+        consoleLogger.Initialize(loggerEvents, parameters);
+
+        var testRunStartEventArgs = new TestRunStartEventArgs(new TestRunCriteria(new List<string> { testFilePath }, 1));
+        loggerEvents.RaiseTestRunStart(testRunStartEventArgs);
+        loggerEvents.WaitForEventCompletion();
+
+        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestSourcesDiscovered, 1), OutputLevel.Information), Times.Once());
+    }
+
+    [TestMethod]
     public void TestRunStartHandlerShouldWriteNumberOfTestSourcesDiscoveredOnConsole()
     {
         var loggerEvents = new InternalTestLoggerEvents(TestSessionMessageLogger.Instance);

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -2604,6 +2604,75 @@ public class TestRequestManagerTests
     }
 
     [TestMethod]
+    public void WritingTestCaseFilterThroughArgumentExecutorIsObservedByTestRequestManager()
+    {
+        // -- Arrange
+        // The --TestCaseFilter argument executor (the writer) and this TestRequestManager (the reader) are handed the
+        // same CommandLineOptions instance: _commandLineOptions, which was injected into the manager in the test
+        // constructor. This guards the same-instance contract of the injection - a value the writer sets on the injected
+        // options has to be observed by the reader precisely because both ends resolve to one object and not to two
+        // separate copies.
+        const string filter = "FullyQualifiedName~SharedInstanceMarker";
+
+        // The process-wide static default is a different object. Capturing it up front lets us prove the write lands on
+        // the injected instance only, and that a reader bound to the static default observes none of it.
+        var staticDefault = CommandLineOptions.Instance;
+        staticDefault.Should().NotBeSameAs(_commandLineOptions, "the manager under test was injected with a separate CommandLineOptions instance");
+
+        var payload = new DiscoveryRequestPayload()
+        {
+            Sources = new List<string>() { "AnyCPU.dll" },
+            RunSettings = DefaultRunsettings
+        };
+
+        DiscoveryCriteria? observedCriteria = null;
+        _mockTestPlatform.Setup(mt => mt.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>()))
+            .Callback((IRequestData _, DiscoveryCriteria criteria, TestPlatformOptions _, Dictionary<string, SourceDetail> _, IWarningLogger _) =>
+                observedCriteria = criteria)
+            .Returns(_mockDiscoveryRequest.Object);
+
+        // -- Act
+        // Writer: parsing "--TestCaseFilter <filter>" sets TestCaseFilterValue on the injected instance and nowhere else.
+        new TestCaseFilterArgumentExecutor(_commandLineOptions).Initialize(filter);
+        _commandLineOptions.TestCaseFilterValue.Should().Be(filter, "the executor writes the filter on the injected instance");
+        staticDefault.TestCaseFilterValue.Should().BeNull("the write must not leak onto the static default instance");
+
+        // Reader: the manager copies TestCaseFilterValue from the same injected instance onto the DiscoveryCriteria.
+        _testRequestManager.DiscoverTests(payload, new Mock<ITestDiscoveryEventsRegistrar>().Object, _protocolConfig);
+
+        // -- Assert
+        observedCriteria.Should().NotBeNull();
+        observedCriteria!.TestCaseFilter.Should().Be(filter, "the reader observed the writer's value through the shared instance");
+
+        // Reader-vs-reader: a second manager bound to the static default instance (which never received the write) must
+        // NOT observe the filter - it falls back to the run settings, which carry none, so the criteria filter is null.
+        DiscoveryCriteria? staticDefaultCriteria = null;
+        var mockTestPlatformForStaticDefault = new Mock<ITestPlatform>();
+        mockTestPlatformForStaticDefault.Setup(mt => mt.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>()))
+            .Callback((IRequestData _, DiscoveryCriteria criteria, TestPlatformOptions _, Dictionary<string, SourceDetail> _, IWarningLogger _) =>
+                staticDefaultCriteria = criteria)
+            .Returns(new Mock<IDiscoveryRequest>().Object);
+
+        var managerBoundToStaticDefault = new TestRequestManager(
+            staticDefault,
+            mockTestPlatformForStaticDefault.Object,
+            new DummyTestRunResultAggregator(),
+            _mockTestPlatformEventSource.Object,
+            _inferHelper,
+            _mockMetricsPublisherTask,
+            _mockProcessHelper.Object,
+            _mockAttachmentsProcessingManager.Object,
+            _mockEnvironment.Object,
+            _mockEnvironmentVariableHelper.Object,
+            _runSettingsHelper);
+
+        managerBoundToStaticDefault.DiscoverTests(payload, new Mock<ITestDiscoveryEventsRegistrar>().Object, _protocolConfig);
+
+        staticDefaultCriteria.Should().NotBeNull();
+        staticDefaultCriteria!.TestCaseFilter.Should().BeNull("the manager bound to the static default instance never saw the write");
+    }
+
+    [TestMethod]
     public void UsingInvalidValueForDefaultPlatformSettingThrowsSettingsException()
     {
         var settingXml = @"


### PR DESCRIPTION
This continues moving `vstest.console` off the process-wide `CommandLineOptions.Instance` singleton. Phase 3 (#16208) threaded one injected `CommandLineOptions` into the argument processors (the writers) and deliberately left the readers on the static. This converts the two remaining readers, so in a test a value a writer sets on an injected `CommandLineOptions` is observed by the reader through the *same* instance. Production is unchanged: every composition root still defaults to the one `CommandLineOptions.Instance` field, so writers and readers resolve to the same object exactly as before.

## Changes

- `TestRequestManager` gets an intermediate `internal TestRequestManager(CommandLineOptions)` ctor that derives all of its other defaults from the passed instance, including the `IsDesignMode` flag the metrics publisher reads. The parameterless ctor becomes `: this(CommandLineOptions.Instance)`, which is the single remaining root default. `TestRequestManager()` -> `this(CommandLineOptions.Instance)` is byte-for-byte identical to what ran before.
- `ConsoleLogger` is a reflection-instantiated extension logger, so it has no ctor seam to thread through. It keeps a nullable `CommandLineOptions?` field (null on the reflection path) and reads `_commandLineOptions ?? CommandLineOptions.Instance` lazily at event time. Because `CommandLineOptions.Reset()` nulls the singleton between requests, reading lazily rather than capturing in the ctor keeps the behavior identical.

`Executor` and `ArgumentProcessorFactory` are unchanged: their `?? CommandLineOptions.Instance` fallbacks are the composition-root defaults this threads *from*, and I deliberately do not have `Executor` eagerly build a `TestRequestManager` — the processors still resolve the lazy `TestRequestManager.Instance` at run/discovery time, so writers and readers keep sharing the one static instance in production.

## Verification

The point of this phase is the reader-side guard, so there is a #16207-style test: a `--TestCaseFilter` executor (writer) sets `TestCaseFilterValue` on one injected `CommandLineOptions`, and `TestRequestManager.DiscoverTests` (reader) copies it onto the `DiscoveryCriteria` through the same instance. The assertion is decisive — the shared instance carries the filter and the reader observes it, while the static default instance stays null and a second manager bound to that default observes no filter. A smaller `ConsoleLogger` test injects a `CommandLineOptions` with its own source and asserts the discovered-sources line reflects the injected instance rather than the empty static default.

Verified locally on Windows: `build.cmd -c Release`, `build.cmd -pack`, the full `vstest.console.UnitTests` net481 run (630 passing, 2 pre-existing skips), and `test.cmd -smokeTest` are all green.

No public API changes (the new ctor is `internal`); no `.resx`/`.xlf` changes.
