### PR TITLE
Pass the inferred target platform to the host in run settings

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
@@ -97,6 +97,7 @@ public class RunConfiguration : TestRunSettings
         ForwardStandardOutput = !FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_DISABLE_STANDARD_OUTPUT_FORWARDING);
         DisableSharedTestHost = FeatureFlag.Instance.IsSet(FeatureFlag.VSTEST_DISABLE_SHARING_NETFRAMEWORK_TESTHOST);
         CreateNoNewWindow = true;
+        IsTargetPlatformInferred = true;
     }
 
     /// <summary>
@@ -473,6 +474,15 @@ public class RunConfiguration : TestRunSettings
     /// Skips passing VisualStudio built in adapters to the project.
     /// </summary>
     public bool SkipDefaultAdapters { get; private set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the target platform was inferred by the platform rather than
+    /// pinned by the user (through <c>--arch</c>, <c>/Platform</c>, or <c>RunConfiguration.TargetPlatform</c>).
+    /// vstest.console stamps this into the run settings it hands to the test host manager so that the
+    /// per-request fact travels with the run settings instead of a process-wide singleton. Defaults to
+    /// <see langword="true"/> (inferred). Internal because only the in-box test host manager reads it.
+    /// </summary>
+    internal bool IsTargetPlatformInferred { get; private set; }
 
     /// <inheritdoc/>
     public override XmlElement ToXml()
@@ -1040,6 +1050,25 @@ public class RunConfiguration : TestRunSettings
                             }
 
                             runConfiguration.SkipDefaultAdapters = boolValue;
+                            break;
+                        }
+
+                    case nameof(IsTargetPlatformInferred):
+                        {
+                            // Internal marker stamped by vstest.console recording whether the target platform
+                            // was inferred (true) or pinned by the user (false). Not exposed to the public
+                            // run settings schema; read only by the in-box test host manager.
+                            XmlRunSettingsUtilities.ThrowOnHasAttributes(reader);
+                            string element = reader.ReadElementContentAsString();
+
+                            bool boolValue;
+                            if (!bool.TryParse(element, out boolValue))
+                            {
+                                throw new SettingsException(string.Format(CultureInfo.CurrentCulture,
+                                    Resources.Resources.InvalidSettingsIncorrectValue, Constants.RunConfigurationSettingsName, boolValue, elementName));
+                            }
+
+                            runConfiguration.IsTargetPlatformInferred = boolValue;
                             break;
                         }
 

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -64,7 +64,6 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
     private readonly IDotnetHostHelper _dotnetHostHelper;
     private readonly IEnvironment _platformEnvironment;
     private readonly IProcessHelper _processHelper;
-    private readonly IRunSettingsHelper _runsettingHelper;
     private readonly IFileHelper _fileHelper;
     private readonly IWindowsRegistryHelper _windowsRegistryHelper;
     private readonly IEnvironmentVariableHelper _environmentVariableHelper;
@@ -81,6 +80,12 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
     private string? _dotnetHostPath;
     private bool _captureOutput;
     private bool _createNoNewWindow;
+
+    // True when the target platform was inferred by the platform rather than pinned by the user. Read from
+    // the run settings in Initialize (RunConfiguration.IsTargetPlatformInferred), so this per-request fact
+    // travels with the run settings instead of the process-wide RunSettingsHelper singleton. Defaults to
+    // true (inferred), matching the historical RunSettingsHelper default when no marker is present.
+    private bool _isDefaultTargetArchitecture = true;
     private protected TestHostManagerCallbacks? _testHostManagerCallbacks;
 
     /// <summary>
@@ -92,7 +97,6 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
             new FileHelper(),
             new DotnetHostHelper(),
             new PlatformEnvironment(),
