### PR TITLE
[code-simplifier] Remove redundant local variable and verbose comment in ConsoleLogger after #16255

### DIFF
--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -131,8 +131,6 @@ internal class ConsoleLogger : ITestLoggerWithParameters
         Output = output;
         _progressIndicator = progressIndicator;
         _featureFlag = featureFlag;
-        // Never fall back to CommandLineOptions.Instance: the logger owns its own options so tests
-        // stay isolated and the built-in logger no longer reads the process-wide singleton.
         _commandLineOptions = commandLineOptions ?? new CommandLineOptions();
     }
 
@@ -425,11 +423,10 @@ internal class ConsoleLogger : ITestLoggerWithParameters
         TPDebug.Assert(Output != null, "Initialize should have been called");
 
         // Print all test containers.
-        var commandLineOptions = _commandLineOptions;
-        Output.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestSourcesDiscovered, commandLineOptions.Sources.Count()), OutputLevel.Information);
+        Output.WriteLine(string.Format(CultureInfo.CurrentCulture, CommandLineResources.TestSourcesDiscovered, _commandLineOptions.Sources.Count()), OutputLevel.Information);
         if (VerbosityLevel == Verbosity.Detailed)
         {
-            foreach (var source in commandLineOptions.Sources)
+            foreach (var source in _commandLineOptions.Sources)
             {
                 Output.WriteLine(source, OutputLevel.Information);
             }


### PR DESCRIPTION
## Code Simplification - 2026-07-09

This PR simplifies code in `ConsoleLogger.cs` introduced/left-over by #16255, improving clarity without changing any behaviour.

### Files Simplified

- `src/vstest.console/Internal/ConsoleLogger.cs` — remove a now-redundant local variable and a verbose historical comment

### Improvements Made

**1. Removed redundant local variable in `TestRunStartHandler`**

Before #16255 the field was nullable, so callers wrote:
```csharp
var commandLineOptions = _commandLineOptions ?? CommandLineOptions.Instance;
```
After #16255 made the field `CommandLineOptions` (non-nullable), the copy became a plain `var commandLineOptions = _commandLineOptions;` — a no-op alias. The method now references `_commandLineOptions` directly:

```csharp
// Before
var commandLineOptions = _commandLineOptions;
Output.WriteLine(..., commandLineOptions.Sources.Count(), ...);
foreach (var source in commandLineOptions.Sources)

// After
Output.WriteLine(..., _commandLineOptions.Sources.Count(), ...);
foreach (var source in _commandLineOptions.Sources)
```

**2. Removed verbose historical comment from the test constructor**

The two-line comment explained the (now-removed) `?? CommandLineOptions.Instance` fallback that no longer exists. The `?? new CommandLineOptions()` expression is self-explanatory, and the design rationale lives in git history.

### Changes Based On

- #16255 — Make the built-in ConsoleLogger independent of CommandLineOptions.Instance

### Testing

- ✅ All 64 `ConsoleLoggerTests` pass (`vstest.console.UnitTests`)
- ✅ Build succeeds (Debug)
- ✅ No functional changes — behaviour is identical

### Review Focus

Please verify:
- Functionality is preserved
- Removing the intermediate variable doesn't affect any debugger/logging tooling
- Simplifications improve code quality


<!-- gh-aw-tracker-id: code-simplifier -->




> Generated by [Code Simplifier](https://github.com/microsoft/vstest/actions/runs/29030986659) · 81.2 AIC · ⌖ 12.2 AIC · ⊞ 8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fvstest+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
> - [x] expires <!-- gh-aw-expires: 2026-07-10T15:59:49.495Z --> on Jul 10, 2026, 3:59 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.65, model: claude-sonnet-4.6, id: 29030986659, workflow_id: code-simplifier, run: https://github.com/microsoft/vstest/actions/runs/29030986659 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->
<!-- gh-aw-workflow-call-id: microsoft/vstest/code-simplifier -->