### PR TITLE
Source bundled sibling DLLs from producer output in ObjectModel package

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj
+++ b/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj
@@ -23,14 +23,20 @@
     <ProjectReference Include="..\Microsoft.TestPlatform.CoreUtilities\Microsoft.TestPlatform.CoreUtilities.csproj" PrivateAssets="all" />
   </ItemGroup>
 
-  <!-- Bundle CoreUtilities and PlatformAbstractions DLLs + satellite resources into the package (they are not separate NuGet packages). -->
+  <!-- Bundle CoreUtilities and PlatformAbstractions DLLs + satellite resources into the package (they
+       are not separate NuGet packages). Each sibling assembly is taken from its own producing project's
+       build output for the matching target framework rather than cherry-picked from this project's
+       commingled $(OutputPath), so every bundled DLL is the exact build its owning project produced.
+       CoreUtilities and PlatformAbstractions multi-target the same framework set as this project, so
+       $(TargetFramework) maps one-to-one to the sibling's own output folder. Expanded at pack time
+       because the sibling folders are populated during the build. -->
   <Target Name="IncludeBundledAssembliesInPackage">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.TestPlatform.CoreUtilities.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.TestPlatform.PlatformAbstractions.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.CoreUtilities\$(Configuration)\$(TargetFramework)\Microsoft.TestPlatform.CoreUtilities.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.PlatformAbstractions\$(Configuration)\$(TargetFramework)\Microsoft.TestPlatform.PlatformAbstractions.dll" PackagePath="lib/$(TargetFramework)/" />
       <!-- Satellite resources for bundled assemblies -->
-      <TfmSpecificPackageFile Include="$(OutputPath)**/Microsoft.TestPlatform.CoreUtilities.resources.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(OutputPath)**/Microsoft.TestPlatform.PlatformAbstractions.resources.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.CoreUtilities\$(Configuration)\$(TargetFramework)\**\Microsoft.TestPlatform.CoreUtilities.resources.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.PlatformAbstractions\$(Configuration)\$(TargetFramework)\**\Microsoft.TestPlatform.PlatformAbstractions.resources.dll" PackagePath="lib/$(TargetFramework)/" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
## What

`Microsoft.TestPlatform.ObjectModel` bundles the `CoreUtilities` and `PlatformAbstractions` assemblies (and their satellite resources) into its NuGet package because neither ships as a standalone package. Until now those DLLs were cherry-picked out of this project's own `$(OutputPath)`, which is a commingled folder that every `ProjectReference` copies its output into. This is the same anti-pattern fixed for the VS bundle in #16206, the CLI package in #16236, and Portable in #16240: a bundled DLL and its co-shipped `.config`/metadata can end up sourced from different framework resolutions.

This repoints each bundled sibling at **its own producing project's build output** for the matching target framework, so every packaged DLL is exactly the build its owning project produced.

## Why it's safe

`CoreUtilities` and `PlatformAbstractions` multi-target the same framework set as `ObjectModel` (`net462;net8.0;netstandard2.0`), so `$(TargetFramework)` maps one-to-one to each sibling's own output folder — no TFM remapping needed.

Strict no-op, verified against a clean `-c Release -pack`:
- Produced package file set is **byte-for-byte identical (+0/-0)** vs the pre-change baseline (95 payload entries).
- `verify-nupkgs.ps1` reports **all DLL target frameworks match expectations** — no DLL reclassified, no binding-redirect drift.

Part of the repo-wide "publish/build once per producer, glob many" sweep.