-            RunSettingsHelper.Instance,
             new WindowsRegistryHelper(),
             new EnvironmentVariableHelper())
     {
@@ -105,7 +109,6 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
     /// <param name="fileHelper">File helper instance.</param>
     /// <param name="dotnetHostHelper">DotnetHostHelper helper instance.</param>
     /// <param name="platformEnvironment">Platform Environment</param>
-    /// <param name="runsettingHelper">RunsettingHelper instance</param>
     /// <param name="windowsRegistryHelper">WindowsRegistryHelper instance</param>
     /// <param name="environmentVariableHelper">EnvironmentVariableHelper instance</param>
     internal DotnetTestHostManager(
@@ -113,7 +116,6 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
         IFileHelper fileHelper,
         IDotnetHostHelper dotnetHostHelper,
         IEnvironment platformEnvironment,
-        IRunSettingsHelper runsettingHelper,
         IWindowsRegistryHelper windowsRegistryHelper,
         IEnvironmentVariableHelper environmentVariableHelper)
     {
@@ -121,7 +123,6 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
         _fileHelper = fileHelper;
         _dotnetHostHelper = dotnetHostHelper;
         _platformEnvironment = platformEnvironment;
-        _runsettingHelper = runsettingHelper;
         _windowsRegistryHelper = windowsRegistryHelper;
         _environmentVariableHelper = environmentVariableHelper;
     }
@@ -205,6 +206,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
         _architecture = runConfiguration.TargetPlatform;
         _targetFramework = runConfiguration.TargetFramework;
         _dotnetHostPath = runConfiguration.DotnetHostPath;
+        _isDefaultTargetArchitecture = runConfiguration.IsTargetPlatformInferred;
     }
 
     /// <inheritdoc/>
@@ -483,7 +485,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
 
             // We silently force x64 only if the target architecture is the default one and is not specified by user
             // through --arch or runsettings or -- RunConfiguration.TargetPlatform=arch
-            bool forceToX64 = _runsettingHelper.IsDefaultTargetArchitecture && SilentlyForceToX64(sourcePath);
+            bool forceToX64 = _isDefaultTargetArchitecture && SilentlyForceToX64(sourcePath);
             EqtTrace.Verbose($"DotnetTestHostmanager: Current process architetcure '{_processHelper.GetCurrentProcessArchitecture()}'");
             bool isSameArchitecture = IsSameArchitecture(_architecture, _processHelper.GetCurrentProcessArchitecture());
             var currentProcessPath = _processHelper.GetCurrentProcessFileName()!;
@@ -505,7 +507,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
                 EqtTrace.Verbose($"DotnetTestHostmanager: Searching muxer for the architecture '{targetArchitecture}', OS '{_platformEnvironment.OperatingSystem}' framework '{_targetFramework}' SDK platform architecture '{_platformEnvironment.Architecture}'");
                 if (forceToX64)
                 {
-                    EqtTrace.Verbose($"DotnetTestHostmanager: Forcing the search to x64 architecure, IsDefaultTargetArchitecture '{_runsettingHelper.IsDefaultTargetArchitecture}' OS '{_platformEnvironment.OperatingSystem}' framework '{_targetFramework}'");
+                    EqtTrace.Verbose($"DotnetTestHostmanager: Forcing the search to x64 architecure, IsDefaultTargetArchitecture '{_isDefaultTargetArchitecture}' OS '{_platformEnvironment.OperatingSystem}' framework '{_targetFramework}'");
                 }
 
                 // Check if DOTNET_ROOT resolution should be bypassed.

--- a/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
+++ b/src/Microsoft.TestPlatform.Utilities/InferRunSettingsHelper.cs
@@ -32,11 +32,13 @@ public class InferRunSettingsHelper
     private const string TargetPlatformNodeName = "TargetPlatform";
     private const string TargetFrameworkNodeName = "TargetFrameworkVersion";
     private const string TargetDevice = "TargetDevice";
+    private const string IsTargetPlatformInferredNodeName = "IsTargetPlatformInferred";
 
     private const string DesignModeNodePath = @"/RunSettings/RunConfiguration/DesignMode";
     private const string BatchSizeNodePath = @"/RunSettings/RunConfiguration/BatchSize";
     private const string CollectSourceInformationNodePath = @"/RunSettings/RunConfiguration/CollectSourceInformation";
     private const string RunConfigurationNodePath = @"/RunSettings/RunConfiguration";
+    private const string IsTargetPlatformInferredNodePath = @"/RunSettings/RunConfiguration/IsTargetPlatformInferred";
     private const string TargetPlatformNodePath = @"/RunSettings/RunConfiguration/TargetPlatform";
     private const string TargetFrameworkNodePath = @"/RunSettings/RunConfiguration/TargetFrameworkVersion";
     private const string ResultsDirectoryNodePath = @"/RunSettings/RunConfiguration/ResultsDirectory";
