### PR TITLE
Delete the TestRequestManager.Instance singleton

### DIFF
--- a/src/vstest.console/CommandLine/Executor.cs
+++ b/src/vstest.console/CommandLine/Executor.cs
@@ -67,9 +67,10 @@ internal class Executor
     private readonly IRunSettingsHelper _runSettingsHelper;
     private readonly CommandLineOptions _commandLineOptions;
     private readonly TestRunResultAggregator _testRunResultAggregator;
-    // Left null in production so the argument processors resolve TestRequestManager.Instance lazily
-    // (only when a run/discovery command actually executes); tests inject a specific instance.
-    private readonly ITestRequestManager? _testRequestManager;
+    // The single request manager for this Executor. It is built lazily (the real manager reads the
+    // parsed command line and loads the test platform, which must happen after argument parsing), so
+    // commands that never run or discover tests (for example --Help) never construct it.
+    private readonly ITestRequestManager _testRequestManager;
     private bool _showHelp;
 
     /// <summary>
@@ -124,7 +125,7 @@ internal class Executor
         _runSettingsHelper = runSettingsHelper;
         _commandLineOptions = commandLineOptions;
         _testRunResultAggregator = testRunResultAggregator;
-        _testRequestManager = testRequestManager;
+        _testRequestManager = testRequestManager ?? new LazyTestRequestManager(() => new TestRequestManager(_commandLineOptions));
     }
 
     /// <summary>
@@ -230,7 +231,7 @@ internal class Executor
         _testPlatformEventSource.MetricsDisposeStart();
 
         // Disposing Metrics Publisher when VsTestConsole ends
-        TestRequestManager.Instance.Dispose();
+        _testRequestManager.Dispose();
 
         _testPlatformEventSource.MetricsDisposeStop();
         return exitCode;

--- a/src/vstest.console/Processors/ListFullyQualifiedTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ListFullyQualifiedTestsArgumentProcessor.cs
@@ -8,7 +8,6 @@ using System.Linq;
 
 using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
 using Microsoft.VisualStudio.TestPlatform.CommandLine.Internal;
-using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
 using Microsoft.VisualStudio.TestPlatform.Common;
 using Microsoft.VisualStudio.TestPlatform.Common.Filtering;
 using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
@@ -34,9 +33,9 @@ internal class ListFullyQualifiedTestsArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
     private readonly CommandLineOptions _commandLineOptions;
-    private readonly ITestRequestManager? _testRequestManager;
+    private readonly ITestRequestManager _testRequestManager;
 
-    public ListFullyQualifiedTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider, ITestRequestManager? testRequestManager = null)
+    public ListFullyQualifiedTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider, ITestRequestManager testRequestManager)
     {
         _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
@@ -59,7 +58,7 @@ internal class ListFullyQualifiedTestsArgumentProcessor : IArgumentProcessor
             new ListFullyQualifiedTestsArgumentExecutor(
                 _commandLineOptions,
                 _runSettingsProvider,
-                _testRequestManager ?? TestRequestManager.Instance));
+                _testRequestManager));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/ListTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/ListTestsArgumentProcessor.cs
@@ -7,7 +7,6 @@ using System.Linq;
 
 using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
 using Microsoft.VisualStudio.TestPlatform.CommandLine.Internal;
-using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
 using Microsoft.VisualStudio.TestPlatform.Common;
 using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -37,9 +36,9 @@ internal class ListTestsArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
     private readonly CommandLineOptions _commandLineOptions;
-    private readonly ITestRequestManager? _testRequestManager;
+    private readonly ITestRequestManager _testRequestManager;
 
-    public ListTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider, ITestRequestManager? testRequestManager = null)
+    public ListTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider, ITestRequestManager testRequestManager)
     {
         _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
@@ -62,7 +61,7 @@ internal class ListTestsArgumentProcessor : IArgumentProcessor
             new ListTestsArgumentExecutor(
                 _commandLineOptions,
                 _runSettingsProvider,
-                _testRequestManager ?? TestRequestManager.Instance));
+                _testRequestManager));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/PortArgumentProcessor.cs
+++ b/src/vstest.console/Processors/PortArgumentProcessor.cs
@@ -8,7 +8,6 @@ using System.Globalization;
 
 using Microsoft.VisualStudio.TestPlatform.Client.DesignMode;
 using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
-using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Abstraction::Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
 using Abstraction::Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
@@ -32,9 +31,9 @@ internal class PortArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsHelper _runSettingsHelper;
     private readonly CommandLineOptions _commandLineOptions;
