### PR TITLE
Assert apartment state instead of using Clipboard in UI tests

### DIFF
--- a/test/TestAssets/SimpleTestProject3/SimpleTestProject3.csproj
+++ b/test/TestAssets/SimpleTestProject3/SimpleTestProject3.csproj
@@ -12,7 +12,4 @@
     <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestTestAdapterVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(PackageVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net451'))">
-    <Reference Include="System.Windows.Forms" />
-  </ItemGroup>
 </Project>

--- a/test/TestAssets/SimpleTestProject3/UnitTest1.cs
+++ b/test/TestAssets/SimpleTestProject3/UnitTest1.cs
@@ -7,9 +7,6 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Threading;
-#if NETFRAMEWORK
-using System.Windows.Forms;
-#endif
 
 namespace SampleUnitTestProject3
 {
@@ -43,13 +40,13 @@ namespace SampleUnitTestProject3
         [TestMethod]
         public void UITestMethod()
         {
-            Clipboard.SetText("Clipboard");
+            Assert.AreEqual(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
         }
 
         [TestMethod]
         public void UITestWithSleep1()
         {
-            Clipboard.SetText("Clipboard");
+            Assert.AreEqual(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
             Thread.Sleep(1000 * 3);
         }
 #endif


### PR DESCRIPTION
The apartment-state acceptance tests (`ExecutionThreadApartmentStateTests`) run SimpleTestProject3's `UITestMethod` and `UITestWithSleep1`, which called `Clipboard.SetText` as a stand-in for an STA-only API. On the shared CI agents that clipboard call intermittently throws `ExternalException: Requested Clipboard operation did not succeed`, and reddens the Windows integration test leg with a single flaky failure on `UITestShouldPassIfApartmentStateIsSTA`. It is a flake, not a regression, the same commit passes and fails across different builds.

Replace the clipboard call with `Assert.AreEqual(ApartmentState.STA, Thread.CurrentThread.GetApartmentState())`, which is exactly what these tests check, STA passes and MTA fails, just without touching the OS clipboard. Also remove the now unused `System.Windows.Forms` using and reference.

Verified locally: `SimpleTestProject3` builds for net481, and `ExecutionThreadApartmentStateTests` runs green (`UITestShouldPassIfApartmentStateIsSTA` passes, `UITestShouldFailWhenDefaultApartmentStateIsMTA` still fails as expected).
