### PR TITLE
Inject built-in ConsoleLogger from the composition root instead of reflection-activating it

### DIFF
--- a/src/Microsoft.TestPlatform.Common/RequestData.cs
+++ b/src/Microsoft.TestPlatform.Common/RequestData.cs
@@ -55,4 +55,14 @@ public class RequestData : IRequestData
     /// Gets or sets a value indicating whether is telemetry opted in.
     /// </summary>
     public bool IsTelemetryOptedIn { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional factory the composition root uses to supply pre-configured instances
+    /// of its own built-in extensions (keyed by extension URI) instead of reflection-activating them.
+    /// Returns <see langword="null"/> for unknown / third-party extensions, which continue to be
+    /// created by reflection. This is an internal, closed injection seam for our own extensions and is
+    /// deliberately not part of the public <see cref="IRequestData"/> contract, so it never becomes a
+    /// third-party extension point.
+    /// </summary>
+    internal Func<Uri, object?>? KnownExtensionInstanceFactory { get; set; }
 }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/TestLoggerManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/TestLoggerManager.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Reflection;
 using System.Xml;
 
+using Microsoft.VisualStudio.TestPlatform.Common;
 using Microsoft.VisualStudio.TestPlatform.Common.Exceptions;
 using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
 using Microsoft.VisualStudio.TestPlatform.Common.Logging;
@@ -354,6 +355,17 @@ internal class TestLoggerManager : ITestLoggerManager
         ValidateArg.NotNull(uri, nameof(uri));
         CheckDisposed();
 
+        // Give the composition root the first chance to supply a pre-configured instance of its own
+        // built-in logger (keyed by URI) so it receives injected dependencies instead of a
+        // reflection-activated one. This covers loggers the user names explicitly in run settings by URI
+        // or by friendly name (which is resolved to a URI before we get here). Unknown / third-party
+        // loggers return null and fall through to the reflection-based extension manager below, exactly
+        // as before, so this does not widen any public extension point.
+        if ((_requestData as RequestData)?.KnownExtensionInstanceFactory?.Invoke(uri) is ITestLogger knownLogger)
+        {
+            return InitializeKnownLogger(knownLogger, uri, parameters);
+        }
+
         // Look up the extension and initialize it if one is found.
         var extensionManager = TestLoggerExtensionManager;
         var logger = extensionManager.TryGetTestExtension(uri.AbsoluteUri);
@@ -541,6 +553,23 @@ internal class TestLoggerManager : ITestLoggerManager
                 assembly?.GetTypes()
                     .FirstOrDefault(x => string.Equals(x.AssemblyQualifiedName, assemblyQualifiedName));
 
+            // Give the composition root (vstest.console) the first chance to supply a pre-configured
+            // instance of one of its own built-in loggers (for example ConsoleLogger with the parsed
+            // CommandLineOptions injected). This is the path our shipped ConsoleLogger actually takes:
+            // it is registered in run settings by assembly-qualified name (see AddConsoleLogger), not
+            // discovered through the logger extension manager, so it is always activated here. The
+            // instance is looked up by the extension URI declared on the resolved type, letting our
+            // extensions receive their dependencies by injection instead of reaching for process-wide
+            // singletons. Unknown / third-party loggers are not matched by the factory and fall through
+            // to reflection activation below, exactly as before, so this does not widen any public
+            // extension point.
+            if (loggerType?.GetCustomAttribute<ExtensionUriAttribute>()?.ExtensionUri is { } extensionUri
+                && Uri.TryCreate(extensionUri, UriKind.Absolute, out var loggerUri)
+                && (_requestData as RequestData)?.KnownExtensionInstanceFactory?.Invoke(loggerUri) is ITestLogger knownLogger)
+            {
+                return InitializeKnownLogger(knownLogger, loggerUri, parameters);
+            }
+
             // Create logger instance
             var constructorInfo = loggerType?.GetConstructor(Type.EmptyTypes);
             var logger = constructorInfo?.Invoke([]);
@@ -575,6 +604,30 @@ internal class TestLoggerManager : ITestLoggerManager
                 "TestLoggerManager: Error occurred while initializing the Logger assemblyQualifiedName : {0}, codeBase : {1} , Exception Details : {2}", assemblyQualifiedName, codeBase, ex);
             return false;
         }