@@ -225,6 +227,19 @@ public class InferRunSettingsHelper
     public static void UpdateCollectSourceInformation(XmlDocument runSettingsDocument, bool collectSourceInformationValue)
     {
         AddNodeIfNotPresent(runSettingsDocument, CollectSourceInformationNodePath, CollectSourceInformationNodeName, collectSourceInformationValue);
+    }
+
+    /// <summary>
+    /// Records whether the target platform was inferred by the platform (<see langword="true"/>) or pinned
+    /// by the user (<see langword="false"/>) into <c>RunConfiguration.IsTargetPlatformInferred</c>. Always
+    /// overwrites so the value reflects the current run. This is an internal marker read by the in-box test
+    /// host manager; it is not part of the public run settings schema.
+    /// </summary>
+    /// <param name="runSettingsDocument">Document for runsettings xml</param>
+    /// <param name="isTargetPlatformInferred">Value to set</param>
+    public static void UpdateIsTargetPlatformInferred(XmlDocument runSettingsDocument, bool isTargetPlatformInferred)
+    {
+        AddNodeIfNotPresent(runSettingsDocument, IsTargetPlatformInferredNodePath, IsTargetPlatformInferredNodeName, isTargetPlatformInferred, overwrite: true);
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.Utilities/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TestPlatform.Utilities/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Microsoft.VisualStudio.TestPlatform.Utilities.InferRunSettingsHelper.UpdateIsTargetPlatformInferred(System.Xml.XmlDocument! runSettingsDocument, bool isTargetPlatformInferred) -> void

--- a/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
+++ b/src/vstest.console/TestPlatformHelpers/TestRequestManager.cs
@@ -710,6 +710,7 @@ internal class TestRequestManager : ITestRequestManager
         }
 
         settingsUpdated |= UpdateDesignMode(document, runConfiguration);
+        settingsUpdated |= UpdateIsTargetPlatformInferred(document);
         settingsUpdated |= UpdateCollectSourceInformation(document, runConfiguration);
         settingsUpdated |= UpdateTargetDevice(navigator, document);
         settingsUpdated |= AddOrUpdateBuiltInLoggers(document, runConfiguration, loggerRunSettings);
@@ -881,6 +882,19 @@ internal class TestRequestManager : ITestRequestManager
                 _commandLineOptions.IsDesignMode);
         }
         return updateRequired;
+    }
+
+    private bool UpdateIsTargetPlatformInferred(XmlDocument document)
+    {
+        // Stamp whether the target platform was inferred by the platform rather than pinned by the user
+        // (through --arch, /Platform, or RunConfiguration.TargetPlatform). The test host manager reads this
+        // per-request fact from the run settings instead of the process-wide RunSettingsHelper singleton, so
+        // it does not leak across requests when a single vstest.console process serves multiple requests in
+        // design mode. Always written so the marker reflects the current request.
+        InferRunSettingsHelper.UpdateIsTargetPlatformInferred(
+            document,
+            _runSettingsHelper.IsDefaultTargetArchitecture);
+        return true;
     }
 
     internal /* for testing purposes */ static bool AddOrUpdateBatchSize(XmlDocument document, RunConfiguration runConfiguration, bool isDiscovery)

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Client/ProxyOperationManagerTests.cs
@@ -44,7 +44,6 @@ public class ProxyOperationManagerTests : ProxyBaseManagerTests
     private readonly Mock<IRequestData> _mockRequestData;
 
     private Mock<IProcessHelper>? _mockProcessHelper;
-    private Mock<IRunSettingsHelper>? _mockRunsettingHelper;
     private Mock<IWindowsRegistryHelper>? _mockWindowsRegistry;
     private Mock<IEnvironmentVariableHelper>? _mockEnvironmentVariableHelper;
     private Mock<IFileHelper>? _mockFileHelper;
