### PR TITLE
Revert ObjectModel package producer-output sourcing (#16250)

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj
+++ b/src/Microsoft.TestPlatform.ObjectModel/Microsoft.TestPlatform.ObjectModel.csproj
@@ -23,20 +23,14 @@
     <ProjectReference Include="..\Microsoft.TestPlatform.CoreUtilities\Microsoft.TestPlatform.CoreUtilities.csproj" PrivateAssets="all" />
   </ItemGroup>
 
-  <!-- Bundle CoreUtilities and PlatformAbstractions DLLs + satellite resources into the package (they
-       are not separate NuGet packages). Each sibling assembly is taken from its own producing project's
-       build output for the matching target framework rather than cherry-picked from this project's
-       commingled $(OutputPath), so every bundled DLL is the exact build its owning project produced.
-       CoreUtilities and PlatformAbstractions multi-target the same framework set as this project, so
-       $(TargetFramework) maps one-to-one to the sibling's own output folder. Expanded at pack time
-       because the sibling folders are populated during the build. -->
+  <!-- Bundle CoreUtilities and PlatformAbstractions DLLs + satellite resources into the package (they are not separate NuGet packages). -->
   <Target Name="IncludeBundledAssembliesInPackage">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.CoreUtilities\$(Configuration)\$(TargetFramework)\Microsoft.TestPlatform.CoreUtilities.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.PlatformAbstractions\$(Configuration)\$(TargetFramework)\Microsoft.TestPlatform.PlatformAbstractions.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.TestPlatform.CoreUtilities.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.TestPlatform.PlatformAbstractions.dll" PackagePath="lib/$(TargetFramework)/" />
       <!-- Satellite resources for bundled assemblies -->
-      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.CoreUtilities\$(Configuration)\$(TargetFramework)\**\Microsoft.TestPlatform.CoreUtilities.resources.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.PlatformAbstractions\$(Configuration)\$(TargetFramework)\**\Microsoft.TestPlatform.PlatformAbstractions.resources.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(OutputPath)**/Microsoft.TestPlatform.CoreUtilities.resources.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(OutputPath)**/Microsoft.TestPlatform.PlatformAbstractions.resources.dll" PackagePath="lib/$(TargetFramework)/" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Reverts the ObjectModel packaging change from #16250.

## Why

The "source each bundled payload from its producer's own output" pattern earns its keep only when **many projects with different target frameworks publish into one shared folder**, so a single filename can be captured in the wrong framework flavor (the `.dll` / `.config` binding-redirect split fixed for the VS bundle #16206, CLI #16236, and Portable #16240).

`Microsoft.TestPlatform.ObjectModel` is an ordinary multi-targeting library. Its `$(OutputPath)` is **per-TFM** (`bin/<cfg>/net8.0/`, `.../net462/`, `.../netstandard2.0/`), so the sibling `CoreUtilities`/`PlatformAbstractions` DLL that sits in each folder is already the single correct flavor for that framework — there is no commingling to protect against. The conversion only added indirection (longer producer paths) for no safety benefit.

## Safety

The original conversion was a strict no-op (+0/-0, no DLL reclassified), so this revert is equally a no-op. Verified against a clean `-c Release -pack`: package file set **+0/-0** (95 payload entries), binding redirects and DLL target frameworks all match, no `eng/expected-*.json` regeneration.
