### PR TITLE
Add .github/release.yml to exclude bot authors from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,8 @@
+changelog:
+  exclude:
+    authors:
+      - dotnet-bot
+      - dotnet-maestro
+      - dotnet-maestro[bot]
+      - dependabot
+      - dependabot[bot]


### PR DESCRIPTION
Ports [`.github/release.yml`](https://github.com/microsoft/testfx/blob/main/.github/release.yml) from microsoft/testfx. It tells GitHub's auto-generated release notes to drop PRs authored by the dependency bots (dotnet-bot, dotnet-maestro, dependabot), so the generated changelog only lists real changes instead of a wall of dependency bumps.