### PR TITLE
Delete the CommandLineOptions.Instance singleton

### DIFF
--- a/src/vstest.console/CommandLine/CommandLineOptions.cs
+++ b/src/vstest.console/CommandLine/CommandLineOptions.cs
@@ -44,19 +44,11 @@ internal class CommandLineOptions
     /// </summary>
     private readonly TimeSpan _defaultRetrievalTimeout = new(0, 0, 0, 1, 500);
 
-    private static CommandLineOptions? s_instance;
-
     private List<string> _sources = new();
 
     private Architecture _architecture;
 
     private Framework? _frameworkVersion;
-
-    /// <summary>
-    /// Gets the instance.
-    /// </summary>
-    internal static CommandLineOptions Instance
-        => s_instance ??= new CommandLineOptions();
 
     /// <summary>
     /// Default constructor.
@@ -290,14 +282,6 @@ internal class CommandLineOptions
         // Add the matching files to source list
         var filteredFiles = KnownPlatformSourceFilter.FilterKnownPlatformSources(matchingFiles);
         _sources = _sources.Union(filteredFiles).ToList();
-    }
-
-    /// <summary>
-    /// Resets the options. Clears the sources.
-    /// </summary>
-    internal static void Reset()
-    {
-        s_instance = null;
     }
 
 }

--- a/src/vstest.console/Internal/ConsoleLogger.cs
+++ b/src/vstest.console/Internal/ConsoleLogger.cs
@@ -131,8 +131,8 @@ internal class ConsoleLogger : ITestLoggerWithParameters
         Output = output;
         _progressIndicator = progressIndicator;
         _featureFlag = featureFlag;
-        // Never fall back to CommandLineOptions.Instance: the logger owns its own options so tests
-        // stay isolated and the built-in logger no longer reads the process-wide singleton.
+        // The logger owns its own options so tests stay isolated and the built-in logger never reads a
+        // process-wide singleton (there is none): callers inject the options, tests get a fresh instance.
         _commandLineOptions = commandLineOptions ?? new CommandLineOptions();
     }
 

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -180,7 +180,10 @@ internal class TestRequestManager : ITestRequestManager
     /// <inheritdoc />
     public void ResetOptions()
     {
-        CommandLineOptions.Reset();
+        // Nothing to reset. The manager holds the CommandLineOptions it was constructed with and
+        // never mutates them per request; design-mode requests derive their state from the request
+        // payload (sources, run settings), not from shared mutable command-line options. This used
+        // to null a process-wide CommandLineOptions singleton, which no longer exists.
     }
 
     /// <inheritdoc />

--- a/test/vstest.console.UnitTests/CommandLine/CommandLineOptionsTests.cs
+++ b/test/vstest.console.UnitTests/CommandLine/CommandLineOptionsTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.CommandLine;
 [TestClass]
 public class CommandLineOptionsTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private readonly Mock<IFileHelper> _fileHelper;
     private readonly FilePatternParser _filePatternParser;
     private readonly string _currentDirectory = @"C:\\Temp";
@@ -27,16 +28,15 @@ public class CommandLineOptionsTests
     {
         _fileHelper = new Mock<IFileHelper>();
         _filePatternParser = new FilePatternParser(new Mock<Matcher>().Object, _fileHelper.Object);
-        CommandLineOptions.Reset();
-        CommandLineOptions.Instance.FileHelper = _fileHelper.Object;
-        CommandLineOptions.Instance.FilePatternParser = _filePatternParser;
+        _commandLineOptions.FileHelper = _fileHelper.Object;
+        _commandLineOptions.FilePatternParser = _filePatternParser;
         _fileHelper.Setup(fh => fh.GetCurrentDirectory()).Returns(_currentDirectory);
     }
 
     [TestMethod]
     public void CommandLineOptionsDefaultBatchSizeIsTen()
     {
-        Assert.AreEqual(10, CommandLineOptions.Instance.BatchSize);
+        Assert.AreEqual(10, _commandLineOptions.BatchSize);
     }
 
     [TestMethod]
@@ -51,29 +51,29 @@ public class CommandLineOptionsTests
     public void CommandLineOptionsDefaultTestRunStatsEventTimeoutIsOnePointFiveSec()
     {
         var timeout = new TimeSpan(0, 0, 0, 1, 500);
-        Assert.AreEqual(timeout, CommandLineOptions.Instance.TestStatsEventTimeout);
+        Assert.AreEqual(timeout, _commandLineOptions.TestStatsEventTimeout);
     }
 
     [TestMethod]
     public void CommandLineOptionsGetForSourcesPropertyShouldReturnReadonlySourcesEnumerable()
     {
-        Assert.IsTrue(CommandLineOptions.Instance.Sources is ReadOnlyCollection<string>);
+        Assert.IsTrue(_commandLineOptions.Sources is ReadOnlyCollection<string>);
     }
 
     [TestMethod]
     public void CommandLineOptionsGetForHasPhoneContextPropertyIfTargetDeviceIsSetReturnsTrue()
     {
-        Assert.IsFalse(CommandLineOptions.Instance.HasPhoneContext);
+        Assert.IsFalse(_commandLineOptions.HasPhoneContext);
 
         // Set some not null value
-        CommandLineOptions.Instance.TargetDevice = "TargetDevice";
-        Assert.IsTrue(CommandLineOptions.Instance.HasPhoneContext);
+        _commandLineOptions.TargetDevice = "TargetDevice";
+        Assert.IsTrue(_commandLineOptions.HasPhoneContext);
     }
 
     [TestMethod]
     public void CommandLineOptionsAddSourceShouldThrowCommandLineExceptionForNullSource()
     {
-        Assert.ThrowsExactly<TestSourceException>(() => CommandLineOptions.Instance.AddSource(null!));
+        Assert.ThrowsExactly<TestSourceException>(() => _commandLineOptions.AddSource(null!));
     }
 
     [TestMethod]
@@ -84,14 +84,14 @@ public class CommandLineOptionsTests
         _fileHelper.Setup(fh => fh.Exists(absolutePath)).Returns(true);
 
         // Pass relative path
-        CommandLineOptions.Instance.AddSource(relativeTestFilePath);
-        Assert.IsTrue(CommandLineOptions.Instance.Sources.Contains(absolutePath));
+        _commandLineOptions.AddSource(relativeTestFilePath);
+        Assert.IsTrue(_commandLineOptions.Sources.Contains(absolutePath));
     }
 
     [TestMethod]
     public void CommandLineOptionsAddSourceShouldThrowCommandLineExceptionForInvalidSource()
     {
-        Assert.ThrowsExactly<TestSourceException>(() => CommandLineOptions.Instance.AddSource("DummySource"));
+        Assert.ThrowsExactly<TestSourceException>(() => _commandLineOptions.AddSource("DummySource"));
     }
 
     [TestMethod]
@@ -100,8 +100,8 @@ public class CommandLineOptionsTests
         string testFilePath = Path.Combine(Path.GetTempPath(), "DummyTestFile.txt");
         _fileHelper.Setup(fh => fh.Exists(testFilePath)).Returns(true);
 
-        CommandLineOptions.Instance.AddSource(testFilePath);
+        _commandLineOptions.AddSource(testFilePath);
 
-        Assert.IsTrue(CommandLineOptions.Instance.Sources.Contains(testFilePath));
+        Assert.IsTrue(_commandLineOptions.Sources.Contains(testFilePath));
     }
 }

--- a/test/vstest.console.UnitTests/CommandLine/GenerateFakesUtilitiesTests.cs
+++ b/test/vstest.console.UnitTests/CommandLine/GenerateFakesUtilitiesTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.CommandLineUtilities;
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.CommandLine;
 [TestClass]
 public class GenerateFakesUtilitiesTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private readonly Mock<IFileHelper> _fileHelper;
     private readonly string _currentDirectory = @"C:\\Temp";
     private readonly string _runSettings = string.Empty;
@@ -19,8 +20,7 @@ public class GenerateFakesUtilitiesTests
     public GenerateFakesUtilitiesTests()
     {
         _fileHelper = new Mock<IFileHelper>();
-        CommandLineOptions.Reset();
-        CommandLineOptions.Instance.FileHelper = _fileHelper.Object;
+        _commandLineOptions.FileHelper = _fileHelper.Object;
         _fileHelper.Setup(fh => fh.GetCurrentDirectory()).Returns(_currentDirectory);
         _runSettings = @"<RunSettings><RunConfiguration><TargetFrameworkVersion>.netstandard,Version=5.0</TargetFrameworkVersion></RunConfiguration ></RunSettings>";
     }
@@ -28,16 +28,16 @@ public class GenerateFakesUtilitiesTests
     [TestMethod]
     public void CommandLineOptionsDefaultDisableAutoFakesIsFalse()
     {
-        Assert.IsFalse(CommandLineOptions.Instance.DisableAutoFakes);
+        Assert.IsFalse(_commandLineOptions.DisableAutoFakes);
     }
 
     [TestMethod]
     public void FakesShouldNotBeGeneratedIfDisableAutoFakesSetToTrue()
     {
-        CommandLineOptions.Instance.DisableAutoFakes = true;
+        _commandLineOptions.DisableAutoFakes = true;
         string runSettingsXml = @"<RunSettings><RunConfiguration><TargetFrameworkVersion>.netstandard,Version=5.0</TargetFrameworkVersion></RunConfiguration ></RunSettings>";
 
-        runSettingsXml = GenerateFakesUtilities.GenerateFakesSettings(CommandLineOptions.Instance, [], runSettingsXml);
+        runSettingsXml = GenerateFakesUtilities.GenerateFakesSettings(_commandLineOptions, [], runSettingsXml);
         Assert.AreEqual(runSettingsXml, _runSettings);
     }
 

--- a/test/vstest.console.UnitTests/ExecutorUnitTests.cs
+++ b/test/vstest.console.UnitTests/ExecutorUnitTests.cs
@@ -31,6 +31,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests;
 [DoNotParallelize]
 public class ExecutorUnitTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private readonly Mock<ITestPlatformEventSource> _mockTestPlatformEventSource;
 
     public ExecutorUnitTests()
@@ -389,7 +390,7 @@ public class ExecutorUnitTests
             new PlatformEnvironment(),
             RunSettingsManager.Instance,
             RunSettingsHelper.Instance,
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             injectedAggregator).Execute("--help");
 
         Assert.AreEqual(1, exitCodeWithInjected, "Executor must observe the injected aggregator's Failed outcome.");
@@ -403,7 +404,7 @@ public class ExecutorUnitTests
             new PlatformEnvironment(),
             RunSettingsManager.Instance,
             RunSettingsHelper.Instance,
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             TestRunResultAggregator.Instance).Execute("--help");
 
         Assert.AreEqual(0, exitCodeWithStatic, "The static default aggregator is still Passed, so its Executor must not set the failure bit.");

--- a/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
+++ b/test/vstest.console.UnitTests/Internal/ConsoleLoggerTests.cs
@@ -1004,12 +1004,11 @@ public class ConsoleLoggerTests
     }
 
     [TestMethod]
-    public void TestRunStartHandlerShouldUseInjectedCommandLineOptionsSourcesRatherThanTheStaticDefault()
+    public void TestRunStartHandlerShouldUseInjectedCommandLineOptionsSourcesRatherThanASeparateInstance()
     {
         // The console logger reads the discovered sources from the CommandLineOptions it was given. Injecting a distinct
-        // instance (with its own source) while the static default stays empty proves the reader resolves to the injected
-        // instance rather than to CommandLineOptions.Instance.
-        CommandLineOptions.Reset();
+        // instance (with its own source) while a separate instance stays empty proves the reader resolves to the injected
+        // instance rather than to some other CommandLineOptions.
 
         var fileHelper = new Mock<IFileHelper>();
         var injectedOptions = new CommandLineOptions
@@ -1021,8 +1020,8 @@ public class ConsoleLoggerTests
         fileHelper.Setup(fh => fh.Exists(testFilePath)).Returns(true);
         injectedOptions.AddSource(testFilePath);
 
-        // The static default carries no sources, so a discovered count of 1 can only come from the injected instance.
-        Assert.AreEqual(0, CommandLineOptions.Instance.Sources.Count());
+        // The separate instance carries no sources, so a discovered count of 1 can only come from the injected instance.
+        Assert.AreEqual(0, _commandLineOptions.Sources.Count());
 
         var consoleLogger = new ConsoleLogger(_mockOutput.Object, _mockProgressIndicator.Object, _mockFeatureFlag.Object, injectedOptions);
 

--- a/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/CLIRunSettingsArgumentProcessorTests.cs
@@ -57,7 +57,7 @@ public class CliRunSettingsArgumentProcessorTests
 
     public CliRunSettingsArgumentProcessorTests()
     {
-        _commandLineOptions = CommandLineOptions.Instance;
+        _commandLineOptions = new CommandLineOptions();
         _settingsProvider = new TestableRunSettingsProvider();
         _runSettingsHelper = new RunSettingsHelper();
         _executor = new CliRunSettingsArgumentExecutor(_settingsProvider, _commandLineOptions, _runSettingsHelper);
@@ -66,20 +66,19 @@ public class CliRunSettingsArgumentProcessorTests
     [TestCleanup]
     public void Cleanup()
     {
-        CommandLineOptions.Reset();
     }
 
     [TestMethod]
     public void GetMetadataShouldReturnRunSettingsArgumentProcessorCapabilities()
     {
-        var processor = new CliRunSettingsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), _runSettingsHelper);
+        var processor = new CliRunSettingsArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider(), _runSettingsHelper);
         Assert.IsTrue(processor.Metadata.Value is CliRunSettingsArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnRunSettingsArgumentProcessorCapabilities()
     {
-        var processor = new CliRunSettingsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), _runSettingsHelper);
+        var processor = new CliRunSettingsArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider(), _runSettingsHelper);
         Assert.IsTrue(processor.Executor!.Value is CliRunSettingsArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/DisableAutoFakesArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/DisableAutoFakesArgumentProcessorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.CommandLine.Processors;
@@ -10,11 +10,12 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [TestClass]
 public class DisableAutoFakesArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private readonly DisableAutoFakesArgumentProcessor _disableAutoFakesArgumentProcessor;
 
     public DisableAutoFakesArgumentProcessorTests()
     {
-        _disableAutoFakesArgumentProcessor = new DisableAutoFakesArgumentProcessor(CommandLineOptions.Instance);
+        _disableAutoFakesArgumentProcessor = new DisableAutoFakesArgumentProcessor(_commandLineOptions);
     }
 
     [TestMethod]
@@ -48,6 +49,6 @@ public class DisableAutoFakesArgumentProcessorTests
     public void DisableAutoFakesArgumentProcessorExecutorShouldSetCommandLineDisableAutoFakeValueAsPerArgumentProvided()
     {
         _disableAutoFakesArgumentProcessor.Executor!.Value.Initialize("true");
-        Assert.IsTrue(CommandLineOptions.Instance.DisableAutoFakes);
+        Assert.IsTrue(_commandLineOptions.DisableAutoFakes);
     }
 }

