### PR TITLE
Make the built-in ConsoleLogger independent of CommandLineOptions.Instance

### DIFF
--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -131,7 +131,9 @@ internal class ConsoleLogger : ITestLoggerWithParameters
         Output = output;
         _progressIndicator = progressIndicator;
         _featureFlag = featureFlag;
-        _commandLineOptions = commandLineOptions;
+        // Never fall back to CommandLineOptions.Instance: the logger owns its own options so tests
+        // stay isolated and the built-in logger no longer reads the process-wide singleton.
+        _commandLineOptions = commandLineOptions ?? new CommandLineOptions();
     }
 
     /// <summary>
@@ -148,7 +150,7 @@ internal class ConsoleLogger : ITestLoggerWithParameters
 
     private readonly IFeatureFlag _featureFlag = FeatureFlag.Instance;
 
-    private readonly CommandLineOptions? _commandLineOptions;
+    private readonly CommandLineOptions _commandLineOptions;
 
     /// <summary>
     /// Get the verbosity level for the console logger
@@ -423,7 +425,7 @@ internal class ConsoleLogger : ITestLoggerWithParameters
         TPDebug.Assert(Output != null, "Initialize should have been called");
 
         // Print all test containers.
-        var commandLineOptions = _commandLineOptions ?? CommandLineOptions.Instance;
+        var commandLineOptions = _commandLineOptions;
         Output.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestSourcesDiscovered, commandLineOptions.Sources.Count()), OutputLevel.Information);
         if (VerbosityLevel == Verbosity.Detailed)
         {
@@ -693,7 +695,7 @@ internal class ConsoleLogger : ITestLoggerWithParameters
                 // DISABLE_ARTIFACTS_POSTPROCESSING_NEW_SDK_UX(new UX) is disabled
                 _featureFlag.IsSet(FeatureFlag.VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING_NEW_SDK_UX) ||
                 // TestSessionCorrelationId is null(we're not running through the dotnet SDK).
-                (_commandLineOptions ?? CommandLineOptions.Instance).TestSessionCorrelationId is null)
+                _commandLineOptions.TestSessionCorrelationId is null)
             {
                 Output.Information(false, CommandLineResources.AttachmentsBanner);
                 TPDebug.Assert(e.AttachmentSets != null, "e.AttachmentSets should not be null when runLevelAttachmentsCount > 0.");

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -38,6 +38,7 @@ public class ConsoleLoggerTests
     private readonly ConsoleLogger _consoleLogger;
     private readonly Mock<IProgressIndicator> _mockProgressIndicator;
     private readonly Mock<IFeatureFlag> _mockFeatureFlag;
+    private readonly CommandLineOptions _commandLineOptions;
 
     private const string PassedTestIndicator = "  Passed ";
     private const string FailedTestIndicator = "  Failed ";
@@ -53,7 +54,8 @@ public class ConsoleLoggerTests
 
         _mockOutput = new Mock<IOutput>();
         _mockProgressIndicator = new Mock<IProgressIndicator>();
-        _consoleLogger = new ConsoleLogger(_mockOutput.Object, _mockProgressIndicator.Object, _mockFeatureFlag.Object);
+        _commandLineOptions = new CommandLineOptions();
+        _consoleLogger = new ConsoleLogger(_mockOutput.Object, _mockProgressIndicator.Object, _mockFeatureFlag.Object, _commandLineOptions);
 
         RunTestsArgumentProcessorTests.SetupMockExtensions();
     }
@@ -1046,13 +1048,12 @@ public class ConsoleLoggerTests
         loggerEvents.EnableEvents();
 
         var fileHelper = new Mock<IFileHelper>();
-        CommandLineOptions.Reset();
-        CommandLineOptions.Instance.FileHelper = fileHelper.Object;
-        CommandLineOptions.Instance.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, fileHelper.Object);
+        _commandLineOptions.FileHelper = fileHelper.Object;
+        _commandLineOptions.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, fileHelper.Object);
         string testFilePath = Path.Combine(Path.GetTempPath(), "DmmyTestFile.dll");
         fileHelper.Setup(fh => fh.Exists(testFilePath)).Returns(true);
 
-        CommandLineOptions.Instance.AddSource(testFilePath);
+        _commandLineOptions.AddSource(testFilePath);
 
         var parameters = new Dictionary<string, string?>
         {
@@ -1064,7 +1065,7 @@ public class ConsoleLoggerTests
         loggerEvents.RaiseTestRunStart(testRunStartEventArgs);
         loggerEvents.WaitForEventCompletion();
 
-        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestSourcesDiscovered, CommandLineOptions.Instance.Sources.Count()), OutputLevel.Information), Times.Once());
+        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestSourcesDiscovered, _commandLineOptions.Sources.Count()), OutputLevel.Information), Times.Once());
     }
 
     [TestMethod]
