### PR TITLE
Fix protocol negotiation timeout when STJ reflection is disabled (18.8.1)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
       from appending +<commitId>, which breaks DTAAgent.
     -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
-    <VersionPrefix>18.8.0</VersionPrefix>
+    <VersionPrefix>18.8.1</VersionPrefix>
     <PreReleaseVersionLabel>release</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <!-- Allowed values: '', 'prerelease', 'release'. Set to 'release' when stabilizing. -->

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.Stj.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/JsonDataSerializer.Stj.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Serialization;
 using Microsoft.VisualStudio.TestPlatform.Common.DataCollection;
@@ -74,6 +75,11 @@ public partial class JsonDataSerializer
         NumberHandling = JsonNumberHandling.AllowReadingFromString,
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
         ReferenceHandler = ReferenceHandler.IgnoreCycles,
+        // Assign an explicit reflection-based resolver. When TypeInfoResolver is null, STJ falls back to
+        // the implicit default resolver which is disabled when a test project sets
+        // JsonSerializerIsReflectionEnabledByDefault=false (that switch flows into the testhost runtimeconfig),
+        // making testhost throw while deserializing the first protocol message and the runner time out. See #16274.
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
     };
 
     private static partial (int version, string? messageType) ParseHeaderFromJson(string rawMessage)


### PR DESCRIPTION
Backport of the minimal fix for #16274 to rel/18.8.

Test projects that set `JsonSerializerIsReflectionEnabledByDefault=false` write that switch into their `runtimeconfig.json`, and testhost runs under that same config. In 18.8.0 the STJ options left `TypeInfoResolver` null, so System.Text.Json falls back to the implicit default resolver that the switch disables, testhost throws while deserializing the first protocol message and dies, and the runner waits out the whole connection timeout and prints "Failed to negotiate protocol, waiting for response timed out after 90 seconds". Projects that don't set the property are unaffected, which is why it didn't show up for everyone.

The fix assigns an explicit `DefaultJsonTypeInfoResolver`, which keeps reflection-based serialization working regardless of the switch. main and rel/18.9 already resolve this as part of the larger NativeAOT work in #16045, this is just the one-line servicing equivalent for 18.8.1.

Validated against a net10 xUnit repro with the property set: 18.8.0 times out, this build (18.8.1-dev) passes and the testhost diag shows STJ in use with no exceptions.

Also bumps VersionPrefix to 18.8.1.
