### PR TITLE
Enrich filter escaping, runsettings link, coverage, and CLI reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ NOTE: When adding a new public API, always add it directly to the `PublicAPI.Shi
 - [Environment Variables](./docs/environment-variables.md)
 - [Roadmap](./docs/releases.md)
 - [Troubleshooting guide](./docs/troubleshooting.md)
+- Command-line options reference: [vstest.console.exe options](https://learn.microsoft.com/visualstudio/test/vstest-console-options) and [dotnet test options](https://learn.microsoft.com/dotnet/core/tools/dotnet-test)
 
 ## Building
 

--- a/docs/RunSettingsArguments.md
+++ b/docs/RunSettingsArguments.md
@@ -36,7 +36,7 @@ where `additionalargs.runsettings` is:
 </RunSettings> 
 ```
 
-The syntax in (1) is another way of passing runsettings configuration and you need not author a runsetting file while using `Runsettings arguments`. More details about runsettings can be found [here](https://msdn.microsoft.com/library/jj635153.aspx).
+The syntax in (1) is another way of passing runsettings configuration and you need not author a runsetting file while using `Runsettings arguments`. More details about runsettings can be found [here](https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file).
 
 `Runsettings arguments` takes precedence over `runsettings`.
 

--- a/docs/RunSettingsArguments.md
+++ b/docs/RunSettingsArguments.md
@@ -36,9 +36,9 @@ where `additionalargs.runsettings` is:
 </RunSettings> 
 ```
 
-The syntax in (1) is another way of passing runsettings configuration and you need not author a runsetting file while using `Runsettings arguments`. More details about runsettings can be found [here](https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file).
+The syntax in (1) is another way of passing runsettings configuration and you need not author a `.runsettings` file while using `RunSettings arguments`. More details about runsettings can be found [here](https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file).
 
-`Runsettings arguments` takes precedence over `runsettings`.
+`RunSettings arguments` takes precedence over `runsettings`.
 
 For example, in below command the final value for `MapInconclusiveToFailed` will be `False` and value for `DeploymentEnabled` will be unchanged, that is `False`.
 

--- a/docs/analyze.md
+++ b/docs/analyze.md
@@ -160,10 +160,48 @@ In TPv2, DataCollectors are loaded from `TestAdaptersPaths` specified in runSett
 
 ## Working with Code Coverage<a name="coverage"></a>
 
-> **Requirements:**
-> Code Coverage requires the machine to have Visual Studio 2017 Enterprise ([15.3.0](https://www.visualstudio.com/vs) or later installed and a Windows operating system.
+Code coverage can be collected from the command line with `dotnet test` or from Visual Studio Test Explorer. For current .NET projects, choose the collector that matches your platform and report format needs:
 
-### Setup a project
+- `dotnet test --collect "Code Coverage"` uses the built-in Visual Studio code coverage collector. It produces Visual Studio coverage output and is supported on Windows.
+- `dotnet test --collect "XPlat Code Coverage"` uses the cross-platform Coverlet collector. It works on Windows, Linux, and macOS and produces coverage files such as Cobertura XML.
+
+For complete command-line examples, package requirements, report generation, and customization options, see [Unit testing code coverage for .NET](https://learn.microsoft.com/dotnet/core/testing/unit-testing-code-coverage).
+
+### Analyze coverage with Visual Studio
+
+> **Legacy version note:**
+>
+> If you are on older tooling, this feature requires [Visual Studio 2017 15.3.0](https://www.visualstudio.com/vs) or later. Current Visual Studio versions support it out of the box.
+
+Use the `Analyze Code Coverage` context menu available in the `Test Explorer` tool window to start a coverage run.
+
+After the coverage run is complete, a detailed report will be available in the `Code Coverage Results` tool window.
+
+For Visual Studio-specific details, see [Use code coverage to determine how much code is being tested](https://learn.microsoft.com/visualstudio/test/using-code-coverage-to-determine-how-much-code-is-being-tested).
+
+### Collect coverage with command line runner
+
+Use one of the following commands to collect coverage data for tests:
+
+```shell
+dotnet test --collect "Code Coverage"
+dotnet test --collect "XPlat Code Coverage"
+```
+
+### Collect coverage in Azure Pipelines
+
+In Azure DevOps pipelines you can run tests and collect coverage with the Visual Studio Test task, which wraps `vstest.console.exe`. Enable coverage via the task's `codeCoverageEnabled` input (or pass `/collect:"Code Coverage"` through `otherConsoleOptions`). See [VSTest@2 - Visual Studio Test task](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/vstest-v2).
+
+Coverage attachments are written under the test run's `TestResults` directory.
+
+### Setup a project (legacy: Visual Studio 2017 / netcoreapp1.1)
+
+> **Legacy guidance:**
+>
+> The steps below apply only to older projects that are pinned to Visual Studio 2017
+> and `netcoreapp1.1`. Modern SDK-style projects do not need this setup — the code
+> coverage collectors ship with the .NET SDK. Prefer the `dotnet test --collect`
+> commands shown above unless you are constrained to this legacy tooling.
 
 Here's a sample project file, please note the xml entity marked as `Required`. Previously, the `Microsoft.VisualStudio.CodeCoverage` was required, but is now shipped with the SDK.
 
@@ -172,7 +210,7 @@ Here's a sample project file, please note the xml entity marked as `Required`. P
 
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
-    
+
     <!-- Required in both test/product projects. This is a temporary workaround for https://github.com/Microsoft/vstest/issues/800 -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
@@ -186,22 +224,7 @@ Here's a sample project file, please note the xml entity marked as `Required`. P
 </Project>
 ```
 
-
-### Analyze coverage with Visual Studio
-
-> **Version note:**
->
-> Try this feature with [Visual Studio 2017 15.3.0](https://www.visualstudio.com/vs) or later.
-
-Use the `Analyze Code Coverage` context menu available in `Test Explorer` tool window to start a coverage run.
-
-After the coverage run is complete, a detailed report will be available in the `Code Coverage Results` tool window.
-
-Please refer the documentation for additional details: <https://learn.microsoft.com/en-us/visualstudio/test/using-code-coverage-to-determine-how-much-code-is-being-tested>
-
-### Collect coverage with command line runner
-
-Use the following command line to collect coverage data for tests:
+To collect coverage for such a project with the standalone runner:
 
 ```shell
 > "%vsinstalldir%\Common7\IDE\Extensions\TestPlatform\vstest.console.exe" --collect:"Code Coverage" --framework:".NETCoreApp,Version=v1.1" d:\testproject\bin\Debug\netcoreapp1.1\testproject.dll

--- a/docs/analyze.md
+++ b/docs/analyze.md
@@ -169,10 +169,6 @@ For complete command-line examples, package requirements, report generation, and
 
 ### Analyze coverage with Visual Studio
 
-> **Legacy version note:**
->
-> If you are on older tooling, this feature requires [Visual Studio 2017 15.3.0](https://www.visualstudio.com/vs) or later. Current Visual Studio versions support it out of the box.
-
 Use the `Analyze Code Coverage` context menu available in the `Test Explorer` tool window to start a coverage run.
 
 After the coverage run is complete, a detailed report will be available in the `Code Coverage Results` tool window.
@@ -193,44 +189,6 @@ dotnet test --collect "XPlat Code Coverage"
 In Azure DevOps pipelines you can run tests and collect coverage with the Visual Studio Test task, which wraps `vstest.console.exe`. Enable coverage via the task's `codeCoverageEnabled` input (or pass `/collect:"Code Coverage"` through `otherConsoleOptions`). See [VSTest@2 - Visual Studio Test task](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/vstest-v2).
 
 Coverage attachments are written under the test run's `TestResults` directory.
-
-### Setup a project (legacy: Visual Studio 2017 / netcoreapp1.1)
-
-> **Legacy guidance:**
->
-> The steps below apply only to older projects that are pinned to Visual Studio 2017
-> and `netcoreapp1.1`. Modern SDK-style projects typically don't need this setup — use
-> `dotnet test --collect` instead (note: `"XPlat Code Coverage"` requires the `coverlet.collector` package).
-> Prefer the commands shown above unless you are constrained to this legacy tooling.
-
-Here's a sample project file, please note the xml entity marked as `Required`. Previously, the `Microsoft.VisualStudio.CodeCoverage` was required, but is now shipped with the SDK.
-
-```xml
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-
-    <!-- Required in both test/product projects. This is a temporary workaround for https://github.com/Microsoft/vstest/issues/800 -->
-    <DebugType>Full</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.17" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.17" />
-  </ItemGroup>
-
-</Project>
-```
-
-To collect coverage for such a project with the standalone runner:
-
-```shell
-> "%vsinstalldir%\Common7\IDE\Extensions\TestPlatform\vstest.console.exe" --collect:"Code Coverage" --framework:".NETCoreApp,Version=v1.1" d:\testproject\bin\Debug\netcoreapp1.1\testproject.dll
-```
-
-This will generate a `*.coverage` file in the `<Current working directory>\TestResults` directory.
 
 ### Event Log Data Collector
 

--- a/docs/analyze.md
+++ b/docs/analyze.md
@@ -163,7 +163,7 @@ In TPv2, DataCollectors are loaded from `TestAdaptersPaths` specified in runSett
 Code coverage can be collected from the command line with `dotnet test` or from Visual Studio Test Explorer. For current .NET projects, choose the collector that matches your platform and report format needs:
 
 - `dotnet test --collect "Code Coverage"` uses the built-in Visual Studio code coverage collector. It produces Visual Studio coverage output and is supported on Windows.
-- `dotnet test --collect "XPlat Code Coverage"` uses the cross-platform Coverlet collector. It works on Windows, Linux, and macOS and produces coverage files such as Cobertura XML.
+- `dotnet test --collect "XPlat Code Coverage"` uses the cross-platform Coverlet collector (requires the `coverlet.collector` NuGet package). It works on Windows, Linux, and macOS and produces coverage files such as Cobertura XML.
 
 For complete command-line examples, package requirements, report generation, and customization options, see [Unit testing code coverage for .NET](https://learn.microsoft.com/dotnet/core/testing/unit-testing-code-coverage).
 

--- a/docs/analyze.md
+++ b/docs/analyze.md
@@ -199,9 +199,9 @@ Coverage attachments are written under the test run's `TestResults` directory.
 > **Legacy guidance:**
 >
 > The steps below apply only to older projects that are pinned to Visual Studio 2017
-> and `netcoreapp1.1`. Modern SDK-style projects do not need this setup — the code
-> coverage collectors ship with the .NET SDK. Prefer the `dotnet test --collect`
-> commands shown above unless you are constrained to this legacy tooling.
+> and `netcoreapp1.1`. Modern SDK-style projects typically don't need this setup — use
+> `dotnet test --collect` instead (note: `"XPlat Code Coverage"` requires the `coverlet.collector` package).
+> Prefer the commands shown above unless you are constrained to this legacy tooling.
 
 Here's a sample project file, please note the xml entity marked as `Required`. Previously, the `Microsoft.VisualStudio.CodeCoverage` was required, but is now shipped with the SDK.
 

--- a/docs/filter.md
+++ b/docs/filter.md
@@ -47,6 +47,22 @@ Allowed **operators**:
 A helper method `Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities.FilterHelper.Escape`
 is also available by referencing the `Microsoft.VisualStudio.TestPlatform.ObjectModel` NuGet package, which can be used to escape strings programatically.
 
+### Shell escaping
+
+The filter expression is parsed by both your shell and the test platform, so some characters may need shell-specific escaping before VSTest receives them.
+
+On Linux and macOS shells, escape `!` with a backslash when using the `!~` operator:
+
+```shell
+dotnet test --filter FullyQualifiedName\!~IntegrationTests
+```
+
+If a `FullyQualifiedName` value contains a comma, such as a generic type argument list, escape the comma as `%2C` in the filter value:
+
+```shell
+dotnet test --filter "FullyQualifiedName=MyNamespace.MyTestsClass<ParameterType1%2CParameterType2>.MyTestMethod"
+```
+
 Expressions can be joined with boolean operators. The following boolean operators are supported:
 
 * `|` implies a boolean `OR`

--- a/docs/filter.md
+++ b/docs/filter.md
@@ -57,7 +57,7 @@ On Linux and macOS shells, escape `!` with a backslash when using the `!~` opera
 dotnet test --filter FullyQualifiedName\!~IntegrationTests
 ```
 
-If a `FullyQualifiedName` value contains a comma, such as a generic type argument list, quote the filter expression so the comma is passed through literally (required in PowerShell):
+If a `FullyQualifiedName` value contains characters with special meaning to your shell (for example `<`, `>`, or `,` in a generic type argument list), quote the filter expression so it is passed through literally (required in PowerShell, where `,` is the array operator):
 
     dotnet test --filter "FullyQualifiedName=MyNamespace.MyTestsClass<ParameterType1,ParameterType2>.MyTestMethod"
 

--- a/docs/filter.md
+++ b/docs/filter.md
@@ -57,11 +57,9 @@ On Linux and macOS shells, escape `!` with a backslash when using the `!~` opera
 dotnet test --filter FullyQualifiedName\!~IntegrationTests
 ```
 
-If a `FullyQualifiedName` value contains a comma, such as a generic type argument list, escape the comma as `%2C` in the filter value:
+If a `FullyQualifiedName` value contains a comma, such as a generic type argument list, quote the filter expression so the comma is passed through literally (required in PowerShell):
 
-```shell
-dotnet test --filter "FullyQualifiedName=MyNamespace.MyTestsClass<ParameterType1%2CParameterType2>.MyTestMethod"
-```
+    dotnet test --filter "FullyQualifiedName=MyNamespace.MyTestsClass<ParameterType1,ParameterType2>.MyTestMethod"
 
 Expressions can be joined with boolean operators. The following boolean operators are supported:
 


### PR DESCRIPTION
Enrichment of several test-platform docs (split from a larger docs pass; blame is a separate PR).

- **filter.md** — add shell escaping guidance (backslash-escaping `!` on Linux/macOS shells) and comma escaping for generic type arguments in `FullyQualifiedName`.
- **RunSettingsArguments.md** — replace a dead MSDN link with the current Microsoft Learn runsettings reference.
- **analyze.md** — modernize the code-coverage section (`dotnet test --collect "Code Coverage"` / `"XPlat Code Coverage"`), add an Azure Pipelines VSTest task pointer, and remove guidance covering end-of-life products (the VS2017 15.3.0 legacy version note and the Visual Studio 2017 / netcoreapp1.1 "Setup a project" section).
- **README.md** — add command-line options reference links.
