### PR TITLE
Publish packaging payloads into each producer's own bin

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,14 +9,6 @@
     <IsSourceFile>false</IsSourceFile>
     <IsSourceFile Condition="$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectFullPath)).StartsWith('src/')) OR $([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectFullPath)).StartsWith('src\'))">true</IsSourceFile>
     <SrcPackageFolder>$(RepoRoot)src\package\</SrcPackageFolder>
-    <!--
-      Canonical root for per-product publish outputs consumed by the src/package/* self-contained
-      "tool" packages (Microsoft.TestPlatform, .CLI, .Portable, ...). A bundled product publishes
-      itself exactly once per (project, TFM) into
-      $(TestPlatformPackagingPublishRoot)<ProjectName>\<TargetFramework>\, and the tool packages
-      harvest those folders via globs at pack time. See eng/PublishForPackaging.targets.
-    -->
-    <TestPlatformPackagingPublishRoot Condition="'$(TestPlatformPackagingPublishRoot)' == ''">$(ArtifactsDir)publish\</TestPlatformPackagingPublishRoot>
     <Nullable>enable</Nullable>
     <!-- When building the .NET product, there's no need to publish Windows PDBs. Any conversion to Windows PDBs will be done during staging, if necessary. -->
     <PublishWindowsPdb Condition="'$(DotNetBuild)' == 'true'">false</PublishWindowsPdb>

--- a/eng/PublishForPackaging.targets
+++ b/eng/PublishForPackaging.targets
@@ -13,10 +13,11 @@
 
     Instead, every bundled product publishes ITSELF exactly once. A product's own build emits
     the DLLs together with the matching .config / binding redirects, so publishing it guarantees
-    a self-consistent set. The output lands in a canonical, per-(project, TFM) folder that the
-    tool packages then harvest via globs at pack time. A product is never published more than
-    once per build, even though several tool packages bundle it, because each inner (per-TFM)
-    build's Build target runs exactly once.
+    a self-consistent set. The output lands in a per-TFM publish folder under the product's own
+    bin ($(ArtifactsBinDir)<ProjectName>\$(Configuration)\<TargetFramework>\publish\) that the tool
+    packages then harvest via globs at pack time. A product is never published more than once per
+    build, even though several tool packages bundle it, because each inner (per-TFM) build's Build
+    target runs exactly once.
 
     Opt a product in with:
       <PropertyGroup>
@@ -30,9 +31,13 @@
   -->
 
   <PropertyGroup Condition="'$(PublishForPackaging)' == 'true' and '$(TargetFramework)' != ''">
-    <!-- Canonical publish dir for THIS product+TFM. Consumers (tool packages) compute the same
-         path as $(TestPlatformPackagingPublishRoot)<ProjectName>\<TargetFramework>\. -->
-    <_PackagingPublishDir>$(TestPlatformPackagingPublishRoot)$(MSBuildProjectName)\$(TargetFramework)\</_PackagingPublishDir>
+    <!-- Publish into a stable, RID-independent folder under the product's own bin:
+         $(ArtifactsBinDir)<ProjectName>\$(Configuration)\<TargetFramework>\publish\. We spell this
+         out rather than using $(OutputPath)publish\ because $(OutputPath) picks up the
+         RuntimeIdentifier subfolder for RID-qualified builds (e.g. net462\win7-x64\), whereas the
+         tool packages that harvest this content recompute the same RID-less path from the producer
+         name + TFM. Both sides therefore agree on one predictable location. -->
+    <_PackagingPublishDir>$(ArtifactsBinDir)$(MSBuildProjectName)\$(Configuration)\$(TargetFramework)\publish\</_PackagingPublishDir>
   </PropertyGroup>
 
   <!--

--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.csproj
+++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.csproj
@@ -378,7 +378,7 @@
           Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(OS)' == 'Windows_NT' and '$(TargetFramework)' == '$(_CliContentTfm)'"
           Returns="@(TfmSpecificPackageFile)">
     <PropertyGroup>
-      <_CliRunnerPublishDir>$(TestPlatformPackagingPublishRoot)vstest.console\$(NetSDKTargetFramework)\</_CliRunnerPublishDir>
+      <_CliRunnerPublishDir>$(ArtifactsBinDir)vstest.console\$(Configuration)\$(NetSDKTargetFramework)\publish\</_CliRunnerPublishDir>
     </PropertyGroup>
     <Error Condition="!Exists('$(_CliRunnerPublishDir)')"
            Text="Expected published .NET runner at '$(_CliRunnerPublishDir)'. It is produced by src\vstest.console\vstest.console.csproj during the build when packing; ensure the build ran with -pack (Arcade sets __ImportPackTargets)." />
@@ -495,7 +495,7 @@
           Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(OS)' == 'Windows_NT' and '$(TargetFramework)' == '$(_CliContentTfm)'"
           Returns="@(TfmSpecificPackageFile)">
     <PropertyGroup>
-      <_CliNetFrameworkTestHostPublishDir>$(TestPlatformPackagingPublishRoot)testhost\$(NetFrameworkMinimum)\</_CliNetFrameworkTestHostPublishDir>
+      <_CliNetFrameworkTestHostPublishDir>$(ArtifactsBinDir)testhost\$(Configuration)\$(NetFrameworkMinimum)\publish\</_CliNetFrameworkTestHostPublishDir>
     </PropertyGroup>
     <Error Condition="!Exists('$(_CliNetFrameworkTestHostPublishDir)')"
            Text="Expected published .NET Framework testhost at '$(_CliNetFrameworkTestHostPublishDir)'. It is produced by src\testhost\testhost.csproj during the build when packing; ensure the build ran with -pack (Arcade sets __ImportPackTargets)." />

--- a/src/package/Microsoft.TestPlatform.Portable/Microsoft.TestPlatform.Portable.csproj
+++ b/src/package/Microsoft.TestPlatform.Portable/Microsoft.TestPlatform.Portable.csproj
@@ -184,7 +184,7 @@
           Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(OS)' == 'Windows_NT' and '$(TargetFramework)' == '$(NetFrameworkRunnerTargetFramework)'"
           Returns="@(TfmSpecificPackageFile)">
     <PropertyGroup>
-      <_PortableNetFxRunnerPublishDir>$(TestPlatformPackagingPublishRoot)vstest.console\$(NetFrameworkRunnerTargetFramework)\</_PortableNetFxRunnerPublishDir>
+      <_PortableNetFxRunnerPublishDir>$(ArtifactsBinDir)vstest.console\$(Configuration)\$(NetFrameworkRunnerTargetFramework)\publish\</_PortableNetFxRunnerPublishDir>
     </PropertyGroup>
     <Error Condition="!Exists('$(_PortableNetFxRunnerPublishDir)')"
            Text="Expected published .NET Framework runner at '$(_PortableNetFxRunnerPublishDir)'. It is produced by src\vstest.console\vstest.console.csproj during the build when packing; ensure the build ran with -pack (Arcade sets __ImportPackTargets)." />
@@ -275,7 +275,7 @@
           Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(OS)' == 'Windows_NT' and '$(TargetFramework)' == '$(NetCoreAppMinimum)'"
           Returns="@(TfmSpecificPackageFile)">
     <PropertyGroup>
-      <_PortableNetRunnerPublishDir>$(TestPlatformPackagingPublishRoot)vstest.console\$(NetCoreAppMinimum)\</_PortableNetRunnerPublishDir>
+      <_PortableNetRunnerPublishDir>$(ArtifactsBinDir)vstest.console\$(Configuration)\$(NetCoreAppMinimum)\publish\</_PortableNetRunnerPublishDir>
     </PropertyGroup>
     <Error Condition="!Exists('$(_PortableNetRunnerPublishDir)')"
            Text="Expected published .NET runner at '$(_PortableNetRunnerPublishDir)'. It is produced by src\vstest.console\vstest.console.csproj during the build when packing; ensure the build ran with -pack (Arcade sets __ImportPackTargets)." />
@@ -355,7 +355,7 @@
           Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(OS)' == 'Windows_NT' and '$(TargetFramework)' == '$(NetCoreAppMinimum)'"
           Returns="@(TfmSpecificPackageFile)">
     <PropertyGroup>
-      <_PortableNetFrameworkTestHostPublishDir>$(TestPlatformPackagingPublishRoot)testhost\$(NetFrameworkMinimum)\</_PortableNetFrameworkTestHostPublishDir>
+      <_PortableNetFrameworkTestHostPublishDir>$(ArtifactsBinDir)testhost\$(Configuration)\$(NetFrameworkMinimum)\publish\</_PortableNetFrameworkTestHostPublishDir>
     </PropertyGroup>
     <Error Condition="!Exists('$(_PortableNetFrameworkTestHostPublishDir)')"
            Text="Expected published .NET Framework testhost at '$(_PortableNetFrameworkTestHostPublishDir)'. It is produced by src\testhost\testhost.csproj during the build when packing; ensure the build ran with -pack (Arcade sets __ImportPackTargets)." />

--- a/src/package/Microsoft.TestPlatform.TestHost/Microsoft.TestPlatform.TestHost.csproj
+++ b/src/package/Microsoft.TestPlatform.TestHost/Microsoft.TestPlatform.TestHost.csproj
@@ -90,7 +90,7 @@
       <!-- Canonical folders that the testhost projects publish/build into (see
            eng/PublishForPackaging.targets). Populated during the solution Build pass, which
            completes before any package Pack pass, so they are present here. -->
-      <_NetTestHostPublishDir>$(TestPlatformPackagingPublishRoot)testhost\$(NetCoreAppMinimum)\</_NetTestHostPublishDir>
+      <_NetTestHostPublishDir>$(ArtifactsBinDir)testhost\$(Configuration)\$(NetCoreAppMinimum)\publish\</_NetTestHostPublishDir>
       <_NetTestHostX86Dir>$(ArtifactsBinDir)testhost.x86\$(Configuration)\$(NetCoreAppMinimum)\win-x86\</_NetTestHostX86Dir>
     </PropertyGroup>
     <Error Condition="!Exists('$(_NetTestHostPublishDir)')"

--- a/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.csproj
+++ b/src/package/Microsoft.TestPlatform/Microsoft.TestPlatform.csproj
@@ -339,7 +339,7 @@
       <!-- Canonical folder that src\testhost\testhost.csproj publishes into once (see
            eng/PublishForPackaging.targets). Populated during the solution Build pass, which
            completes before any package Pack pass, so it is present here. -->
-      <_NetTestHostPublishDir>$(TestPlatformPackagingPublishRoot)testhost\$(NetCoreAppMinimum)\</_NetTestHostPublishDir>
+      <_NetTestHostPublishDir>$(ArtifactsBinDir)testhost\$(Configuration)\$(NetCoreAppMinimum)\publish\</_NetTestHostPublishDir>
     </PropertyGroup>
     <Error Condition="!Exists('$(_NetTestHostPublishDir)')"
            Text="Expected published .NET testhost at '$(_NetTestHostPublishDir)'. It is produced by src\testhost\testhost.csproj during the build when packing; ensure the build ran with -pack (Arcade sets __ImportPackTargets)." />
@@ -377,7 +377,7 @@
   -->
   <Target Name="_PublishRunnerRootContent" Condition="'$(TargetFramework)' == '$(NetFrameworkRunnerTargetFramework)'" Returns="@(TfmSpecificPackageFile)">
     <PropertyGroup>
-      <_RunnerRootPublishDir>$(TestPlatformPackagingPublishRoot)vstest.console\$(NetFrameworkRunnerTargetFramework)\</_RunnerRootPublishDir>
+      <_RunnerRootPublishDir>$(ArtifactsBinDir)vstest.console\$(Configuration)\$(NetFrameworkRunnerTargetFramework)\publish\</_RunnerRootPublishDir>
     </PropertyGroup>
     <Error Condition="!Exists('$(_RunnerRootPublishDir)')"
            Text="Expected published .NET Framework runner at '$(_RunnerRootPublishDir)'. It is produced by src\vstest.console\vstest.console.csproj during the build when packing; ensure the build ran with -pack (Arcade sets __ImportPackTargets)." />


### PR DESCRIPTION
Follow-up cleanup to the "publish once, glob many" packaging work (#16206, #16236, #16240, #16246).

The self-contained tool packages harvest each bundled product from a publish output that is produced once per (project, TFM). Until now that output landed in a separate top-level tree, `artifacts/publish/<Project>/<TFM>/`, addressed through a `TestPlatformPackagingPublishRoot` property.

This moves it under the producer's own bin instead — `$(ArtifactsBinDir)<Project>/<Configuration>/<TFM>/publish/` — so the publish output is cleaned together with the project and there is no parallel top-level tree. `TestPlatformPackagingPublishRoot` is removed.

The path is spelled out RID-less on both the producer and consumer side rather than reusing `$(OutputPath)publish\`, because `$(OutputPath)` picks up the RuntimeIdentifier subfolder for the net462/net48 RID-qualified builds (`.../net462/win7-x64/`), while the consumers recompute the path from producer name + TFM.

Pure no-op on shipped files: all four affected nupkgs (Microsoft.TestPlatform, .CLI, .Portable, .TestHost) are +0/-0 vs a clean `-c Release -pack` baseline, and `verify-nupkgs.ps1` still reports all binding redirects and DLL target frameworks matching (no expected-*.json regeneration).