--- a/test/vstest.console.UnitTests/Processors/EnableCodeCoverageArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableCodeCoverageArgumentProcessorTests.cs
@@ -18,6 +18,7 @@ namespace vstest.console.UnitTests.Processors;
 [TestClass]
 public class EnableCodeCoverageArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private readonly TestableRunSettingsProvider _settingsProvider;
     private readonly EnableCodeCoverageArgumentExecutor _executor;
 
@@ -32,7 +33,7 @@ public class EnableCodeCoverageArgumentProcessorTests
     public EnableCodeCoverageArgumentProcessorTests()
     {
         _settingsProvider = new TestableRunSettingsProvider();
-        _executor = new EnableCodeCoverageArgumentExecutor(CommandLineOptions.Instance, _settingsProvider,
+        _executor = new EnableCodeCoverageArgumentExecutor(_commandLineOptions, _settingsProvider,
             new Mock<IFileHelper>().Object);
         CollectArgumentExecutor.EnabledDataCollectors.Clear();
     }
@@ -40,14 +41,14 @@ public class EnableCodeCoverageArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnEnableCodeCoverageArgumentProcessorCapabilities()
     {
-        var processor = new EnableCodeCoverageArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        var processor = new EnableCodeCoverageArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is EnableCodeCoverageArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnEnableCodeCoverageArgumentProcessorCapabilities()
     {
-        var processor = new EnableCodeCoverageArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        var processor = new EnableCodeCoverageArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is EnableCodeCoverageArgumentExecutor);
     }
 
@@ -79,11 +80,11 @@ public class EnableCodeCoverageArgumentProcessorTests
         runsettings.LoadSettingsXml(runsettingsString);
         _settingsProvider.SetActiveRunSettings(runsettings);
 
-        CommandLineOptions.Instance.EnableCodeCoverage = false;
+        _commandLineOptions.EnableCodeCoverage = false;
 
         _executor.Initialize(string.Empty);
 
-        Assert.IsTrue(CommandLineOptions.Instance.EnableCodeCoverage,
+        Assert.IsTrue(_commandLineOptions.EnableCodeCoverage,
             "/EnableCoverage should set CommandLineOption.EnableCodeCoverage to true");
     }
 

--- a/test/vstest.console.UnitTests/Processors/EnvironmentArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnvironmentArgumentProcessorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;
@@ -31,7 +31,7 @@ public class EnvironmentArgumentProcessorTests
 
     public EnvironmentArgumentProcessorTests()
     {
-        _commandLineOptions = CommandLineOptions.Instance;
+        _commandLineOptions = new CommandLineOptions();
         _settingsProvider = new TestableRunSettingsProvider();
         _settingsProvider.UpdateRunSettings(DefaultRunSettings);
         _mockOutput = new Mock<IOutput>();
@@ -40,7 +40,6 @@ public class EnvironmentArgumentProcessorTests
     [TestCleanup]
     public void Cleanup()
     {
-        CommandLineOptions.Reset();
     }
 
     [TestMethod]

--- a/test/vstest.console.UnitTests/Processors/FrameworkArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/FrameworkArgumentProcessorTests.cs
@@ -15,31 +15,31 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [TestClass]
 public class FrameworkArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private readonly FrameworkArgumentExecutor _executor;
     private readonly TestableRunSettingsProvider _runSettingsProvider;
 
     public FrameworkArgumentProcessorTests()
     {
         _runSettingsProvider = new TestableRunSettingsProvider();
-        _executor = new FrameworkArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider);
+        _executor = new FrameworkArgumentExecutor(_commandLineOptions, _runSettingsProvider);
     }
     [TestCleanup]
     public void TestCleanup()
     {
-        CommandLineOptions.Reset();
     }
 
     [TestMethod]
     public void GetMetadataShouldReturnFrameworkArgumentProcessorCapabilities()
     {
-        var processor = new FrameworkArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        var processor = new FrameworkArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is FrameworkArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnFrameworkArgumentExecutor()
     {
-        var processor = new FrameworkArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        var processor = new FrameworkArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is FrameworkArgumentExecutor);
     }
 
@@ -91,7 +91,7 @@ public class FrameworkArgumentProcessorTests
     public void InitializeShouldSetCommandLineOptionsAndRunSettingsFramework()
     {
         _executor.Initialize(".NETCoreApp,Version=v1.0");
-        Assert.AreEqual(".NETCoreApp,Version=v1.0", CommandLineOptions.Instance.TargetFrameworkVersion!.Name);
+        Assert.AreEqual(".NETCoreApp,Version=v1.0", _commandLineOptions.TargetFrameworkVersion!.Name);
         Assert.AreEqual(".NETCoreApp,Version=v1.0", _runSettingsProvider.QueryRunSettingsNode(FrameworkArgumentExecutor.RunSettingsPath));
     }
 
@@ -99,7 +99,7 @@ public class FrameworkArgumentProcessorTests
     public void InitializeShouldSetCommandLineOptionsFrameworkForOlderFrameworks()
     {
         _executor.Initialize("Framework35");
-        Assert.AreEqual(".NETFramework,Version=v3.5", CommandLineOptions.Instance.TargetFrameworkVersion!.Name);
+        Assert.AreEqual(".NETFramework,Version=v3.5", _commandLineOptions.TargetFrameworkVersion!.Name);
         Assert.AreEqual(".NETFramework,Version=v3.5", _runSettingsProvider.QueryRunSettingsNode(FrameworkArgumentExecutor.RunSettingsPath));
     }
 
@@ -107,7 +107,7 @@ public class FrameworkArgumentProcessorTests
     public void InitializeShouldSetCommandLineOptionsFrameworkForCaseInsensitiveFramework()
     {
         _executor.Initialize(".netcoreApp,Version=v1.0");
-        Assert.AreEqual(".NETCoreApp,Version=v1.0", CommandLineOptions.Instance.TargetFrameworkVersion!.Name);
+        Assert.AreEqual(".NETCoreApp,Version=v1.0", _commandLineOptions.TargetFrameworkVersion!.Name);
         Assert.AreEqual(".NETCoreApp,Version=v1.0", _runSettingsProvider.QueryRunSettingsNode(FrameworkArgumentExecutor.RunSettingsPath));
     }
 
@@ -115,9 +115,9 @@ public class FrameworkArgumentProcessorTests
     public void InitializeShouldNotSetFrameworkIfSettingsFileIsLegacy()
     {
         _runSettingsProvider.UpdateRunSettingsNode(FrameworkArgumentExecutor.RunSettingsPath, nameof(FrameworkVersion.Framework45));
-        CommandLineOptions.Instance.SettingsFile = @"c:\tmp\settings.testsettings";
+        _commandLineOptions.SettingsFile = @"c:\tmp\settings.testsettings";
         _executor.Initialize(".NETFramework,Version=v3.5");
-        Assert.AreEqual(".NETFramework,Version=v3.5", CommandLineOptions.Instance.TargetFrameworkVersion!.Name);
+        Assert.AreEqual(".NETFramework,Version=v3.5", _commandLineOptions.TargetFrameworkVersion!.Name);
         Assert.AreEqual(nameof(FrameworkVersion.Framework45), _runSettingsProvider.QueryRunSettingsNode(FrameworkArgumentExecutor.RunSettingsPath));
     }
 

--- a/test/vstest.console.UnitTests/Processors/InIsolationArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/InIsolationArgumentProcessorTests.cs
@@ -14,39 +14,39 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [TestClass]
 public class InIsolationArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private readonly InIsolationArgumentExecutor _executor;
     private readonly TestableRunSettingsProvider _runSettingsProvider;
 
     public InIsolationArgumentProcessorTests()
     {
         _runSettingsProvider = new TestableRunSettingsProvider();
-        _executor = new InIsolationArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider);
+        _executor = new InIsolationArgumentExecutor(_commandLineOptions, _runSettingsProvider);
     }
 
     [TestCleanup]
     public void TestCleanup()
     {
-        CommandLineOptions.Reset();
     }
 
     [TestMethod]
     public void GetMetadataShouldReturnInProcessArgumentProcessorCapabilities()
     {
-        var processor = new InIsolationArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        var processor = new InIsolationArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is InIsolationArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnInProcessArgumentExecutor()
     {
-        var processor = new InIsolationArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        var processor = new InIsolationArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is InIsolationArgumentExecutor);
     }
 
     [TestMethod]
     public void InIsolationArgumentProcessorMetadataShouldProvideAppropriateCapabilities()
     {
-        var isolationProcessor = new InIsolationArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        var isolationProcessor = new InIsolationArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider());
         Assert.IsFalse(isolationProcessor.Metadata.Value.AllowMultiple);
         Assert.IsFalse(isolationProcessor.Metadata.Value.AlwaysExecute);
         Assert.IsFalse(isolationProcessor.Metadata.Value.IsAction);
@@ -70,7 +70,7 @@ public class InIsolationArgumentProcessorTests
     public void InitializeShouldSetInIsolationValue()
     {
         _executor.Initialize(null);
-        Assert.IsTrue(CommandLineOptions.Instance.InIsolation, "InProcess option must be set to true.");
+        Assert.IsTrue(_commandLineOptions.InIsolation, "InProcess option must be set to true.");
         Assert.AreEqual("true", _runSettingsProvider.QueryRunSettingsNode(InIsolationArgumentExecutor.RunSettingsPath));
     }
 

--- a/test/vstest.console.UnitTests/Processors/ListFullyQualifiedTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListFullyQualifiedTestsArgumentProcessorTests.cs
@@ -38,6 +38,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [TestClass]
 public class ListFullyQualifiedTestsArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private readonly Mock<IFileHelper> _mockFileHelper;
     private readonly Mock<IAssemblyMetadataProvider> _mockAssemblyMetadataProvider;
     private readonly InferHelper _inferHelper;
@@ -51,13 +52,13 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
     private readonly Mock<IEnvironment> _mockEnvironment;
     private readonly Mock<IEnvironmentVariableHelper> _mockEnvironmentVariableHelper;
 
-    private static ListFullyQualifiedTestsArgumentExecutor GetExecutor(ITestRequestManager testRequestManager, IOutput? output)
+    private ListFullyQualifiedTestsArgumentExecutor GetExecutor(ITestRequestManager testRequestManager, IOutput? output)
     {
         var runSettingsProvider = new TestableRunSettingsProvider();
         runSettingsProvider.AddDefaultRunSettings();
         var listFullyQualifiedTestsArgumentExecutor =
             new ListFullyQualifiedTestsArgumentExecutor(
-                CommandLineOptions.Instance,
+                _commandLineOptions,
                 runSettingsProvider,
                 testRequestManager,
                 output ?? ConsoleOutput.Instance);
@@ -68,7 +69,6 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
     public void Cleanup()
     {
         File.Delete(_dummyFilePath);
-        CommandLineOptions.Reset();
     }
 
     public ListFullyQualifiedTestsArgumentProcessorTests()
@@ -95,7 +95,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnListFullyQualifiedTestsArgumentProcessorCapabilities()
     {
-        var processor = new ListFullyQualifiedTestsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
+        var processor = new ListFullyQualifiedTestsArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
         Assert.IsTrue(processor.Metadata.Value is ListFullyQualifiedTestsArgumentProcessorCapabilities);
     }
 
@@ -105,7 +105,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
     [TestMethod]
     public void GetExecuterShouldReturnListFullyQualifiedTestsArgumentProcessorCapabilities()
     {
-        var processor = new ListFullyQualifiedTestsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
+        var processor = new ListFullyQualifiedTestsArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
         Assert.IsTrue(processor.Executor!.Value is ListFullyQualifiedTestsArgumentExecutor);
     }
 
@@ -131,21 +131,20 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
     [TestMethod]
     public void ExecutorInitializeWithValidSourceShouldAddItToTestSources()
     {
-        CommandLineOptions.Instance.FileHelper = _mockFileHelper.Object;
-        CommandLineOptions.Instance.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, _mockFileHelper.Object);
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        _commandLineOptions.FileHelper = _mockFileHelper.Object;
+        _commandLineOptions.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, _mockFileHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager, null);
 
         executor.Initialize(_dummyTestFilePath);
 
-        Assert.IsTrue(Enumerable.Contains(CommandLineOptions.Instance.Sources, _dummyTestFilePath));
+        Assert.IsTrue(Enumerable.Contains(_commandLineOptions.Sources, _dummyTestFilePath));
     }
 
     [TestMethod]
     public void ExecutorExecuteForNoSourcesShouldReturnFail()
     {
-        CommandLineOptions.Reset();
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager, null);
 
         Assert.ThrowsExactly<CommandLineException>(() => executor.Execute());
