### PR TITLE
Revert Internal.Uwp package producer-output sourcing (#16247)

### DIFF
--- a/src/package/Microsoft.TestPlatform.Internal.Uwp/Microsoft.TestPlatform.Internal.Uwp.csproj
+++ b/src/package/Microsoft.TestPlatform.Internal.Uwp/Microsoft.TestPlatform.Internal.Uwp.csproj
@@ -30,25 +30,20 @@
     <None Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
-  <!-- Bundle the test platform DLLs (ObjectModel, CrossPlatEngine and their dependency closure) plus
-       the ObjectModel and CoreUtilities satellite resources into lib/netstandard2.0. Each assembly is
-       taken from the single project that produces it (its own netstandard2.0 build output) rather than
-       cherry-picked from this package's commingled $(OutputPath), into which every ProjectReference
-       copies its output. Sourcing each DLL from its producer guarantees a self-consistent set instead
-       of files that happened to win a race in the shared folder. Expanded at pack time because the
-       producer folders are populated during the build. -->
+  <!-- Bundle the test platform DLLs (ObjectModel, CrossPlatEngine and their dependencies) plus the
+       ObjectModel and CoreUtilities satellite resources into lib/netstandard2.0. -->
   <Target Name="IncludeBundledAssembliesInPackage">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.ObjectModel\$(Configuration)\netstandard2.0\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.CoreUtilities\$(Configuration)\netstandard2.0\Microsoft.TestPlatform.CoreUtilities.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.CrossPlatEngine\$(Configuration)\netstandard2.0\Microsoft.TestPlatform.CrossPlatEngine.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.CommunicationUtilities\$(Configuration)\netstandard2.0\Microsoft.TestPlatform.CommunicationUtilities.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.Utilities\$(Configuration)\netstandard2.0\Microsoft.TestPlatform.Utilities.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.Common\$(Configuration)\netstandard2.0\Microsoft.VisualStudio.TestPlatform.Common.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.PlatformAbstractions\$(Configuration)\netstandard2.0\Microsoft.TestPlatform.PlatformAbstractions.dll" PackagePath="lib/$(TargetFramework)/" />
-      <!-- Only ObjectModel and CoreUtilities satellite resources are shipped, each from its own build. -->
-      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.ObjectModel\$(Configuration)\netstandard2.0\**\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll" PackagePath="lib/$(TargetFramework)/" />
-      <TfmSpecificPackageFile Include="$(ArtifactsBinDir)Microsoft.TestPlatform.CoreUtilities\$(Configuration)\netstandard2.0\**\Microsoft.TestPlatform.CoreUtilities.resources.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.TestPlatform.CoreUtilities.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.TestPlatform.CrossPlatEngine.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.TestPlatform.CommunicationUtilities.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.TestPlatform.Utilities.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.VisualStudio.TestPlatform.Common.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(OutputPath)Microsoft.TestPlatform.PlatformAbstractions.dll" PackagePath="lib/$(TargetFramework)/" />
+      <!-- Only ObjectModel and CoreUtilities satellite resources are shipped. -->
+      <TfmSpecificPackageFile Include="$(OutputPath)**/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll" PackagePath="lib/$(TargetFramework)/" />
+      <TfmSpecificPackageFile Include="$(OutputPath)**/Microsoft.TestPlatform.CoreUtilities.resources.dll" PackagePath="lib/$(TargetFramework)/" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Reverts the Internal.Uwp packaging change from #16247.

## Why

The "source each bundled payload from its producer's own output" pattern earns its keep only when **many projects with different target frameworks publish into one shared folder**, so a single filename can be captured in the wrong framework flavor (the `.dll` / `.config` binding-redirect split fixed for the VS bundle #16206, CLI #16236, and Portable #16240).

`Microsoft.TestPlatform.Internal.Uwp` is a **single-target** (`netstandard2.0`) package, so every bundled sibling resolves to exactly one flavor — there is no commingling to protect against. The conversion only added indirection for no safety benefit.

## Safety

The original conversion was a strict no-op (+0/-0, no DLL reclassified), so this revert is equally a no-op. Verified against a clean `-c Release -pack`: package file set **+0/-0** (38 payload entries), binding redirects and DLL target frameworks all match, no `eng/expected-*.json` regeneration.
