### PR TITLE
Load inbox extensions without reading the RunSettingsManager singleton

### DIFF
--- a/src/Microsoft.TestPlatform.Client/TestPlatform.cs
+++ b/src/Microsoft.TestPlatform.Client/TestPlatform.cs
@@ -246,7 +246,13 @@ internal class TestPlatform : ITestPlatform
         // Otherwise we will always get a "No suitable test runtime provider found for this run." error.
         // I (@haplois) will modify this behavior later on, but we also need to consider legacy adapters
         // and make sure they still work after modification.
-        string? runSettings = RunSettingsManager.Instance.ActiveRunSettings.SettingsXml;
+        //
+        // The inbox extensions are loaded once, at type initialization, using the default adapter
+        // loading strategy. We intentionally do not read the ambient RunSettingsManager singleton
+        // here: this runs before any request's run settings are known (see the note above), so it
+        // could only ever observe the default settings anyway. Request-specific test adapter paths
+        // are still loaded later, per request, through the normal PopulateExtensions flow.
+        string? runSettings = null;
         RunConfiguration runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(runSettings);
         TestAdapterLoadingStrategy strategy = runConfiguration.TestAdapterLoadingStrategy;
 


### PR DESCRIPTION
`TestPlatform`'s static constructor loads the inbox extensions (TrxLogger, the runtime providers, the legacy MSTest v1 and C++ adapters) and picked the adapter loading strategy by reading `RunSettingsManager.Instance.ActiveRunSettings`. That is the shared run settings static state this cleanup is about: in design mode one process serves many requests and they all observe whatever that singleton happens to hold.

The read never did what it looks like it does. The static constructor runs once, at type load, before any request's run settings are known (the existing `@haplois` note above the method already calls the ordering out as incorrect), so it only ever saw the default settings anyway. The load now uses the default strategy directly and does not touch `RunSettingsManager`. Request specific test adapter paths are still loaded per request through the normal `PopulateExtensions` flow, so `/testadapterpath` and `<TestAdaptersPaths>` are unaffected.

The load stays in the static constructor on purpose. It has to run once and early, before host provider resolution reads `DefaultExtensionPaths`. Moving it into the per request path makes every run fail with "No suitable test runtime provider was found", so only the source of the run settings changed, not the timing.

After this the only remaining `RunSettingsManager.Instance` references are the composition root defaults, which sets up deleting the singleton in a follow up.

Build, unit tests (Client and vstest.console) and smoke tests verified locally on net11.0 and net481.

Continues the static-state cleanup from #16200/#16205/#16208/#16228/#16243/#16245/#16257/#16258/#16261/#16262.