@@ -162,7 +161,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
 
         ResetAndAddSourceToCommandLineOptions(true);
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
 
         var executor = GetExecutor(testRequestManager, null);
 
@@ -179,7 +178,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockDiscoveryRequest.Object);
         ResetAndAddSourceToCommandLineOptions(true);
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
 
         var listTestsArgumentExecutor = GetExecutor(testRequestManager, null);
 
@@ -198,7 +197,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
         ResetAndAddSourceToCommandLineOptions(true);
 
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
 
         var listTestsArgumentExecutor = GetExecutor(testRequestManager, null);
 
@@ -216,7 +215,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
 
         ResetAndAddSourceToCommandLineOptions(true);
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
 
         var executor = GetExecutor(testRequestManager, null);
 
@@ -304,7 +303,7 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockDiscoveryRequest.Object);
 
         ResetAndAddSourceToCommandLineOptions(legitPath);
-        var cmdOptions = CommandLineOptions.Instance;
+        var cmdOptions = _commandLineOptions;
         cmdOptions.TestCaseFilterValue = "TestCategory=MyCat";
 
         var testRequestManager = new TestRequestManager(cmdOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
@@ -325,18 +324,17 @@ public class ListFullyQualifiedTestsArgumentProcessorTests
 
         ResetAndAddSourceToCommandLineOptions(legitPath);
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
 
         GetExecutor(testRequestManager, mockConsoleOutput.Object).Execute();
     }
 
     private void ResetAndAddSourceToCommandLineOptions(bool legitPath)
     {
-        CommandLineOptions.Reset();
 
-        CommandLineOptions.Instance.FileHelper = _mockFileHelper.Object;
-        CommandLineOptions.Instance.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, _mockFileHelper.Object);
-        CommandLineOptions.Instance.AddSource(_dummyTestFilePath);
-        CommandLineOptions.Instance.ListTestsTargetPath = legitPath ? _dummyFilePath : string.Empty;
+        _commandLineOptions.FileHelper = _mockFileHelper.Object;
+        _commandLineOptions.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, _mockFileHelper.Object);
+        _commandLineOptions.AddSource(_dummyTestFilePath);
+        _commandLineOptions.ListTestsTargetPath = legitPath ? _dummyFilePath : string.Empty;
     }
 }

--- a/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListTestsArgumentProcessorTests.cs
@@ -37,6 +37,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [TestClass]
 public class ListTestsArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private readonly Mock<IFileHelper> _mockFileHelper;
     private readonly Mock<IAssemblyMetadataProvider> _mockAssemblyMetadataProvider;
     private readonly InferHelper _inferHelper;
@@ -49,14 +50,14 @@ public class ListTestsArgumentProcessorTests
     private readonly Mock<IEnvironment> _mockEnvironment;
     private readonly Mock<IEnvironmentVariableHelper> _mockEnvironmentVariableHelper;
 
-    private static ListTestsArgumentExecutor GetExecutor(ITestRequestManager testRequestManager, IOutput? output)
+    private ListTestsArgumentExecutor GetExecutor(ITestRequestManager testRequestManager, IOutput? output)
     {
         var runSettingsProvider = new TestableRunSettingsProvider();
 
         runSettingsProvider.AddDefaultRunSettings();
         var listTestsArgumentExecutor =
             new ListTestsArgumentExecutor(
-                CommandLineOptions.Instance,
+                _commandLineOptions,
                 runSettingsProvider,
                 testRequestManager,
                 output ?? ConsoleOutput.Instance);
@@ -66,7 +67,6 @@ public class ListTestsArgumentProcessorTests
     [TestCleanup]
     public void Cleanup()
     {
-        CommandLineOptions.Reset();
     }
 
     public ListTestsArgumentProcessorTests()
@@ -93,7 +93,7 @@ public class ListTestsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnListTestsArgumentProcessorCapabilities()
     {
-        var processor = new ListTestsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
+        var processor = new ListTestsArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
         Assert.IsTrue(processor.Metadata.Value is ListTestsArgumentProcessorCapabilities);
     }
 
@@ -103,7 +103,7 @@ public class ListTestsArgumentProcessorTests
     [TestMethod]
     public void GetExecuterShouldReturnListTestsArgumentProcessorCapabilities()
     {
-        var processor = new ListTestsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
+        var processor = new ListTestsArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
         Assert.IsTrue(processor.Executor!.Value is ListTestsArgumentExecutor);
     }
 
@@ -133,22 +133,21 @@ public class ListTestsArgumentProcessorTests
     [TestMethod]
     public void ExecutorInitializeWithValidSourceShouldAddItToTestSources()
     {
-        CommandLineOptions.Instance.FileHelper = _mockFileHelper.Object;
-        CommandLineOptions.Instance.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, _mockFileHelper.Object);
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        _commandLineOptions.FileHelper = _mockFileHelper.Object;
+        _commandLineOptions.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, _mockFileHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager, null);
 
         executor.Initialize(_dummyTestFilePath);
 
-        Assert.IsTrue(Enumerable.Contains(CommandLineOptions.Instance.Sources, _dummyTestFilePath));
+        Assert.IsTrue(Enumerable.Contains(_commandLineOptions.Sources, _dummyTestFilePath));
     }
 
     [TestMethod]
     public void ExecutorExecuteForNoSourcesShouldReturnFail()
     {
-        CommandLineOptions.Reset();
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager, null);
 
         Assert.ThrowsExactly<CommandLineException>(() => executor.Execute());
@@ -165,7 +164,7 @@ public class ListTestsArgumentProcessorTests
 
         ResetAndAddSourceToCommandLineOptions();
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager, null);
 
         Assert.ThrowsExactly<TestPlatformException>(() => executor.Execute());
@@ -182,7 +181,7 @@ public class ListTestsArgumentProcessorTests
 
         ResetAndAddSourceToCommandLineOptions();
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var listTestsArgumentExecutor = GetExecutor(testRequestManager, null);
 
         Assert.ThrowsExactly<SettingsException>(() => listTestsArgumentExecutor.Execute());
@@ -199,7 +198,7 @@ public class ListTestsArgumentProcessorTests
 
         ResetAndAddSourceToCommandLineOptions();
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var listTestsArgumentExecutor = GetExecutor(testRequestManager, null);
 
         Assert.ThrowsExactly<InvalidOperationException>(() => listTestsArgumentExecutor.Execute());
@@ -216,7 +215,7 @@ public class ListTestsArgumentProcessorTests
 
         ResetAndAddSourceToCommandLineOptions();
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager, null);
 
         Assert.ThrowsExactly<Exception>(() => executor.Execute());
@@ -275,16 +274,15 @@ public class ListTestsArgumentProcessorTests
 
         ResetAndAddSourceToCommandLineOptions();
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         GetExecutor(testRequestManager, mockConsoleOutput.Object).Execute();
     }
 
     private void ResetAndAddSourceToCommandLineOptions()
     {
-        CommandLineOptions.Reset();
 
-        CommandLineOptions.Instance.FileHelper = _mockFileHelper.Object;
-        CommandLineOptions.Instance.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, _mockFileHelper.Object);
-        CommandLineOptions.Instance.AddSource(_dummyTestFilePath);
+        _commandLineOptions.FileHelper = _mockFileHelper.Object;
+        _commandLineOptions.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, _mockFileHelper.Object);
+        _commandLineOptions.AddSource(_dummyTestFilePath);
     }
 }