+    }
+
+    /// <summary>
+    /// Initializes a logger instance supplied directly by the composition root (see
+    /// <see cref="RequestData.KnownExtensionInstanceFactory"/>) rather than one created by reflection.
+    /// Mirrors the dedup / initialize / track steps used by the reflection-based paths.
+    /// </summary>
+    private bool InitializeKnownLogger(ITestLogger logger, Uri uri, Dictionary<string, string?>? parameters)
+    {
+        // If the logger has already been initialized just return.
+        if (_initializedLoggers.Contains(logger.GetType()))
+        {
+            EqtTrace.Verbose("TestLoggerManager: Skipping duplicate logger initialization: {0}", logger.GetType());
+            return true;
+        }
+
+        var initialized = InitializeLogger(logger, uri.AbsoluteUri, parameters);
+
+        if (initialized)
+        {
+            _initializedLoggers.Add(logger.GetType());
+        }
+
+        return initialized;
     }
 
     private bool InitializeLogger(object? logger, string? extensionUri, Dictionary<string, string?>? parameters)

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -112,10 +112,15 @@ internal class ConsoleLogger : ITestLoggerWithParameters
     private string? _targetFramework;
 
     /// <summary>
-    /// Default constructor.
+    /// Constructor. The built-in console logger is activated directly by the composition root (see
+    /// <see cref="TestPlatformHelpers.TestRequestManager"/>) rather than by reflection, so it receives
+    /// the parsed <see cref="CommandLineOptions"/> by injection instead of reaching for the process-wide
+    /// singleton. <see cref="Output"/> and the progress indicator are established later, in
+    /// <see cref="Initialize(TestLoggerEvents, string)"/>.
     /// </summary>
-    public ConsoleLogger()
+    internal ConsoleLogger(CommandLineOptions commandLineOptions)
     {
+        _commandLineOptions = commandLineOptions;
     }
 
     /// <summary>

--- a/src/vstest.console/Processors/ListExtensionsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ListExtensionsArgumentProcessor.cs
@@ -160,7 +160,15 @@ internal class ListLoggersArgumentExecutor : IArgumentExecutor
         var extensionManager = TestLoggerExtensionManager.Create(new NullMessageLogger());
         foreach (var extension in extensionManager.TestExtensions)
         {
-            ConsoleOutput.Instance.WriteLine(extension.Value.GetType().FullName, OutputLevel.Information);
+            // Report the logger's type name from its discovery metadata instead of instantiating the
+            // extension. Our built-in ConsoleLogger is activated by injection and no longer exposes a
+            // parameterless constructor, so forcing extension.Value here would fail; and naming the
+            // available loggers should never require constructing them.
+            var loggerTypeName = extension.TestPluginInfo?.AssemblyQualifiedName is { } assemblyQualifiedName
+                ? assemblyQualifiedName.Split(',')[0]
+                : extension.Value.GetType().FullName;
+
+            ConsoleOutput.Instance.WriteLine(loggerTypeName, OutputLevel.Information);
             ConsoleOutput.Instance.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.AvailableExtensionsMetadataFormat, "Uri", extension.Metadata.ExtensionUri), OutputLevel.Information);
             ConsoleOutput.Instance.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.AvailableExtensionsMetadataFormat, "FriendlyName", string.Join(", ", extension.Metadata.FriendlyName)), OutputLevel.Information);
         }

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -1421,9 +1421,21 @@ internal class TestRequestManager : ITestRequestManager
                 _telemetryOptedIn || IsTelemetryOptedIn()
                     ? new MetricsCollection()
                     : new NoOpMetricsCollection(),
-            IsTelemetryOptedIn = _telemetryOptedIn || IsTelemetryOptedIn()
+            IsTelemetryOptedIn = _telemetryOptedIn || IsTelemetryOptedIn(),
+            KnownExtensionInstanceFactory = CreateKnownExtensionInstance,
         };
     }
+
+    /// <summary>
+    /// Supplies pre-configured instances of vstest.console's own built-in extensions so they receive
+    /// injected dependencies (here: the parsed <see cref="CommandLineOptions"/>) instead of reaching
+    /// for process-wide singletons. Unknown extension URIs return <see langword="null"/> and are
+    /// reflection-activated as before, so this does not widen any public extension point.
+    /// </summary>
+    private object? CreateKnownExtensionInstance(Uri extensionUri)
+        => string.Equals(extensionUri.AbsoluteUri, ConsoleLogger.ExtensionUri, StringComparison.OrdinalIgnoreCase)
+            ? new ConsoleLogger(_commandLineOptions)
+            : null;
 
     private static List<string> GetSources(TestRunRequestPayload testRunRequestPayload)
     {

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
@@ -388,6 +388,30 @@ public class ExecutionTests : AcceptanceTestBase
     }
 
     [TestMethod]
