### PR TITLE
Inject TestRunResultAggregator into vstest.console Executor

### DIFF
--- a/src/vstest.console/CommandLine/Executor.cs
+++ b/src/vstest.console/CommandLine/Executor.cs
@@ -66,6 +66,7 @@ internal class Executor
     private readonly IRunSettingsProvider _runSettingsProvider;
     private readonly IRunSettingsHelper _runSettingsHelper;
     private readonly CommandLineOptions _commandLineOptions;
+    private readonly TestRunResultAggregator _testRunResultAggregator;
     // Left null in production so the argument processors resolve TestRequestManager.Instance lazily
     // (only when a run/discovery command actually executes); tests inject a specific instance.
     private readonly ITestRequestManager? _testRequestManager;
@@ -99,16 +100,16 @@ internal class Executor
     }
 
     internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment)
-        : this(output, testPlatformEventSource, processHelper, environment, RunSettingsManager.Instance, RunSettingsHelper.Instance, CommandLineOptions.Instance)
+        : this(output, testPlatformEventSource, processHelper, environment, RunSettingsManager.Instance, RunSettingsHelper.Instance, CommandLineOptions.Instance, TestRunResultAggregator.Instance)
     {
     }
 
     internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment, IRunSettingsProvider runSettingsProvider)
-        : this(output, testPlatformEventSource, processHelper, environment, runSettingsProvider, RunSettingsHelper.Instance, CommandLineOptions.Instance)
+        : this(output, testPlatformEventSource, processHelper, environment, runSettingsProvider, RunSettingsHelper.Instance, CommandLineOptions.Instance, TestRunResultAggregator.Instance)
     {
     }
 
-    internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment, IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper, CommandLineOptions commandLineOptions, ITestRequestManager? testRequestManager = null)
+    internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment, IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper, CommandLineOptions commandLineOptions, TestRunResultAggregator testRunResultAggregator, ITestRequestManager? testRequestManager = null)
     {
         DebuggerBreakpoint.AttachVisualStudioDebugger(WellKnownDebugEnvironmentVariables.VSTEST_RUNNER_DEBUG_ATTACHVS);
         DebuggerBreakpoint.WaitForNativeDebugger(WellKnownDebugEnvironmentVariables.VSTEST_RUNNER_NATIVE_DEBUG);
@@ -122,6 +123,7 @@ internal class Executor
         _runSettingsProvider = runSettingsProvider;
         _runSettingsHelper = runSettingsHelper;
         _commandLineOptions = commandLineOptions;
+        _testRunResultAggregator = testRunResultAggregator;
         _testRequestManager = testRequestManager;
     }
 
@@ -219,7 +221,7 @@ internal class Executor
         }
 
         // Use the test run result aggregator to update the exit code.
-        exitCode |= (TestRunResultAggregator.Instance.Outcome == TestOutcome.Passed) ? 0 : 1;
+        exitCode |= (_testRunResultAggregator.Outcome == TestOutcome.Passed) ? 0 : 1;
 
         EqtTrace.Verbose("Executor.Execute: Exiting with exit code of {0}", exitCode);
 

--- a/test/vstest.console.UnitTests/ExecutorUnitTests.cs
+++ b/test/vstest.console.UnitTests/ExecutorUnitTests.cs
@@ -15,9 +15,12 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
+using Microsoft.VisualStudio.TestPlatform.Utilities.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
+
+using vstest.console.UnitTests.TestDoubles;
 
 using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Resources.Resources;
 
@@ -356,6 +359,55 @@ public class ExecutorUnitTests
         Assert.HasCount(3, mockOutput.Messages);
         Assert.MatchesRegex(@"VSTest version .* \(x64\)", mockOutput.Messages[0].Message!);
         Assert.DoesNotContain(message => message.Message!.Contains("vstest.console.exe is running in emulated mode"), mockOutput.Messages);