--- a/test/vstest.console.UnitTests/Processors/ListTestsTargetPathArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ListTestsTargetPathArgumentProcessorTests.cs
@@ -11,17 +11,18 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [TestClass]
 public class ListTestsTargetPathArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     [TestMethod]
     public void GetMetadataShouldReturnListTestsTargetPathArgumentProcessorCapabilities()
     {
-        ListTestsTargetPathArgumentProcessor processor = new(CommandLineOptions.Instance);
+        ListTestsTargetPathArgumentProcessor processor = new(_commandLineOptions);
         Assert.IsTrue(processor.Metadata.Value is ListTestsTargetPathArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecutorShouldReturnListTestsTargetPathArgumentProcessorCapabilities()
     {
-        ListTestsTargetPathArgumentProcessor processor = new(CommandLineOptions.Instance);
+        ListTestsTargetPathArgumentProcessor processor = new(_commandLineOptions);
         Assert.IsTrue(processor.Executor!.Value is ListTestsTargetPathArgumentExecutor);
     }
 
@@ -46,7 +47,7 @@ public class ListTestsTargetPathArgumentProcessorTests
     [TestMethod]
     public void ExecutorInitializeWithNullOrEmptyListTestsTargetPathShouldThrowCommandLineException()
     {
-        var options = CommandLineOptions.Instance;
+        var options = new CommandLineOptions();
         ListTestsTargetPathArgumentExecutor executor = new(options);
 
         var ex = Assert.ThrowsExactly<CommandLineException>(() => executor.Initialize(null));
@@ -56,7 +57,7 @@ public class ListTestsTargetPathArgumentProcessorTests
     [TestMethod]
     public void ExecutorInitializeWithValidListTestsTargetPathShouldAddListTestsTargetPathToCommandLineOptions()
     {
-        var options = CommandLineOptions.Instance;
+        var options = new CommandLineOptions();
         ListTestsTargetPathArgumentExecutor executor = new(options);
 
         executor.Initialize(@"C:\sample.txt");
@@ -66,7 +67,7 @@ public class ListTestsTargetPathArgumentProcessorTests
     [TestMethod]
     public void ExecutorListTestsTargetPathArgumentProcessorResultSuccess()
     {
-        var executor = new ListTestsTargetPathArgumentExecutor(CommandLineOptions.Instance);
+        var executor = new ListTestsTargetPathArgumentExecutor(_commandLineOptions);
         var result = executor.Execute();
         Assert.AreEqual(ArgumentProcessorResult.Success, result);
     }

--- a/test/vstest.console.UnitTests/Processors/ParallelArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ParallelArgumentProcessorTests.cs
@@ -12,31 +12,31 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [TestClass]
 public class ParallelArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private readonly ParallelArgumentExecutor _executor;
     private readonly TestableRunSettingsProvider _runSettingsProvider;
 
     public ParallelArgumentProcessorTests()
     {
         _runSettingsProvider = new TestableRunSettingsProvider();
-        _executor = new ParallelArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider);
+        _executor = new ParallelArgumentExecutor(_commandLineOptions, _runSettingsProvider);
     }
     [TestCleanup]
     public void TestCleanup()
     {
-        CommandLineOptions.Reset();
     }
 
     [TestMethod]
     public void GetMetadataShouldReturnParallelArgumentProcessorCapabilities()
     {
-        var processor = new ParallelArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        var processor = new ParallelArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is ParallelArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnParallelArgumentExecutor()
     {
-        var processor = new ParallelArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        var processor = new ParallelArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is ParallelArgumentExecutor);
     }
 
@@ -76,7 +76,7 @@ public class ParallelArgumentProcessorTests
     public void InitializeShouldSetParallelValue()
     {
         _executor.Initialize(null);
-        Assert.IsTrue(CommandLineOptions.Instance.Parallel, "Parallel option must be set to true.");
+        Assert.IsTrue(_commandLineOptions.Parallel, "Parallel option must be set to true.");
         Assert.AreEqual("0", _runSettingsProvider.QueryRunSettingsNode(ParallelArgumentExecutor.RunSettingsPath));
     }
 

--- a/test/vstest.console.UnitTests/Processors/ParentProcessIdArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ParentProcessIdArgumentProcessorTests.cs
@@ -12,17 +12,18 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [TestClass]
 public class ParentProcessIdArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     [TestMethod]
     public void GetMetadataShouldReturnParentProcessIdArgumentProcessorCapabilities()
     {
-        var processor = new ParentProcessIdArgumentProcessor(CommandLineOptions.Instance);
+        var processor = new ParentProcessIdArgumentProcessor(_commandLineOptions);
         Assert.IsTrue(processor.Metadata.Value is ParentProcessIdArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecutorShouldReturnParentProcessIdArgumentProcessorCapabilities()
     {
-        var processor = new ParentProcessIdArgumentProcessor(CommandLineOptions.Instance);
+        var processor = new ParentProcessIdArgumentProcessor(_commandLineOptions);
         Assert.IsTrue(processor.Executor!.Value is ParentProcessIdArgumentExecutor);
     }
 
@@ -55,7 +56,7 @@ public class ParentProcessIdArgumentProcessorTests
     [TestMethod]
     public void ExecutorInitializeWithNullOrEmptyParentProcessIdShouldThrowCommandLineException()
     {
-        var executor = new ParentProcessIdArgumentExecutor(CommandLineOptions.Instance);
+        var executor = new ParentProcessIdArgumentExecutor(_commandLineOptions);
         var ex = Assert.ThrowsExactly<CommandLineException>(() => executor.Initialize(null));
         Assert.AreEqual("The --ParentProcessId|/ParentProcessId argument requires the process id which is an integer. Specify the process id of the parent process that launched this process.", ex.Message);
     }
@@ -63,7 +64,7 @@ public class ParentProcessIdArgumentProcessorTests
     [TestMethod]
     public void ExecutorInitializeWithInvalidParentProcessIdShouldThrowCommandLineException()
     {
-        var executor = new ParentProcessIdArgumentExecutor(CommandLineOptions.Instance);
+        var executor = new ParentProcessIdArgumentExecutor(_commandLineOptions);
         var ex = Assert.ThrowsExactly<CommandLineException>(() => executor.Initialize("Foo"));
         Assert.AreEqual("The --ParentProcessId|/ParentProcessId argument requires the process id which is an integer. Specify the process id of the parent process that launched this process.", ex.Message);
     }
@@ -71,16 +72,16 @@ public class ParentProcessIdArgumentProcessorTests
     [TestMethod]
     public void ExecutorInitializeWithValidPortShouldAddParentProcessIdToCommandLineOptions()
     {
-        var executor = new ParentProcessIdArgumentExecutor(CommandLineOptions.Instance);
+        var executor = new ParentProcessIdArgumentExecutor(_commandLineOptions);
         int parentProcessId = 2345;
         executor.Initialize(parentProcessId.ToString(CultureInfo.InvariantCulture));
-        Assert.AreEqual(parentProcessId, CommandLineOptions.Instance.ParentProcessId);
+        Assert.AreEqual(parentProcessId, _commandLineOptions.ParentProcessId);
     }
 
     [TestMethod]
     public void ExecutorExecuteReturnsArgumentProcessorResultSuccess()
     {
-        var executor = new ParentProcessIdArgumentExecutor(CommandLineOptions.Instance);
+        var executor = new ParentProcessIdArgumentExecutor(_commandLineOptions);
 
         int parentProcessId = 2345;
         executor.Initialize(parentProcessId.ToString(CultureInfo.InvariantCulture));

--- a/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
@@ -16,6 +16,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [TestClass]
 public class PlatformArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private readonly PlatformArgumentExecutor _executor;
     private readonly TestableRunSettingsProvider _runSettingsProvider;
     private readonly IRunSettingsHelper _runSettingsHelper;
@@ -24,26 +25,25 @@ public class PlatformArgumentProcessorTests
     {
         _runSettingsProvider = new TestableRunSettingsProvider();
         _runSettingsHelper = new RunSettingsHelper();
-        _executor = new PlatformArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider, _runSettingsHelper);
+        _executor = new PlatformArgumentExecutor(_commandLineOptions, _runSettingsProvider, _runSettingsHelper);
     }
 
     [TestCleanup]
     public void TestCleanup()
     {
-        CommandLineOptions.Reset();
     }
 
     [TestMethod]
     public void GetMetadataShouldReturnPlatformArgumentProcessorCapabilities()
     {
-        var processor = new PlatformArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), _runSettingsHelper);
+        var processor = new PlatformArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider(), _runSettingsHelper);
         Assert.IsTrue(processor.Metadata.Value is PlatformArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnPlatformArgumentExecutor()
     {
-        var processor = new PlatformArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), _runSettingsHelper);
+        var processor = new PlatformArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider(), _runSettingsHelper);
         Assert.IsTrue(processor.Executor!.Value is PlatformArgumentExecutor);
     }
 
@@ -102,7 +102,7 @@ public class PlatformArgumentProcessorTests
     public void InitializeShouldSetCommandLineOptionsArchitecture()
     {
         _executor.Initialize("x64");
-        Assert.AreEqual(ObjectModel.Architecture.X64, CommandLineOptions.Instance.TargetArchitecture);
+        Assert.AreEqual(ObjectModel.Architecture.X64, _commandLineOptions.TargetArchitecture);
         Assert.AreEqual(nameof(ObjectModel.Architecture.X64), _runSettingsProvider.QueryRunSettingsNode(PlatformArgumentExecutor.RunSettingsPath));
     }
 
@@ -110,7 +110,7 @@ public class PlatformArgumentProcessorTests
     public void InitializeShouldNotConsiderCaseSensitivityOfTheArgumentPassed()
     {
         _executor.Initialize("ArM");
-        Assert.AreEqual(ObjectModel.Architecture.ARM, CommandLineOptions.Instance.TargetArchitecture);
+        Assert.AreEqual(ObjectModel.Architecture.ARM, _commandLineOptions.TargetArchitecture);
         Assert.AreEqual(nameof(ObjectModel.Architecture.ARM), _runSettingsProvider.QueryRunSettingsNode(PlatformArgumentExecutor.RunSettingsPath));
     }
 

--- a/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PortArgumentProcessorTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [TestClass]
 public class PortArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private readonly Mock<IProcessHelper> _mockProcessHelper;
     private readonly Mock<IDesignModeClient> _testDesignModeClient;
     private readonly Mock<ITestRequestManager> _testRequestManager;
@@ -34,20 +35,20 @@ public class PortArgumentProcessorTests
         _testDesignModeClient = new Mock<IDesignModeClient>();
         _testRequestManager = new Mock<ITestRequestManager>();
         _runSettingsHelper = new RunSettingsHelper();
-        _executor = new PortArgumentExecutor(CommandLineOptions.Instance, _testRequestManager.Object, _runSettingsHelper);
+        _executor = new PortArgumentExecutor(_commandLineOptions, _testRequestManager.Object, _runSettingsHelper);
     }
 
     [TestMethod]
     public void GetMetadataShouldReturnPortArgumentProcessorCapabilities()
     {
-        var processor = new PortArgumentProcessor(CommandLineOptions.Instance, _runSettingsHelper, _testRequestManager.Object);
+        var processor = new PortArgumentProcessor(_commandLineOptions, _runSettingsHelper, _testRequestManager.Object);
         Assert.IsTrue(processor.Metadata.Value is PortArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecutorShouldReturnPortArgumentProcessorCapabilities()
     {
-        var processor = new PortArgumentProcessor(CommandLineOptions.Instance, _runSettingsHelper, _testRequestManager.Object);
+        var processor = new PortArgumentProcessor(_commandLineOptions, _runSettingsHelper, _testRequestManager.Object);
         Assert.IsTrue(processor.Executor!.Value is PortArgumentExecutor);
     }
 
@@ -89,11 +90,11 @@ public class PortArgumentProcessorTests
     public void ExecutorInitializeWithValidPortShouldAddPortToCommandLineOptionsAndInitializeDesignModeManager()
     {
         int port = 2345;
-        CommandLineOptions.Instance.ParentProcessId = 0;
+        _commandLineOptions.ParentProcessId = 0;
 
         _executor.Initialize(port.ToString(CultureInfo.InvariantCulture));
 
-        Assert.AreEqual(port, CommandLineOptions.Instance.Port);
+        Assert.AreEqual(port, _commandLineOptions.Port);
         Assert.IsNotNull(DesignModeClient.Instance);
     }
 
@@ -101,18 +102,18 @@ public class PortArgumentProcessorTests
     public void ExecutorInitializeShouldSetDesignMode()
     {
         int port = 2345;
-        CommandLineOptions.Instance.ParentProcessId = 0;
+        _commandLineOptions.ParentProcessId = 0;
 
         _executor.Initialize(port.ToString(CultureInfo.InvariantCulture));
 
-        Assert.IsTrue(CommandLineOptions.Instance.IsDesignMode);
+        Assert.IsTrue(_commandLineOptions.IsDesignMode);
         Assert.IsTrue(_runSettingsHelper.IsDesignMode);
     }
 
     [TestMethod]
     public void ExecutorInitializeShouldSetProcessExitCallback()
     {
-        _executor = new PortArgumentExecutor(CommandLineOptions.Instance, _testRequestManager.Object, _mockProcessHelper.Object, _runSettingsHelper);
+        _executor = new PortArgumentExecutor(_commandLineOptions, _testRequestManager.Object, _mockProcessHelper.Object, _runSettingsHelper);
         int port = 2345;
 #if NET5_0_OR_GREATER
         var pid = Environment.ProcessId;
@@ -121,7 +122,7 @@ public class PortArgumentProcessorTests
         using (var p = Process.GetCurrentProcess())
             pid = p.Id;
 #endif
-        CommandLineOptions.Instance.ParentProcessId = pid;
+        _commandLineOptions.ParentProcessId = pid;
 
         _executor.Initialize(port.ToString(CultureInfo.InvariantCulture));
 
@@ -131,7 +132,7 @@ public class PortArgumentProcessorTests
     [TestMethod]
     public void ExecutorExecuteForValidConnectionReturnsArgumentProcessorResultSuccess()
     {
-        _executor = new PortArgumentExecutor(CommandLineOptions.Instance, _testRequestManager.Object,
+        _executor = new PortArgumentExecutor(_commandLineOptions, _testRequestManager.Object,
             (parentProcessId, ph) => _testDesignModeClient.Object, _mockProcessHelper.Object, _runSettingsHelper);
 
         int port = 2345;
@@ -147,7 +148,7 @@ public class PortArgumentProcessorTests
     [TestMethod]
     public void ExecutorExecuteForFailedConnectionShouldThrowCommandLineException()
     {
-        _executor = new PortArgumentExecutor(CommandLineOptions.Instance, _testRequestManager.Object,
+        _executor = new PortArgumentExecutor(_commandLineOptions, _testRequestManager.Object,
             (parentProcessId, ph) => _testDesignModeClient.Object, _mockProcessHelper.Object, _runSettingsHelper);
 
         _testDesignModeClient.Setup(td => td.ConnectToClientAndProcessRequests(It.IsAny<int>(),
@@ -165,11 +166,11 @@ public class PortArgumentProcessorTests
     public void ExecutorExecuteSetsParentProcessIdOnDesignModeInitializer()
     {
         var parentProcessId = 2346;
-        var parentProcessIdArgumentExecutor = new ParentProcessIdArgumentExecutor(CommandLineOptions.Instance);
+        var parentProcessIdArgumentExecutor = new ParentProcessIdArgumentExecutor(_commandLineOptions);
         parentProcessIdArgumentExecutor.Initialize(parentProcessId.ToString(CultureInfo.InvariantCulture));
 
         int actualParentProcessId = -1;
-        _executor = new PortArgumentExecutor(CommandLineOptions.Instance,
+        _executor = new PortArgumentExecutor(_commandLineOptions,
             _testRequestManager.Object,
             (ppid, ph) =>
             {

--- a/test/vstest.console.UnitTests/Processors/ResponseFileArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ResponseFileArgumentProcessorTests.cs
@@ -9,12 +9,6 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [TestClass]
 public class ResponseFileArgumentProcessorTests
 {
-    [TestCleanup]
-    public void TestCleanup()
-    {
-        CommandLineOptions.Reset();
-    }
-
     [TestMethod]
     public void GetMetadataShouldReturnResponseFileArgumentProcessorCapabilities()
     {

--- a/test/vstest.console.UnitTests/Processors/ResultsDirectoryArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ResultsDirectoryArgumentProcessorTests.cs
@@ -16,32 +16,32 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [TestClass]
 public class ResultsDirectoryArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private readonly ResultsDirectoryArgumentExecutor _executor;
     private readonly TestableRunSettingsProvider _runSettingsProvider;
 
     public ResultsDirectoryArgumentProcessorTests()
     {
         _runSettingsProvider = new TestableRunSettingsProvider();
-        _executor = new ResultsDirectoryArgumentExecutor(CommandLineOptions.Instance, _runSettingsProvider);
+        _executor = new ResultsDirectoryArgumentExecutor(_commandLineOptions, _runSettingsProvider);
     }
 
     [TestCleanup]
     public void TestCleanup()
     {
-        CommandLineOptions.Reset();
     }
 
     [TestMethod]
     public void GetMetadataShouldReturnResultsDirectoryArgumentProcessorCapabilities()
     {
-        var processor = new ResultsDirectoryArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        var processor = new ResultsDirectoryArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is ResultsDirectoryArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnResultsDirectoryArgumentExecutor()
     {
-        var processor = new ResultsDirectoryArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        var processor = new ResultsDirectoryArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is ResultsDirectoryArgumentExecutor);
     }
 
@@ -118,7 +118,7 @@ public class ResultsDirectoryArgumentProcessorTests
         var relativePath = TranslatePath(@".\relative\path");
         var absolutePath = Path.GetFullPath(relativePath);
         _executor.Initialize(relativePath);
-        Assert.AreEqual(absolutePath, CommandLineOptions.Instance.ResultsDirectory);
+        Assert.AreEqual(absolutePath, _commandLineOptions.ResultsDirectory);
         Assert.AreEqual(absolutePath, _runSettingsProvider.QueryRunSettingsNode(ResultsDirectoryArgumentExecutor.RunSettingsPath));
     }
 
@@ -127,7 +127,7 @@ public class ResultsDirectoryArgumentProcessorTests
     {
         var absolutePath = TranslatePath(@"c:\random\someone\testresults");
         _executor.Initialize(absolutePath);
-        Assert.AreEqual(absolutePath, CommandLineOptions.Instance.ResultsDirectory);
+        Assert.AreEqual(absolutePath, _commandLineOptions.ResultsDirectory);
         Assert.AreEqual(absolutePath, _runSettingsProvider.QueryRunSettingsNode(ResultsDirectoryArgumentExecutor.RunSettingsPath));
     }
 

--- a/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSettingsArgumentProcessorTests.cs
@@ -25,6 +25,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [TestClass]
 public class RunSettingsArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private readonly TestableRunSettingsProvider _settingsProvider;
 
     public RunSettingsArgumentProcessorTests()
@@ -35,20 +36,19 @@ public class RunSettingsArgumentProcessorTests
     [TestCleanup]
     public void TestCleanup()
     {
-        CommandLineOptions.Reset();
     }
 
     [TestMethod]
     public void GetMetadataShouldReturnRunSettingsArgumentProcessorCapabilities()
     {
-        var processor = new RunSettingsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new RunSettingsHelper());
+        var processor = new RunSettingsArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider(), new RunSettingsHelper());
         Assert.IsTrue(processor.Metadata.Value is RunSettingsArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnRunSettingsArgumentExecutor()
     {
-        var processor = new RunSettingsArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new RunSettingsHelper());
+        var processor = new RunSettingsArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider(), new RunSettingsHelper());
         Assert.IsTrue(processor.Executor!.Value is RunSettingsArgumentExecutor);
     }
 
@@ -78,14 +78,14 @@ public class RunSettingsArgumentProcessorTests
     [TestMethod]
     public void InitializeShouldThrowExceptionIfArgumentIsNull()
     {
-        var ex = Assert.ThrowsExactly<CommandLineException>(() => new RunSettingsArgumentExecutor(CommandLineOptions.Instance, null!, new RunSettingsHelper()).Initialize(null));
+        var ex = Assert.ThrowsExactly<CommandLineException>(() => new RunSettingsArgumentExecutor(_commandLineOptions, null!, new RunSettingsHelper()).Initialize(null));
         Assert.Contains("The /Settings parameter requires a settings file to be provided.", ex.Message);
     }
 
     [TestMethod]
     public void InitializeShouldThrowExceptionIfArgumentIsWhiteSpace()
     {
-        var ex = Assert.ThrowsExactly<CommandLineException>(() => new RunSettingsArgumentExecutor(CommandLineOptions.Instance, null!, new RunSettingsHelper()).Initialize("  "));
+        var ex = Assert.ThrowsExactly<CommandLineException>(() => new RunSettingsArgumentExecutor(_commandLineOptions, null!, new RunSettingsHelper()).Initialize("  "));
         Assert.Contains("The /Settings parameter requires a settings file to be provided.", ex.Message);
     }
 
@@ -94,7 +94,7 @@ public class RunSettingsArgumentProcessorTests
     {
         var fileName = "C:\\Imaginary\\nonExistentFile.txt";
 
-        var executor = new RunSettingsArgumentExecutor(CommandLineOptions.Instance, null!, new RunSettingsHelper());
+        var executor = new RunSettingsArgumentExecutor(_commandLineOptions, null!, new RunSettingsHelper());
         var mockFileHelper = new Mock<IFileHelper>();
         mockFileHelper.Setup(fh => fh.Exists(It.IsAny<string>())).Returns(false);
 
@@ -112,7 +112,7 @@ public class RunSettingsArgumentProcessorTests
         var settingsXml = "<BadRunSettings></BadRunSettings>";
 
         var executor = new TestableRunSettingsArgumentExecutor(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _settingsProvider,
             settingsXml);
 
@@ -135,7 +135,7 @@ public class RunSettingsArgumentProcessorTests
         var settingsXml = "<RunSettings></RunSettings>";
 
         var executor = new TestableRunSettingsArgumentExecutor(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _settingsProvider,
             settingsXml);
 
@@ -149,7 +149,7 @@ public class RunSettingsArgumentProcessorTests
 
         // Assert.
         Assert.IsNotNull(_settingsProvider.ActiveRunSettings);
-        Assert.AreEqual(fileName, CommandLineOptions.Instance.SettingsFile);
+        Assert.AreEqual(fileName, _commandLineOptions.SettingsFile);
     }
 
     [TestMethod]
@@ -160,7 +160,7 @@ public class RunSettingsArgumentProcessorTests
         var settingsXml = "<RunSettings></RunSettings>";
 
         var executor = new TestableRunSettingsArgumentExecutor(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _settingsProvider,
             settingsXml);
 
@@ -173,7 +173,7 @@ public class RunSettingsArgumentProcessorTests
         executor.Initialize(fileName);
 
         // Assert.
-        Assert.AreEqual(fileName, CommandLineOptions.Instance.SettingsFile);
+        Assert.AreEqual(fileName, _commandLineOptions.SettingsFile);
     }
 
     [TestMethod]
@@ -184,7 +184,7 @@ public class RunSettingsArgumentProcessorTests
         var settingsXml = "<RunSettings></RunSettings>";
 
         var executor = new TestableRunSettingsArgumentExecutor(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _settingsProvider,
             settingsXml);
 
@@ -214,7 +214,7 @@ public class RunSettingsArgumentProcessorTests
         var settingsXml = "<TestSettings></TestSettings>";
 
         var executor = new TestableRunSettingsArgumentExecutor(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _settingsProvider,
             settingsXml);
 
@@ -258,7 +258,7 @@ public class RunSettingsArgumentProcessorTests
         var settingsXml = $"<RunSettings><RunConfiguration><TargetPlatform>{nameof(Architecture.X64)}</TargetPlatform><TargetFrameworkVersion>{Constants.DotNetFramework46}</TargetFrameworkVersion></RunConfiguration></RunSettings>";
 
         var executor = new TestableRunSettingsArgumentExecutor(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _settingsProvider,
             settingsXml);
 
@@ -271,10 +271,10 @@ public class RunSettingsArgumentProcessorTests
         executor.Initialize(fileName);
 
         // Assert.
-        Assert.IsTrue(CommandLineOptions.Instance.ArchitectureSpecified);
-        Assert.IsTrue(CommandLineOptions.Instance.FrameworkVersionSpecified);
-        Assert.AreEqual(Architecture.X64, CommandLineOptions.Instance.TargetArchitecture);
-        Assert.AreEqual(Constants.DotNetFramework46, CommandLineOptions.Instance.TargetFrameworkVersion.Name);
+        Assert.IsTrue(_commandLineOptions.ArchitectureSpecified);
+        Assert.IsTrue(_commandLineOptions.FrameworkVersionSpecified);
+        Assert.AreEqual(Architecture.X64, _commandLineOptions.TargetArchitecture);
+        Assert.AreEqual(Constants.DotNetFramework46, _commandLineOptions.TargetFrameworkVersion.Name);
     }
 
     [TestMethod]
@@ -285,7 +285,7 @@ public class RunSettingsArgumentProcessorTests
         var settingsXml = "<RunSettings><RunConfiguration></RunConfiguration></RunSettings>";
 
         var executor = new TestableRunSettingsArgumentExecutor(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _settingsProvider,
             settingsXml);
 
@@ -298,8 +298,8 @@ public class RunSettingsArgumentProcessorTests
         executor.Initialize(fileName);
 
         // Assert.
-        Assert.IsFalse(CommandLineOptions.Instance.ArchitectureSpecified);
-        Assert.IsFalse(CommandLineOptions.Instance.FrameworkVersionSpecified);
+        Assert.IsFalse(_commandLineOptions.ArchitectureSpecified);
+        Assert.IsFalse(_commandLineOptions.FrameworkVersionSpecified);
     }
 
     [TestMethod]
@@ -311,7 +311,7 @@ public class RunSettingsArgumentProcessorTests
         File.WriteAllText(runsettingsFile, settingsXml, Encoding.UTF8);
 
         var executor = new TestableRunSettingsArgumentExecutor(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _settingsProvider,
             null);
 
@@ -329,7 +329,7 @@ public class RunSettingsArgumentProcessorTests
         var fileName = "C:\\temp\\r.runsettings";
 
         var executor = new TestableRunSettingsArgumentExecutor(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _settingsProvider,
             settingsXml);
 
@@ -342,7 +342,7 @@ public class RunSettingsArgumentProcessorTests
         executor.Initialize(fileName);
 
         // Assert.
-        Assert.IsTrue(CommandLineOptions.Instance.InIsolation);
+        Assert.IsTrue(_commandLineOptions.InIsolation);
         Assert.AreEqual("true", _settingsProvider.QueryRunSettingsNode(InIsolationArgumentExecutor.RunSettingsPath));
     }
 
@@ -355,7 +355,7 @@ public class RunSettingsArgumentProcessorTests
         var fileName = "C:\\temp\\r.runsettings";
 
         var executor = new TestableRunSettingsArgumentExecutor(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _settingsProvider,
             settingsXml);
 
@@ -368,7 +368,7 @@ public class RunSettingsArgumentProcessorTests
         executor.Initialize(fileName);
 
         // Assert.
-        Assert.IsFalse(CommandLineOptions.Instance.InIsolation);
+        Assert.IsFalse(_commandLineOptions.InIsolation);
         Assert.IsNull(_settingsProvider.QueryRunSettingsNode(InIsolationArgumentExecutor.RunSettingsPath));
     }
 
@@ -381,7 +381,7 @@ public class RunSettingsArgumentProcessorTests
         var settingsXml = $"<RunSettings><RunConfiguration><TestCaseFilter>{filter}</TestCaseFilter></RunConfiguration></RunSettings>";
 
         var executor = new TestableRunSettingsArgumentExecutor(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _settingsProvider,
             settingsXml);
 
@@ -394,7 +394,7 @@ public class RunSettingsArgumentProcessorTests
         executor.Initialize(fileName);
 
         // Assert.
-        Assert.AreEqual(filter, CommandLineOptions.Instance.TestCaseFilterValue);
+        Assert.AreEqual(filter, _commandLineOptions.TestCaseFilterValue);
     }
     #endregion
 

--- a/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunSpecificTestsArgumentProcessorTests.cs
@@ -33,6 +33,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [TestClass]
 public class RunSpecificTestsArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private const string NoDiscoveredTestsWarning = @"No test is available in DummyTest.dll. Make sure that installed test discoverers & executors, platform & framework version settings are appropriate and try again.";
     private const string TestAdapterPathSuggestion = @"Additionally, path to test adapters can be specified using /TestAdapterPath command. Example  /TestAdapterPath:<pathToCustomAdapters>.";
     private readonly Mock<IFileHelper> _mockFileHelper;
@@ -53,7 +54,7 @@ public class RunSpecificTestsArgumentProcessorTests
     {
         var runSettingsProvider = new TestableRunSettingsProvider();
         runSettingsProvider.AddDefaultRunSettings();
-        return new RunSpecificTestsArgumentExecutor(CommandLineOptions.Instance, runSettingsProvider, testRequestManager, _mockArtifactProcessingManager.Object, _mockOutput.Object);
+        return new RunSpecificTestsArgumentExecutor(_commandLineOptions, runSettingsProvider, testRequestManager, _mockArtifactProcessingManager.Object, _mockOutput.Object);
     }
 
     public RunSpecificTestsArgumentProcessorTests()
@@ -81,7 +82,7 @@ public class RunSpecificTestsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnRunSpecificTestsArgumentProcessorCapabilities()
     {
-        RunSpecificTestsArgumentProcessor processor = new(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
+        RunSpecificTestsArgumentProcessor processor = new(_commandLineOptions, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
 
         Assert.IsTrue(processor.Metadata.Value is RunSpecificTestsArgumentProcessorCapabilities);
     }
@@ -89,7 +90,7 @@ public class RunSpecificTestsArgumentProcessorTests
     [TestMethod]
     public void GetExecutorShouldReturnRunSpecificTestsArgumentExecutor()
     {
-        RunSpecificTestsArgumentProcessor processor = new(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
+        RunSpecificTestsArgumentProcessor processor = new(_commandLineOptions, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
 
         Assert.IsTrue(processor.Executor!.Value is RunSpecificTestsArgumentExecutor);
     }
@@ -119,9 +120,8 @@ public class RunSpecificTestsArgumentProcessorTests
     [TestMethod]
     public void InitializeShouldThrowIfArgumentIsNull()
     {
-        CommandLineOptions.Reset();
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         Assert.ThrowsExactly<CommandLineException>(() => executor.Initialize(null));
@@ -130,9 +130,8 @@ public class RunSpecificTestsArgumentProcessorTests
     [TestMethod]
     public void InitializeShouldThrowIfArgumentIsEmpty()
     {
-        CommandLineOptions.Reset();
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         Assert.ThrowsExactly<CommandLineException>(() => executor.Initialize(string.Empty));
@@ -141,9 +140,8 @@ public class RunSpecificTestsArgumentProcessorTests
     [TestMethod]
     public void InitializeShouldThrowIfArgumentIsWhiteSpace()
     {
-        CommandLineOptions.Reset();
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         Assert.ThrowsExactly<CommandLineException>(() => executor.Initialize(" "));
@@ -152,9 +150,8 @@ public class RunSpecificTestsArgumentProcessorTests
     [TestMethod]
     public void InitializeShouldThrowIfArgumentsAreEmpty()
     {
-        CommandLineOptions.Reset();
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         Assert.ThrowsExactly<CommandLineException>(() => executor.Initialize(" , "));
@@ -163,9 +160,8 @@ public class RunSpecificTestsArgumentProcessorTests
     [TestMethod]
     public void ExecutorShouldSplitTestsSeparatedByComma()
     {
-        CommandLineOptions.Reset();
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         Assert.ThrowsExactly<CommandLineException>(() => executor.Execute());
@@ -174,9 +170,8 @@ public class RunSpecificTestsArgumentProcessorTests
     [TestMethod]
     public void ExecutorExecuteForNoSourcesShouldThrowCommandLineException()
     {
-        CommandLineOptions.Reset();
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         Assert.ThrowsExactly<CommandLineException>(() => executor.Execute());
@@ -201,10 +196,10 @@ public class RunSpecificTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockTestRunRequest.Object);
         mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockDiscoveryRequest.Object);
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
-        CommandLineOptions.Instance.TestCaseFilterValue = "Filter";
+        _commandLineOptions.TestCaseFilterValue = "Filter";
         executor.Initialize("Test1");
         ArgumentProcessorResult argumentProcessorResult = executor.Execute();
 
@@ -226,7 +221,7 @@ public class RunSpecificTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockDiscoveryRequest.Object);
 
         ResetAndAddSourceToCommandLineOptions();
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         Assert.ThrowsExactly<TestPlatformException>(() => executor.Execute());
@@ -244,7 +239,7 @@ public class RunSpecificTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockDiscoveryRequest.Object);
 
         ResetAndAddSourceToCommandLineOptions();
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         Assert.ThrowsExactly<InvalidOperationException>(() => executor.Execute());
@@ -262,7 +257,7 @@ public class RunSpecificTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockDiscoveryRequest.Object);
 
         ResetAndAddSourceToCommandLineOptions();
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         Assert.ThrowsExactly<SettingsException>(() => executor.Execute());
@@ -287,7 +282,7 @@ public class RunSpecificTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockDiscoveryRequest.Object);
 
         ResetAndAddSourceToCommandLineOptions();
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         executor.Initialize("Test1");
@@ -314,7 +309,7 @@ public class RunSpecificTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockDiscoveryRequest.Object);
 
         ResetAndAddSourceToCommandLineOptions();
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         executor.Initialize("Test1");
@@ -342,7 +337,7 @@ public class RunSpecificTestsArgumentProcessorTests
 
         ResetAndAddSourceToCommandLineOptions();
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         executor.Initialize("Test1");
@@ -359,11 +354,11 @@ public class RunSpecificTestsArgumentProcessorTests
         ResetAndAddSourceToCommandLineOptions();
 
         // Setting some test adapter path
-        CommandLineOptions.Instance.TestAdapterPath = [@"C:\Foo"];
+        _commandLineOptions.TestAdapterPath = [@"C:\Foo"];
 
         mockDiscoveryRequest.Setup(dr => dr.DiscoverAsync()).Raises(dr => dr.OnDiscoveredTests += null, new DiscoveredTestsEventArgs(new List<TestCase>()));
         mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockDiscoveryRequest.Object);
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         executor.Initialize("Test1");
@@ -384,7 +379,7 @@ public class RunSpecificTestsArgumentProcessorTests
 
         mockDiscoveryRequest.Setup(dr => dr.DiscoverAsync()).Raises(dr => dr.OnDiscoveredTests += null, new DiscoveredTestsEventArgs(new List<TestCase>()));
         mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockDiscoveryRequest.Object);
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         executor.Initialize("Test1");
@@ -410,7 +405,7 @@ public class RunSpecificTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockTestRunRequest.Object);
         mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockDiscoveryRequest.Object);
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         executor.Initialize("Test1");
@@ -438,7 +433,7 @@ public class RunSpecificTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockTestRunRequest.Object);
         mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockDiscoveryRequest.Object);
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         executor.Initialize("Test1, Test2");
@@ -467,7 +462,7 @@ public class RunSpecificTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockTestRunRequest.Object);
         mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockDiscoveryRequest.Object);
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         executor.Initialize("Test1");
@@ -492,7 +487,7 @@ public class RunSpecificTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockTestRunRequest.Object);
         mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockDiscoveryRequest.Object);
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         executor.Initialize("Test1, Test2");
@@ -521,7 +516,7 @@ public class RunSpecificTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockTestRunRequest.Object);
         mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockDiscoveryRequest.Object);
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         executor.Initialize("Test1(a\\,b), Test2(c\\,d)");
@@ -553,7 +548,7 @@ public class RunSpecificTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockDiscoveryRequest.Object);
 
         ResetAndAddSourceToCommandLineOptions();
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         executor.Initialize("Test1");
@@ -584,7 +579,7 @@ public class RunSpecificTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockDiscoveryRequest.Object);
 
         ResetAndAddSourceToCommandLineOptions();
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _mockEnvironment.Object, _mockEnvironmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         executor.Initialize("Test1");
@@ -597,10 +592,9 @@ public class RunSpecificTestsArgumentProcessorTests
 
     private void ResetAndAddSourceToCommandLineOptions()
     {
-        CommandLineOptions.Reset();
-        CommandLineOptions.Instance.TestCaseFilterValue = null;
-        CommandLineOptions.Instance.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, _mockFileHelper.Object);
-        CommandLineOptions.Instance.FileHelper = _mockFileHelper.Object;
-        CommandLineOptions.Instance.AddSource(_dummyTestFilePath);
+        _commandLineOptions.TestCaseFilterValue = null;
+        _commandLineOptions.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, _mockFileHelper.Object);
+        _commandLineOptions.FileHelper = _mockFileHelper.Object;
+        _commandLineOptions.AddSource(_dummyTestFilePath);
     }
 }

