### PR TITLE
Remove dead DotNet-VSTS-Infra-Access variable group reference

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -91,8 +91,6 @@ variables:
     - name: Codeql.Cadence 
       value: 0
 
-  # Group gives access to $dn-bot-devdiv-drop-rw-code-rw and dn-bot-dnceng-build-rw-code-rw
-  - group: DotNet-VSTS-Infra-Access
   # DevDiv drop access token is acquired via WIF service connection (dnceng-devdiv-drop-rw-code-rw-wif)
   - name: _DevDivDropAccessToken
     value: ''


### PR DESCRIPTION
Backport of #16203 to `rel/18.8`.

The official pipeline (definition 1222 in dnceng/internal) fails to load on `rel/18.8` with "Variable group was not found or is not authorized for use", because `azure-pipelines-official.yml` still references the `DotNet-VSTS-Infra-Access` variable group. That group (VG 4) only held the `dn-bot-devdiv-drop-r-code-r` PAT, which was migrated to WIF and is now expired and disabled, so the reference no longer resolves.

The reference is dead already on this branch: the DevDiv drop token is acquired via the `dnceng-devdiv-drop-rw-code-rw-wif` service connection in the Publish job, and nothing consumes a variable from the group. Removing it unblocks the load, same as on main.