-    private readonly ITestRequestManager? _testRequestManager;
+    private readonly ITestRequestManager _testRequestManager;
 
-    public PortArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsHelper runSettingsHelper, ITestRequestManager? testRequestManager = null)
+    public PortArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsHelper runSettingsHelper, ITestRequestManager testRequestManager)
     {
         _commandLineOptions = commandLineOptions;
         _runSettingsHelper = runSettingsHelper;
@@ -53,7 +52,7 @@ internal class PortArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new PortArgumentExecutor(_commandLineOptions, _testRequestManager ?? TestRequestManager.Instance, _runSettingsHelper));
+            new PortArgumentExecutor(_commandLineOptions, _testRequestManager, _runSettingsHelper));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/RunSpecificTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunSpecificTestsArgumentProcessor.cs
@@ -10,7 +10,6 @@ using System.Linq;
 
 using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
 using Microsoft.VisualStudio.TestPlatform.CommandLine.Internal;
-using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
 using Microsoft.VisualStudio.TestPlatform.Common;
 using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
@@ -32,9 +31,9 @@ internal class RunSpecificTestsArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
     private readonly CommandLineOptions _commandLineOptions;
-    private readonly ITestRequestManager? _testRequestManager;
+    private readonly ITestRequestManager _testRequestManager;
 
-    public RunSpecificTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider, ITestRequestManager? testRequestManager = null)
+    public RunSpecificTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider, ITestRequestManager testRequestManager)
     {
         _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
@@ -51,7 +50,7 @@ internal class RunSpecificTestsArgumentProcessor : IArgumentProcessor
             new RunSpecificTestsArgumentExecutor(
                 _commandLineOptions,
                 _runSettingsProvider,
-                _testRequestManager ?? TestRequestManager.Instance,
+                _testRequestManager,
                 new ArtifactProcessingManager(_commandLineOptions.TestSessionCorrelationId),
                 ConsoleOutput.Instance));
 

--- a/src/vstest.console/Processors/RunTestsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/RunTestsArgumentProcessor.cs
@@ -6,7 +6,6 @@ using System.Linq;
 
 using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
 using Microsoft.VisualStudio.TestPlatform.CommandLine.Internal;
-using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
 using Microsoft.VisualStudio.TestPlatform.Common;
 using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
@@ -28,9 +27,9 @@ internal class RunTestsArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentExecutor>? _executor;
     private readonly IRunSettingsProvider _runSettingsProvider;
     private readonly CommandLineOptions _commandLineOptions;
-    private readonly ITestRequestManager? _testRequestManager;
+    private readonly ITestRequestManager _testRequestManager;
 
-    public RunTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider, ITestRequestManager? testRequestManager = null)
+    public RunTestsArgumentProcessor(CommandLineOptions commandLineOptions, IRunSettingsProvider runSettingsProvider, ITestRequestManager testRequestManager)
     {
         _commandLineOptions = commandLineOptions;
         _runSettingsProvider = runSettingsProvider;
@@ -47,7 +46,7 @@ internal class RunTestsArgumentProcessor : IArgumentProcessor
             new RunTestsArgumentExecutor(
                 _commandLineOptions,
                 _runSettingsProvider,
-                _testRequestManager ?? TestRequestManager.Instance,
+                _testRequestManager,
                 new ArtifactProcessingManager(_commandLineOptions.TestSessionCorrelationId),
                 ConsoleOutput.Instance));
 

--- a/src/vstest.console/Processors/UseVsixExtensionsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/UseVsixExtensionsArgumentProcessor.cs
@@ -5,7 +5,6 @@ using System;
 using System.Globalization;
 
 using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
-using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
 using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
 using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
@@ -27,9 +26,9 @@ internal class UseVsixExtensionsArgumentProcessor : IArgumentProcessor
     private Lazy<IArgumentProcessorCapabilities>? _metadata;
     private Lazy<IArgumentExecutor>? _executor;
     private readonly CommandLineOptions _commandLineOptions;
-    private readonly ITestRequestManager? _testRequestManager;
+    private readonly ITestRequestManager _testRequestManager;
 