--- a/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/RunTestsArgumentProcessorTests.cs
@@ -40,6 +40,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [TestClass]
 public class RunTestsArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private readonly Mock<IFileHelper> _mockFileHelper;
     private readonly Mock<IOutput> _mockOutput;
     private readonly Mock<IAssemblyMetadataProvider> _mockAssemblyMetadataProvider;
@@ -79,14 +80,14 @@ public class RunTestsArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnRunTestsArgumentProcessorCapabilities()
     {
-        RunTestsArgumentProcessor processor = new(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
+        RunTestsArgumentProcessor processor = new(_commandLineOptions, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
         Assert.IsTrue(processor.Metadata.Value is RunTestsArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnRunTestsArgumentProcessorCapabilities()
     {
-        RunTestsArgumentProcessor processor = new(CommandLineOptions.Instance, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
+        RunTestsArgumentProcessor processor = new(_commandLineOptions, new TestableRunSettingsProvider(), new Mock<ITestRequestManager>().Object);
         Assert.IsTrue(processor.Executor!.Value is RunTestsArgumentExecutor);
     }
 
@@ -118,10 +119,9 @@ public class RunTestsArgumentProcessorTests
         var runSettingsProvider = new TestableRunSettingsProvider();
         runSettingsProvider.UpdateRunSettings("<RunSettings/>");
 
-        CommandLineOptions.Reset();
-        CommandLineOptions.Instance.IsDesignMode = true;
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
-        var executor = new RunTestsArgumentExecutor(CommandLineOptions.Instance, runSettingsProvider, testRequestManager, _artifactProcessingManager.Object, _mockOutput.Object);
+        _commandLineOptions.IsDesignMode = true;
+        var testRequestManager = new TestRequestManager(_commandLineOptions, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
+        var executor = new RunTestsArgumentExecutor(_commandLineOptions, runSettingsProvider, testRequestManager, _artifactProcessingManager.Object, _mockOutput.Object);
 
         Assert.AreEqual(ArgumentProcessorResult.Success, executor.Execute());
     }
@@ -129,8 +129,7 @@ public class RunTestsArgumentProcessorTests
     [TestMethod]
     public void ExecutorExecuteForNoSourcesShouldThrowCommandLineException()
     {
-        CommandLineOptions.Reset();
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, TestPlatformFactory.GetTestPlatform(), TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         Assert.ThrowsExactly<CommandLineException>(() => executor.Execute());
@@ -141,7 +140,7 @@ public class RunTestsArgumentProcessorTests
         var runSettingsProvider = new TestableRunSettingsProvider();
         runSettingsProvider.AddDefaultRunSettings();
         var executor = new RunTestsArgumentExecutor(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             runSettingsProvider,
             testRequestManager,
             _artifactProcessingManager.Object,
@@ -160,7 +159,7 @@ public class RunTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockTestRunRequest.Object);
 
         ResetAndAddSourceToCommandLineOptions();
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         Assert.ThrowsExactly<TestPlatformException>(() => executor.Execute());
@@ -176,7 +175,7 @@ public class RunTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockTestRunRequest.Object);
 
         ResetAndAddSourceToCommandLineOptions();
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         Assert.ThrowsExactly<SettingsException>(() => executor.Execute());
@@ -192,7 +191,7 @@ public class RunTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockTestRunRequest.Object);
 
         ResetAndAddSourceToCommandLineOptions();
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         Assert.ThrowsExactly<InvalidOperationException>(() => executor.Execute());
@@ -208,7 +207,7 @@ public class RunTestsArgumentProcessorTests
         mockTestPlatform.Setup(tp => tp.CreateTestRunRequest(It.IsAny<IRequestData>(), It.IsAny<TestRunCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>())).Returns(mockTestRunRequest.Object);
 
         ResetAndAddSourceToCommandLineOptions();
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         Assert.ThrowsExactly<Exception>(() => executor.Execute());
@@ -265,7 +264,7 @@ public class RunTestsArgumentProcessorTests
 
         ResetAndAddSourceToCommandLineOptions();
 
-        var testRequestManager = new TestRequestManager(CommandLineOptions.Instance, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
+        var testRequestManager = new TestRequestManager(_commandLineOptions, mockTestPlatform.Object, TestRunResultAggregator.Instance, _mockTestPlatformEventSource.Object, _inferHelper, _mockMetricsPublisherTask, _mockProcessHelper.Object, _mockAttachmentsProcessingManager.Object, _environment.Object, _environmentVariableHelper.Object);
         var executor = GetExecutor(testRequestManager);
 
         return executor.Execute();
@@ -273,11 +272,10 @@ public class RunTestsArgumentProcessorTests
 
     private void ResetAndAddSourceToCommandLineOptions()
     {
-        CommandLineOptions.Reset();
 
-        CommandLineOptions.Instance.FileHelper = _mockFileHelper.Object;
-        CommandLineOptions.Instance.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, _mockFileHelper.Object);
-        CommandLineOptions.Instance.AddSource(_dummyTestFilePath);
+        _commandLineOptions.FileHelper = _mockFileHelper.Object;
+        _commandLineOptions.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, _mockFileHelper.Object);
+        _commandLineOptions.AddSource(_dummyTestFilePath);
     }
 
     public static void SetupMockExtensions()

--- a/test/vstest.console.UnitTests/Processors/TestAdapterLoadingStrategyArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestAdapterLoadingStrategyArgumentProcessorTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [DoNotParallelize]
 public class TestAdapterLoadingStrategyArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private readonly RunSettings _currentActiveSetting;
 
     public TestAdapterLoadingStrategyArgumentProcessorTests()
@@ -49,7 +50,7 @@ public class TestAdapterLoadingStrategyArgumentProcessorTests
         mockFileHelper.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
         mockFileHelper.Setup(x => x.GetFullPath(It.IsAny<string>())).Returns((Func<string, string>)(s => Path.GetFullPath(s)));
 
-        var executor = new TestAdapterLoadingStrategyArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance, mockOutput.Object, mockFileHelper.Object);
+        var executor = new TestAdapterLoadingStrategyArgumentExecutor(_commandLineOptions, RunSettingsManager.Instance, mockOutput.Object, mockFileHelper.Object);
 
         executor.Initialize(nameof(TestAdapterLoadingStrategy.Default));
         var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(RunSettingsManager.Instance.ActiveRunSettings.SettingsXml);
@@ -71,7 +72,7 @@ public class TestAdapterLoadingStrategyArgumentProcessorTests
 
         mockFileHelper.Setup(x => x.DirectoryExists("d:\\users")).Returns(false);
         mockFileHelper.Setup(x => x.DirectoryExists("c:\\users")).Returns(true);
-        var executor = new TestAdapterLoadingStrategyArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance, mockOutput.Object, mockFileHelper.Object);
+        var executor = new TestAdapterLoadingStrategyArgumentExecutor(_commandLineOptions, RunSettingsManager.Instance, mockOutput.Object, mockFileHelper.Object);
 
         var message = "The path 'd:\\users' specified in the 'TestAdapterPath' is invalid. Error: The custom test adapter search path provided was not found, provide a valid path and try again.";
 
@@ -91,7 +92,7 @@ public class TestAdapterLoadingStrategyArgumentProcessorTests
         RunSettingsManager.Instance.SetActiveRunSettings(runSettings);
 
         var mockOutput = new Mock<IOutput>();
-        var executor = new TestAdapterLoadingStrategyArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance, mockOutput.Object, new FileHelper());
+        var executor = new TestAdapterLoadingStrategyArgumentExecutor(_commandLineOptions, RunSettingsManager.Instance, mockOutput.Object, new FileHelper());
 
         var message = $"The path '{folder}' specified in the 'TestAdapterPath' is invalid. Error: The custom test adapter search path provided was not found, provide a valid path and try again.";
 

