### PR TITLE
Delete the RunSettingsManager.Instance singleton

### DIFF
--- a/src/Microsoft.TestPlatform.Common/RunSettingsManager.cs
+++ b/src/Microsoft.TestPlatform.Common/RunSettingsManager.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 
@@ -13,14 +12,10 @@ namespace Microsoft.VisualStudio.TestPlatform.Common;
 /// </summary>
 internal class RunSettingsManager : IRunSettingsProvider
 {
-    private static readonly object LockObject = new();
-
-    private static RunSettingsManager? s_runSettingsManagerInstance;
-
     /// <summary>
     /// Default constructor.
     /// </summary>
-    private RunSettingsManager()
+    internal RunSettingsManager()
     {
         ActiveRunSettings = new RunSettings();
     }
@@ -33,29 +28,6 @@ internal class RunSettingsManager : IRunSettingsProvider
     public RunSettings ActiveRunSettings { get; private set; }
 
     #endregion
-
-    [AllowNull]
-    public static RunSettingsManager Instance
-    {
-        get
-        {
-            if (s_runSettingsManagerInstance != null)
-            {
-                return s_runSettingsManagerInstance;
-            }
-
-            lock (LockObject)
-            {
-                s_runSettingsManagerInstance ??= new RunSettingsManager();
-            }
-
-            return s_runSettingsManagerInstance;
-        }
-        internal set
-        {
-            s_runSettingsManagerInstance = value;
-        }
-    }
 
     /// <summary>
     /// Set the active run settings.

--- a/src/vstest.console/CommandLine/Executor.cs
+++ b/src/vstest.console/CommandLine/Executor.cs
@@ -101,7 +101,7 @@ internal class Executor
     }
 
     internal Executor(IOutput output, ITestPlatformEventSource testPlatformEventSource, IProcessHelper processHelper, IEnvironment environment)
-        : this(output, testPlatformEventSource, processHelper, environment, RunSettingsManager.Instance, RunSettingsHelper.Instance, new CommandLineOptions(), new TestRunResultAggregator())
+        : this(output, testPlatformEventSource, processHelper, environment, new RunSettingsManager(), RunSettingsHelper.Instance, new CommandLineOptions(), new TestRunResultAggregator())
     {
     }
 

--- a/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
+++ b/src/vstest.console/Processors/Utilities/ArgumentProcessorFactory.cs
@@ -52,8 +52,8 @@ internal class ArgumentProcessorFactory
     /// </param>
     /// <param name="runSettingsProvider">
     /// The run settings provider that the created argument processors read from and write to.
-    /// Defaults to the ambient <see cref="RunSettingsManager.Instance"/> when not provided, so that
-    /// callers (and the composition root) can inject an isolated instance instead of sharing static state.
+    /// When not provided a fresh, request-scoped instance is created, so that callers never
+    /// share run settings state through a static singleton.
     /// </param>
     /// <param name="runSettingsHelper">
     /// The run settings helper that the created argument processors write request-scoped flags to.
