### PR TITLE
Inject runsettings environment variables on the MTP execution path

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpProxyExecutionManager.cs
@@ -16,6 +16,7 @@ using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.DataCollection.Interfa
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Engine;
+using Microsoft.VisualStudio.TestPlatform.Utilities;
 
 namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.MTP;
 
@@ -78,6 +79,13 @@ internal sealed class MtpProxyExecutionManager : IProxyExecutionManager, IDispos
         var invokedDataCollectors = new List<InvokedDataCollector>();
         int processId = 0;
         bool aborted = false;
+
+        // Inject environment variables declared in the runsettings RunConfiguration/EnvironmentVariables
+        // into the MTP application launch. On the classic path ProxyOperationManager reads these from the
+        // runsettings and passes them to the testhost process; the MTP application is its own host, so we
+        // apply them here. Done before BeforeTestRun so datacollector-provided profiler variables merge on
+        // top and win on collision (matching the classic ordering).
+        ApplyRunSettingsEnvironmentVariables(testRunCriteria.TestRunSettings);
 
         BeforeTestRun(eventHandler);
 
@@ -369,6 +377,26 @@ internal sealed class MtpProxyExecutionManager : IProxyExecutionManager, IDispos
 
         return (criteria.Sources ?? Enumerable.Empty<string>())
             .Select(source => (source, (List<TestCase>?)null));
+    }
+
+    /// <summary>
+    /// Reads the environment variables declared in the runsettings
+    /// <c>RunConfiguration/EnvironmentVariables</c> and merges them into <see cref="EnvironmentVariables"/>
+    /// so they are applied to the MTP application launch.
+    /// </summary>
+    private void ApplyRunSettingsEnvironmentVariables(string? runSettings)
+    {
+        Dictionary<string, string?>? runSettingsEnvironmentVariables = InferRunSettingsHelper.GetEnvironmentVariables(runSettings);
+        if (runSettingsEnvironmentVariables is null || runSettingsEnvironmentVariables.Count == 0)
+        {
+            return;
+        }
+
+        EnvironmentVariables ??= new Dictionary<string, string?>();
+        foreach (KeyValuePair<string, string?> variable in runSettingsEnvironmentVariables)
+        {
+            EnvironmentVariables[variable.Key] = variable.Value;
+        }
     }
 
     private static List<Dictionary<string, object?>> BuildTestsFilter(List<TestCase> tests)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpProxyExecutionManager.cs
@@ -392,11 +392,12 @@ internal sealed class MtpProxyExecutionManager : IProxyExecutionManager, IDispos
             return;
         }
 
-        EnvironmentVariables ??= new Dictionary<string, string?>();
-        foreach (KeyValuePair<string, string?> variable in runSettingsEnvironmentVariables)
-        {
-            EnvironmentVariables[variable.Key] = variable.Value;
-        }
+EnvironmentVariables ??= new Dictionary<string, string?>(
+    Environment.OSVersion.Platform == PlatformID.Win32NT ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+foreach (KeyValuePair<string, string?> variable in runSettingsEnvironmentVariables)
+{
+    EnvironmentVariables[variable.Key] = variable.Value;
+}
     }
 
     private static List<Dictionary<string, object?>> BuildTestsFilter(List<TestCase> tests)

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpProxyExecutionManager.cs
@@ -392,12 +392,12 @@ internal sealed class MtpProxyExecutionManager : IProxyExecutionManager, IDispos
             return;
         }
 
-EnvironmentVariables ??= new Dictionary<string, string?>(
-    Environment.OSVersion.Platform == PlatformID.Win32NT ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
-foreach (KeyValuePair<string, string?> variable in runSettingsEnvironmentVariables)
-{
-    EnvironmentVariables[variable.Key] = variable.Value;
-}
+        EnvironmentVariables ??= new Dictionary<string, string?>(
+            Environment.OSVersion.Platform == PlatformID.Win32NT ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+        foreach (KeyValuePair<string, string?> variable in runSettingsEnvironmentVariables)
+        {
+            EnvironmentVariables[variable.Key] = variable.Value;
+        }
     }
 
     private static List<Dictionary<string, object?>> BuildTestsFilter(List<TestCase> tests)

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/MtpUnderVstestTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/MtpUnderVstestTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.IO;
 
 using Microsoft.TestPlatform.TestUtilities;
@@ -45,7 +46,7 @@ public class MtpUnderVstestTests : AcceptanceTestBase
 
         InvokeVsTest(arguments);
 
-        ValidateSummaryStatus(2, 1, 1);
+        ValidateSummaryStatus(3, 1, 1);
     }
 
     [TestMethod]
@@ -67,13 +68,13 @@ public class MtpUnderVstestTests : AcceptanceTestBase
 
         InvokeVsTest(arguments);
 
-        // Classic 1/1/1 + MTP 2/1/1 aggregated into one run summary.
-        ValidateSummaryStatus(3, 2, 2);
+        // Classic 1/1/1 + MTP 3/1/1 aggregated into one run summary.
+        ValidateSummaryStatus(4, 2, 2);
     }
 
     [TestMethod]
     // Prove a TRX logger aggregates results from both the classic and the MTP source in a mixed run into a