--- a/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
@@ -26,6 +26,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [DoNotParallelize]
 public class TestAdapterPathArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private readonly RunSettings _currentActiveSetting;
 
     public TestAdapterPathArgumentProcessorTests()
@@ -43,14 +44,14 @@ public class TestAdapterPathArgumentProcessorTests
     [TestMethod]
     public void GetMetadataShouldReturnTestAdapterPathArgumentProcessorCapabilities()
     {
-        var processor = new TestAdapterPathArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        var processor = new TestAdapterPathArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Metadata.Value is TestAdapterPathArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnTestAdapterPathArgumentProcessorCapabilities()
     {
-        var processor = new TestAdapterPathArgumentProcessor(CommandLineOptions.Instance, new TestableRunSettingsProvider());
+        var processor = new TestAdapterPathArgumentProcessor(_commandLineOptions, new TestableRunSettingsProvider());
         Assert.IsTrue(processor.Executor!.Value is TestAdapterPathArgumentExecutor);
     }
 
@@ -82,7 +83,7 @@ public class TestAdapterPathArgumentProcessorTests
     {
         var mockRunSettingsProvider = new Mock<IRunSettingsProvider>();
         var mockOutput = new Mock<IOutput>();
-        var executor = new TestAdapterPathArgumentExecutor(CommandLineOptions.Instance, mockRunSettingsProvider.Object, mockOutput.Object, new FileHelper());
+        var executor = new TestAdapterPathArgumentExecutor(_commandLineOptions, mockRunSettingsProvider.Object, mockOutput.Object, new FileHelper());
 
         var message =
             @"The /TestAdapterPath parameter requires a value, which is path of a location containing custom test adapters. Example:  /TestAdapterPath:c:\MyCustomAdapters";
@@ -96,7 +97,7 @@ public class TestAdapterPathArgumentProcessorTests
     {
         var mockRunSettingsProvider = new Mock<IRunSettingsProvider>();
         var mockOutput = new Mock<IOutput>();
-        var executor = new TestAdapterPathArgumentExecutor(CommandLineOptions.Instance, mockRunSettingsProvider.Object, mockOutput.Object, new FileHelper());
+        var executor = new TestAdapterPathArgumentExecutor(_commandLineOptions, mockRunSettingsProvider.Object, mockOutput.Object, new FileHelper());
 
         var message =
             @"The /TestAdapterPath parameter requires a value, which is path of a location containing custom test adapters. Example:  /TestAdapterPath:c:\MyCustomAdapters";
@@ -111,7 +112,7 @@ public class TestAdapterPathArgumentProcessorTests
         RunSettingsManager.Instance.AddDefaultRunSettings();
 
         var mockOutput = new Mock<IOutput>();
-        var executor = new TestAdapterPathArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance, mockOutput.Object, new FileHelper());
+        var executor = new TestAdapterPathArgumentExecutor(_commandLineOptions, RunSettingsManager.Instance, mockOutput.Object, new FileHelper());
 
         var currentAssemblyPath = typeof(TestAdapterPathArgumentExecutor).Assembly.Location;
         var currentFolder = Path.GetDirectoryName(currentAssemblyPath);
@@ -133,7 +134,7 @@ public class TestAdapterPathArgumentProcessorTests
         var mockOutput = new Mock<IOutput>();
 
         mockFileHelper.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
-        var executor = new TestAdapterPathArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance, mockOutput.Object, mockFileHelper.Object);
+        var executor = new TestAdapterPathArgumentExecutor(_commandLineOptions, RunSettingsManager.Instance, mockOutput.Object, mockFileHelper.Object);
 
         executor.Initialize("c:\\users");
         var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(RunSettingsManager.Instance.ActiveRunSettings.SettingsXml);
@@ -152,7 +153,7 @@ public class TestAdapterPathArgumentProcessorTests
         var mockOutput = new Mock<IOutput>();
 
         mockFileHelper.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
-        var executor = new TestAdapterPathArgumentExecutor(CommandLineOptions.Instance, RunSettingsManager.Instance, mockOutput.Object, mockFileHelper.Object);
+        var executor = new TestAdapterPathArgumentExecutor(_commandLineOptions, RunSettingsManager.Instance, mockOutput.Object, mockFileHelper.Object);
 
         executor.Initialize("\"c:\\users\"");
         var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(RunSettingsManager.Instance.ActiveRunSettings.SettingsXml);

--- a/test/vstest.console.UnitTests/Processors/TestCaseFilterArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestCaseFilterArgumentProcessorTests.cs
@@ -11,17 +11,18 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [TestClass]
 public class TestCaseFilterArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     [TestMethod]
     public void GetMetadataShouldReturnTestCaseFilterArgumentProcessorCapabilities()
     {
-        TestCaseFilterArgumentProcessor processor = new(CommandLineOptions.Instance);
+        TestCaseFilterArgumentProcessor processor = new(_commandLineOptions);
         Assert.IsTrue(processor.Metadata.Value is TestCaseFilterArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecutorShouldReturnTestCaseFilterArgumentProcessorCapabilities()
     {
-        TestCaseFilterArgumentProcessor processor = new(CommandLineOptions.Instance);
+        TestCaseFilterArgumentProcessor processor = new(_commandLineOptions);
         Assert.IsTrue(processor.Executor!.Value is TestCaseFilterArgumentExecutor);
     }
 
@@ -48,7 +49,7 @@ public class TestCaseFilterArgumentProcessorTests
     [TestMethod]
     public void ExecutorInitializeWithNullOrEmptyTestCaseFilterShouldThrowCommandLineException()
     {
-        var options = CommandLineOptions.Instance;
+        var options = new CommandLineOptions();
         TestCaseFilterArgumentExecutor executor = new(options);
 
         var ex = Assert.ThrowsExactly<CommandLineException>(() => executor.Initialize(null));
@@ -58,7 +59,7 @@ public class TestCaseFilterArgumentProcessorTests
     [TestMethod]
     public void ExecutorInitializeWithNullOrEmptyTestCaseFilterShouldNotThrowWhenTestFilterWasSpecifiedByPreviousStep()
     {
-        var options = CommandLineOptions.Instance;
+        var options = new CommandLineOptions();
         options.TestCaseFilterValue = "Test=FilterFromPreviousStep";
         TestCaseFilterArgumentExecutor executor = new(options);
 
@@ -68,7 +69,7 @@ public class TestCaseFilterArgumentProcessorTests
     [TestMethod]
     public void ExecutorInitializeWithTestCaseFilterShouldMergeWithTheValueProvidedByPreviousStep()
     {
-        var options = CommandLineOptions.Instance;
+        var options = new CommandLineOptions();
         var defaultValue = "Test=FilterFromPreviousStep";
         options.TestCaseFilterValue = defaultValue;
         Assert.AreEqual(defaultValue, options.TestCaseFilterValue);
@@ -84,7 +85,7 @@ public class TestCaseFilterArgumentProcessorTests
     [TestMethod]
     public void ExecutorExecutoreturnArgumentProcessorResultSuccess()
     {
-        var executor = new TestCaseFilterArgumentExecutor(CommandLineOptions.Instance);
+        var executor = new TestCaseFilterArgumentExecutor(_commandLineOptions);
         var result = executor.Execute();
         Assert.AreEqual(ArgumentProcessorResult.Success, result);
     }

--- a/test/vstest.console.UnitTests/Processors/TestSourceArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestSourceArgumentProcessorTests.cs
@@ -20,13 +20,14 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 [TestClass]
 public class TestSourceArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     /// <summary>
     /// The help argument processor get metadata should return help argument processor capabilities.
     /// </summary>
     [TestMethod]
     public void GetMetadataShouldReturnTestSourceArgumentProcessorCapabilities()
     {
-        TestSourceArgumentProcessor processor = new(CommandLineOptions.Instance);
+        TestSourceArgumentProcessor processor = new(_commandLineOptions);
         Assert.IsTrue(processor.Metadata.Value is TestSourceArgumentProcessorCapabilities);
     }
 
@@ -36,7 +37,7 @@ public class TestSourceArgumentProcessorTests
     [TestMethod]
     public void GetExecuterShouldReturnTestSourceArgumentProcessorCapabilities()
     {
-        TestSourceArgumentProcessor processor = new(CommandLineOptions.Instance);
+        TestSourceArgumentProcessor processor = new(_commandLineOptions);
         Assert.IsTrue(processor.Executor!.Value is TestSourceArgumentExecutor);
     }
 
@@ -65,7 +66,7 @@ public class TestSourceArgumentProcessorTests
     [TestMethod]
     public void ExecuterInitializeWithInvalidSourceShouldThrowCommandLineException()
     {
-        var options = CommandLineOptions.Instance;
+        var options = new CommandLineOptions();
         var mockFileHelper = new Mock<IFileHelper>();
         mockFileHelper.Setup(x => x.GetCurrentDirectory()).Returns("");
         options.FileHelper = mockFileHelper.Object;
@@ -87,8 +88,7 @@ public class TestSourceArgumentProcessorTests
         mockFileHelper.Setup(fh => fh.Exists(testFilePath)).Returns(true);
         mockFileHelper.Setup(x => x.GetCurrentDirectory()).Returns("");
 
-        var options = CommandLineOptions.Instance;
-        CommandLineOptions.Reset();
+        var options = new CommandLineOptions();
         options.FileHelper = mockFileHelper.Object;
         options.FilePatternParser = new FilePatternParser(new Mock<Matcher>().Object, mockFileHelper.Object);
         var executor = new TestSourceArgumentExecutor(options);
@@ -102,7 +102,7 @@ public class TestSourceArgumentProcessorTests
     [TestMethod]
     public void ExecutorExecuteReturnArgumentProcessorResultSuccess()
     {
-        var options = CommandLineOptions.Instance;
+        var options = new CommandLineOptions();
         var executor = new TestSourceArgumentExecutor(options);
         var result = executor.Execute();
         Assert.AreEqual(ArgumentProcessorResult.Success, result);

--- a/test/vstest.console.UnitTests/Processors/UseVsixExtensionsArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/UseVsixExtensionsArgumentProcessorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -17,6 +17,7 @@ namespace vstest.console.UnitTests.Processors;
 [TestClass]
 public class UseVsixExtensionsArgumentProcessorTests
 {
+    private readonly CommandLineOptions _commandLineOptions = new();
     private const string DeprecationMessage = @"/UseVsixExtensions is getting deprecated. Please use /TestAdapterPath instead.";
     private readonly Mock<ITestRequestManager> _testRequestManager;
     private readonly Mock<IVSExtensionManager> _extensionManager;
@@ -28,20 +29,20 @@ public class UseVsixExtensionsArgumentProcessorTests
         _testRequestManager = new Mock<ITestRequestManager>();
         _extensionManager = new Mock<IVSExtensionManager>();
         _output = new Mock<IOutput>();
-        _executor = new UseVsixExtensionsArgumentExecutor(CommandLineOptions.Instance, _testRequestManager.Object, _extensionManager.Object, _output.Object);
+        _executor = new UseVsixExtensionsArgumentExecutor(_commandLineOptions, _testRequestManager.Object, _extensionManager.Object, _output.Object);
     }
 
     [TestMethod]
     public void GetMetadataShouldReturnUseVsixExtensionsArgumentProcessorCapabilities()
     {
-        var processor = new UseVsixExtensionsArgumentProcessor(CommandLineOptions.Instance, _testRequestManager.Object);
+        var processor = new UseVsixExtensionsArgumentProcessor(_commandLineOptions, _testRequestManager.Object);
         Assert.IsTrue(processor.Metadata.Value is UseVsixExtensionsArgumentProcessorCapabilities);
     }
 
     [TestMethod]
     public void GetExecuterShouldReturnUseVsixExtensionsArgumentProcessorCapabilities()
     {
-        var processor = new UseVsixExtensionsArgumentProcessor(CommandLineOptions.Instance, _testRequestManager.Object);
+        var processor = new UseVsixExtensionsArgumentProcessor(_commandLineOptions, _testRequestManager.Object);
         Assert.IsTrue(processor.Executor!.Value is UseVsixExtensionsArgumentExecutor);
     }
 

--- a/test/vstest.console.UnitTests/Processors/Utilities/ArgumentProcessorFactoryTests.cs
+++ b/test/vstest.console.UnitTests/Processors/Utilities/ArgumentProcessorFactoryTests.cs
@@ -174,7 +174,7 @@ public class ArgumentProcessorFactoryTests
             // optionally followed by an IRunSettingsProvider and/or IRunSettingsHelper, and the run/discovery
             // ones also take an ITestRequestManager; a few legacy ones take only a run settings dependency, and
             // the rest are parameterless. Try the known shapes from most to least specific.
-            var commandLineOptions = CommandLineOptions.Instance;
+            var commandLineOptions = new CommandLineOptions();
             var runSettingsProvider = new TestableRunSettingsProvider();
             var runSettingsHelper = new RunSettingsHelper();
             var testRequestManager = new Mock<ITestRequestManager>().Object;

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -118,7 +118,6 @@ public class TestRequestManagerTests
     [TestCleanup]
     public void Cleanup()
     {
-        CommandLineOptions.Reset();
 
         // Opt out the Telemetry
         Environment.SetEnvironmentVariable("VSTEST_TELEMETRY_OPTEDIN", "0");
@@ -127,9 +126,9 @@ public class TestRequestManagerTests
     [TestMethod]
     public void TestRequestManagerShouldNotInitializeConsoleLoggerIfDesignModeIsSet()
     {
-        CommandLineOptions.Instance.IsDesignMode = true;
+        _commandLineOptions.IsDesignMode = true;
         _mockLoggerEvents = new DummyLoggerEvents(TestSessionMessageLogger.Instance);
-        _ = new TestRequestManager(CommandLineOptions.Instance,
+        _ = new TestRequestManager(_commandLineOptions,
             new Mock<ITestPlatform>().Object,
             TestRunResultAggregator.Instance,
             new Mock<ITestPlatformEventSource>().Object,
@@ -156,10 +155,10 @@ public class TestRequestManagerTests
     [TestMethod]
     public void ResetShouldResetCommandLineOptionsInstance()
     {
-        var oldInstance = CommandLineOptions.Instance;
+        var oldInstance = new CommandLineOptions();
         _testRequestManager.ResetOptions();
 
-        var newInstance = CommandLineOptions.Instance;
+        var newInstance = new CommandLineOptions();
 
         Assert.AreNotEqual(oldInstance, newInstance, "CommandLineOptions must be cleaned up");
     }
@@ -210,8 +209,8 @@ public class TestRequestManagerTests
         var mockDiscoveryRegistrar = new Mock<ITestDiscoveryEventsRegistrar>();
 
         string testCaseFilterValue = "TestFilter";
-        CommandLineOptions.Instance.TestCaseFilterValue = testCaseFilterValue;
-        _testRequestManager = new TestRequestManager(CommandLineOptions.Instance,
+        _commandLineOptions.TestCaseFilterValue = testCaseFilterValue;
+        _testRequestManager = new TestRequestManager(_commandLineOptions,
             _mockTestPlatform.Object,
             TestRunResultAggregator.Instance,
             _mockTestPlatformEventSource.Object,
@@ -262,8 +261,8 @@ public class TestRequestManagerTests
         var mockDiscoveryRegistrar = new Mock<ITestDiscoveryEventsRegistrar>();
 
         string testCaseFilterValue = "TestFilter";
-        CommandLineOptions.Instance.TestCaseFilterValue = testCaseFilterValue;
-        _testRequestManager = new TestRequestManager(CommandLineOptions.Instance,
+        _commandLineOptions.TestCaseFilterValue = testCaseFilterValue;
+        _testRequestManager = new TestRequestManager(_commandLineOptions,
             _mockTestPlatform.Object,
             TestRunResultAggregator.Instance,
             _mockTestPlatformEventSource.Object,
@@ -313,7 +312,7 @@ public class TestRequestManagerTests
             (IRequestData requestData, DiscoveryCriteria discoveryCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap, IWarningLogger _) => actualRequestData = requestData).Returns(mockDiscoveryRequest.Object);
 
         _testRequestManager = new TestRequestManager(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _mockTestPlatform.Object,
             TestRunResultAggregator.Instance,
             _mockTestPlatformEventSource.Object,
@@ -364,7 +363,7 @@ public class TestRequestManagerTests
             (IRequestData requestData, DiscoveryCriteria discoveryCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap, IWarningLogger _) => actualRequestData = requestData).Returns(mockDiscoveryRequest.Object);
 
         _testRequestManager = new TestRequestManager(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _mockTestPlatform.Object,
             TestRunResultAggregator.Instance,
             _mockTestPlatformEventSource.Object,
@@ -409,7 +408,7 @@ public class TestRequestManagerTests
             (IRequestData requestData, DiscoveryCriteria discoveryCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap, IWarningLogger _) => actualRequestData = requestData).Returns(mockDiscoveryRequest.Object);
 
         _testRequestManager = new TestRequestManager(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _mockTestPlatform.Object,
             TestRunResultAggregator.Instance,
             _mockTestPlatformEventSource.Object,
@@ -454,7 +453,7 @@ public class TestRequestManagerTests
             (IRequestData requestData, DiscoveryCriteria discoveryCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap, IWarningLogger _) => actualRequestData = requestData).Returns(mockDiscoveryRequest.Object);
 
         _testRequestManager = new TestRequestManager(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _mockTestPlatform.Object,
             TestRunResultAggregator.Instance,
             _mockTestPlatformEventSource.Object,
@@ -499,7 +498,7 @@ public class TestRequestManagerTests
             (IRequestData requestData, DiscoveryCriteria discoveryCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap, IWarningLogger _) => actualRequestData = requestData).Returns(mockDiscoveryRequest.Object);
 
         _testRequestManager = new TestRequestManager(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _mockTestPlatform.Object,
             TestRunResultAggregator.Instance,
             _mockTestPlatformEventSource.Object,
@@ -510,11 +509,11 @@ public class TestRequestManagerTests
             _mockEnvironment.Object,
             _mockEnvironmentVariableHelper.Object);
 
-        CommandLineOptions.Instance.Parallel = true;
-        CommandLineOptions.Instance.EnableCodeCoverage = true;
-        CommandLineOptions.Instance.InIsolation = true;
-        CommandLineOptions.Instance.UseVsixExtensions = true;
-        CommandLineOptions.Instance.SettingsFile = @"c://temp/.runsettings";
+        _commandLineOptions.Parallel = true;
+        _commandLineOptions.EnableCodeCoverage = true;
+        _commandLineOptions.InIsolation = true;
+        _commandLineOptions.UseVsixExtensions = true;
+        _commandLineOptions.SettingsFile = @"c://temp/.runsettings";
 
         // Act
         _testRequestManager.DiscoverTests(payload, mockDiscoveryRegistrar.Object, mockProtocolConfig);
@@ -556,7 +555,7 @@ public class TestRequestManagerTests
             (IRequestData requestData, DiscoveryCriteria discoveryCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap, IWarningLogger _) => actualRequestData = requestData).Returns(mockDiscoveryRequest.Object);
 
         _testRequestManager = new TestRequestManager(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _mockTestPlatform.Object,
             TestRunResultAggregator.Instance,
             _mockTestPlatformEventSource.Object,
@@ -567,7 +566,7 @@ public class TestRequestManagerTests
             _mockEnvironment.Object,
             _mockEnvironmentVariableHelper.Object);
 
-        CommandLineOptions.Instance.SettingsFile = @"c://temp/.testsettings";
+        _commandLineOptions.SettingsFile = @"c://temp/.testsettings";
 
         // Act
         _testRequestManager.DiscoverTests(payload, mockDiscoveryRegistrar.Object, mockProtocolConfig);
@@ -604,7 +603,7 @@ public class TestRequestManagerTests
             (IRequestData requestData, DiscoveryCriteria discoveryCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap, IWarningLogger _) => actualRequestData = requestData).Returns(mockDiscoveryRequest.Object);
 
         _testRequestManager = new TestRequestManager(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _mockTestPlatform.Object,
             TestRunResultAggregator.Instance,
             _mockTestPlatformEventSource.Object,
@@ -615,7 +614,7 @@ public class TestRequestManagerTests
             _mockEnvironment.Object,
             _mockEnvironmentVariableHelper.Object);
 
-        CommandLineOptions.Instance.SettingsFile = @"c://temp/.vsmdi";
+        _commandLineOptions.SettingsFile = @"c://temp/.vsmdi";
 
         // Act
         _testRequestManager.DiscoverTests(payload, mockDiscoveryRegistrar.Object, mockProtocolConfig);
@@ -652,7 +651,7 @@ public class TestRequestManagerTests
             (IRequestData requestData, DiscoveryCriteria discoveryCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap, IWarningLogger _) => actualRequestData = requestData).Returns(mockDiscoveryRequest.Object);
 
         _testRequestManager = new TestRequestManager(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _mockTestPlatform.Object,
             TestRunResultAggregator.Instance,
             _mockTestPlatformEventSource.Object,
@@ -663,7 +662,7 @@ public class TestRequestManagerTests
             _mockEnvironment.Object,
             _mockEnvironmentVariableHelper.Object);
 
-        CommandLineOptions.Instance.SettingsFile = @"c://temp/.testrunConfig";
+        _commandLineOptions.SettingsFile = @"c://temp/.testrunConfig";
 
         // Act
         _testRequestManager.DiscoverTests(payload, mockDiscoveryRegistrar.Object, mockProtocolConfig);
@@ -956,7 +955,7 @@ public class TestRequestManagerTests
             (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap, IWarningLogger _) => actualRequestData = requestData).Returns(mockDiscoveryRequest.Object);
 
         _testRequestManager = new TestRequestManager(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _mockTestPlatform.Object,
             TestRunResultAggregator.Instance,
             _mockTestPlatformEventSource.Object,
@@ -967,11 +966,11 @@ public class TestRequestManagerTests
             _mockEnvironment.Object,
             _mockEnvironmentVariableHelper.Object);
 
-        CommandLineOptions.Instance.Parallel = true;
-        CommandLineOptions.Instance.EnableCodeCoverage = true;
-        CommandLineOptions.Instance.InIsolation = true;
-        CommandLineOptions.Instance.UseVsixExtensions = true;
-        CommandLineOptions.Instance.SettingsFile = @"c://temp/.runsettings";
+        _commandLineOptions.Parallel = true;
+        _commandLineOptions.EnableCodeCoverage = true;
+        _commandLineOptions.InIsolation = true;
+        _commandLineOptions.UseVsixExtensions = true;
+        _commandLineOptions.SettingsFile = @"c://temp/.runsettings";
 
         // Act.
         _testRequestManager.RunTests(payload, new Mock<ITestHostLauncher3>().Object, new Mock<ITestRunEventsRegistrar>().Object, mockProtocolConfig);
@@ -1022,7 +1021,7 @@ public class TestRequestManagerTests
             (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap, IWarningLogger _) => actualRequestData = requestData).Returns(mockDiscoveryRequest.Object);
 
         _testRequestManager = new TestRequestManager(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _mockTestPlatform.Object,
             TestRunResultAggregator.Instance,
             _mockTestPlatformEventSource.Object,
@@ -1071,7 +1070,7 @@ public class TestRequestManagerTests
             (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap, IWarningLogger _) => actualRequestData = requestData).Returns(mockDiscoveryRequest.Object);
 
         _testRequestManager = new TestRequestManager(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _mockTestPlatform.Object,
             TestRunResultAggregator.Instance,
             _mockTestPlatformEventSource.Object,
@@ -1118,7 +1117,7 @@ public class TestRequestManagerTests
             (IRequestData requestData, TestRunCriteria runCriteria, TestPlatformOptions options, Dictionary<string, SourceDetail> sourceToSourceDetailMap, IWarningLogger _) => actualRequestData = requestData).Returns(mockDiscoveryRequest.Object);
 
         _testRequestManager = new TestRequestManager(
-            CommandLineOptions.Instance,
+            _commandLineOptions,
             _mockTestPlatform.Object,
             TestRunResultAggregator.Instance,
             _mockTestPlatformEventSource.Object,
@@ -1167,7 +1166,7 @@ public class TestRequestManagerTests
 
         string testCaseFilterValue = "TestFilter";
         payload.TestPlatformOptions = new TestPlatformOptions { TestCaseFilter = testCaseFilterValue };
-        _testRequestManager = new TestRequestManager(CommandLineOptions.Instance,
+        _testRequestManager = new TestRequestManager(_commandLineOptions,
             _mockTestPlatform.Object,
             TestRunResultAggregator.Instance,
             _mockTestPlatformEventSource.Object,
@@ -2614,10 +2613,10 @@ public class TestRequestManagerTests
         // separate copies.
         const string filter = "FullyQualifiedName~SharedInstanceMarker";
 
-        // The process-wide static default is a different object. Capturing it up front lets us prove the write lands on
-        // the injected instance only, and that a reader bound to the static default observes none of it.
-        var staticDefault = CommandLineOptions.Instance;
-        staticDefault.Should().NotBeSameAs(_commandLineOptions, "the manager under test was injected with a separate CommandLineOptions instance");
+        // A separate instance is a different object. Capturing it up front lets us prove the write lands on
+        // the injected instance only, and that a reader bound to the separate instance observes none of it.
+        var separateInstance = new CommandLineOptions();
+        separateInstance.Should().NotBeSameAs(_commandLineOptions, "the manager under test was injected with a separate CommandLineOptions instance");
 
         var payload = new DiscoveryRequestPayload()
         {
@@ -2635,7 +2634,7 @@ public class TestRequestManagerTests
         // Writer: parsing "--TestCaseFilter <filter>" sets TestCaseFilterValue on the injected instance and nowhere else.
         new TestCaseFilterArgumentExecutor(_commandLineOptions).Initialize(filter);
         _commandLineOptions.TestCaseFilterValue.Should().Be(filter, "the executor writes the filter on the injected instance");
-        staticDefault.TestCaseFilterValue.Should().BeNull("the write must not leak onto the static default instance");
+        separateInstance.TestCaseFilterValue.Should().BeNull("the write must not leak onto the separate instance");
 
         // Reader: the manager copies TestCaseFilterValue from the same injected instance onto the DiscoveryCriteria.
         _testRequestManager.DiscoverTests(payload, new Mock<ITestDiscoveryEventsRegistrar>().Object, _protocolConfig);
@@ -2644,17 +2643,17 @@ public class TestRequestManagerTests
         observedCriteria.Should().NotBeNull();
         observedCriteria!.TestCaseFilter.Should().Be(filter, "the reader observed the writer's value through the shared instance");
 
-        // Reader-vs-reader: a second manager bound to the static default instance (which never received the write) must
+        // Reader-vs-reader: a second manager bound to the separate instance (which never received the write) must
         // NOT observe the filter - it falls back to the run settings, which carry none, so the criteria filter is null.
-        DiscoveryCriteria? staticDefaultCriteria = null;
+        DiscoveryCriteria? separateInstanceCriteria = null;
         var mockTestPlatformForStaticDefault = new Mock<ITestPlatform>();
         mockTestPlatformForStaticDefault.Setup(mt => mt.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>()))
             .Callback((IRequestData _, DiscoveryCriteria criteria, TestPlatformOptions _, Dictionary<string, SourceDetail> _, IWarningLogger _) =>
-                staticDefaultCriteria = criteria)
+                separateInstanceCriteria = criteria)
             .Returns(new Mock<IDiscoveryRequest>().Object);
 
         var managerBoundToStaticDefault = new TestRequestManager(
-            staticDefault,
+            separateInstance,
             mockTestPlatformForStaticDefault.Object,
             new DummyTestRunResultAggregator(),
             _mockTestPlatformEventSource.Object,
@@ -2668,8 +2667,8 @@ public class TestRequestManagerTests
 
         managerBoundToStaticDefault.DiscoverTests(payload, new Mock<ITestDiscoveryEventsRegistrar>().Object, _protocolConfig);
 
-        staticDefaultCriteria.Should().NotBeNull();
-        staticDefaultCriteria!.TestCaseFilter.Should().BeNull("the manager bound to the static default instance never saw the write");
+        separateInstanceCriteria.Should().NotBeNull();
+        separateInstanceCriteria!.TestCaseFilter.Should().BeNull("the manager bound to the separate instance never saw the write");
     }
 
     [TestMethod]


### PR DESCRIPTION
Finishes removing the `CommandLineOptions.Instance` singleton. Production already stopped reading it in the two prior steps - `Executor` and the argument-processor factory build a request-scoped `CommandLineOptions` and thread it into every processor (#16258), and `TestRequestManager` takes it by constructor (#16257). Nothing in `src` reads the static anymore, so it was only test scaffolding.

`ResetOptions()` used to null the singleton so the next design-mode request rebuilt defaults. The manager now holds the options it was constructed with and never mutates them per request - design mode derives its state from the request payload (sources, run settings), not from shared command-line options - so `ResetOptions()` is a no-op and the static `Reset()` is gone.

`CommandLineOptions` is internal, so no third-party extension can see it and there is no compatibility surface to keep. The tests now build their own `CommandLineOptions` per test class instead of poking a shared static, which also drops the `Reset()` calls they needed for isolation.

Continues the static-state cleanup (#16200/#16205/#16208/#16228/#16243/#16245/#16255/#16257/#16258).