@@ -74,7 +74,7 @@ internal class ArgumentProcessorFactory
     /// <returns>ArgumentProcessorFactory.</returns>
     internal static ArgumentProcessorFactory Create(IFeatureFlag? featureFlag = null, IRunSettingsProvider? runSettingsProvider = null, IRunSettingsHelper? runSettingsHelper = null, CommandLineOptions? commandLineOptions = null, ITestRequestManager? testRequestManager = null)
     {
-        runSettingsProvider ??= RunSettingsManager.Instance;
+        runSettingsProvider ??= new RunSettingsManager();
         runSettingsHelper ??= RunSettingsHelper.Instance;
         commandLineOptions ??= new CommandLineOptions();
         testRequestManager ??= new LazyTestRequestManager(() => new TestRequestManager(commandLineOptions, new TestRunResultAggregator()));

--- a/test/Microsoft.TestPlatform.Common.UnitTests/RunSettingsManagerTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/RunSettingsManagerTests.cs
@@ -9,37 +9,12 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace TestPlatform.Common.UnitTests;
 
 [TestClass]
-[DoNotParallelize]
 public class RunSettingsManagerTests
 {
-    [TestCleanup]
-    public void TestCleanup()
-    {
-        RunSettingsManager.Instance = null;
-    }
-
-    [TestMethod]
-    public void InstanceShouldReturnARunSettingsManagerInstance()
-    {
-        var instance = RunSettingsManager.Instance;
-
-        Assert.IsNotNull(instance);
-        Assert.AreEqual(typeof(RunSettingsManager), instance.GetType());
-    }
-
-    [TestMethod]
-    public void InstanceShouldReturnACachedValue()
-    {
-        var instance = RunSettingsManager.Instance;
-        var instance2 = RunSettingsManager.Instance;
-
-        Assert.AreEqual(instance, instance2);
-    }
-
     [TestMethod]
     public void ActiveRunSettingsShouldBeNonNullByDefault()
     {
-        var instance = RunSettingsManager.Instance;
+        var instance = new RunSettingsManager();
 
         Assert.IsNotNull(instance.ActiveRunSettings);
     }
@@ -47,7 +22,7 @@ public class RunSettingsManagerTests
     [TestMethod]
     public void SetActiveRunSettingsShouldThrowIfRunSettingsPassedIsNull()
     {
-        var instance = RunSettingsManager.Instance;
+        var instance = new RunSettingsManager();
 
         Assert.ThrowsExactly<ArgumentNullException>(() => instance.SetActiveRunSettings(null!));
     }
@@ -55,7 +30,7 @@ public class RunSettingsManagerTests
     [TestMethod]
     public void SetActiveRunSettingsShouldSetTheActiveRunSettingsProperty()
     {
-        var instance = RunSettingsManager.Instance;
+        var instance = new RunSettingsManager();
 
         var runSettings = new RunSettings();
         runSettings.LoadSettingsXml("<RunSettings></RunSettings>");

--- a/test/vstest.console.UnitTests/ExecutorUnitTests.cs
+++ b/test/vstest.console.UnitTests/ExecutorUnitTests.cs
@@ -27,11 +27,12 @@ using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Res
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests;
 
 [TestClass]
-// Because runsettings tests use the instance of RunSettingsManager which is static.
+// These tests construct real Executors and share fixed temp-file names, so they must not run in parallel.
 [DoNotParallelize]
 public class ExecutorUnitTests
 {
     private readonly CommandLineOptions _commandLineOptions = new();
+    private readonly RunSettingsManager _runSettingsManager = new();
     private readonly Mock<ITestPlatformEventSource> _mockTestPlatformEventSource;
 
     public ExecutorUnitTests()
@@ -150,8 +151,8 @@ public class ExecutorUnitTests
     public void ExecuteShouldInitializeDefaultRunsettings()
     {
         var mockOutput = new MockOutput();
-        _ = new Executor(mockOutput, _mockTestPlatformEventSource.Object, new ProcessHelper(), new PlatformEnvironment()).Execute(null);
-        RunConfiguration runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(RunSettingsManager.Instance.ActiveRunSettings.SettingsXml);
+        _ = new Executor(mockOutput, _mockTestPlatformEventSource.Object, new ProcessHelper(), new PlatformEnvironment(), _runSettingsManager).Execute(null);
+        RunConfiguration runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(_runSettingsManager.ActiveRunSettings.SettingsXml);
         Assert.AreEqual(Constants.DefaultResultsDirectory, runConfiguration.ResultsDirectory);
         Assert.AreEqual(Framework.DefaultFramework.ToString(), runConfiguration.TargetFramework!.ToString());
         Assert.AreEqual(Constants.DefaultPlatform, runConfiguration.TargetPlatform);
@@ -212,7 +213,6 @@ public class ExecutorUnitTests
     [TestMethod]
     public void ExecuteShouldNotThrowSettingsExceptionButLogOutput()
     {
-        var activeRunSetting = RunSettingsManager.Instance.ActiveRunSettings;
         var runSettingsFile = Path.Combine(Path.GetTempPath(), "ExecutorShouldShowRightErrorMessage.runsettings");
 
         try
@@ -244,14 +244,12 @@ public class ExecutorUnitTests
         finally
         {
             File.Delete(runSettingsFile);
-            RunSettingsManager.Instance.SetActiveRunSettings(activeRunSetting);
         }
     }
 
     [TestMethod]
     public void ExecuteShouldReturnNonZeroExitCodeIfSettingsException()
     {
-        var activeRunSetting = RunSettingsManager.Instance.ActiveRunSettings;
         var runSettingsFile = Path.Combine(Path.GetTempPath(), "ExecutorShouldShowRightErrorMessage.runsettings");
 
         try
@@ -281,14 +279,12 @@ public class ExecutorUnitTests
         finally
         {
             File.Delete(runSettingsFile);
-            RunSettingsManager.Instance.SetActiveRunSettings(activeRunSetting);
         }
     }
 
     [TestMethod]
     public void ExecutorShouldShowRightErrorMessage()
     {
-        var activeRunSetting = RunSettingsManager.Instance.ActiveRunSettings;
         var runSettingsFile = Path.Combine(Path.GetTempPath(), "ExecutorShouldShowRightErrorMessage.runsettings");
 
         try
@@ -318,7 +314,6 @@ public class ExecutorUnitTests
         finally
         {
             File.Delete(runSettingsFile);
-            RunSettingsManager.Instance.SetActiveRunSettings(activeRunSetting);
         }
     }
 
@@ -384,7 +379,7 @@ public class ExecutorUnitTests
             _mockTestPlatformEventSource.Object,
             new ProcessHelper(),
             new PlatformEnvironment(),
-            RunSettingsManager.Instance,
+            _runSettingsManager,
             RunSettingsHelper.Instance,
             _commandLineOptions,
             injectedAggregator).Execute("--help");
@@ -399,7 +394,7 @@ public class ExecutorUnitTests
             _mockTestPlatformEventSource.Object,
             new ProcessHelper(),
             new PlatformEnvironment(),
-            RunSettingsManager.Instance,
+            _runSettingsManager,
             RunSettingsHelper.Instance,
             _commandLineOptions,
             defaultAggregator).Execute("--help");

--- a/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/EnableLoggersArgumentProcessorTests.cs
@@ -15,21 +15,15 @@ using CommandLineResources = Microsoft.VisualStudio.TestPlatform.CommandLine.Res
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 
 [TestClass]
-// Because runsettings tests use the instance of RunSettingsManager which is static.
 [DoNotParallelize]
 public class EnableLoggersArgumentProcessorTests
 {
+    private readonly RunSettingsManager _runSettingsManager = new();
+
     [TestInitialize]
     public void Initialize()
     {
-        RunSettingsManager.Instance = null;
         RunTestsArgumentProcessorTests.SetupMockExtensions();
-    }
-
-    [TestCleanup]
-    public void Cleanup()
-    {
-        RunSettingsManager.Instance = null;
     }
 
     [TestMethod]
@@ -72,7 +66,7 @@ public class EnableLoggersArgumentProcessorTests
     [DataRow("TestLoggerExtension;==;;;Collection=http://localhost:8080/tfs/DefaultCollection;TeamProject=MyProject;BuildName=DailyBuild_20121130.1")]
     public void ExectorInitializeShouldThrowExceptionIfInvalidArgumentIsPassed(string argument)
     {
-        var executor = new EnableLoggerArgumentExecutor(RunSettingsManager.Instance);
+        var executor = new EnableLoggerArgumentExecutor(_runSettingsManager);
         var e = Assert.ThrowsExactly<CommandLineException>(() => executor.Initialize(argument));
         string exceptionMessage = string.Format(CultureInfo.CurrentCulture, CommandLineResources.LoggerUriInvalid, argument);
         Assert.IsInstanceOfType<CommandLineException>(e);
@@ -82,7 +76,7 @@ public class EnableLoggersArgumentProcessorTests
     [TestMethod]
     public void ExecutorExecuteShouldReturnArgumentProcessorResultSuccess()
     {
-        var executor = new EnableLoggerArgumentExecutor(RunSettingsManager.Instance);
+        var executor = new EnableLoggerArgumentExecutor(_runSettingsManager);
         var result = executor.Execute();
         Assert.AreEqual(ArgumentProcessorResult.Success, result);
     }
@@ -105,9 +99,9 @@ public class EnableLoggersArgumentProcessorTests
 
         var runSettings = new RunSettings();
         runSettings.LoadSettingsXml(settingsXml);
-        RunSettingsManager.Instance.SetActiveRunSettings(runSettings);
+        _runSettingsManager.SetActiveRunSettings(runSettings);
 
-        var executor = new EnableLoggerArgumentExecutor(RunSettingsManager.Instance);
+        var executor = new EnableLoggerArgumentExecutor(_runSettingsManager);
         executor.Initialize("DummyLoggerExtension");
 
         string expectedSettingsXml =
@@ -128,7 +122,7 @@ public class EnableLoggersArgumentProcessorTests
   </LoggerRunSettings>
 </RunSettings>";
 
-        Assert.AreEqual(expectedSettingsXml, RunSettingsManager.Instance.ActiveRunSettings?.SettingsXml);
+        Assert.AreEqual(expectedSettingsXml, _runSettingsManager.ActiveRunSettings?.SettingsXml);
     }
 
     [TestMethod]
@@ -149,9 +143,9 @@ public class EnableLoggersArgumentProcessorTests
 
         var runSettings = new RunSettings();
         runSettings.LoadSettingsXml(settingsXml);
-        RunSettingsManager.Instance.SetActiveRunSettings(runSettings);
+        _runSettingsManager.SetActiveRunSettings(runSettings);
 
-        var executor = new EnableLoggerArgumentExecutor(RunSettingsManager.Instance);
+        var executor = new EnableLoggerArgumentExecutor(_runSettingsManager);
         executor.Initialize("logger://DummyLoggerUri");
 
         string expectedSettingsXml =
@@ -172,7 +166,7 @@ public class EnableLoggersArgumentProcessorTests
   </LoggerRunSettings>
 </RunSettings>";
 
-        Assert.AreEqual(expectedSettingsXml, RunSettingsManager.Instance.ActiveRunSettings?.SettingsXml);
+        Assert.AreEqual(expectedSettingsXml, _runSettingsManager.ActiveRunSettings?.SettingsXml);
     }
 
     [TestMethod]
@@ -193,9 +187,9 @@ public class EnableLoggersArgumentProcessorTests
 
         var runSettings = new RunSettings();
         runSettings.LoadSettingsXml(settingsXml);
-        RunSettingsManager.Instance.SetActiveRunSettings(runSettings);
+        _runSettingsManager.SetActiveRunSettings(runSettings);
 
-        var executor = new EnableLoggerArgumentExecutor(RunSettingsManager.Instance);
+        var executor = new EnableLoggerArgumentExecutor(_runSettingsManager);
         executor.Initialize("logger://DummyLoggerUri;Collection=http://localhost:8080/tfs/DefaultCollection;TeamProject=MyProject;BuildName=DailyBuild_20121130.1");
 
         string expectedSettingsXml =
@@ -222,15 +216,15 @@ public class EnableLoggersArgumentProcessorTests
   </LoggerRunSettings>
 </RunSettings>";
 
-        Assert.AreEqual(expectedSettingsXml, RunSettingsManager.Instance.ActiveRunSettings?.SettingsXml);
+        Assert.AreEqual(expectedSettingsXml, _runSettingsManager.ActiveRunSettings?.SettingsXml);
     }
 
     [TestMethod]
     public void ExecutorInitializeShouldCorrectlyAddLoggerWhenRunSettingsNotPassed()
     {
-        RunSettingsManager.Instance.SetActiveRunSettings(new RunSettings());
+        _runSettingsManager.SetActiveRunSettings(new RunSettings());
 
-        var executor = new EnableLoggerArgumentExecutor(RunSettingsManager.Instance);
+        var executor = new EnableLoggerArgumentExecutor(_runSettingsManager);
         executor.Initialize("logger://DummyLoggerUri;Collection=http://localhost:8080/tfs/DefaultCollection;TeamProject=MyProject;BuildName=DailyBuild_20121130.1");
 
         string expectedSettingsXml =
@@ -246,7 +240,7 @@ public class EnableLoggersArgumentProcessorTests
       </Logger>
     </Loggers>
   </LoggerRunSettings>";
-        Assert.Contains(expectedSettingsXml, RunSettingsManager.Instance.ActiveRunSettings!.SettingsXml!);
+        Assert.Contains(expectedSettingsXml, _runSettingsManager.ActiveRunSettings!.SettingsXml!);
     }
 
     [TestMethod]
@@ -281,9 +275,9 @@ public class EnableLoggersArgumentProcessorTests
 
         var runSettings = new RunSettings();
         runSettings.LoadSettingsXml(settingsXml);
-        RunSettingsManager.Instance.SetActiveRunSettings(runSettings);
+        _runSettingsManager.SetActiveRunSettings(runSettings);
 
-        var executor = new EnableLoggerArgumentExecutor(RunSettingsManager.Instance);
+        var executor = new EnableLoggerArgumentExecutor(_runSettingsManager);
         executor.Initialize("logger://DummyLoggerUri;Collection=http://localhost:8080/tfs/DefaultCollection;TeamProject=MyProject;BuildName=DailyBuild_20121130.1");
 
         string expectedSettingsXml =
@@ -319,7 +313,7 @@ public class EnableLoggersArgumentProcessorTests
   </LoggerRunSettings>
 </RunSettings>";
 
-        Assert.AreEqual(expectedSettingsXml, RunSettingsManager.Instance.ActiveRunSettings?.SettingsXml);
+        Assert.AreEqual(expectedSettingsXml, _runSettingsManager.ActiveRunSettings?.SettingsXml);
     }
 
     [TestMethod]
@@ -354,9 +348,9 @@ public class EnableLoggersArgumentProcessorTests
 
         var runSettings = new RunSettings();
         runSettings.LoadSettingsXml(settingsXml);
-        RunSettingsManager.Instance.SetActiveRunSettings(runSettings);
+        _runSettingsManager.SetActiveRunSettings(runSettings);
 
-        var executor = new EnableLoggerArgumentExecutor(RunSettingsManager.Instance);
+        var executor = new EnableLoggerArgumentExecutor(_runSettingsManager);
         executor.Initialize("tempLogger2");
 
         string expectedSettingsXml =
@@ -385,7 +379,7 @@ public class EnableLoggersArgumentProcessorTests
   </LoggerRunSettings>
 </RunSettings>";
 
-        Assert.AreEqual(expectedSettingsXml, RunSettingsManager.Instance.ActiveRunSettings?.SettingsXml);
+        Assert.AreEqual(expectedSettingsXml, _runSettingsManager.ActiveRunSettings?.SettingsXml);
     }
 
     [TestMethod]