@@ -1074,17 +1075,16 @@ public class ConsoleLoggerTests
         loggerEvents.EnableEvents();
 
         var fileHelper = new Mock<IFileHelper>();
-        CommandLineOptions.Reset();
-        CommandLineOptions.Instance.FileHelper = fileHelper.Object;
-        CommandLineOptions.Instance.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, fileHelper.Object);
+        _commandLineOptions.FileHelper = fileHelper.Object;
+        _commandLineOptions.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, fileHelper.Object);
         var temp = Path.GetTempPath();
         string testFilePath = Path.Combine(temp, "DummyTestFile.dll");
         fileHelper.Setup(fh => fh.Exists(testFilePath)).Returns(true);
         string testFilePath2 = Path.Combine(temp, "DummyTestFile2.dll");
         fileHelper.Setup(fh => fh.Exists(testFilePath2)).Returns(true);
 
-        CommandLineOptions.Instance.AddSource(testFilePath);
-        CommandLineOptions.Instance.AddSource(testFilePath2);
+        _commandLineOptions.AddSource(testFilePath);
+        _commandLineOptions.AddSource(testFilePath2);
 
         var parameters = new Dictionary<string, string?>
         {
@@ -1096,7 +1096,7 @@ public class ConsoleLoggerTests
         loggerEvents.RaiseTestRunStart(testRunStartEventArgs);
         loggerEvents.WaitForEventCompletion();
 
-        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestSourcesDiscovered, CommandLineOptions.Instance.Sources.Count()), OutputLevel.Information), Times.Once());
+        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestSourcesDiscovered, _commandLineOptions.Sources.Count()), OutputLevel.Information), Times.Once());
         _mockOutput.Verify(o => o.WriteLine(testFilePath, OutputLevel.Information), Times.Once);
         _mockOutput.Verify(o => o.WriteLine(testFilePath, OutputLevel.Information), Times.Once);
     }
@@ -1108,17 +1108,16 @@ public class ConsoleLoggerTests
         loggerEvents.EnableEvents();
 
         var fileHelper = new Mock<IFileHelper>();
-        CommandLineOptions.Reset();
-        CommandLineOptions.Instance.FileHelper = fileHelper.Object;
-        CommandLineOptions.Instance.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, fileHelper.Object);
+        _commandLineOptions.FileHelper = fileHelper.Object;
+        _commandLineOptions.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, fileHelper.Object);
         var temp = Path.GetTempPath();
         string testFilePath = Path.Combine(temp, "DummyTestFile.dll");
         fileHelper.Setup(fh => fh.Exists(testFilePath)).Returns(true);
         string testFilePath2 = Path.Combine(temp, "DummyTestFile2.dll");
         fileHelper.Setup(fh => fh.Exists(testFilePath2)).Returns(true);
 
-        CommandLineOptions.Instance.AddSource(testFilePath);
-        CommandLineOptions.Instance.AddSource(testFilePath2);
+        _commandLineOptions.AddSource(testFilePath);
+        _commandLineOptions.AddSource(testFilePath2);
 
         var parameters = new Dictionary<string, string?>
         {
@@ -1130,7 +1129,7 @@ public class ConsoleLoggerTests
         loggerEvents.RaiseTestRunStart(testRunStartEventArgs);
         loggerEvents.WaitForEventCompletion();
 
-        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestSourcesDiscovered, CommandLineOptions.Instance.Sources.Count()), OutputLevel.Information), Times.Once());
+        _mockOutput.Verify(o => o.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestSourcesDiscovered, _commandLineOptions.Sources.Count()), OutputLevel.Information), Times.Once());
         _mockOutput.Verify(o => o.WriteLine(testFilePath, OutputLevel.Information), Times.Never);
         _mockOutput.Verify(o => o.WriteLine(testFilePath2, OutputLevel.Information), Times.Never);
     }


### PR DESCRIPTION
Follow-up to #16248. Now that the console logger is activated from the composition root with an injected `CommandLineOptions`, the `?? CommandLineOptions.Instance` fallback in its two event handlers was already dead in production. This removes it, makes the field non-nullable so the type system enforces that it is always injected, and defaults the test constructor to a fresh `CommandLineOptions`.

The built-in logger no longer reads the process-wide singleton, and its tests use a per-instance options object instead of `CommandLineOptions.Reset()` plus poking the static one, so test methods no longer share state.

Covered by the existing ConsoleLoggerTests on net481 and net11.0 and the real-logger acceptance test added in #16248.