### PR TITLE
Source Microsoft.TestPlatform.Internal.Uwp payload from each producer's own build

### DIFF
--- a/src/package/Microsoft.TestPlatform.Internal.Uwp/Microsoft.TestPlatform.Internal.Uwp.csproj
+++ b/src/package/Microsoft.TestPlatform.Internal.Uwp/Microsoft.TestPlatform.Internal.Uwp.csproj
@@ -30,20 +30,25 @@
     <None Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
-  <!-- Bundle the test platform DLLs (ObjectModel, CrossPlatEngine and their dependencies) plus the
-       ObjectModel and CoreUtilities satellite resources into lib/netstandard2.0. -->
+  <!-- Bundle the test platform DLLs (ObjectModel, CrossPlatEngine and their dependency closure) plus
+       the ObjectModel and CoreUtilities satellite resources into lib/netstandard2.0. Each assembly is
+       taken from the single project that produces it (its own netstandard2.0 build output) rather than
+       cherry-picked from this package's commingled $(OutputPath), into which every ProjectReference
+       copies its output. Sourcing each DLL from its producer guarantees a self-consistent set instead
+       of files that happened to win a race in the shared folder. Expanded at pack time because the
+       producer folders are populated during the build. -->
   <Target Name="IncludeBundledAssembliesInPackage">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.TestPlatform.CoreUtilities.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.TestPlatform.CrossPlatEngine.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.TestPlatform.CommunicationUtilities.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.TestPlatform.Utilities.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.VisualStudio.TestPlatform.Common.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.TestPlatform.PlatformAbstractions.dll" PackagePath="lib/$(TargetFramework)/" />
-      <!-- Only ObjectModel and CoreUtilities satellite resources are shipped. -->
-      <TfmSpecificPackageFile Include="$(OutputPath)**/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(OutputPath)**/Microsoft.TestPlatform.CoreUtilities.resources.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.ObjectModel\$(Configuration)\netstandard2.0\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.CoreUtilities\$(Configuration)\netstandard2.0\Microsoft.TestPlatform.CoreUtilities.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.CrossPlatEngine\$(Configuration)\netstandard2.0\Microsoft.TestPlatform.CrossPlatEngine.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.CommunicationUtilities\$(Configuration)\netstandard2.0\Microsoft.TestPlatform.CommunicationUtilities.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.Utilities\$(Configuration)\netstandard2.0\Microsoft.TestPlatform.Utilities.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.Common\$(Configuration)\netstandard2.0\Microsoft.VisualStudio.TestPlatform.Common.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.PlatformAbstractions\$(Configuration)\netstandard2.0\Microsoft.TestPlatform.PlatformAbstractions.dll" PackagePath="lib/$(TargetFramework)/" />
+      <!-- Only ObjectModel and CoreUtilities satellite resources are shipped, each from its own build. -->
+      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.ObjectModel\$(Configuration)\netstandard2.0\**\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.CoreUtilities\$(Configuration)\netstandard2.0\**\Microsoft.TestPlatform.CoreUtilities.resources.dll" PackagePath="lib/$(TargetFramework)/" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Applies the same publish-once / glob-many packaging pattern as #16206, #16236, #16240 and #16246 to **Microsoft.TestPlatform.Internal.Uwp**.

### The problem
`IncludeBundledAssembliesInPackage` cherry-picked its seven netstandard2.0 assemblies (and the ObjectModel/CoreUtilities satellites) out of this package's own `$(OutputPath)`, a single folder that both ProjectReferences (ObjectModel, CrossPlatEngine) and their transitive dependency closure copy their outputs into. When many projects build into one folder, a bundled DLL can be a copy that happened to win a race there rather than the assembly its owning project actually produced.

### The change
Each bundled assembly is now taken from the single project that produces it — its own `netstandard2.0` build output under `artifacts\bin\<project>\<config>\netstandard2.0\` — and the ObjectModel/CoreUtilities satellites come from those two projects' own builds. The set is name-scoped, so the payload is exactly the same assemblies as before.

This is a single-TFM `lib/` package with only two references, so it did not actively diverge the way the multi-TFM VS bundle did; the change is for consistency with the rest of the repo's packaging.

### Validation
Clean `-c Release -pack`: 0 warnings, 0 errors, DLL target frameworks match. The produced `.nupkg` file set is the same 39 entries as before this change (+0/-0).