+    [TestMatrix(testHost: Net)]
+    public void ExplicitConsoleLoggerActivatesWhenRequestedByName(RunnerInfo runnerInfo)
+    {
+        // The built-in console logger is activated by the composition root (TestRequestManager) handing
+        // over a pre-built instance with the parsed CommandLineOptions injected, instead of being
+        // reflection-activated, and it no longer has a parameterless constructor. When the user asks for
+        // it explicitly with /logger:console it is registered in run settings by assembly-qualified name
+        // (UpdateConsoleLoggerIfExists) with no URI, so it goes through the assembly-qualified-name
+        // activation path. This is the path that broke when the parameterless constructor was removed, so
+        // this test guards that regression end-to-end. The pass/fail/skip summary asserted below is
+        // printed by the console logger itself, so a passing assertion proves it activated and ran.
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var testDll = GetAssetFullPath("MSTestProject1.dll");
+
+        var arguments = PrepareArguments(testDll, GetTestAdapterPath(), string.Empty, framework: string.Empty, _testEnvironment.InIsolationValue, resultsDirectory: TempDirectory.Path);
+        arguments = string.Concat(arguments, " /logger:\"console;verbosity=normal\"");
+        InvokeVsTest(arguments);
+
+        ValidateSummaryStatus(1, 1, 1);
+        ExitCodeEquals(1); // failing test in MSTestProject1
+    }
+
+    [TestMethod]
     // This is a built-in assembly filter test. It changes with vstest.version, so testing against 1 version of console is enough.
     [TestMatrix(console: Net, testHost: Net)]
     public void RunXunitTestsWhenProvidingAllDllsInBin(RunnerInfo runnerInfo)

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestLoggerManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestLoggerManagerTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 using Microsoft.TestPlatform.TestUtilities;
+using Microsoft.VisualStudio.TestPlatform.Common;
 using Microsoft.VisualStudio.TestPlatform.Common.Exceptions;
 using Microsoft.VisualStudio.TestPlatform.Common.Logging;
 using Microsoft.VisualStudio.TestPlatform.Common.Telemetry;