-    public UseVsixExtensionsArgumentProcessor(CommandLineOptions commandLineOptions, ITestRequestManager? testRequestManager = null)
+    public UseVsixExtensionsArgumentProcessor(CommandLineOptions commandLineOptions, ITestRequestManager testRequestManager)
     {
         _commandLineOptions = commandLineOptions;
         _testRequestManager = testRequestManager;
@@ -48,7 +47,7 @@ internal class UseVsixExtensionsArgumentProcessor : IArgumentProcessor
     public Lazy<IArgumentExecutor>? Executor
     {
         get => _executor ??= new Lazy<IArgumentExecutor>(() =>
-            new UseVsixExtensionsArgumentExecutor(_commandLineOptions, _testRequestManager ?? TestRequestManager.Instance, new VSExtensionManager(), ConsoleOutput.Instance));
+            new UseVsixExtensionsArgumentExecutor(_commandLineOptions, _testRequestManager, new VSExtensionManager(), ConsoleOutput.Instance));
 
         set => _executor = value;
     }

--- a/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
+++ b/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 
 using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
+using Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
 using Microsoft.VisualStudio.TestPlatform.Common;
 using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -66,9 +67,9 @@ internal class ArgumentProcessorFactory
     /// </param>
     /// <param name="testRequestManager">
     /// The test request manager that the run/discovery argument processors hand to their executors.
-    /// When not provided the processors fall back to the ambient <see cref="Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers.TestRequestManager.Instance"/>
-    /// lazily, at the point the executor is built, so that commands that never touch it (for example
-    /// <c>--Help</c>) do not force its (relatively heavy) construction.
+    /// When not provided a request-scoped manager is created lazily, at the point the executor is
+    /// built, so that commands that never touch it (for example <c>--Help</c>) do not force its
+    /// (relatively heavy) construction.
     /// </param>
     /// <returns>ArgumentProcessorFactory.</returns>
     internal static ArgumentProcessorFactory Create(IFeatureFlag? featureFlag = null, IRunSettingsProvider? runSettingsProvider = null, IRunSettingsHelper? runSettingsHelper = null, CommandLineOptions? commandLineOptions = null, ITestRequestManager? testRequestManager = null)
@@ -76,6 +77,7 @@ internal class ArgumentProcessorFactory
         runSettingsProvider ??= RunSettingsManager.Instance;
         runSettingsHelper ??= RunSettingsHelper.Instance;
         commandLineOptions ??= CommandLineOptions.Instance;
+        testRequestManager ??= new LazyTestRequestManager(() => new TestRequestManager(commandLineOptions));
         var defaultArgumentProcessor = GetDefaultArgumentProcessors(runSettingsProvider, runSettingsHelper, commandLineOptions, testRequestManager);
 
         if (!(featureFlag ?? FeatureFlag.Instance).IsSet(FeatureFlag.VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING))
@@ -210,7 +212,7 @@ internal class ArgumentProcessorFactory
             .Where(lazyProcessor => lazyProcessor.Metadata.Value.IsSpecialCommand && lazyProcessor.Metadata.Value.AlwaysExecute);
     }
 
