### PR TITLE
Surface test host crashes during protocol negotiation

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/TestRequestSender.cs
@@ -281,9 +281,29 @@ public class TestRequestSender : ITestRequestSender
 
             _channel.Send(data);
 
-            // Wait for negotiation response
+            // Wait for the negotiation response, or for the test host to exit. If the test host exits
+            // before it answers (for example it crashed while deserializing the version check message)
+            // we must stop waiting immediately instead of blocking for the whole connection timeout, and
+            // surface the error it wrote to its standard error rather than a generic timeout message.
             var timeout = EnvironmentHelper.GetConnectionTimeout();
-            if (!protocolNegotiated.WaitOne(timeout * 1000))
+            var waitResult = WaitHandle.WaitAny([protocolNegotiated, _clientExited.WaitHandle], timeout * 1000);
+
+            // The test host process exited before it negotiated the protocol version.
+            if (waitResult == 1)
+            {
+                // Surface the error the test host wrote to its standard error (captured in
+                // OnClientProcessExit) so the user sees the real cause instead of a timeout.
+                var reason = CommonResources.TestHostProcessCrashed;
+                if (!string.IsNullOrWhiteSpace(_clientExitErrorMessage))
+                {
+                    reason = $"{reason} : {_clientExitErrorMessage}";
+                }
+
+                throw new TestPlatformException(reason);
+            }
+
+            // Neither the negotiation response nor the test host exit happened within the timeout.
+            if (waitResult == WaitHandle.WaitTimeout)
             {
                 throw new TestPlatformException(string.Format(CultureInfo.CurrentCulture, CommonResources.VersionCheckTimedout, timeout, EnvironmentHelper.VstestConnectionTimeout));
             }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/EventHandlers/TestRequestHandler.cs
@@ -376,6 +376,13 @@ public class TestRequestHandler : ITestRequestHandler, IDeploymentAwareTestReque
                     _messageProcessingUnrecoverableError = ex;
                     EqtTrace.Error("Failed processing message {0}, aborting test run.", message.MessageType);
                     EqtTrace.Error(ex);
+
+                    // The protocol version is not negotiated yet, so we cannot report this error back to
+                    // the runner over the communication channel (serializing the response would hit the
+                    // same failure). Write it to standard error instead, so the runner can capture it from
+                    // the test host process output and show the real cause instead of a connection timeout.
+                    WriteToStandardError($"Failed to process {message.MessageType} message in test host: {ex}");
+
                     goto case MessageType.AbortTestRun;
                 }
                 break;
@@ -592,6 +599,13 @@ public class TestRequestHandler : ITestRequestHandler, IDeploymentAwareTestReque
                     break;
                 }
         }
+    }
+
+    // Writes a message to the test host standard error stream. Virtual so tests can observe what the
+    // test host writes to standard error without depending on the process-wide Console.Error stream.
+    internal virtual void WriteToStandardError(string message)
+    {
+        ConsoleOutput.Instance.WriteLine(message, OutputLevel.Error);
     }
 
     private static ITestCaseEventsHandler? GetTestCaseEventsHandler(string? runSettings)

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/TestRequestSenderTests.cs
@@ -286,6 +286,24 @@ public class TestRequestSenderTests
         Assert.AreEqual(message, TimoutErrorMessage);
     }
 
+    [TestMethod]
+    public void CheckVersionWithTestHostShouldThrowWithTestHostErrorIfTestHostExitsDuringNegotiation()
+    {
+        // The test host connected but then exited during protocol negotiation, for example it crashed while
+        // deserializing the version check message when reflection-based serialization is disabled (issue #16274).
+        // OnClientProcessExit records the standard error and signals the exit. CheckVersionWithTestHost must stop
+        // waiting immediately and surface that error, instead of blocking for the whole connection timeout and
+        // reporting a generic timeout message.
+        SetupFakeCommunicationChannel();
+        _testRequestSender.OnClientProcessExit("System.InvalidOperationException: Reflection-based serialization has been disabled for this application.");
+
+        var message = Assert.ThrowsExactly<TestPlatformException>(() => _testRequestSender.CheckVersionWithTestHost()).Message;
+
+        Assert.Contains("Test host process crashed", message);
+        Assert.Contains("Reflection-based serialization has been disabled", message);
+        Assert.AreNotEqual(TimoutErrorMessage, message);
+    }
+
     #endregion
 
     #region Discovery Protocol Tests

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/EventHandlers/TestRequestHandlerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/EventHandlers/TestRequestHandlerTests.cs
@@ -169,6 +169,24 @@ public class TestRequestHandlerTests
         SendSessionEnd();
     }
 
+    [TestMethod]
+    public void ProcessRequestsVersionCheckFailureShouldWriteErrorToStandardError()
+    {
+        // A VersionCheck payload that is not an int makes DeserializePayload<int> throw, which simulates
+        // the unrecoverable serializer failure the test host hits when reflection-based serialization is
+        // disabled (issue #16274). The protocol version is not negotiated yet, so the error cannot be sent
+        // back over the channel and must instead be written to standard error for the runner to capture.
+        var message = new Message { MessageType = MessageType.VersionCheck, RawMessage = JsonDataSerializer.Instance.SerializePayload(MessageType.VersionCheck, "not-an-int", 1) };
+        ProcessRequestsAsync(_mockTestHostManagerFactory.Object);
+
+        SendMessageOnChannel(message);
+
+        var handler = (TestableTestRequestHandler)_requestHandler;
+        var standardError = string.Join(Environment.NewLine, handler.StandardErrorMessages);
+        Assert.Contains(MessageType.VersionCheck, standardError);
+        SendSessionEnd();
+    }
+
     #endregion
 
     #region Discovery Protocol
@@ -521,6 +539,8 @@ public class TestRequestHandlerTests
 
 public class TestableTestRequestHandler : TestRequestHandler
 {
+    public List<string> StandardErrorMessages { get; } = new();
+
     public TestableTestRequestHandler(
         TestHostConnectionInfo testHostConnectionInfo,
         ICommunicationEndpointFactory communicationEndpointFactory,
@@ -534,6 +554,11 @@ public class TestableTestRequestHandler : TestRequestHandler
             OnLaunchAdapterProcessWithDebuggerAttachedAckReceived,
             OnAttachDebuggerAckRecieved)
     {
+    }
+
+    internal override void WriteToStandardError(string message)
+    {
+        StandardErrorMessages.Add(message);
     }
 
     private static void OnLaunchAdapterProcessWithDebuggerAttachedAckReceived(Message message)


### PR DESCRIPTION
Follow-up to #16274. The serializer bug itself is fixed in 18.9 and backported to 18.8.1 in #16281, this PR is about diagnosability, so the next time the test host dies during negotiation the user sees why instead of a 90 second timeout.

When the test host crashes while negotiating the protocol version (in #16274 it could not deserialize the version check message because reflection based serialization was disabled) two things hid the cause. The test host could not send the error back, because the protocol is not negotiated yet and serializing the response hits the same failure, so the error only reached the diag log. And `CheckVersionWithTestHost` only waited on the negotiation event, it ignored the test host exit, so it blocked for the whole connection timeout and then reported a generic "waiting for response timed out after 90 seconds" message.

Now the test host writes the unrecoverable negotiation error to its standard error, which the runner already captures from the process output. `CheckVersionWithTestHost` waits for the negotiation response or for the test host to exit, whichever comes first, and when the host exits it throws with the captured standard error instead of the timeout message.

Added unit tests for both sides: the test host writes a failed version check to standard error, and the runner surfaces the captured error and stops waiting when the host exits during negotiation.
