### PR TITLE
Surface per-test standard output/error on the MTP execution path

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpConstants.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpConstants.cs
@@ -45,6 +45,8 @@ internal static class MtpConstants
     public const string TimeDurationMs = "time.duration-ms";
     public const string ErrorMessage = "error.message";
     public const string ErrorStackTrace = "error.stacktrace";
+    public const string StandardOutput = "standardOutput";
+    public const string StandardError = "standardError";
     public const string LocationFile = "location.file";
     public const string LocationLineStart = "location.line-start";
     public const string Traits = "traits";

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpTestNodeConverter.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpTestNodeConverter.cs
@@ -82,6 +82,21 @@ internal static class MtpTestNodeConverter
             result.Duration = TimeSpan.FromMilliseconds(durationMs);
         }
 
+        // Surface the test's captured standard output/error (when the MTP node carries it) as result
+        // messages so the console and TRX loggers show it, matching the classic path where a test's
+        // stdout/stderr is attached to its result.
+        string? standardOutput = MtpJson.GetString(node, MtpConstants.StandardOutput);
+        if (!string.IsNullOrEmpty(standardOutput))
+        {
+            result.Messages.Add(new TestResultMessage(TestResultMessage.StandardOutCategory, standardOutput));
+        }
+
+        string? standardError = MtpJson.GetString(node, MtpConstants.StandardError);
+        if (!string.IsNullOrEmpty(standardError))
+        {
+            result.Messages.Add(new TestResultMessage(TestResultMessage.StandardErrorCategory, standardError));
+        }
+
         return result;
     }
 

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/MtpUnderVstestTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/MtpUnderVstestTests.cs
@@ -122,4 +122,35 @@ public class MtpUnderVstestTests : AcceptanceTestBase
 
         ValidateSummaryStatus(2, 1, 1);
     }
+
+    [TestMethod]
+    // A test's captured standard output/error must be surfaced to the loggers. The MTP node carries the
+    // per-test standardOutput/standardError; MtpTestNodeConverter now maps them onto the vstest result so
+    // the console and TRX show them. Before this the markers appeared nowhere. TestPassesToo writes the
+    // markers; the run produces a TRX that must contain them.
+    [TestMatrix(testHost: Target.Net)]
+    public void RunMtpApplicationSurfacesPerTestStandardOutput(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+
+        var trxFileName = "stdout.trx";
+        var arguments = PrepareArguments(
+            GetAssetFullPath(MtpApp),
+            testAdapterPath: null,
+            runSettings: string.Empty,
+            FrameworkArgValue,
+            runnerInfo.InIsolationValue,
+            resultsDirectory: TempDirectory.Path);
+        arguments = string.Concat(arguments, $" /logger:trx;LogFileName={trxFileName}");
+
+        InvokeVsTest(arguments);
+
+        ValidateSummaryStatus(2, 1, 1);
+
+        var trxPath = Path.Combine(TempDirectory.Path, trxFileName);
+        Assert.IsTrue(File.Exists(trxPath), "Expected a TRX at '{0}'.", trxPath);
+        var trx = File.ReadAllText(trxPath);
+        Assert.Contains("MTP_STDOUT_MARKER", trx, "Expected the test's standard output to be surfaced into the TRX.");
+        Assert.Contains("MTP_STDERR_MARKER", trx, "Expected the test's standard error to be surfaced into the TRX.");
+    }
 }

--- a/test/TestAssets/MtpMSTestProject/UnitTests.cs
+++ b/test/TestAssets/MtpMSTestProject/UnitTests.cs
@@ -21,6 +21,10 @@ public class UnitTests
     [TestMethod]
     public void TestPassesToo()
     {
+        // Writes to stdout and stderr (and still passes) so the MTP-under-vstest stdout acceptance test can
+        // assert the captured per-test output is surfaced to the console and TRX loggers.
+        System.Console.WriteLine("MTP_STDOUT_MARKER");
+        System.Console.Error.WriteLine("MTP_STDERR_MARKER");
         Assert.AreEqual(2, Add(1, 1));
     }
 


### PR DESCRIPTION
## Problem
On the `vstest.console` path that runs a Microsoft.Testing.Platform (MTP) app as its own testhost (microsoft/vstest#16201), a test's standard output/error appeared in **neither the console nor the TRX**. Diagnostic output printed by tests was lost.

## Root cause
The MTP test node *does* carry per-test `standardOutput`/`standardError` (confirmed from the raw JSON-RPC node), but `MtpTestNodeConverter.ToTestResult` never read them, so nothing was attached to the vstest `TestResult` for the loggers to write.

## Fix
Map the node's `standardOutput`/`standardError` onto `TestResult.Messages` with the `StandardOut`/`StandardError` categories, matching the classic path where a test's captured output is attached to its result.

## Test
New acceptance test `RunMtpApplicationSurfacesPerTestStandardOutput`: `TestPassesToo` now writes `MTP_STDOUT_MARKER`/`MTP_STDERR_MARKER`; the test runs the MTP app with `/logger:trx` and asserts both markers appear in the TRX.

## Validation
- `RunMtpApplicationSurfacesPerTestStandardOutput`: **2/2 matrix cases pass** (markers absent on `main`).
- Release build of `Microsoft.TestPlatform.CrossPlatEngine` and the acceptance project: clean.
- Verified end-to-end against a real TUnit MTP app: the markers now appear in the TRX StdOut/StdErr.