@@ -266,6 +267,113 @@ public class TestLoggerManagerTests
     {
         var testLoggerManager = new DummyTestLoggerManager();
         Assert.IsFalse(testLoggerManager.InitializeLoggerByUri(new Uri("logger://NotALogger"), null));
+    }
+
+    [TestMethod]
+    public void InitializeLoggerByUriShouldUseTheInstanceSuppliedByTheCompositionRootForAKnownLogger()
+    {
+        // The composition root (vstest.console) can hand a pre-configured instance of one of its own
+        // built-in loggers (for example ConsoleLogger with the parsed CommandLineOptions injected) to
+        // the logger manager through RequestData. When it does, that exact instance must be used and
+        // initialized instead of the logger being reflection-activated, which is how our shipped
+        // extensions get their dependencies by injection rather than reaching for process-wide singletons.
+        var injectedLogger = new Mock<ITestLogger>();
+        var requestData = new RequestData
+        {
+            KnownExtensionInstanceFactory = uri =>
+                uri.AbsoluteUri == new Uri(_loggerUri).AbsoluteUri ? injectedLogger.Object : null,
+        };
+        var testLoggerManager = new DummyTestLoggerManager(requestData);
+
+        var initialized = testLoggerManager.InitializeLoggerByUri(new Uri(_loggerUri), new());
+
+        Assert.IsTrue(initialized);
+        injectedLogger.Verify(l => l.Initialize(It.IsAny<TestLoggerEvents>(), It.IsAny<string>()), Times.Once);
+    }
+
+    [TestMethod]
+    public void InitializeShouldUseTheCompositionRootInstanceForALoggerEnabledByFriendlyNameInDesignMode()
+    {
+        // Mirrors a user explicitly enabling the built-in console logger in run settings while in design
+        // mode. Design mode only suppresses adding the *default* logger at activation time; a logger the
+        // user asked for is still activated. The friendly name resolves to the logger URI, which the
+        // composition root's factory then services with an injected instance instead of a
+        // reflection-activated one.
+        var injectedLogger = new Mock<ITestLogger>();
+        var requestData = new RequestData
+        {
+            KnownExtensionInstanceFactory = uri =>
+                uri.AbsoluteUri == new Uri(_loggerUri).AbsoluteUri ? injectedLogger.Object : null,
+        };
+        var testLoggerManager = new DummyTestLoggerManager(requestData);
+
+        string settingsXml =
+            @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <RunSettings>
+                  <RunConfiguration>
+                    <DesignMode>true</DesignMode>
+                  </RunConfiguration>
+                  <LoggerRunSettings>
+                    <Loggers>
+                      <Logger friendlyName=""TestLoggerExtension"" enabled=""true"" />
+                    </Loggers>
+                  </LoggerRunSettings>
+                </RunSettings>";
+
+        testLoggerManager.Initialize(settingsXml);
+
+        injectedLogger.Verify(l => l.Initialize(It.IsAny<TestLoggerEvents>(), It.IsAny<string>()), Times.Once);
+    }
+
+    [TestMethod]
+    public void InitializeLoggerByUriShouldFallBackToReflectionWhenTheCompositionRootHasNoInstance()
+    {
+        // Loggers the composition root does not know about (third-party loggers loaded via
+        // /testadapterpath, and any of our own not wired into the factory) must continue to be
+        // reflection-activated exactly as before: the factory returns null and we fall through to the
+        // extension manager. This keeps the injection seam closed to our own built-in extensions and
+        // does not widen any public extension point.
+        var requestData = new RequestData();
+        var testLoggerManager = new DummyTestLoggerManager(requestData);
+
+        var initialized = testLoggerManager.InitializeLoggerByUri(new Uri(_loggerUri), new());
+
+        Assert.IsTrue(initialized);
+    }
+
+    [TestMethod]
+    public void InitializeByAssemblyQualifiedNameShouldUseTheInstanceSuppliedByTheCompositionRootForAKnownLogger()
+    {
+        // This is the path our shipped ConsoleLogger actually takes: it is registered in run settings by
+        // assembly-qualified name (see TestRequestManager.AddConsoleLogger), not discovered through the
+        // logger extension manager, so it is activated by InitializeLoggerByType rather than by URI. The
+        // composition root's factory must service that path too, keyed by the extension URI declared on
+        // the resolved type, so the known logger receives its injected dependencies instead of being
+        // reflection-activated. Removing ConsoleLogger's parameterless constructor depends on exactly this.
+        var injectedLogger = new Mock<ITestLogger>();
+        var requestData = new RequestData
+        {
+            KnownExtensionInstanceFactory = uri =>
+                uri.AbsoluteUri == new Uri(_loggerUri).AbsoluteUri ? injectedLogger.Object : null,
+        };
+        var testLoggerManager = new DummyTestLoggerManager(requestData);
+
+        var assemblyQualifiedName = typeof(ValidLogger).AssemblyQualifiedName;
+        var codeBase = typeof(TestLoggerManagerTests).Assembly.Location;
+
+        string settingsXml =
+            @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <RunSettings>
+                  <LoggerRunSettings>
+                    <Loggers>
+                      <Logger assemblyQualifiedName=""" + assemblyQualifiedName + @""" codeBase=""" + codeBase + @"""></Logger>
+                    </Loggers>
+                  </LoggerRunSettings>
+                </RunSettings>";
+
+        testLoggerManager.Initialize(settingsXml);
+
+        injectedLogger.Verify(l => l.Initialize(It.IsAny<TestLoggerEvents>(), It.IsAny<string>()), Times.Once);
     }
 
     [TestMethod]


### PR DESCRIPTION
ConsoleLogger reached for `CommandLineOptions.Instance` because it was reflection-activated through the logger manager and had nowhere to get the parsed options from. This gives the composition root (`TestRequestManager`) a closed internal factory on `RequestData` that hands the logger manager a ready-made instance for our own built-in extensions, keyed by extension URI. `ConsoleLogger` now takes `CommandLineOptions` by constructor injection and its parameterless constructor is gone.

Third-party loggers are untouched: the factory returns null for anything it doesn't recognize and they fall through to reflection exactly as before. The seam is `internal` and deliberately not on `IRequestData`, so it never turns into an extension point. That is the point of the shape here — our own extensions can be injected, and `.Instance` stays only behind the boundary for other people's code.

One thing worth knowing while reading: ConsoleLogger isn't discovered through the logger extension manager. `AddConsoleLogger` / `UpdateConsoleLoggerIfExists` write it into run settings by assembly-qualified name, so it's always activated in `InitializeLoggerByType`. That's where the seam had to go, keyed off the `[ExtensionUri]` on the resolved type. The by-URI path is covered too, so both entry points behave the same and a logger the user names by friendly name or URI is serviced identically.

`--ListLoggers` now names loggers from their discovery metadata instead of constructing them, since it can no longer `new` up ConsoleLogger.

Tests: added URI-path, AQN-path, design-mode + friendly-name, and a reflection-fallback negative control to `TestLoggerManagerTests`. Ran the full class (65/65 on net11.0 + net481) and the smoke suite (`dotnet test --logger:Console`, Acceptance 5/5 + Library 4/4) green. The AQN-path test is the one that guards the regression removing the parameterless constructor would otherwise reintroduce.