-    // single .trx with all seven tests.
+    // single .trx with all eight tests.
     [TestMatrix(testHost: Target.Net)]
     public void RunMixedClassicAndMtpApplicationsWritesSingleTrx(RunnerInfo runnerInfo)
     {
@@ -91,7 +92,7 @@ public class MtpUnderVstestTests : AcceptanceTestBase
 
         InvokeVsTest(arguments);
 
-        ValidateSummaryStatus(3, 2, 2);
+        ValidateSummaryStatus(4, 2, 2);
 
         var trxPath = Path.Combine(TempDirectory.Path, trxFileName);
         Assert.IsTrue(File.Exists(trxPath), "Expected a single TRX to be written for the mixed run at '{0}'.", trxPath);
@@ -120,6 +121,47 @@ public class MtpUnderVstestTests : AcceptanceTestBase
 
         InvokeVsTest(arguments);
 
-        ValidateSummaryStatus(2, 1, 1);
+        ValidateSummaryStatus(3, 1, 1);
+    }
+
+    [TestMethod]
+    // Environment variables declared in a runsettings RunConfiguration/EnvironmentVariables block must be
+    // injected into the self-hosted MTP process. There is no testhost here, so vstest.console applies them
+    // to the MTP application launch. The guarded RunSettingsEnvironmentVariableIsInjected test asserts the
+    // injected value; CHECK_RUNSETTINGS_VAR is passed as a process env var (inherited by the host) to opt
+    // the check in, so the run passes only when runsettings injection actually delivered the value. If the
+    // value did not reach the host that test fails and the summary would be 2/2/1 instead of 3/1/1.
+    [TestMatrix(testHost: Target.Net)]
+    public void RunMtpApplicationInjectsRunSettingsEnvironmentVariables(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var runsettingsXml = @"<RunSettings>
+                                    <RunConfiguration>
+                                      <EnvironmentVariables>
+                                        <MTP_FROM_RUNSETTINGS>mtp-runsettings-value</MTP_FROM_RUNSETTINGS>
+                                      </EnvironmentVariables>
+                                    </RunConfiguration>
+                                   </RunSettings>";
+        var runsettingsPath = Path.Combine(TempDirectory.Path, "mtp_env_" + System.Guid.NewGuid() + ".runsettings");
+        File.WriteAllText(runsettingsPath, runsettingsXml);
+
+        var arguments = PrepareArguments(
+            GetAssetFullPath(MtpApp),
+            testAdapterPath: null,
+            runSettings: runsettingsPath,
+            FrameworkArgValue,
+            runnerInfo.InIsolationValue,
+            resultsDirectory: TempDirectory.Path);
+
+        var env = new Dictionary<string, string?>
+        {
+            ["CHECK_RUNSETTINGS_VAR"] = "1",
+        };
+
+        InvokeVsTest(arguments, env);
+
+        // The guarded test passes only if MTP_FROM_RUNSETTINGS reached the host with the runsettings value.
+        ValidateSummaryStatus(3, 1, 1);
     }
 }

--- a/test/TestAssets/MtpMSTestProject/UnitTests.cs
+++ b/test/TestAssets/MtpMSTestProject/UnitTests.cs
@@ -36,4 +36,22 @@ public class UnitTests
     {
         Assert.Fail("should never run");
     }
+
+    // Verifies that environment variables declared in a runsettings RunConfiguration/EnvironmentVariables
+    // block are injected into the self-hosted MTP process. The check is opted into by the
+    // CHECK_RUNSETTINGS_VAR control variable, which the env-var acceptance test passes as a *process*
+    // environment variable (inherited by the host regardless of the fix), so the guard is decisive: when
+    // runsettings injection works MTP_FROM_RUNSETTINGS carries the expected value and the test passes; when
+    // it is broken the variable is absent and the assert fails. In every other run the control variable is
+    // unset, so the test is a no-op and stays green.
+    [TestMethod]
+    public void RunSettingsEnvironmentVariableIsInjected()
+    {
+        if (System.Environment.GetEnvironmentVariable("CHECK_RUNSETTINGS_VAR") != "1")
+        {
+            return;
+        }
+
+        Assert.AreEqual("mtp-runsettings-value", System.Environment.GetEnvironmentVariable("MTP_FROM_RUNSETTINGS"));
+    }
 }


### PR DESCRIPTION
## Problem
On the `vstest.console` path that runs a Microsoft.Testing.Platform (MTP) app as its own testhost (microsoft/vstest#16201), environment variables declared in a `.runsettings` `RunConfiguration/EnvironmentVariables` block were **not passed to the MTP test process**. Inherited process env vars reached the app, but the documented runsettings-driven injection was silently dropped.

## Root cause
On the classic path `ProxyOperationManager` reads the runsettings env vars and merges them into the testhost `ProcessStartInfo`. The MTP application is its own host, so that code is bypassed and `MtpProxyExecutionManager` only ever populated the launch environment with datacollector-provided profiler variables.

## Fix
`MtpProxyExecutionManager` now reads the runsettings env vars via `InferRunSettingsHelper.GetEnvironmentVariables` and merges them into the launch environment **before** `BeforeTestRun`, so datacollector profiler variables still win on collision (matching the classic ordering).

## Test
New acceptance test `RunMtpApplicationInjectsRunSettingsEnvironmentVariables` runs the MTP app with a runsettings file that injects `MTP_FROM_RUNSETTINGS` and a guarded `RunSettingsEnvironmentVariableIsInjected` asset test (opted in via a `CHECK_RUNSETTINGS_VAR` **process** env var inherited by the host). The guarded test passes only when the runsettings value actually reaches the host, so a broken injection turns the 3/1/1 summary into 2/2/1. Existing MTP summary counts are updated for the added asset test.

## Validation
- `RunMtpApplicationInjectsRunSettingsEnvironmentVariables` and the count-updated `RunMtpApplicationExecutesTestsOverMtpProtocol`: **4/4 matrix cases pass**.
- Release build of `Microsoft.TestPlatform.CrossPlatEngine` and the acceptance project: clean.
- Verified end-to-end against a real TUnit MTP app (wrong-value runsettings makes the guarded assert fail, proving the value was injected).