@@ -358,7 +357,7 @@ public class ProxyOperationManagerTests : ProxyBaseManagerTests
     public void SetupChannelForDotnetHostManagerWithIsVersionCheckRequiredFalseShouldNotCheckVersionWithTestHost()
     {
         SetUpMocksForDotNetTestHost();
-        var testHostManager = new TestableDotnetTestHostManager(false, _mockProcessHelper.Object, _mockFileHelper.Object, _mockEnvironment.Object, _mockRunsettingHelper.Object, _mockWindowsRegistry.Object, _mockEnvironmentVariableHelper.Object);
+        var testHostManager = new TestableDotnetTestHostManager(false, _mockProcessHelper.Object, _mockFileHelper.Object, _mockEnvironment.Object, _mockWindowsRegistry.Object, _mockEnvironmentVariableHelper.Object);
         testHostManager.Initialize(new NullMessageLogger(), DefaultRunSettings);
 
         var operationManager = new TestableProxyOperationManager(_mockRequestData.Object, _mockRequestSender.Object, testHostManager);
@@ -372,7 +371,7 @@ public class ProxyOperationManagerTests : ProxyBaseManagerTests
     public void SetupChannelForDotnetHostManagerWithIsVersionCheckRequiredTrueShouldCheckVersionWithTestHost()
     {
         SetUpMocksForDotNetTestHost();
-        var testHostManager = new TestableDotnetTestHostManager(true, _mockProcessHelper.Object, _mockFileHelper.Object, _mockEnvironment.Object, _mockRunsettingHelper.Object, _mockWindowsRegistry.Object, _mockEnvironmentVariableHelper.Object);
+        var testHostManager = new TestableDotnetTestHostManager(true, _mockProcessHelper.Object, _mockFileHelper.Object, _mockEnvironment.Object, _mockWindowsRegistry.Object, _mockEnvironmentVariableHelper.Object);
         testHostManager.Initialize(new NullMessageLogger(), DefaultRunSettings);
         var operationManager = new TestableProxyOperationManager(_mockRequestData.Object, _mockRequestSender.Object, testHostManager);
 
@@ -649,17 +648,15 @@ public class ProxyOperationManagerTests : ProxyBaseManagerTests
         Assert.Contains("--telemetryoptedin false", receivedTestProcessInfo.Arguments!);
     }
 
-    [MemberNotNull(nameof(_mockProcessHelper), nameof(_mockFileHelper), nameof(_mockEnvironment), nameof(_mockRunsettingHelper), nameof(_mockWindowsRegistry), nameof(_mockEnvironmentVariableHelper))]
+    [MemberNotNull(nameof(_mockProcessHelper), nameof(_mockFileHelper), nameof(_mockEnvironment), nameof(_mockWindowsRegistry), nameof(_mockEnvironmentVariableHelper))]
     private void SetUpMocksForDotNetTestHost()
     {
         _mockProcessHelper = new Mock<IProcessHelper>();
         _mockFileHelper = new Mock<IFileHelper>();
         _mockEnvironment = new Mock<IEnvironment>();
-        _mockRunsettingHelper = new Mock<IRunSettingsHelper>();
         _mockWindowsRegistry = new Mock<IWindowsRegistryHelper>();
         _mockEnvironmentVariableHelper = new Mock<IEnvironmentVariableHelper>();
 
-        _mockRunsettingHelper.SetupGet(r => r.IsDefaultTargetArchitecture).Returns(true);
         _mockProcessHelper.Setup(
                 ph =>
                     ph.LaunchProcess(
@@ -715,14 +712,12 @@ public class ProxyOperationManagerTests : ProxyBaseManagerTests
             IProcessHelper processHelper,
             IFileHelper fileHelper,
             IEnvironment environment,
-            IRunSettingsHelper runsettingHelper,
             IWindowsRegistryHelper windowsRegistryHelper,
             IEnvironmentVariableHelper environmentVariableHelper) : base(
             processHelper,
             fileHelper,
             new DotnetHostHelper(fileHelper, environment, windowsRegistryHelper, environmentVariableHelper, processHelper),
             environment,
-            runsettingHelper,
             windowsRegistryHelper,
             environmentVariableHelper)
         {

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunConfigurationTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunConfigurationTests.cs
@@ -400,4 +400,51 @@ public class RunConfigurationTests
 
         Assert.Contains("<CreateNoNewWindow>True</CreateNoNewWindow>", runConfiguration.ToXml().InnerXml);
     }
+
+    [TestMethod]
+    public void RunConfigurationReadsIsTargetPlatformInferredFromXml()
+    {
+        string settingsXml =
+            @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <RunSettings>
+                     <RunConfiguration>
+                       <IsTargetPlatformInferred>false</IsTargetPlatformInferred>
+                     </RunConfiguration>
+                </RunSettings>";
+
+        var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(settingsXml);
+
+        Assert.IsFalse(runConfiguration.IsTargetPlatformInferred);
+    }
+
+    [TestMethod]
+    public void RunConfigurationIsTargetPlatformInferredDefaultsToTrueWhenNotPresentInXml()
+    {
+        string settingsXml =
+            @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <RunSettings>
+                     <RunConfiguration>
+                       <TargetPlatform>x64</TargetPlatform>
+                     </RunConfiguration>
+                </RunSettings>";
+
+        var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(settingsXml);
+
+        Assert.IsTrue(runConfiguration.IsTargetPlatformInferred);
+    }
+
+    [TestMethod]
+    public void RunConfigurationFromXmlThrowsSettingsExceptionIfIsTargetPlatformInferredIsInvalid()
+    {
+        string settingsXml =
+            @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <RunSettings>
+                     <RunConfiguration>
+                       <IsTargetPlatformInferred>InvalidValue</IsTargetPlatformInferred>
+                     </RunConfiguration>
+                </RunSettings>";
+
+        Assert.ThrowsExactly<SettingsException>(
+                () => XmlRunSettingsUtilities.GetRunConfigurationNode(settingsXml));
+    }
 }

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerFilesystemIntegrationTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerFilesystemIntegrationTests.cs
@@ -37,7 +37,6 @@ public class DotnetTestHostManagerFilesystemIntegrationTests
     private readonly Mock<IProcessHelper> _mockProcessHelper = new();
     private readonly Mock<IEnvironment> _mockEnvironment = new();
     private readonly Mock<IMessageLogger> _mockMessageLogger = new();
-    private readonly Mock<IRunSettingsHelper> _mockRunsettingsHelper = new();
     private readonly Mock<IWindowsRegistryHelper> _mockWindowsRegistry = new();
     private readonly Mock<IEnvironmentVariableHelper> _mockEnvironmentVariable = new();
     private readonly TestRunnerConnectionInfo _connectionInfo = new()
@@ -56,7 +55,6 @@ public class DotnetTestHostManagerFilesystemIntegrationTests
         // Simulate non-Windows so the code goes to testhost.dll discovery (not testhost.exe).
         _mockEnvironment.Setup(e => e.OperatingSystem).Returns(PlatformOperatingSystem.Unix);
         _mockEnvironment.SetupGet(e => e.Architecture).Returns(PlatformArchitecture.X64);
-        _mockRunsettingsHelper.SetupGet(r => r.IsDefaultTargetArchitecture).Returns(true);
 
         // Current process is a dotnet muxer so it is used as-is for FileName.
         _mockProcessHelper.Setup(p => p.GetCurrentProcessFileName()).Returns("/usr/bin/dotnet");
@@ -292,7 +290,6 @@ public class DotnetTestHostManagerFilesystemIntegrationTests
             fileHelper,
             new DotnetHostHelper(fileHelper, _mockEnvironment.Object, _mockWindowsRegistry.Object, _mockEnvironmentVariable.Object, _mockProcessHelper.Object),
             _mockEnvironment.Object,
-            _mockRunsettingsHelper.Object,
             _mockWindowsRegistry.Object,
             _mockEnvironmentVariable.Object);
 }

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -43,7 +43,6 @@ public class DotnetTestHostManagerTests
     private readonly Mock<IWindowsRegistryHelper> _mockWindowsRegistry;
     private readonly Mock<IMessageLogger> _mockMessageLogger;
     private readonly Mock<IEnvironment> _mockEnvironment;