@@ -420,9 +414,9 @@ public class EnableLoggersArgumentProcessorTests
 
         var runSettings = new RunSettings();
         runSettings.LoadSettingsXml(settingsXml);
-        RunSettingsManager.Instance.SetActiveRunSettings(runSettings);
+        _runSettingsManager.SetActiveRunSettings(runSettings);
 
-        var executor = new EnableLoggerArgumentExecutor(RunSettingsManager.Instance);
+        var executor = new EnableLoggerArgumentExecutor(_runSettingsManager);
         executor.Initialize("tempLoggER2");
 
         string expectedSettingsXml =
@@ -451,7 +445,7 @@ public class EnableLoggersArgumentProcessorTests
   </LoggerRunSettings>
 </RunSettings>";
 
-        Assert.AreEqual(expectedSettingsXml, RunSettingsManager.Instance.ActiveRunSettings?.SettingsXml);
+        Assert.AreEqual(expectedSettingsXml, _runSettingsManager.ActiveRunSettings?.SettingsXml);
     }
 
     [TestMethod]
@@ -494,9 +488,9 @@ public class EnableLoggersArgumentProcessorTests
 
         var runSettings = new RunSettings();
         runSettings.LoadSettingsXml(settingsXml);
-        RunSettingsManager.Instance.SetActiveRunSettings(runSettings);
+        _runSettingsManager.SetActiveRunSettings(runSettings);
 
