### PR TITLE
Revert TranslationLayer package producer-output sourcing (#16251)

### DIFF
--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.csproj
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.csproj
@@ -43,31 +43,17 @@
     <None Include="$(SrcPackageFolder)ThirdPartyNotices.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
-  <!-- Bundle Common and CommunicationUtilities DLLs plus satellite resources (including CoreUtilities
-       resources) into the package (they are not separate NuGet packages). Each bundled assembly is
-       taken from its own producing project's build output for the matching target framework rather
-       than cherry-picked from this project's commingled $(OutputPath), so every bundled DLL is the
-       exact build its owning project produced. CommunicationUtilities and CoreUtilities multi-target
-       the same framework set as this project, so $(TargetFramework) maps one-to-one to their own
-       output. Common only builds net462 and netstandard2.0, so for .NET (Core) folders such as net8.0
-       the nearest-compatible netstandard2.0 flavor is used - exactly the one a Common ProjectReference
-       resolved into $(OutputPath) before this change. Expanded at pack time because the sibling folders
-       are populated during the build. -->
+  <!-- Bundle Common and CommunicationUtilities DLLs plus satellite resources (including CoreUtilities resources) into the package. -->
   <Target Name="IncludeBundledAssembliesInPackage">
-    <PropertyGroup>
-      <!-- Common has no net8.0 build; fall back to its netstandard2.0 flavor for .NET (Core) folders. -->
-      <_TranslationLayerCommonTfm>$(TargetFramework)</_TranslationLayerCommonTfm>
-      <_TranslationLayerCommonTfm Condition="!Exists('$(ArtifactsBinDir)Microsoft.TestPlatform.Common\$(Configuration)\$(TargetFramework)\')">netstandard2.0</_TranslationLayerCommonTfm>
-    </PropertyGroup>
     <ItemGroup>
-      <!-- The XML doc is emitted into this project's own intermediate output, so include it explicitly (pack does not auto-pick it up). -->
+      <!-- The XML doc is emitted into the intermediate output, so include it explicitly (pack does not auto-pick it up). -->
       <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.TestPlatform.VsTestConsole.TranslationLayer.XML" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.Common\$(Configuration)\$(_TranslationLayerCommonTfm)\Microsoft.VisualStudio.TestPlatform.Common.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.CommunicationUtilities\$(Configuration)\$(TargetFramework)\Microsoft.TestPlatform.CommunicationUtilities.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.VisualStudio.TestPlatform.Common.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.TestPlatform.CommunicationUtilities.dll" PackagePath="lib/$(TargetFramework)/" />
       <!-- Satellite resources for bundled assemblies -->
-      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.Common\$(Configuration)\$(_TranslationLayerCommonTfm)\**\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.CommunicationUtilities\$(Configuration)\$(TargetFramework)\**\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.CoreUtilities\$(Configuration)\$(TargetFramework)\**\Microsoft.TestPlatform.CoreUtilities.resources.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(OutputPath)**/Microsoft.VisualStudio.TestPlatform.Common.resources.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(OutputPath)**/Microsoft.TestPlatform.CommunicationUtilities.resources.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(OutputPath)**/Microsoft.TestPlatform.CoreUtilities.resources.dll" PackagePath="lib/$(TargetFramework)/" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Reverts the TranslationLayer packaging change from #16251.

## Why

The "source each bundled payload from its producer's own output" pattern earns its keep only when **many projects with different target frameworks publish into one shared folder**, so a single filename can be captured in the wrong framework flavor (the `.dll` / `.config` binding-redirect split fixed for the VS bundle #16206, CLI #16236, and Portable #16240).

`Microsoft.TestPlatform.TranslationLayer` is an ordinary multi-targeting library. Its `$(OutputPath)` is **per-TFM**, so the sibling `Common`/`CommunicationUtilities` DLL in each folder is already the single correct flavor — there is no commingling to protect against.

It was actually the clearest example of the pattern hurting readability: because `Common` has no `net8.0` build, the conversion had to hand-roll a `net8.0 → netstandard2.0` fallback that the build previously resolved for free when the `ProjectReference` was copied into `$(OutputPath)`. Extra logic, more to get wrong, zero benefit.

## Safety

The original conversion was a strict no-op (+0/-0, no DLL reclassified), so this revert is equally a no-op. Verified against a clean `-c Release -pack`: package file set **+0/-0** (174 payload entries), binding redirects and DLL target frameworks all match, no `eng/expected-*.json` regeneration.
