### PR TITLE
Source bundled sibling DLLs from producer output in TranslationLayer package

### DIFF
--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.csproj
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.csproj
@@ -43,17 +43,31 @@
     <None Include="$(SrcPackageFolder)ThirdPartyNotices.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
-  <!-- Bundle Common and CommunicationUtilities DLLs plus satellite resources (including CoreUtilities resources) into the package. -->
+  <!-- Bundle Common and CommunicationUtilities DLLs plus satellite resources (including CoreUtilities
+       resources) into the package (they are not separate NuGet packages). Each bundled assembly is
+       taken from its own producing project's build output for the matching target framework rather
+       than cherry-picked from this project's commingled $(OutputPath), so every bundled DLL is the
+       exact build its owning project produced. CommunicationUtilities and CoreUtilities multi-target
+       the same framework set as this project, so $(TargetFramework) maps one-to-one to their own
+       output. Common only builds net462 and netstandard2.0, so for .NET (Core) folders such as net8.0
+       the nearest-compatible netstandard2.0 flavor is used - exactly the one a Common ProjectReference
+       resolved into $(OutputPath) before this change. Expanded at pack time because the sibling folders
+       are populated during the build. -->
   <Target Name="IncludeBundledAssembliesInPackage">
+    <PropertyGroup>
+      <!-- Common has no net8.0 build; fall back to its netstandard2.0 flavor for .NET (Core) folders. -->
+      <_TranslationLayerCommonTfm>$(TargetFramework)</_TranslationLayerCommonTfm>
+      <_TranslationLayerCommonTfm Condition="!Exists('$(ArtifactsBinDir)Microsoft.TestPlatform.Common\$(Configuration)\$(TargetFramework)\')">netstandard2.0</_TranslationLayerCommonTfm>
+    </PropertyGroup>
     <ItemGroup>
-      <!-- The XML doc is emitted into the intermediate output, so include it explicitly (pack does not auto-pick it up). -->
+      <!-- The XML doc is emitted into this project's own intermediate output, so include it explicitly (pack does not auto-pick it up). -->
       <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.TestPlatform.VsTestConsole.TranslationLayer.XML" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.VisualStudio.TestPlatform.Common.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.TestPlatform.CommunicationUtilities.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.Common\$(Configuration)\$(_TranslationLayerCommonTfm)\Microsoft.VisualStudio.TestPlatform.Common.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.CommunicationUtilities\$(Configuration)\$(TargetFramework)\Microsoft.TestPlatform.CommunicationUtilities.dll" PackagePath="lib/$(TargetFramework)/" />
       <!-- Satellite resources for bundled assemblies -->
-      <TfmSpecificPackageFile Include="$(OutputPath)**/Microsoft.VisualStudio.TestPlatform.Common.resources.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(OutputPath)**/Microsoft.TestPlatform.CommunicationUtilities.resources.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(OutputPath)**/Microsoft.TestPlatform.CoreUtilities.resources.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.Common\$(Configuration)\$(_TranslationLayerCommonTfm)\**\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.CommunicationUtilities\$(Configuration)\$(TargetFramework)\**\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.CoreUtilities\$(Configuration)\$(TargetFramework)\**\Microsoft.TestPlatform.CoreUtilities.resources.dll" PackagePath="lib/$(TargetFramework)/" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
## What

`Microsoft.TestPlatform.TranslationLayer` bundles the `Common` and `CommunicationUtilities` assemblies (and the `Common`/`CommunicationUtilities`/`CoreUtilities` satellite resources) into its NuGet package because none of them ship as standalone packages. Until now those DLLs were cherry-picked out of this project's own `$(OutputPath)`, which is a commingled folder that every `ProjectReference` copies its output into. This is the same anti-pattern fixed for the VS bundle in #16206, the CLI package in #16236, Portable in #16240, and ObjectModel in #16250: a bundled DLL and its co-shipped metadata can end up sourced from different framework resolutions.

This repoints each bundled sibling at **its own producing project's build output** for the matching target framework.

## Why it's safe

- `CommunicationUtilities` and `CoreUtilities` multi-target the same framework set as `TranslationLayer` (`net462;net8.0;netstandard2.0`), so `$(TargetFramework)` maps one-to-one to their own output.
- `Common` only builds `net462` and `netstandard2.0`. Its `net8.0` package folder has always carried Common's **netstandard2.0** flavor (the nearest-compatible build a `ProjectReference` resolved into `$(OutputPath)`), so the target maps net8.0 → netstandard2.0 for Common only. Verified empirically: the Common DLL in the baseline `lib/net8.0` folder is byte-identical to Common's `netstandard2.0` build output.

Strict no-op, verified against a clean `-c Release -pack`:
- Produced package file set is **byte-for-byte identical (+0/-0)** vs the pre-change baseline (174 payload entries).
- `verify-nupkgs.ps1` reports **all binding redirects match their DLL versions** and **all DLL target frameworks match expectations** — no DLL reclassified.

This completes the repo-wide "publish/build once per producer, glob many" sweep.