-    private readonly Mock<IRunSettingsHelper> _mockRunsettingHelper;
     private readonly TestRunnerConnectionInfo _defaultConnectionInfo;
     private readonly string[] _testSource = ["test.dll"];
     private readonly string _defaultTestHostPath;
@@ -68,11 +67,9 @@ public class DotnetTestHostManagerTests
         _mockEnvironment = new Mock<IEnvironment>();
         _mockWindowsRegistry = new Mock<IWindowsRegistryHelper>();
         _mockEnvironmentVariable = new Mock<IEnvironmentVariableHelper>();
-        _mockRunsettingHelper = new Mock<IRunSettingsHelper>();
         _defaultConnectionInfo = new TestRunnerConnectionInfo { Port = 123, ConnectionInfo = new TestHostConnectionInfo { Endpoint = "127.0.0.1:123", Role = ConnectionRole.Client }, RunnerProcessId = 0 };
 
         _mockEnvironment.SetupGet(e => e.Architecture).Returns((PlatformArchitecture)Enum.Parse(typeof(PlatformArchitecture), Constants.DefaultPlatform.ToString()));
-        _mockRunsettingHelper.SetupGet(r => r.IsDefaultTargetArchitecture).Returns(true);
         string defaultSourcePath = Path.Combine(_temp, "test.dll");
         _defaultTestHostPath = Path.Combine(_temp, "testhost.dll");
         _dotnetHostManager = new TestableDotnetTestHostManager(
@@ -80,7 +77,6 @@ public class DotnetTestHostManagerTests
             _mockFileHelper.Object,
             new DotnetHostHelper(_mockFileHelper.Object, _mockEnvironment.Object, _mockWindowsRegistry.Object, _mockEnvironmentVariable.Object, _mockProcessHelper.Object),
             _mockEnvironment.Object,
-            _mockRunsettingHelper.Object,
             _mockWindowsRegistry.Object,
             _mockEnvironmentVariable.Object);
         _dotnetHostManager.Initialize(_mockMessageLogger.Object, string.Empty);