-        var executor = new EnableLoggerArgumentExecutor(RunSettingsManager.Instance);
+        var executor = new EnableLoggerArgumentExecutor(_runSettingsManager);
         executor.Initialize("logger://DummyLoggerUri;Collection=http://localhost:8080/tfs/DefaultCollectionOverride;TeamProjectOverride=MyProject;BuildName=DailyBuild_20121130.1Override;NewAttr=value");
 
         string expectedSettingsXml =
@@ -533,6 +527,6 @@ public class EnableLoggersArgumentProcessorTests
   </LoggerRunSettings>
 </RunSettings>";
 
-        Assert.AreEqual(expectedSettingsXml, RunSettingsManager.Instance.ActiveRunSettings?.SettingsXml);
+        Assert.AreEqual(expectedSettingsXml, _runSettingsManager.ActiveRunSettings?.SettingsXml);
     }
 }

--- a/test/vstest.console.UnitTests/Processors/TestAdapterLoadingStrategyArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestAdapterLoadingStrategyArgumentProcessorTests.cs
@@ -18,23 +18,11 @@ using Moq;
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 
 [TestClass]
-// Because runsettings tests use the instance of RunSettingsManager which is static.
 [DoNotParallelize]
 public class TestAdapterLoadingStrategyArgumentProcessorTests
 {
     private readonly CommandLineOptions _commandLineOptions = new();
-    private readonly RunSettings _currentActiveSetting;
-
-    public TestAdapterLoadingStrategyArgumentProcessorTests()
-    {
-        _currentActiveSetting = RunSettingsManager.Instance.ActiveRunSettings;
-    }
-
-    [TestCleanup]
-    public void TestClean()
-    {
-        RunSettingsManager.Instance.SetActiveRunSettings(_currentActiveSetting);
-    }
+    private readonly RunSettingsManager _runSettingsManager = new();
 
     [TestMethod]
     [TestCategory("Windows")]
@@ -43,17 +31,17 @@ public class TestAdapterLoadingStrategyArgumentProcessorTests
         var runSettingsXml = "<RunSettings><RunConfiguration><TestAdaptersPaths>%temp%\\adapters1;%temp%\\adapters2</TestAdaptersPaths></RunConfiguration></RunSettings>";
         var runSettings = new RunSettings();
         runSettings.LoadSettingsXml(runSettingsXml);
-        RunSettingsManager.Instance.SetActiveRunSettings(runSettings);
+        _runSettingsManager.SetActiveRunSettings(runSettings);
         var mockFileHelper = new Mock<IFileHelper>();
         var mockOutput = new Mock<IOutput>();
 
         mockFileHelper.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
         mockFileHelper.Setup(x => x.GetFullPath(It.IsAny<string>())).Returns((Func<string, string>)(s => Path.GetFullPath(s)));
 
-        var executor = new TestAdapterLoadingStrategyArgumentExecutor(_commandLineOptions, RunSettingsManager.Instance, mockOutput.Object, mockFileHelper.Object);
+        var executor = new TestAdapterLoadingStrategyArgumentExecutor(_commandLineOptions, _runSettingsManager, mockOutput.Object, mockFileHelper.Object);
 
         executor.Initialize(nameof(TestAdapterLoadingStrategy.Default));
-        var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(RunSettingsManager.Instance.ActiveRunSettings.SettingsXml);
+        var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(_runSettingsManager.ActiveRunSettings.SettingsXml);
 
         var tempPath = Path.GetFullPath(Environment.ExpandEnvironmentVariables("%temp%"));
         Assert.AreEqual($"{tempPath}\\adapters1;{tempPath}\\adapters2", runConfiguration.TestAdaptersPaths);
@@ -66,13 +54,13 @@ public class TestAdapterLoadingStrategyArgumentProcessorTests
         var runSettingsXml = "<RunSettings><RunConfiguration><TestAdaptersPaths>d:\\users</TestAdaptersPaths></RunConfiguration></RunSettings>";
         var runSettings = new RunSettings();
         runSettings.LoadSettingsXml(runSettingsXml);
-        RunSettingsManager.Instance.SetActiveRunSettings(runSettings);
+        _runSettingsManager.SetActiveRunSettings(runSettings);
         var mockFileHelper = new Mock<IFileHelper>();
         var mockOutput = new Mock<IOutput>();
 
         mockFileHelper.Setup(x => x.DirectoryExists("d:\\users")).Returns(false);
         mockFileHelper.Setup(x => x.DirectoryExists("c:\\users")).Returns(true);
-        var executor = new TestAdapterLoadingStrategyArgumentExecutor(_commandLineOptions, RunSettingsManager.Instance, mockOutput.Object, mockFileHelper.Object);
+        var executor = new TestAdapterLoadingStrategyArgumentExecutor(_commandLineOptions, _runSettingsManager, mockOutput.Object, mockFileHelper.Object);
 
         var message = "The path 'd:\\users' specified in the 'TestAdapterPath' is invalid. Error: The custom test adapter search path provided was not found, provide a valid path and try again.";
 
@@ -89,10 +77,10 @@ public class TestAdapterLoadingStrategyArgumentProcessorTests
         var runSettings = new RunSettings();
 
         runSettings.LoadSettingsXml(runSettingsXml);
-        RunSettingsManager.Instance.SetActiveRunSettings(runSettings);
+        _runSettingsManager.SetActiveRunSettings(runSettings);
 
         var mockOutput = new Mock<IOutput>();
-        var executor = new TestAdapterLoadingStrategyArgumentExecutor(_commandLineOptions, RunSettingsManager.Instance, mockOutput.Object, new FileHelper());
+        var executor = new TestAdapterLoadingStrategyArgumentExecutor(_commandLineOptions, _runSettingsManager, mockOutput.Object, new FileHelper());
 
         var message = $"The path '{folder}' specified in the 'TestAdapterPath' is invalid. Error: The custom test adapter search path provided was not found, provide a valid path and try again.";
 

--- a/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/TestAdapterPathArgumentProcessorTests.cs
@@ -22,23 +22,11 @@ using vstest.console.UnitTests.Processors;
 namespace Microsoft.VisualStudio.TestPlatform.CommandLine.UnitTests.Processors;
 
 [TestClass]
-// Because runsettings tests use the instance of RunSettingsManager which is static.
 [DoNotParallelize]
 public class TestAdapterPathArgumentProcessorTests
 {
     private readonly CommandLineOptions _commandLineOptions = new();
-    private readonly RunSettings _currentActiveSetting;
-
-    public TestAdapterPathArgumentProcessorTests()
-    {
-        _currentActiveSetting = RunSettingsManager.Instance.ActiveRunSettings;
-    }
-
-    [TestCleanup]
-    public void TestClean()
-    {
-        RunSettingsManager.Instance.SetActiveRunSettings(_currentActiveSetting);
-    }
+    private readonly RunSettingsManager _runSettingsManager = new();
 
 
     [TestMethod]
@@ -109,16 +97,16 @@ public class TestAdapterPathArgumentProcessorTests
     [TestMethod]
     public void InitializeShouldUpdateTestAdapterPathInRunSettings()
     {
-        RunSettingsManager.Instance.AddDefaultRunSettings();
+        _runSettingsManager.AddDefaultRunSettings();
 
         var mockOutput = new Mock<IOutput>();
-        var executor = new TestAdapterPathArgumentExecutor(_commandLineOptions, RunSettingsManager.Instance, mockOutput.Object, new FileHelper());
+        var executor = new TestAdapterPathArgumentExecutor(_commandLineOptions, _runSettingsManager, mockOutput.Object, new FileHelper());
 
         var currentAssemblyPath = typeof(TestAdapterPathArgumentExecutor).Assembly.Location;
         var currentFolder = Path.GetDirectoryName(currentAssemblyPath);
 
         executor.Initialize(currentFolder);
-        var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(RunSettingsManager.Instance.ActiveRunSettings.SettingsXml);
+        var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(_runSettingsManager.ActiveRunSettings.SettingsXml);
         Assert.AreEqual(currentFolder, runConfiguration.TestAdaptersPaths);
     }
 
@@ -129,15 +117,15 @@ public class TestAdapterPathArgumentProcessorTests
         var runSettingsXml = "<RunSettings><RunConfiguration><TestAdaptersPaths>d:\\users;f:\\users</TestAdaptersPaths></RunConfiguration></RunSettings>";
         var runSettings = new RunSettings();
         runSettings.LoadSettingsXml(runSettingsXml);
-        RunSettingsManager.Instance.SetActiveRunSettings(runSettings);
+        _runSettingsManager.SetActiveRunSettings(runSettings);
         var mockFileHelper = new Mock<IFileHelper>();
         var mockOutput = new Mock<IOutput>();
 
         mockFileHelper.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
-        var executor = new TestAdapterPathArgumentExecutor(_commandLineOptions, RunSettingsManager.Instance, mockOutput.Object, mockFileHelper.Object);
+        var executor = new TestAdapterPathArgumentExecutor(_commandLineOptions, _runSettingsManager, mockOutput.Object, mockFileHelper.Object);
 
         executor.Initialize("c:\\users");
-        var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(RunSettingsManager.Instance.ActiveRunSettings.SettingsXml);
+        var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(_runSettingsManager.ActiveRunSettings.SettingsXml);
         Assert.AreEqual("d:\\users;f:\\users;c:\\users", runConfiguration.TestAdaptersPaths);
     }
 
@@ -148,15 +136,15 @@ public class TestAdapterPathArgumentProcessorTests
         var runSettingsXml = "<RunSettings><RunConfiguration><TestAdaptersPaths>d:\\users</TestAdaptersPaths></RunConfiguration></RunSettings>";
         var runSettings = new RunSettings();
         runSettings.LoadSettingsXml(runSettingsXml);
-        RunSettingsManager.Instance.SetActiveRunSettings(runSettings);
+        _runSettingsManager.SetActiveRunSettings(runSettings);
         var mockFileHelper = new Mock<IFileHelper>();
         var mockOutput = new Mock<IOutput>();
 
         mockFileHelper.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
-        var executor = new TestAdapterPathArgumentExecutor(_commandLineOptions, RunSettingsManager.Instance, mockOutput.Object, mockFileHelper.Object);
+        var executor = new TestAdapterPathArgumentExecutor(_commandLineOptions, _runSettingsManager, mockOutput.Object, mockFileHelper.Object);
 
         executor.Initialize("\"c:\\users\"");
-        var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(RunSettingsManager.Instance.ActiveRunSettings.SettingsXml);
+        var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(_runSettingsManager.ActiveRunSettings.SettingsXml);
         Assert.AreEqual("d:\\users;c:\\users", runConfiguration.TestAdaptersPaths);
 
     }


### PR DESCRIPTION
The active run settings were shared process-wide through the `RunSettingsManager.Instance` singleton. In design mode one vstest.console process serves many requests, so that shared instance leaked run settings across them and forced tests to null and reset the static to isolate cases.

#16263 removed the last production reader (the `TestPlatform` static constructor); the only references left were composition-root defaults. The `Executor` convenience constructor and the `ArgumentProcessorFactory` fallback now build a fresh, request-scoped `new RunSettingsManager()` instead of reading the singleton. `RunSettingsManager` is internal and not in the public API, so nothing outside the assembly could read it, and deleting `Instance` (with its backing field, lock, and setter) is safe.

The tests move to a per-class `new RunSettingsManager()` field, so each test method gets its own instance and the save/restore and reset hygiene goes away. The two tests that only covered the singleton getter caching are removed with it.

### Validation
- Release build clean (4 pre-existing IL warnings only)
- `vstest.console.UnitTests` 631/633 (2 pre-existing skips) on net11.0 and net481
- `Microsoft.TestPlatform.Common.UnitTests` 393/395 (2 pre-existing skips) on net11.0 and net481
- Smoke: Acceptance 5/5 and Library 4/4 on both TFMs