-    private static IList<IArgumentProcessor> GetDefaultArgumentProcessors(IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper, CommandLineOptions commandLineOptions, ITestRequestManager? testRequestManager) => new List<IArgumentProcessor> {
+    private static IList<IArgumentProcessor> GetDefaultArgumentProcessors(IRunSettingsProvider runSettingsProvider, IRunSettingsHelper runSettingsHelper, CommandLineOptions commandLineOptions, ITestRequestManager testRequestManager) => new List<IArgumentProcessor> {
         new HelpArgumentProcessor(),
         new TestSourceArgumentProcessor(commandLineOptions),
         new ListTestsArgumentProcessor(commandLineOptions, runSettingsProvider, testRequestManager),

--- a/src/vstest.console/TestPlatformHelpers/LazyTestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/LazyTestRequestManager.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestPlatform.Client.RequestHelper;
+using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
+
+namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
+
+/// <summary>
+/// An <see cref="ITestRequestManager"/> that defers construction of the real
+/// <see cref="TestRequestManager"/> until the first member is used. This lets the composition root
+/// own a single request manager instead of reaching for a process-wide singleton, while still
+/// building it lazily: the real manager reads the parsed command line (for example
+/// <c>IsDesignMode</c>) and loads the test platform, so it must be created only after the command
+/// line has been parsed, and never for commands that neither run nor discover tests (for example
+/// <c>--Help</c>).
+/// </summary>
+internal sealed class LazyTestRequestManager : ITestRequestManager
+{
+    private readonly Lazy<ITestRequestManager> _inner;
+
+    public LazyTestRequestManager(Func<ITestRequestManager> factory)
+    {
+        _inner = new Lazy<ITestRequestManager>(factory);
+    }
+
+    public void InitializeExtensions(IEnumerable<string>? pathToAdditionalExtensions, bool skipExtensionFilters)
+        => _inner.Value.InitializeExtensions(pathToAdditionalExtensions, skipExtensionFilters);
+
+    public void ResetOptions()
+        => _inner.Value.ResetOptions();
+
+    public void DiscoverTests(DiscoveryRequestPayload discoveryPayload, ITestDiscoveryEventsRegistrar disoveryEventsRegistrar, ProtocolConfig protocolConfig)
+        => _inner.Value.DiscoverTests(discoveryPayload, disoveryEventsRegistrar, protocolConfig);
+
+    public void RunTests(TestRunRequestPayload testRunRequestPayLoad, ITestHostLauncher3? customTestHostLauncher, ITestRunEventsRegistrar testRunEventsRegistrar, ProtocolConfig protocolConfig)
+        => _inner.Value.RunTests(testRunRequestPayLoad, customTestHostLauncher, testRunEventsRegistrar, protocolConfig);
+
+    public void ProcessTestRunAttachments(TestRunAttachmentsProcessingPayload testRunAttachmentsProcessingPayload, ITestRunAttachmentsProcessingEventsHandler testRunAttachmentsProcessingEventsHandler, ProtocolConfig protocolConfig)
+        => _inner.Value.ProcessTestRunAttachments(testRunAttachmentsProcessingPayload, testRunAttachmentsProcessingEventsHandler, protocolConfig);
+
+    public void CancelTestRun()
+        => _inner.Value.CancelTestRun();
+
+    public void AbortTestRun()
+        => _inner.Value.AbortTestRun();
+
+    public void CancelDiscovery()
+        => _inner.Value.CancelDiscovery();
+
+    public void CancelTestRunAttachmentsProcessing()
+        => _inner.Value.CancelTestRunAttachmentsProcessing();
+
+    public void Dispose()
+    {
+        if (_inner.IsValueCreated)
+        {
+            _inner.Value.Dispose();
+        }
+    }
+}

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -47,8 +47,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers;
 /// </summary>
 internal class TestRequestManager : ITestRequestManager
 {
-    private static ITestRequestManager? s_testRequestManagerInstance;
-
     private readonly ITestPlatform _testPlatform;
     private readonly ITestPlatformEventSource _testPlatformEventSource;
     // TODO: No idea what is Task supposed to buy us, Tasks start immediately on instantiation
@@ -92,13 +90,6 @@ internal class TestRequestManager : ITestRequestManager
     /// </summary>
     private CancellationTokenSource? _currentAttachmentsProcessingCancellationTokenSource;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="TestRequestManager"/> class.
-    /// </summary>
-    public TestRequestManager()
-        : this(CommandLineOptions.Instance)
-    {
-    }
 
     internal TestRequestManager(CommandLineOptions commandLineOptions)
         : this(
@@ -169,12 +160,6 @@ internal class TestRequestManager : ITestRequestManager
         _environmentVariableHelper = environmentVariableHelper;
         _runSettingsHelper = runSettingsHelper;
     }
-
-    /// <summary>
-    /// Gets the test request manager instance.
-    /// </summary>
-    public static ITestRequestManager Instance
-        => s_testRequestManagerInstance ??= new TestRequestManager();
 
     #region ITestRequestManager
 

--- a/test/vstest.console.UnitTests/Processors/ListFullyQualifiedTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListFullyQualifiedTestsArgumentProcessorTests.cs
@@ -95,7 +95,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnListFullyQualifiedTestsArgumentProcessorCapabilities()
     {
-        var processor = new ListFullyQualifiedTestsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        var processor = new ListFullyQualifiedTestsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
         Assert.IsTrue(processor.Metadata.Value is ListFullyQualifiedTestsArgumentProcessorCapabilities);
     }
 
@@ -105,7 +105,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
     [TestMethod]
     public void GetExecuterShouldReturnListFullyQualifiedTestsArgumentProcessorCapabilities()
     {
-        var processor = new ListFullyQualifiedTestsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        var processor = new ListFullyQualifiedTestsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
         Assert.IsTrue(processor.Executor!.Value is ListFullyQualifiedTestsArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
@@ -93,7 +93,7 @@ public class ListTestsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnListTestsArgumentProcessorCapabilities()
     {
-        var processor = new ListTestsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        var processor = new ListTestsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
         Assert.IsTrue(processor.Metadata.Value is ListTestsArgumentProcessorCapabilities);
     }
 
@@ -103,7 +103,7 @@ public class ListTestsArgumentProcessorTests
     [TestMethod]
     public void GetExecuterShouldReturnListTestsArgumentProcessorCapabilities()
     {
-        var processor = new ListTestsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        var processor = new ListTestsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
         Assert.IsTrue(processor.Executor!.Value is ListTestsArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
@@ -40,14 +40,14 @@ public class PortArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnPortArgumentProcessorCapabilities()
     {
-        var processor = new PortArgumentProcessor(CommandLineOptions.Instance, _runSettingsHelper);
+        var processor = new PortArgumentProcessor(CommandLineOptions.Instance, _runSettingsHelper, _testRequestManager.Object);
         Assert.IsTrue(processor.Metadata.Value is PortArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecutorShouldReturnPortArgumentProcessorCapabilities()
     {
-        var processor = new PortArgumentProcessor(CommandLineOptions.Instance, _runSettingsHelper);
+        var processor = new PortArgumentProcessor(CommandLineOptions.Instance, _runSettingsHelper, _testRequestManager.Object);
         Assert.IsTrue(processor.Executor!.Value is PortArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
@@ -81,7 +81,7 @@ public class RunSpecificTestsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnRunSpecificTestsArgumentProcessorCapabilities()
     {
-        RunSpecificTestsArgumentProcessor processor = new(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        RunSpecificTestsArgumentProcessor processor = new(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
 
         Assert.IsTrue(processor.Metadata.Value is RunSpecificTestsArgumentProcessorCapabilities);
     }
@@ -89,7 +89,7 @@ public class RunSpecificTestsArgumentProcessorTests
     [TestMethod]
     public void GetExecutorShouldReturnRunSpecificTestsArgumentExecutor()
     {
-        RunSpecificTestsArgumentProcessor processor = new(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        RunSpecificTestsArgumentProcessor processor = new(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
 
         Assert.IsTrue(processor.Executor!.Value is RunSpecificTestsArgumentExecutor);
     }

--- a/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
@@ -79,14 +79,14 @@ public class RunTestsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnRunTestsArgumentProcessorCapabilities()
     {
-        RunTestsArgumentProcessor processor = new(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        RunTestsArgumentProcessor processor = new(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
         Assert.IsTrue(processor.Metadata.Value is RunTestsArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnRunTestsArgumentProcessorCapabilities()
     {
-        RunTestsArgumentProcessor processor = new(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        RunTestsArgumentProcessor processor = new(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
         Assert.IsTrue(processor.Executor!.Value is RunTestsArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/UseVsixExtensionsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/UseVsixExtensionsArgumentProcessorTests.cs
@@ -34,14 +34,14 @@ public class UseVsixExtensionsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnUseVsixExtensionsArgumentProcessorCapabilities()
     {
-        var processor = new UseVsixExtensionsArgumentProcessor(CommandLineOptions.Instance);
+        var processor = new UseVsixExtensionsArgumentProcessor(CommandLineOptions.Instance, _testRequestManager.Object);
         Assert.IsTrue(processor.Metadata.Value is UseVsixExtensionsArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnUseVsixExtensionsArgumentProcessorCapabilities()
     {
-        var processor = new UseVsixExtensionsArgumentProcessor(CommandLineOptions.Instance);
+        var processor = new UseVsixExtensionsArgumentProcessor(CommandLineOptions.Instance, _testRequestManager.Object);
         Assert.IsTrue(processor.Executor!.Value is UseVsixExtensionsArgumentExecutor);
     }
 


### PR DESCRIPTION
vstest.console built its `TestRequestManager` from a process-wide `TestRequestManager.Instance` singleton, and the six run/discovery argument processors fell back to it when no manager was injected. In design mode the same process serves many requests, so that shared instance carried state across them and made the processors hard to test in isolation.

`Executor` now owns a single request manager and hands it to the processors through the factory. It is wrapped in a small `LazyTestRequestManager` so the real manager is still built lazily - it reads the parsed command line and loads the test platform, which has to happen after argument parsing - and commands that never run or discover tests (for example `--Help`) no longer construct one at all. The processors take the manager as a required dependency instead of reaching for the singleton, and `TestRequestManager.Instance` plus its parameterless constructor are gone.

`TestRequestManager` is internal, so no external extension could read the singleton and nothing outside the composition root depended on it.

This continues the static-state cleanup from #16200/#16205/#16208/#16228/#16243/#16245.