@@ -1250,10 +1246,9 @@ public class DotnetTestHostManagerTests
             IFileHelper fileHelper,
             IDotnetHostHelper dotnetTestHostHelper,
             IEnvironment environment,
-            IRunSettingsHelper runsettingsHelper,
             IWindowsRegistryHelper windowsRegistryHelper,
             IEnvironmentVariableHelper environmentVariableHelper)
-            : base(processHelper, fileHelper, dotnetTestHostHelper, environment, runsettingsHelper, windowsRegistryHelper, environmentVariableHelper)
+            : base(processHelper, fileHelper, dotnetTestHostHelper, environment, windowsRegistryHelper, environmentVariableHelper)
         {
         }
 

--- a/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
+++ b/test/vstest.console.UnitTests/TestPlatformHelpers/TestRequestManagerTests.cs
@@ -1360,6 +1360,49 @@ public class TestRequestManagerTests
     }
 
     [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void DiscoverTestsShouldStampIsTargetPlatformInferredFromRunSettingsHelper(bool isTargetPlatformInferred)
+    {
+        var runsettings = "<RunSettings><RunConfiguration><TargetFrameworkVersion>.NETFramework,Version=v4.5</TargetFrameworkVersion></RunConfiguration></RunSettings>";
+        var discoveryPayload = CreateDiscoveryPayload(runsettings);
+        _runSettingsHelper.IsDefaultTargetArchitecture = isTargetPlatformInferred;
+
+        _testRequestManager.DiscoverTests(discoveryPayload, new Mock<ITestDiscoveryEventsRegistrar>().Object, _protocolConfig);
+
+        var marker = $"<IsTargetPlatformInferred>{isTargetPlatformInferred}</IsTargetPlatformInferred>";
+        _mockTestPlatform.Verify(
+            tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.Is<DiscoveryCriteria>(dc => dc.RunSettings!.Contains(marker)), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>()));
+    }
+
+    [TestMethod]
+    public void DiscoverTestsShouldStampIsTargetPlatformInferredPerRequestWithoutLeakingAcrossRequests()
+    {
+        // Two requests handled by the same process must each carry their own IsTargetPlatformInferred
+        // marker in their own run settings. Before this fact travelled with the run settings, the test host
+        // manager read it from the process-wide RunSettingsHelper singleton, so a pinned platform in one
+        // request leaked into the next request that did not pin one.
+        var runsettings = "<RunSettings><RunConfiguration><TargetFrameworkVersion>.NETFramework,Version=v4.5</TargetFrameworkVersion></RunConfiguration></RunSettings>";
+        var capturedRunSettings = new List<string?>();
+        _mockTestPlatform
+            .Setup(tp => tp.CreateDiscoveryRequest(It.IsAny<IRequestData>(), It.IsAny<DiscoveryCriteria>(), It.IsAny<TestPlatformOptions>(), It.IsAny<Dictionary<string, SourceDetail>>(), It.IsAny<IWarningLogger>()))
+            .Callback<IRequestData, DiscoveryCriteria, TestPlatformOptions, Dictionary<string, SourceDetail>, IWarningLogger>((_, dc, _, _, _) => capturedRunSettings.Add(dc.RunSettings))
+            .Returns(_mockDiscoveryRequest.Object);
+
+        // First request: the user pinned the target platform.
+        _runSettingsHelper.IsDefaultTargetArchitecture = false;
+        _testRequestManager.DiscoverTests(CreateDiscoveryPayload(runsettings), new Mock<ITestDiscoveryEventsRegistrar>().Object, _protocolConfig);
+
+        // Second request in the same process: nothing pinned the platform, so it is inferred.
+        _runSettingsHelper.IsDefaultTargetArchitecture = true;
+        _testRequestManager.DiscoverTests(CreateDiscoveryPayload(runsettings), new Mock<ITestDiscoveryEventsRegistrar>().Object, _protocolConfig);
+
+        Assert.HasCount(2, capturedRunSettings);
+        Assert.Contains("<IsTargetPlatformInferred>False</IsTargetPlatformInferred>", capturedRunSettings[0]!);
+        Assert.Contains("<IsTargetPlatformInferred>True</IsTargetPlatformInferred>", capturedRunSettings[1]!);
+    }
+
+    [TestMethod]
     public void DiscoverTestsShouldNotUpdateDesignModeIfUserHasSetDesignModeInRunSettings()
     {
         var runsettings = "<RunSettings><RunConfiguration><DesignMode>False</DesignMode><TargetFrameworkVersion>.NETFramework,Version=v4.5</TargetFrameworkVersion></RunConfiguration></RunSettings>";


### PR DESCRIPTION
`DotnetTestHostManager` decided whether to silently force an AnyCPU test host to x64 by reading `RunSettingsHelper.Instance.IsDefaultTargetArchitecture` on the host launch path. That is the shared run settings static state this cleanup is about: in design mode one process serves many requests, and a request that pins a platform (which sets the flag to false) leaves that value behind for the next request that pins none.

vstest.console already knows this fact per request. It is the `IsDefaultTargetArchitecture` on the injected `IRunSettingsHelper` that the `--Platform` executor writes when the user pins an architecture. Instead of letting the host read it back off a process wide singleton, vstest.console now stamps it into the run settings it hands to the host as `<IsTargetPlatformInferred>`, and the host reads it from `RunConfiguration`. The fact travels through the natural per request channel, the run settings, so nothing is shared between requests.

- `TestRequestManager` writes `<IsTargetPlatformInferred>` under `<RunConfiguration>` from the injected helper while it is already patching the run settings for the request.
- `RunConfiguration.FromXml` parses it into a new internal `IsTargetPlatformInferred` property that defaults to true when the element is absent, so synthetic run settings and the direct API keep the previous behavior.
- `DotnetTestHostManager` reads `RunConfiguration.IsTargetPlatformInferred` in `Initialize` and no longer takes an `IRunSettingsHelper` in its constructor.

The marker is a child element under `<RunConfiguration>`, not an attribute, because the run settings parser rejects unknown attributes but skips unknown elements. An older host ignores the element, and a newer host reading run settings that do not carry it falls back to true, which is the behavior before this change.

After this the only remaining `RunSettingsHelper.Instance` references are the composition root defaults, which sets up deleting the singleton in a follow up.

Build, unit tests (ObjectModel, Utilities, CrossPlatEngine, TestHostProvider and vstest.console) and smoke tests verified locally on net11.0 and net481.

Continues the static-state cleanup from #16200/#16205/#16208/#16228/#16243/#16245/#16257/#16258/#16262/#16263/#16268.