+    }
+
+    [TestMethod]
+    public void MarkingTestRunFailedOnInjectedAggregatorIsObservedByExecutorExitCode()
+    {
+        // The exit code produced at the end of Executor.Execute is OR-ed with the outcome of the
+        // TestRunResultAggregator (Executor.cs: exitCode |= (Outcome == Passed) ? 0 : 1). This test
+        // proves the reader (Executor) observes the SAME aggregator instance it was constructed with,
+        // not the process-wide TestRunResultAggregator.Instance static.
+        //
+        // "--help" is a zero-baseline path: HelpArgumentProcessor runs first and returns Abort, which
+        // does not set the exit bit (only Fail does), so the aggregator's outcome is the sole
+        // contributor to the final exit code. That makes the two outcomes below decisively distinct.
+
+        // Baseline the shared static so the negative control is deterministic.
+        TestRunResultAggregator.Instance.Reset();
+
+        // Writer: mark a failure on an injected aggregator that is a different instance from the static.
+        var injectedAggregator = new DummyTestRunResultAggregator();
+        injectedAggregator.MarkTestRunFailed();
+        Assert.AreNotSame(TestRunResultAggregator.Instance, injectedAggregator);
+
+        // Reader observes the write through the injected instance: Failed outcome sets the exit bit.
+        var exitCodeWithInjected = new Executor(
+            new MockOutput(),
+            _mockTestPlatformEventSource.Object,
+            new ProcessHelper(),
+            new PlatformEnvironment(),
+            RunSettingsManager.Instance,
+            RunSettingsHelper.Instance,
+            CommandLineOptions.Instance,
+            injectedAggregator).Execute("--help");
+
+        Assert.AreEqual(1, exitCodeWithInjected, "Executor must observe the injected aggregator's Failed outcome.");
+
+        // Negative control: an Executor bound to the static default (still Passed) yields a zero exit
+        // for the same args, and the write above did not leak onto the static instance.
+        var exitCodeWithStatic = new Executor(
+            new MockOutput(),
+            _mockTestPlatformEventSource.Object,
+            new ProcessHelper(),
+            new PlatformEnvironment(),
+            RunSettingsManager.Instance,
+            RunSettingsHelper.Instance,
+            CommandLineOptions.Instance,
+            TestRunResultAggregator.Instance).Execute("--help");
+
+        Assert.AreEqual(0, exitCodeWithStatic, "The static default aggregator is still Passed, so its Executor must not set the failure bit.");
+        Assert.AreEqual(TestOutcome.Passed, TestRunResultAggregator.Instance.Outcome, "Marking the injected aggregator failed must not leak onto the static instance.");
     }
 
     private class MockOutput : IOutput


### PR DESCRIPTION
This continues moving `vstest.console` off process-wide mutable singletons. #16243 did the same for `CommandLineOptions`; this one converts the `TestRunResultAggregator.Instance` reader in `Executor`. At the end of `Executor.Execute` the run outcome is folded into the exit code by reading `TestRunResultAggregator.Instance.Outcome` off the static, so a test cannot observe that reader against an injected aggregator. This threads one instance from the composition root and reads it through a field. Production is unchanged: every root still defaults to the one `TestRunResultAggregator.Instance` field.

## Changes

- `Executor` gets a `private readonly TestRunResultAggregator _testRunResultAggregator` field, a matching parameter on the full `internal` ctor, and a `TestRunResultAggregator.Instance` default at the two convenience ctors that call it. The 1-arg production root (`new Executor(ConsoleOutput.Instance)` in `Program.cs`) funnels through the 4-arg ctor, so it stays byte-for-byte identical. Every `new Executor(` in the repo is 1-arg or 4-arg, so there is no caller churn.
- The reader at the end of `Execute` now reads `_testRunResultAggregator.Outcome` instead of `TestRunResultAggregator.Instance.Outcome`.

## Verification

The point of the phase is the reader-side guard, so there is a #16207-style test. It marks an injected `TestRunResultAggregator` failed (writer), builds `Executor` with that instance, and asserts the exit code carries the failure through the same instance. `Execute("--help")` is used because its base exit code is `0` — `HelpArgumentProcessor` returns `ArgumentProcessorResult.Abort`, which does not set the failure bit — so the aggregator's `Outcome` is the only thing that can flip the exit code. The negative control is decisive: a second `Executor` bound to the static default (still `Passed`) exits `0`, and the static's `Outcome` stays `Passed`, proving the write did not leak onto it.

Verified locally on Windows: `build.cmd -c Release`, `build.cmd -pack`, the full `vstest.console.UnitTests` net481 run (2 pre-existing skips, otherwise green), and `test.cmd -smokeTest` are all green.

Both touched types — `TestRunResultAggregator` and `Executor` — are `internal`, so the new ctor parameter adds no public surface: no `PublicAPI.Unshipped.txt`, `.resx`, or `.xlf` changes.