### PR TITLE
Build command line options at the composition root instead of the CommandLineOptions.Instance singleton

### DIFF
--- a/src/vstest.console/CommandLine/Executor.cs
+++ b/src/vstest.console/CommandLine/Executor.cs
@@ -100,12 +100,12 @@ internal class Executor
     }
 
     internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment)
-        : this(output, testPlatformEventSource, processHelper, environment, RunSettingsManager.Instance, RunSettingsHelper.Instance, CommandLineOptions.Instance, TestRunResultAggregator.Instance)
+        : this(output, testPlatformEventSource, processHelper, environment, RunSettingsManager.Instance, RunSettingsHelper.Instance, new CommandLineOptions(), TestRunResultAggregator.Instance)
     {
     }
 
     internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment, IRunSettingsProvider runSettingsProvider)
-        : this(output, testPlatformEventSource, processHelper, environment, runSettingsProvider, RunSettingsHelper.Instance, CommandLineOptions.Instance, TestRunResultAggregator.Instance)
+        : this(output, testPlatformEventSource, processHelper, environment, runSettingsProvider, RunSettingsHelper.Instance, new CommandLineOptions(), TestRunResultAggregator.Instance)
     {
     }
 

--- a/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
+++ b/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
@@ -61,8 +61,8 @@ internal class ArgumentProcessorFactory
     /// </param>
     /// <param name="commandLineOptions">
     /// The command line options that the created argument processors read from and write to.
-    /// Defaults to the ambient <see cref="CommandLineOptions.Instance"/> when not provided, so that
-    /// callers (and the composition root) can inject an isolated instance instead of sharing static state.
+    /// When not provided a fresh, request-scoped instance is created, so that callers never
+    /// share command line state through a static singleton.
     /// </param>
     /// <param name="testRequestManager">
     /// The test request manager that the run/discovery argument processors hand to their executors.
@@ -75,7 +75,7 @@ internal class ArgumentProcessorFactory
     {
         runSettingsProvider ??= RunSettingsManager.Instance;
         runSettingsHelper ??= RunSettingsHelper.Instance;
-        commandLineOptions ??= CommandLineOptions.Instance;
+        commandLineOptions ??= new CommandLineOptions();
         var defaultArgumentProcessor = GetDefaultArgumentProcessors(runSettingsProvider, runSettingsHelper, commandLineOptions, testRequestManager);
 
         if (!(featureFlag ?? FeatureFlag.Instance).IsSet(FeatureFlag.VSTEST_DISABLE_ARTIFACTS_POSTPROCESSING))


### PR DESCRIPTION
The `Executor` seeded its `CommandLineOptions` from the process-wide `CommandLineOptions.Instance` singleton, and `ArgumentProcessorFactory.Create` fell back to the same singleton when no options were passed. In design mode one process serves many command lines, so the parsed options leaked from one request into the next.

The `Executor` now creates its own `CommandLineOptions` and threads that single instance to the argument processors through the factory, which is what the run path already relied on - `Executor` passes its instance to the factory, and the only other caller, the help processor, just needs some options to list the processors for `--Help`. The factory's fallback now builds a fresh instance instead of reaching for the singleton.

`CommandLineOptions` is internal, so nothing outside vstest.console could read the singleton. It stays for now only because the unit tests still use it directly; a follow-up moves those over and removes `CommandLineOptions.Instance` for good.

Continues the static-state cleanup (#16200/#16205/#16208/#16228/#16243/#16245/#16255).
