### PR TITLE
docs: add vstest.console CLI options reference and document missing env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,7 @@ NOTE: When adding a new public API, always add it directly to the `PublicAPI.Shi
 - [Configure a test run (.runsettings)](./docs/configure.md)
 - [Code coverage](./docs/analyze.md)
 - [Diagnostics](./docs/diagnose.md)
-
-### Other
-
 - [Environment Variables](./docs/environment-variables.md)
-- [Roadmap](./docs/releases.md)
 - [Troubleshooting guide](./docs/troubleshooting.md)
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ NOTE: When adding a new public API, always add it directly to the `PublicAPI.Shi
 - [TestSettings Deprecation](./docs/RFCs/0023-TestSettings-Deprecation.md)
 - [Blame Collector Options](./docs/RFCs/0024-Blame-Collector-Options.md)
 
+### Guides
+
+- [Command line options](./docs/commandline.md)
+- [TestCase filtering](./docs/filter.md)
+- [Passing runsettings from the command line](./docs/RunSettingsArguments.md)
+- [Configure a test run (.runsettings)](./docs/configure.md)
+- [Code coverage](./docs/analyze.md)
+- [Diagnostics](./docs/diagnose.md)
+
 ### Other
 
 - [Environment Variables](./docs/environment-variables.md)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ NOTE: When adding a new public API, always add it directly to the `PublicAPI.Shi
 
 ### Guides
 
+- [Quickstart](./docs/quickstart.md)
 - [Command line options](./docs/commandline.md)
 - [TestCase filtering](./docs/filter.md)
 - [Passing runsettings from the command line](./docs/RunSettingsArguments.md)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ NOTE: When adding a new public API, always add it directly to the `PublicAPI.Shi
 - [Diagnostics](./docs/diagnose.md)
 - [Environment Variables](./docs/environment-variables.md)
 - [Troubleshooting guide](./docs/troubleshooting.md)
+- [Roadmap](./docs/releases.md)
 - Command-line options reference: [vstest.console.exe options](https://learn.microsoft.com/visualstudio/test/vstest-console-options) and [dotnet test options](https://learn.microsoft.com/dotnet/core/tools/dotnet-test)
 
 ## Building

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -82,7 +82,7 @@ don't use a data collector, and don't disable app domains.
 
 Target platform architecture to be used for test execution. Values are parsed
 case-insensitively; valid values are `x86`, `x64`, `ARM`, `ARM64`, `S390x`, `Ppc64le`,
-`RiscV64` and `LoongArch64`. (The built-in `--Help` text only lists `x86`, `x64` and `ARM`.)
+`RiscV64` and `LoongArch64`.
 
 ### `/Framework:<Framework Version>`
 

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -1,0 +1,231 @@
+# vstest.console.exe command line options
+
+This document lists the command line options understood by `vstest.console.exe`. It is
+generated from the argument processors in
+[`src/vstest.console/Processors`](../src/vstest.console/Processors) and mirrors the
+built-in `vstest.console.exe --Help` output.
+
+Options are case-insensitive and accept either a `/Option` or a `--Option` prefix (for
+example `/Parallel` and `--Parallel` are equivalent). Some options also have a short
+form (for example `/lt` for `/ListTests`). Options that take a value use a colon, for
+example `/Settings:test.runsettings`.
+
+> **Using `dotnet test`?** `dotnet test` exposes most of these capabilities through its
+> own switches (for example `--filter`, `--logger`, `--collect`, `--diag`,
+> `--results-directory`, `--framework`). See
+> [dotnet test options](https://learn.microsoft.com/dotnet/core/tools/dotnet-test) and
+> [vstest.console.exe options](https://learn.microsoft.com/visualstudio/test/vstest-console-options)
+> for the full, actively maintained reference. To pass runsettings values inline from
+> `dotnet test`, use the `-- [name]=[value]` syntax described in
+> [RunSettingsArguments.md](./RunSettingsArguments.md).
+
+## Usage
+
+```shell
+vstest.console.exe [TestFileNames] [Options]
+```
+
+`TestFileNames` are one or more test containers (assemblies or other sources) separated by
+spaces. Wildcards are supported, for example `**\*.Tests.dll`.
+
+## Test selection and filtering
+
+### `/Tests:<Test Names>`
+
+Run tests with names that match the provided values. To provide multiple values, separate
+them by commas.
+
+```shell
+vstest.console.exe MyTests.dll /Tests:TestMethod1
+vstest.console.exe MyTests.dll /Tests:TestMethod1,TestMethod2
+```
+
+### `/TestCaseFilter:<Expression>`
+
+Run tests that match the given expression. `<Expression>` is of the format
+`<property>Operator<value>[|&<Expression>]` where `Operator` is one of `=`, `!=` or `~`
+(`~` has *contains* semantics and applies to string properties such as `DisplayName`).
+Parentheses `()` group sub-expressions.
+
+```shell
+vstest.console.exe MyTests.dll /TestCaseFilter:"Priority=1"
+vstest.console.exe MyTests.dll /TestCaseFilter:"(FullyQualifiedName~Nightly|Name=MyTestMethod)"
+```
+
+See [filter.md](./filter.md) for the full filtering reference, supported properties per test
+framework, and escaping rules.
+
+### `/ListTests:<File Name>` (short form `/lt`)
+
+Lists all discovered tests from the given test container instead of running them.
+
+## Discovery and execution behavior
+
+### `/Parallel`
+
+Run the tests in parallel. By default up to all available cores on the machine may be
+used. The number of cores to use may be configured with the `MaxCpuCount` element in a
+settings file.
+
+### `/InIsolation`
+
+Runs the tests in an isolated process. This makes `vstest.console.exe` less likely to be
+stopped by an error in the tests, but tests may run slower.
+
+### `/Platform:<Platform type>`
+
+Target platform architecture to be used for test execution. Valid values are `x86`, `x64`
+and `ARM`.
+
+### `/Framework:<Framework Version>`
+
+Target .NET framework version to be used for test execution. Valid values are for example
+`".NETFramework,Version=v4.5.1"` or `".NETCoreApp,Version=v1.0"`. Other supported values
+are `Framework40`, `Framework45`, `FrameworkCore10` and `FrameworkUap10`.
+
+### `/Environment:<NAME>=<VALUE>` (short form `/e`)
+
+Sets the value of an environment variable for the test host. Creates the variable if it
+does not exist, overrides it if it does. This implies `/InIsolation` and forces the tests
+to run in an isolated process. Specify the option multiple times to set multiple
+variables.
+
+```shell
+vstest.console.exe MyTests.dll -e:VARIABLE1=VALUE1
+vstest.console.exe MyTests.dll -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
+```
+
+## Adapters
+
+### `/TestAdapterPath:<path>`
+
+Makes `vstest.console.exe` use custom test adapters from the given path in the test run.
+
+### `/TestAdapterLoadingStrategy:<strategy>`
+
+Affects adapter loading behavior. Supported values (which can be combined):
+
+| Strategy | Behavior |
+| --- | --- |
+| `Explicit` | Only load adapters specified by `/TestAdapterPath` (or the `RunConfiguration.TestAdaptersPaths` node). If no adapter path is specified, the run fails. Implies `/InIsolation`. |
+| `Default` | Load adapters as if the argument was not specified (next to source, provided paths, and the default directory). |
+| `DefaultRuntimeProviders` | Load the default runtime providers shipped with the Test Platform. |
+| `ExtensionsDirectory` | Load adapters inside the `Extensions` folder. |
+| `NextToSource` | Load adapters next to the source. |
+| `Recursive` | Recursively search folders when loading adapters. Requires `Explicit` or `NextToSource`. |
+
+## Settings
+
+### `/Settings:<Settings File>`
+
+Settings to use when running tests. See
+[configure.md](./configure.md) and the
+[.runsettings reference](https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file).
+
+### RunSettings arguments (`-- [name]=[value]`)
+
+Pass runsettings configuration inline through the command line. Arguments are specified as
+`[name]=[value]` pairs after `-- ` (note the space after `--`). Use a space to separate
+multiple pairs; all arguments after `--` are treated as runsettings arguments, so they must
+appear at the end of the command line.
+
+```shell
+vstest.console.exe MyTests.dll -- MSTest.MapInconclusiveToFailed=True
+```
+
+See [RunSettingsArguments.md](./RunSettingsArguments.md) for the full syntax, precedence
+rules, and shell-escaping guidance.
+
+## Loggers, data collection, and results
+
+### `/logger:<Logger Uri/FriendlyName>`
+
+Specify a logger for test results. For example, to log results into a Visual Studio Test
+Results File (TRX) use `/logger:trx[;LogFileName=<name>]`. The console logger verbosity can
+be set with `/logger:console;verbosity=<quiet|minimal|normal|detailed>`. More info:
+[console logger](https://aka.ms/console-logger).
+
+### `/Collect:<DataCollector FriendlyName>`
+
+Enables a data collector for the test run (for example `/Collect:"Code Coverage"` or
+`/Collect:"XPlat Code Coverage"`). More info: [vstest collect](https://aka.ms/vstest-collect).
+See [analyze.md](./analyze.md) for code coverage.
+
+### `/Blame:[CollectDump];[CollectAlways]=[Value];[DumpType]=[Value]`
+
+Runs the test in blame mode to isolate a problematic test that crashes the test host. It
+creates a `Sequence.xml` file capturing the order of execution before the crash, and can
+optionally collect a process dump.
+
+- `CollectAlways` — collect a dump on exit even when there is no crash (`true`/`false`).
+- `DumpType` — dump type (`mini`/`full`).
+
+Collecting a crash dump on Windows requires `procdump.exe`/`procdump64.exe` on `PATH` or in
+the directory pointed to by the `PROCDUMP_PATH` environment variable
+([download procdump](https://learn.microsoft.com/sysinternals/downloads/procdump)).
+
+```shell
+vstest.console.exe MyTests.dll /Blame
+vstest.console.exe MyTests.dll /Blame:CollectDump;CollectAlways=true;DumpType=full
+```
+
+See [extensions/blame-datacollector.md](./extensions/blame-datacollector.md) for the full
+blame collector reference.
+
+### `/ResultsDirectory:<path>`
+
+The test results directory is created at the specified path if it does not exist.
+
+## Diagnostics
+
+### `/Diag:<Path to log file>`
+
+Enable diagnostic logs for the test platform, written to the provided file. Set the trace
+level with `/Diag:<path>;tracelevel=<off|error|warning|info|verbose>` (default `verbose`).
+
+```shell
+vstest.console.exe MyTests.dll /Diag:log.txt
+vstest.console.exe MyTests.dll /Diag:log.txt;tracelevel=info
+```
+
+See [diagnose.md](./diagnose.md) and [troubleshooting.md](./troubleshooting.md) for more.
+
+## General
+
+### `/Help` (short form `/?`)
+
+Display the usage message.
+
+### `@<file>`
+
+Read a response file for more options. Each option is placed on its own line in the file.
+
+```shell
+vstest.console.exe @options.rsp
+```
+
+## Editor/IDE integration options
+
+These options are used by IDEs and hosting tools (such as Visual Studio and
+`dotnet test`) that host `vstest.console.exe`. They are not typically used directly from a
+shell.
+
+### `/Port:<Port>`
+
+The port for the socket connection used to receive event messages from the host.
+
+### `/ParentProcessId:<ParentProcessId>`
+
+Process id of the parent process responsible for launching the current process. Used so the
+runner can exit when its parent exits.
+
+## See also
+
+- [filter.md](./filter.md) — test case filtering reference
+- [RunSettingsArguments.md](./RunSettingsArguments.md) — passing runsettings from the command line
+- [configure.md](./configure.md) — `.runsettings` configuration
+- [analyze.md](./analyze.md) — code coverage
+- [diagnose.md](./diagnose.md) / [troubleshooting.md](./troubleshooting.md) — diagnostics
+- [environment-variables.md](./environment-variables.md) — environment variables
+- [vstest.console.exe options (Microsoft Learn)](https://learn.microsoft.com/visualstudio/test/vstest-console-options)
+- [dotnet test options (Microsoft Learn)](https://learn.microsoft.com/dotnet/core/tools/dotnet-test)

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -253,11 +253,28 @@ that discovers/selects zero tests return `1` instead.
 
 ## Omitted switches
 
-`vstest.console.exe` also accepts a number of internal, legacy, or hidden switches that are
-**not** shown by `--Help` (for example `/EnableCodeCoverage`, `/UseVsixExtensions`, and various
-internal switches used by IDEs and the SDK such as `/ListFullyQualifiedTests`,
-`/ListTestsTargetPath`, `/TestSessionCorrelationId` and `/ArtifactsProcessingMode-*`). Those are
-intentionally omitted here.
+`vstest.console.exe` accepts a number of additional internal, legacy, or hidden switches that
+are not intended for direct use from a shell (they are driven by IDEs, the .NET SDK, or other
+tooling). Most are not shown by `--Help`; `/TestAdapterLoadingStrategy` is the exception — it
+appears in `--Help` but is left out of the reference above because it is an advanced adapter
+option. For completeness, the full set omitted from the reference above is:
+
+| Switch | Purpose |
+| --- | --- |
+| `/EnableCodeCoverage` | Enables the code coverage data collector. Prefer `/Collect:"Code Coverage"`. |
+| `/UseVsixExtensions` | Enables loading of legacy VSIX-installed test adapters. Deprecated. |
+| `/TestAdapterLoadingStrategy` | Controls the order/strategy used to load custom test adapters. |
+| `/DisableAutoFakes` | Disables automatic Microsoft Fakes support. |
+| `/AeDebugger` | Configures the just-in-time (AeDebugger) crash-debugging hook for test hosts. |
+| `/ListFullyQualifiedTests` | Discovers tests and writes their fully qualified names to a file (used with `/ListTestsTargetPath`). |
+| `/ListTestsTargetPath` | Path of the file that `/ListFullyQualifiedTests` writes discovered test names to. |
+| `/TestSessionCorrelationId` | Correlation id used to associate a run with its artifacts across processes. |
+| `/ArtifactsProcessingMode-Collect` | Marks a run so its artifacts are collected for later post-processing. |
+| `/ArtifactsProcessingMode-PostProcess` | Post-processes artifacts collected from earlier runs. |
+| `/ShowDeprecateDotnetVSTestMessage` | Controls whether the `dotnet vstest` deprecation message is shown. |
+| `/RunTests` | Internal command used by design-mode hosts to run the provided tests. |
+| `/TestSource` | Internal command used by design-mode hosts to pass a test source. |
+
 
 ## See also
 

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -1,9 +1,10 @@
 # vstest.console.exe command line options
 
-This document describes the command line options shown by `vstest.console.exe --Help` — the
-options intended for direct use. It is generated from the argument processors in
-[`src/vstest.console/Processors`](../src/vstest.console/Processors) and mirrors the built-in
-`--Help` output.
+This document describes the command line options intended for direct use — the ones shown by
+`vstest.console.exe --Help`. It is generated from the argument processors in
+[`src/vstest.console/Processors`](../src/vstest.console/Processors) and largely follows the
+built-in `--Help` output. A few advanced or internal switches are left out of the main
+reference and collected in [Omitted switches](#omitted-switches) instead.
 
 Options are case-insensitive and accept either a `/Option` or a `--Option` prefix (for
 example `/Parallel` and `--Parallel` are equivalent). Some options also have a short

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -1,9 +1,15 @@
 # vstest.console.exe command line options
 
-This document lists the command line options understood by `vstest.console.exe`. It is
-generated from the argument processors in
-[`src/vstest.console/Processors`](../src/vstest.console/Processors) and mirrors the
-built-in `vstest.console.exe --Help` output.
+This document describes the command line options shown by `vstest.console.exe --Help` — the
+options intended for direct use. It is generated from the argument processors in
+[`src/vstest.console/Processors`](../src/vstest.console/Processors) and mirrors the built-in
+`--Help` output.
+
+`vstest.console.exe` also accepts a number of internal, legacy, or hidden switches that are
+**not** shown by `--Help` (for example `/EnableCodeCoverage`, `/UseVsixExtensions`, and various
+internal switches used by IDEs and the SDK such as `/ListFullyQualifiedTests`,
+`/ListTestsTargetPath`, `/TestSessionCorrelationId` and `/ArtifactsProcessingMode-*`). Those are
+intentionally omitted here.
 
 Options are case-insensitive and accept either a `/Option` or a `--Option` prefix (for
 example `/Parallel` and `--Parallel` are equivalent). Some options also have a short
@@ -27,7 +33,8 @@ vstest.console.exe [TestFileNames] [Options]
 ```
 
 `TestFileNames` are one or more test containers (assemblies or other sources) separated by
-spaces. Wildcards are supported, for example `**\*.Tests.dll`.
+spaces. Wildcards are supported, for example `**/*.Tests.dll`. Use forward slashes (`/`) in
+wildcard patterns so they work on Windows, Linux and macOS.
 
 ## Test selection and filtering
 
@@ -243,13 +250,13 @@ When discovery finds no matching tests the runner prints a **warning** (not an e
 "no tests" condition by itself does not produce an `Error:` line. The message depends on the
 situation:
 
-- A filter matched nothing: `No test matches the given testcase filter '<filter>' in <sources>`.
+- A filter matched nothing: ``No test matches the given testcase filter `<filter>` in <sources>`` (the filter value is shown in backticks).
 - Nothing was discovered from a source: `No test is available in <sources>. Make sure that installed test discoverers & executors, platform & framework version settings are appropriate and try again.` If `/TestAdapterPath` was not provided, a suggestion to specify it is appended.
 - `/Tests:<names>` matched nothing although tests were discovered: `A total of <N> tests were discovered but no test matches the specified selection criteria(<names>). Use right value(s) and try again.`
 
-The exit code is **not uniform** across these cases: a `/Tests` selection that matches nothing
-performs no run and returns `0`, whereas a run that completes with zero results is treated as a
-failure and returns `1`.
+By default this is **not** treated as a failure: the run prints the warning and still returns
+`0`. Set `RunConfiguration.TreatNoTestsAsError` to `true` in a `.runsettings` file to make a run
+that discovers/selects zero tests return `1` instead.
 
 ## See also
 

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -255,9 +255,9 @@ that discovers/selects zero tests return `1` instead.
 
 `vstest.console.exe` accepts a number of additional internal, legacy, or hidden switches that
 are not intended for direct use from a shell (they are driven by IDEs, the .NET SDK, or other
-tooling). Most are not shown by `--Help`; `/TestAdapterLoadingStrategy` is the exception — it
-appears in `--Help` but is left out of the reference above because it is an advanced adapter
-option. For completeness, the full set omitted from the reference above is:
+tooling). Some are shown by `--Help` (notably `/TestAdapterLoadingStrategy`) but are left out
+of the reference above because they are advanced options; the rest are not shown by `--Help` at
+all. For completeness, the full set omitted from the reference above is:
 
 | Switch | Purpose |
 | --- | --- |
@@ -266,6 +266,10 @@ option. For completeness, the full set omitted from the reference above is:
 | `/TestAdapterLoadingStrategy` | Controls the order/strategy used to load custom test adapters. |
 | `/DisableAutoFakes` | Disables automatic Microsoft Fakes support. |
 | `/AeDebugger` | Configures the just-in-time (AeDebugger) crash-debugging hook for test hosts. |
+| `/ListDiscoverers` | Lists the installed test discoverers. |
+| `/ListExecutors` | Lists the installed test executors. |
+| `/ListLoggers` | Lists the installed loggers. |
+| `/ListSettingsProviders` | Lists the installed settings providers. |
 | `/ListFullyQualifiedTests` | Discovers tests and writes their fully qualified names to a file (used with `/ListTestsTargetPath`). |
 | `/ListTestsTargetPath` | Path of the file that `/ListFullyQualifiedTests` writes discovered test names to. |
 | `/TestSessionCorrelationId` | Correlation id used to associate a run with its artifacts across processes. |
@@ -274,6 +278,7 @@ option. For completeness, the full set omitted from the reference above is:
 | `/ShowDeprecateDotnetVSTestMessage` | Controls whether the `dotnet vstest` deprecation message is shown. |
 | `/RunTests` | Internal command used by design-mode hosts to run the provided tests. |
 | `/TestSource` | Internal command used by design-mode hosts to pass a test source. |
+
 
 
 ## See also

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -1,7 +1,7 @@
 # vstest.console.exe command line options
 
 This document describes the command line options intended for direct use — the ones shown by
-`vstest.console.exe --Help`. It is generated from the argument processors in
+`vstest.console.exe --Help`. It is derived from the argument processors in
 [`src/vstest.console/Processors`](../src/vstest.console/Processors) and largely follows the
 built-in `--Help` output. A few advanced or internal switches are left out of the main
 reference and collected in [Omitted switches](#omitted-switches) instead.

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -194,7 +194,7 @@ See [diagnose.md](./diagnose.md) and [troubleshooting.md](./troubleshooting.md) 
 
 ## General
 
-### `/Help` (short form `/?`)
+### `/Help` (short form `/?` or `-?`)
 
 Display the usage message.
 

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -224,6 +224,33 @@ The port for the socket connection used to receive event messages from the host.
 Process id of the parent process responsible for launching the current process. Used so the
 runner can exit when its parent exits.
 
+## Exit codes
+
+`vstest.console.exe` returns only two exit codes:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success — the requested operation completed and, for a test run, all executed tests passed. |
+| `1` | Failure — for example one or more tests failed, a run error was reported, the command line was invalid or missing, a test source could not be loaded, or the run was aborted or canceled. |
+
+The process never returns any other value (`Program.Main` returns `0` on success and `1`
+otherwise). When invoked through `dotnet test`, the SDK surfaces a non-zero exit code when
+the run fails in the same way.
+
+### When no tests are found
+
+When discovery finds no matching tests the runner prints a **warning** (not an error), so the
+"no tests" condition by itself does not produce an `Error:` line. The message depends on the
+situation:
+
+- A filter matched nothing: `No test matches the given testcase filter '<filter>' in <sources>`.
+- Nothing was discovered from a source: `No test is available in <sources>. Make sure that installed test discoverers & executors, platform & framework version settings are appropriate and try again.` If `/TestAdapterPath` was not provided, a suggestion to specify it is appended.
+- `/Tests:<names>` matched nothing although tests were discovered: `A total of <N> tests were discovered but no test matches the specified selection criteria(<names>). Use right value(s) and try again.`
+
+The exit code is **not uniform** across these cases: a `/Tests` selection that matches nothing
+performs no run and returns `0`, whereas a run that completes with zero results is treated as a
+failure and returns `1`.
+
 ## See also
 
 - [filter.md](./filter.md) — test case filtering reference

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -144,8 +144,7 @@ use `/logger:trx;LogFilePrefix=<prefix>` rather than `LogFileName=<name>` when y
 timestamped file per run — `LogFileName` sets the name explicitly and overwrites the previous
 file, whereas `LogFilePrefix` keeps each run's file. The console logger verbosity can be set
 with `/logger:console;verbosity=<quiet|minimal|normal|detailed>`. See
-[report.md](./report.md) for all logger options and
-[console logger](https://aka.ms/console-logger).
+[report.md](./report.md) for all loggers and their options.
 
 ### `/Collect:<DataCollector FriendlyName>`
 

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -144,8 +144,8 @@ use `/logger:trx;LogFilePrefix=<prefix>` rather than `LogFileName=<name>` when y
 timestamped file per run — `LogFileName` sets the name explicitly and overwrites the previous
 file, whereas `LogFilePrefix` keeps each run's file. The console logger verbosity can be set
 with `/logger:console;verbosity=<quiet|minimal|normal|detailed>`. See
-[report.md](https://github.com/Microsoft/vstest-docs/blob/main/docs/report.md) for all logger
-options and [console logger](https://aka.ms/console-logger).
+[report.md](./report.md) for all logger options and
+[console logger](https://aka.ms/console-logger).
 
 ### `/Collect:<DataCollector FriendlyName>`
 
@@ -220,8 +220,9 @@ The port for the socket connection used to receive event messages from the host.
 
 ### `/ParentProcessId:<ParentProcessId>`
 
-Process id of the parent process responsible for launching the current process. Used so the
-runner can exit when its parent exits.
+Records the process id of the parent process that launched the runner. On its own this only
+stores the value; the runner watches the parent and exits when it exits as part of design-mode
+(IDE) integration, which is activated together with `/Port`.
 
 ## Exit codes
 

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -5,12 +5,6 @@ options intended for direct use. It is generated from the argument processors in
 [`src/vstest.console/Processors`](../src/vstest.console/Processors) and mirrors the built-in
 `--Help` output.
 
-`vstest.console.exe` also accepts a number of internal, legacy, or hidden switches that are
-**not** shown by `--Help` (for example `/EnableCodeCoverage`, `/UseVsixExtensions`, and various
-internal switches used by IDEs and the SDK such as `/ListFullyQualifiedTests`,
-`/ListTestsTargetPath`, `/TestSessionCorrelationId` and `/ArtifactsProcessingMode-*`). Those are
-intentionally omitted here.
-
 Options are case-insensitive and accept either a `/Option` or a `--Option` prefix (for
 example `/Parallel` and `--Parallel` are equivalent). Some options also have a short
 form, which accepts a `/` or `-` prefix (for example `/lt` or `-lt` for `/ListTests`, and
@@ -80,18 +74,23 @@ settings file.
 Runs the tests in an isolated process. This makes `vstest.console.exe` less likely to be
 stopped by an error in the tests, but tests may run slower.
 
+In practice most runs already happen in isolation — the main exception is .NET Framework
+test assemblies, which can run inside the runner process when they don't run in parallel,
+don't use a data collector, and don't disable app domains.
+
 ### `/Platform:<Platform type>`
 
 Target platform architecture to be used for test execution. Values are parsed
 case-insensitively; valid values are `x86`, `x64`, `ARM`, `ARM64`, `S390x`, `Ppc64le`,
-`RiscV64` and `LoongArch64`. (The built-in `--Help` text historically lists only `x86`,
-`x64` and `ARM`, but the argument processor accepts the full set above.)
+`RiscV64` and `LoongArch64`. (The built-in `--Help` text only lists `x86`, `x64` and `ARM`.)
 
 ### `/Framework:<Framework Version>`
 
-Target .NET framework version to be used for test execution. Valid values are for example
-`".NETFramework,Version=v4.5.1"` or `".NETCoreApp,Version=v1.0"`. Other supported values
-are `Framework40`, `Framework45`, `FrameworkCore10` and `FrameworkUap10`.
+Target .NET framework version to be used for test execution. Values are parsed with NuGet's
+framework parser, so the common short forms work, for example `net48`, `net6.0` or `net10.0`
+(as well as the long forms `".NETFramework,Version=v4.8"` and `".NETCoreApp,Version=v10.0"`).
+The legacy aliases `Framework40`, `Framework45`, `FrameworkCore10` and `FrameworkUap10` are
+also accepted.
 
 ### `/Environment:<NAME>=<VALUE>` (short form `/e`)
 
@@ -109,20 +108,9 @@ vstest.console.exe MyTests.dll -e:ANOTHER_VARIABLE="VALUE WITH SPACES"
 
 ### `/TestAdapterPath:<path>`
 
-Makes `vstest.console.exe` use custom test adapters from the given path in the test run.
-
-### `/TestAdapterLoadingStrategy:<strategy>`
-
-Affects adapter loading behavior. Supported values (which can be combined):
-
-| Strategy | Behavior |
-| --- | --- |
-| `Explicit` | Only load adapters specified by `/TestAdapterPath` (or the `RunConfiguration.TestAdaptersPaths` node). If no adapter path is specified, the run fails. Implies `/InIsolation`. |
-| `Default` | Load adapters as if the argument was not specified (next to source, provided paths, and the default directory). |
-| `DefaultRuntimeProviders` | Load the default runtime providers shipped with the Test Platform. |
-| `ExtensionsDirectory` | Load adapters inside the `Extensions` folder. |
-| `NextToSource` | Load adapters next to the source. |
-| `Recursive` | Recursively search folders when loading adapters. Requires `Explicit` or `NextToSource`. |
+Makes `vstest.console.exe` use custom test adapters from the given path in the test run. The
+value is a path to a *folder* that contains the adapter assemblies, not a path to a single
+adapter `.dll`.
 
 ## Settings
 
@@ -151,9 +139,13 @@ rules, and shell-escaping guidance.
 ### `/logger:<Logger Uri/FriendlyName>`
 
 Specify a logger for test results. For example, to log results into a Visual Studio Test
-Results File (TRX) use `/logger:trx[;LogFileName=<name>]`. The console logger verbosity can
-be set with `/logger:console;verbosity=<quiet|minimal|normal|detailed>`. More info:
-[console logger](https://aka.ms/console-logger).
+Results File (TRX) use `/logger:trx`. By default the TRX file is named after the test run;
+use `/logger:trx;LogFilePrefix=<prefix>` rather than `LogFileName=<name>` when you want a
+timestamped file per run — `LogFileName` sets the name explicitly and overwrites the previous
+file, whereas `LogFilePrefix` keeps each run's file. The console logger verbosity can be set
+with `/logger:console;verbosity=<quiet|minimal|normal|detailed>`. See
+[report.md](https://github.com/Microsoft/vstest-docs/blob/main/docs/report.md) for all logger
+options and [console logger](https://aka.ms/console-logger).
 
 ### `/Collect:<DataCollector FriendlyName>`
 
@@ -257,6 +249,14 @@ situation:
 By default this is **not** treated as a failure: the run prints the warning and still returns
 `0`. Set `RunConfiguration.TreatNoTestsAsError` to `true` in a `.runsettings` file to make a run
 that discovers/selects zero tests return `1` instead.
+
+## Omitted switches
+
+`vstest.console.exe` also accepts a number of internal, legacy, or hidden switches that are
+**not** shown by `--Help` (for example `/EnableCodeCoverage`, `/UseVsixExtensions`, and various
+internal switches used by IDEs and the SDK such as `/ListFullyQualifiedTests`,
+`/ListTestsTargetPath`, `/TestSessionCorrelationId` and `/ArtifactsProcessingMode-*`). Those are
+intentionally omitted here.
 
 ## See also
 

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -7,7 +7,8 @@ built-in `vstest.console.exe --Help` output.
 
 Options are case-insensitive and accept either a `/Option` or a `--Option` prefix (for
 example `/Parallel` and `--Parallel` are equivalent). Some options also have a short
-form (for example `/lt` for `/ListTests`). Options that take a value use a colon, for
+form, which accepts a `/` or `-` prefix (for example `/lt` or `-lt` for `/ListTests`, and
+`/e` or `-e` for `/Environment`). Options that take a value use a colon, for
 example `/Settings:test.runsettings`.
 
 > **Using `dotnet test`?** `dotnet test` exposes most of these capabilities through its
@@ -15,7 +16,7 @@ example `/Settings:test.runsettings`.
 > `--results-directory`, `--framework`). See
 > [dotnet test options](https://learn.microsoft.com/dotnet/core/tools/dotnet-test) and
 > [vstest.console.exe options](https://learn.microsoft.com/visualstudio/test/vstest-console-options)
-> for the full, actively maintained reference. To pass runsettings values inline from
+> for the complete option reference. To pass runsettings values inline from
 > `dotnet test`, use the `-- [name]=[value]` syntax described in
 > [RunSettingsArguments.md](./RunSettingsArguments.md).
 
@@ -74,8 +75,10 @@ stopped by an error in the tests, but tests may run slower.
 
 ### `/Platform:<Platform type>`
 
-Target platform architecture to be used for test execution. Valid values are `x86`, `x64`
-and `ARM`.
+Target platform architecture to be used for test execution. Values are parsed
+case-insensitively; valid values are `x86`, `x64`, `ARM`, `ARM64`, `S390x`, `Ppc64le`,
+`RiscV64` and `LoongArch64`. (The built-in `--Help` text historically lists only `x86`,
+`x64` and `ARM`, but the argument processor accepts the full set above.)
 
 ### `/Framework:<Framework Version>`
 
@@ -198,7 +201,9 @@ Display the usage message.
 
 ### `@<file>`
 
-Read a response file for more options. Each option is placed on its own line in the file.
+Read additional options from a response file. The file contents are read and parsed like a
+normal command line: arguments are separated by whitespace (spaces or newlines) and quoting
+is supported, so options may be placed on one line or spread across multiple lines.
 
 ```shell
 vstest.console.exe @options.rsp

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -180,8 +180,8 @@ This document lists all environment variables that are understood and handled by
 - **Example**: `VSTEST_DISABLE_UTF8_CONSOLE_ENCODING=1`
 
 ### VSTEST_DISABLE_DOTNET_ROOT_ON_NONWINDOWS
-- **Description**: Disables setting the `DOTNET_ROOT` environment variable on non-Windows platforms. `DOTNET_ROOT` is now always set (previously it was set only on Windows when `testhost.exe` was found) so that frameworks such as xUnit v3 can run tests in a child process. Set this flag to restore the previous behavior.
-- **Values**: Set to any non-zero value to disable
+- **Description**: Reverts to the older, more conservative way of pointing the testhost at the correct `dotnet` installation. By default (flag unset), when a dotnet root path is known (from `VSTEST_DOTNET_ROOT_PATH`, typically set by `dotnet test`, or derived from `DOTNET_ROOT`), vstest sets the architecture-specific `DOTNET_ROOT_<ARCH>` environment variable for the testhost on every run and platform, so it propagates to the testhost and its child processes (needed, for example, when xUnit v3 runs a separate executable under the testhost). Setting this flag restores the previous behavior of setting `DOTNET_ROOT_<ARCH>` only on Windows after `testhost.exe` is located; older (netcoreapp3.1) testhosts that don't understand `DOTNET_ROOT_<ARCH>` fall back to `DOTNET_ROOT(x86)` / `DOTNET_ROOT`.
+- **Values**: Set to any non-zero value to enable the flag (revert to the old behavior)
 - **Example**: `VSTEST_DISABLE_DOTNET_ROOT_ON_NONWINDOWS=1`
 
 ### VSTEST_DISABLE_DYNAMICNATIVE_CODECOVERAGE_DEFAULT_SETTING
@@ -250,7 +250,7 @@ This document lists all environment variables that are understood and handled by
 ## Discovery Variables
 
 ### VSTEST_BACKGROUND_DISCOVERY
-- **Description**: Hints that a discovery is running in the background (for example the continuous discovery an IDE performs while editing). When set to "1" and no explicit `MaxCpuCount` is configured, the platform reduces the number of cores used for parallel discovery to leave processing power for other tasks. Passed as a run settings environment variable (`RunConfiguration/EnvironmentVariables`) rather than a process environment variable, and set by the host (for example Visual Studio).
+- **Description**: Hints that a discovery is running in the background (for example the continuous discovery an IDE performs while editing). It is typically specified via run settings (`RunConfiguration/EnvironmentVariables`) by the host (for example Visual Studio) and then propagated into the testhost process environment. When set to "1" it has two effects: the platform reduces the number of cores used for parallel discovery when no explicit `MaxCpuCount` is configured (to leave processing power for other tasks), and the testhost process priority is lowered to `BelowNormal`.
 - **Values**: Set to "1" to enable
 - **Example**: `VSTEST_BACKGROUND_DISCOVERY=1`
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -179,7 +179,7 @@ This document lists environment variables that are currently handled by VSTest s
 - **Example**: `VSTEST_DISABLE_UTF8_CONSOLE_ENCODING=1`
 
 ### VSTEST_DISABLE_DOTNET_ROOT_ON_NONWINDOWS
-- **Description**: Reverts to the older, more conservative way of pointing the testhost at the correct `dotnet` installation. By default (flag unset), when a dotnet root path is known (from `VSTEST_DOTNET_ROOT_PATH`, typically set by `dotnet test`, or derived from `DOTNET_ROOT`), vstest sets the architecture-specific `DOTNET_ROOT_<ARCH>` environment variable for the testhost on every run and platform, so it propagates to the testhost and its child processes (needed, for example, when xUnit v3 runs a separate executable under the testhost). Setting this flag restores the previous behavior of setting `DOTNET_ROOT_<ARCH>` only on Windows after `testhost.exe` is located; older (netcoreapp3.1) testhosts that don't understand `DOTNET_ROOT_<ARCH>` fall back to `DOTNET_ROOT(x86)` / `DOTNET_ROOT`.
+- **Description**: Reverts to the older, more conservative way of pointing the testhost at the correct `dotnet` installation. By default (flag unset), when a dotnet root path is known, vstest sets the architecture-specific `DOTNET_ROOT_<ARCH>` environment variable for the testhost on every run and platform, so it propagates to the testhost and its child processes (needed, for example, when xUnit v3 runs a separate executable under the testhost). The dotnet root path comes from `VSTEST_DOTNET_ROOT_PATH` (typically set by `dotnet test`); when that is not set — a direct `vstest.console` run — vstest can derive it from `DOTNET_ROOT`, but only on Windows, because the derivation probes `dotnet.exe` PE headers to detect the install architecture and that probe returns nothing on Linux/macOS (so `DOTNET_ROOT` is not auto-derived there). Setting this flag restores the previous behavior of setting `DOTNET_ROOT_<ARCH>` only on Windows after `testhost.exe` is located; older (netcoreapp3.1) testhosts that don't understand `DOTNET_ROOT_<ARCH>` fall back to `DOTNET_ROOT(x86)` / `DOTNET_ROOT`.
 - **Values**: Set to any value other than `0` (for example `1`) to enable the flag and revert to the old behavior. Treated as unset only when absent or exactly `0`.
 - **Example**: `VSTEST_DISABLE_DOTNET_ROOT_ON_NONWINDOWS=1`
 
@@ -234,7 +234,7 @@ This document lists environment variables that are currently handled by VSTest s
 - **Example**: `VSTEST_IGNORE_DOTNET_ROOT=1`
 
 ### VSTEST_DOTNET_ROOT_PATH
-- **Description**: Path to the `dotnet` root that the SDK wants the testhost to use. When set (together with `VSTEST_DOTNET_ROOT_ARCHITECTURE`), vstest configures the architecture-specific `DOTNET_ROOT(x86)` / `DOTNET_ROOT_<ARCH>` environment variables for the testhost so it resolves the correct `hostfxr`. Set by the .NET SDK; not typically set by hand.
+- **Description**: Path to the `dotnet` root that the SDK wants the testhost to use. When set (together with `VSTEST_DOTNET_ROOT_ARCHITECTURE`), vstest points the testhost at the correct `hostfxr` by setting a `DOTNET_ROOT`-family environment variable. The exact variable depends on the testhost: newer testhosts (17.14+, built against net8) understand and get the architecture-specific `DOTNET_ROOT_<ARCH>`, while older (netcoreapp3.1) testhosts get `DOTNET_ROOT(x86)` when the target architecture is x86 and fall back to the architecture-less `DOTNET_ROOT` otherwise. Set by the .NET SDK; not typically set by hand.
 - **Example**: `VSTEST_DOTNET_ROOT_PATH=C:\Program Files\dotnet`
 
 ### VSTEST_DOTNET_ROOT_ARCHITECTURE

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -180,12 +180,12 @@ This document lists environment variables that are currently handled by VSTest s
 
 ### VSTEST_DISABLE_DOTNET_ROOT_ON_NONWINDOWS
 - **Description**: Reverts to the older, more conservative way of pointing the testhost at the correct `dotnet` installation. By default (flag unset), when a dotnet root path is known (from `VSTEST_DOTNET_ROOT_PATH`, typically set by `dotnet test`, or derived from `DOTNET_ROOT`), vstest sets the architecture-specific `DOTNET_ROOT_<ARCH>` environment variable for the testhost on every run and platform, so it propagates to the testhost and its child processes (needed, for example, when xUnit v3 runs a separate executable under the testhost). Setting this flag restores the previous behavior of setting `DOTNET_ROOT_<ARCH>` only on Windows after `testhost.exe` is located; older (netcoreapp3.1) testhosts that don't understand `DOTNET_ROOT_<ARCH>` fall back to `DOTNET_ROOT(x86)` / `DOTNET_ROOT`.
-- **Values**: Set to any non-zero value to enable the flag (revert to the old behavior)
+- **Values**: Set to any value other than `0` (for example `1`) to enable the flag and revert to the old behavior. Treated as unset only when absent or exactly `0`.
 - **Example**: `VSTEST_DISABLE_DOTNET_ROOT_ON_NONWINDOWS=1`
 
 ### VSTEST_DISABLE_DYNAMICNATIVE_CODECOVERAGE_DEFAULT_SETTING
 - **Description**: Disables turning dynamic code coverage for native code OFF by default. When set, the platform skips adding the default setting that disables native dynamic code coverage.
-- **Values**: Set to any non-zero value to disable
+- **Values**: Set to any value other than `0` (for example `1`) to enable this flag (skip adding the default setting). Treated as unset only when absent or exactly `0`.
 - **Example**: `VSTEST_DISABLE_DYNAMICNATIVE_CODECOVERAGE_DEFAULT_SETTING=1`
 
 ## Build and MSBuild Integration Variables
@@ -249,7 +249,7 @@ This document lists environment variables that are currently handled by VSTest s
 ## Discovery Variables
 
 ### VSTEST_BACKGROUND_DISCOVERY
-- **Description**: Hints that a discovery is running in the background (for example the continuous discovery an IDE performs while editing). It is typically specified via run settings (`RunConfiguration/EnvironmentVariables`) by the host (for example Visual Studio) and then propagated into the testhost process environment. When set to "1" it has two effects: the platform reduces the number of cores used for parallel discovery when no explicit `MaxCpuCount` is configured (to leave processing power for other tasks), and the testhost process priority is lowered to `BelowNormal`.
+- **Description**: Hints that a discovery is running in the background (for example the continuous discovery an IDE performs while editing). It is typically specified via run settings (`RunConfiguration/EnvironmentVariables`) by the host (for example Visual Studio) and then propagated into the testhost process environment. When set to "1" it has two effects: the platform reduces the number of cores used for parallelism (this applies to both test discovery and execution) when no explicit `MaxCpuCount` is configured, so it leaves processing power for other tasks, and the testhost process priority is lowered to `BelowNormal`.
 - **Values**: Set to "1" to enable
 - **Example**: `VSTEST_BACKGROUND_DISCOVERY=1`
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -179,6 +179,16 @@ This document lists all environment variables that are understood and handled by
 - **Values**: Set to "1" to disable
 - **Example**: `VSTEST_DISABLE_UTF8_CONSOLE_ENCODING=1`
 
+### VSTEST_DISABLE_DOTNET_ROOT_ON_NONWINDOWS
+- **Description**: Disables setting the `DOTNET_ROOT` environment variable on non-Windows platforms. `DOTNET_ROOT` is now always set (previously it was set only on Windows when `testhost.exe` was found) so that frameworks such as xUnit v3 can run tests in a child process. Set this flag to restore the previous behavior.
+- **Values**: Set to any non-zero value to disable
+- **Example**: `VSTEST_DISABLE_DOTNET_ROOT_ON_NONWINDOWS=1`
+
+### VSTEST_DISABLE_DYNAMICNATIVE_CODECOVERAGE_DEFAULT_SETTING
+- **Description**: Disables turning dynamic code coverage for native code OFF by default. When set, the platform skips adding the default setting that disables native dynamic code coverage.
+- **Values**: Set to any non-zero value to disable
+- **Example**: `VSTEST_DISABLE_DYNAMICNATIVE_CODECOVERAGE_DEFAULT_SETTING=1`
+
 ## Build and MSBuild Integration Variables
 
 ### VSTEST_BUILD_DEBUG
@@ -224,10 +234,25 @@ This document lists all environment variables that are understood and handled by
 - **Default**: "0" (respects DOTNET_ROOT)
 - **Example**: `VSTEST_IGNORE_DOTNET_ROOT=1`
 
+### VSTEST_DOTNET_ROOT_PATH
+- **Description**: Path to the `dotnet` root that the SDK wants the testhost to use. When set (together with `VSTEST_DOTNET_ROOT_ARCHITECTURE`), vstest configures the architecture-specific `DOTNET_ROOT(x86)` / `DOTNET_ROOT_<ARCH>` environment variables for the testhost so it resolves the correct `hostfxr`. Set by the .NET SDK; not typically set by hand.
+- **Example**: `VSTEST_DOTNET_ROOT_PATH=C:\Program Files\dotnet`
+
+### VSTEST_DOTNET_ROOT_ARCHITECTURE
+- **Description**: The target architecture that goes together with `VSTEST_DOTNET_ROOT_PATH`, used to pick the correct architecture-specific `DOTNET_ROOT_<ARCH>` variable for the testhost. Set by the .NET SDK; not typically set by hand.
+- **Example**: `VSTEST_DOTNET_ROOT_ARCHITECTURE=x64`
+
 ### VSTEST_SKIP_FAKES_CONFIGURATION
 - **Description**: Skips Microsoft Fakes configuration during test execution.
 - **Values**: Set to "1" to skip
 - **Example**: `VSTEST_SKIP_FAKES_CONFIGURATION=1`
+
+## Discovery Variables
+
+### VSTEST_BACKGROUND_DISCOVERY
+- **Description**: Hints that a discovery is running in the background (for example the continuous discovery an IDE performs while editing). When set to "1" and no explicit `MaxCpuCount` is configured, the platform reduces the number of cores used for parallel discovery to leave processing power for other tasks. Passed as a run settings environment variable (`RunConfiguration/EnvironmentVariables`) rather than a process environment variable, and set by the host (for example Visual Studio).
+- **Values**: Set to "1" to enable
+- **Example**: `VSTEST_BACKGROUND_DISCOVERY=1`
 
 ## UWP (Universal Windows Platform) Variables
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,1 +1,84 @@
 # Quickstart Guide
+
+This guide gets you running tests from the command line with the Visual Studio Test Platform
+(`vstest.console.exe`). For the exhaustive option list see
+[command line options](./commandline.md).
+
+## Which command should I use?
+
+Most people don't run `vstest.console.exe` directly. Pick the entry point that fits your setup:
+
+| You have… | Use | Notes |
+| --- | --- | --- |
+| The .NET SDK | `dotnet test` | Recommended. Builds the project and wraps `vstest.console` for you. |
+| A built test assembly / CI runner | `vstest.console.exe <TestFile>` | The standalone runner. Does not build; you point it at already-built assemblies. |
+| Old habit of `dotnet vstest` | Prefer `dotnet test` | `dotnet vstest` is deprecated in favor of `dotnet test`. |
+
+## Getting the standalone runner
+
+`vstest.console.exe` is not a separate download; it ships inside the
+[`Microsoft.TestPlatform`](https://www.nuget.org/packages/Microsoft.TestPlatform) NuGet
+package (and with Visual Studio). After restoring/extracting that package, the runner lives
+under the package's `tools/` folder:
+
+- **.NET Framework build** — `tools/net462/Common7/IDE/Extensions/TestPlatform/vstest.console.exe`. Requires .NET Framework (Windows).
+- **.NET build** — the `vstest.console.dll` under the package's .NET `tools/` folder, launched with `dotnet path\to\vstest.console.dll`. Requires a compatible .NET runtime and is cross-platform.
+
+When you use `dotnet test`, the runner and a matching runtime are already provided by the .NET
+SDK (pinned by your `global.json`), so there is nothing extra to install.
+
+## Your first run
+
+1. Build a test project (for example an MSTest, xUnit, or NUnit project) so you have a test
+   assembly such as `bin\Debug\net8.0\MyProject.Tests.dll`.
+2. Run the tests:
+
+   ```shell
+   vstest.console.exe bin\Debug\net8.0\MyProject.Tests.dll
+   ```
+
+   Or, to build and run in one step with the SDK:
+
+   ```shell
+   dotnet test
+   ```
+
+You can pass more than one assembly and use wildcards:
+
+```shell
+vstest.console.exe **\bin\Debug\**\*.Tests.dll
+```
+
+The runner prints a per-test summary and a final total. Test results and any collected
+artifacts are written under a `TestResults` directory.
+
+## Common tasks
+
+| Task | Command |
+| --- | --- |
+| Run a subset of tests | `vstest.console.exe Tests.dll /TestCaseFilter:"Priority=1"` |
+| Produce a TRX report | `vstest.console.exe Tests.dll /logger:trx` |
+| Use a settings file | `vstest.console.exe Tests.dll /Settings:test.runsettings` |
+| Collect code coverage | `vstest.console.exe Tests.dll /Collect:"Code Coverage"` |
+| Run in parallel | `vstest.console.exe Tests.dll /Parallel` |
+| Capture diagnostic logs | `vstest.console.exe Tests.dll /Diag:log.txt` |
+
+The equivalent `dotnet test` switches are `--filter`, `--logger`, `--settings`, `--collect`,
+and `--diag`.
+
+## Exit codes
+
+`vstest.console.exe` returns `0` when the run succeeds and all executed tests pass, and `1`
+otherwise (test failure, run error, invalid command line, etc.). See
+[Exit codes](./commandline.md#exit-codes) for details, including what happens when no tests
+match.
+
+## Next steps
+
+- [Command line options](./commandline.md) — full option reference
+- [TestCase filtering](./filter.md)
+- [Configure a test run (.runsettings)](./configure.md)
+- [Passing runsettings from the command line](./RunSettingsArguments.md)
+- [Code coverage](./analyze.md)
+- [Diagnostics](./diagnose.md) / [Troubleshooting](./troubleshooting.md)
+- [Environment variables](./environment-variables.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,13 +16,18 @@ Most people don't run `vstest.console.exe` directly. Pick the entry point that f
 
 ## Getting the standalone runner
 
-`vstest.console.exe` is not a separate download; it ships inside the
-[`Microsoft.TestPlatform`](https://www.nuget.org/packages/Microsoft.TestPlatform) NuGet
-package (and with Visual Studio). After restoring/extracting that package, the runner lives
-under the package's `tools/` folder:
+`vstest.console` is not a separate download; it ships inside NuGet packages (and with Visual
+Studio). Which package depends on the runtime you need:
 
-- **.NET Framework build** — `tools/net462/Common7/IDE/Extensions/TestPlatform/vstest.console.exe`. Requires .NET Framework (Windows).
-- **.NET build** — the `vstest.console.dll` under the package's .NET `tools/` folder, launched with `dotnet path/to/vstest.console.dll`. Requires a compatible .NET runtime and is cross-platform.
+- **.NET Framework runner (Windows)** — the
+  [`Microsoft.TestPlatform`](https://www.nuget.org/packages/Microsoft.TestPlatform) package.
+  After restoring/extracting it the runner lives at
+  `tools/net462/Common7/IDE/Extensions/TestPlatform/vstest.console.exe` and requires .NET
+  Framework.
+- **Cross-platform .NET runner** — the
+  [`Microsoft.TestPlatform.Portable`](https://www.nuget.org/packages/Microsoft.TestPlatform.Portable)
+  package. It ships `vstest.console.dll` under `tools/net8.0/`, launched with
+  `dotnet path/to/vstest.console.dll`, and requires a compatible .NET runtime.
 
 When you use `dotnet test`, the runner and a matching runtime are already provided by the .NET
 SDK (pinned by your `global.json`), so there is nothing extra to install.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -22,7 +22,7 @@ package (and with Visual Studio). After restoring/extracting that package, the r
 under the package's `tools/` folder:
 
 - **.NET Framework build** — `tools/net462/Common7/IDE/Extensions/TestPlatform/vstest.console.exe`. Requires .NET Framework (Windows).
-- **.NET build** — the `vstest.console.dll` under the package's .NET `tools/` folder, launched with `dotnet path\to\vstest.console.dll`. Requires a compatible .NET runtime and is cross-platform.
+- **.NET build** — the `vstest.console.dll` under the package's .NET `tools/` folder, launched with `dotnet path/to/vstest.console.dll`. Requires a compatible .NET runtime and is cross-platform.
 
 When you use `dotnet test`, the runner and a matching runtime are already provided by the .NET
 SDK (pinned by your `global.json`), so there is nothing extra to install.
@@ -46,7 +46,7 @@ SDK (pinned by your `global.json`), so there is nothing extra to install.
 You can pass more than one assembly and use wildcards:
 
 ```shell
-vstest.console.exe **\bin\Debug\**\*.Tests.dll
+vstest.console.exe **/bin/Debug/**/*.Tests.dll
 ```
 
 The runner prints a per-test summary and a final total. Test results and any collected

--- a/src/vstest.console/Resources/Resources.Designer.cs
+++ b/src/vstest.console/Resources/Resources.Designer.cs
@@ -611,7 +611,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources {
         /// <summary>
         ///   Looks up a localized string similar to --Framework|/Framework:&lt;Framework Version&gt;
         ///      Target .Net Framework version to be used for test execution. 
-        ///      Valid values are &quot;.NETFramework,Version=v4.5.1&quot;, &quot;.NETCoreApp,Version=v1.0&quot; etc.
+        ///      Valid values are short names such as net48 and net10.0, or long names such as &quot;.NETFramework,Version=v4.8&quot; and &quot;.NETCoreApp,Version=v10.0&quot;.
         ///      Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10..
         /// </summary>
         internal static string FrameworkArgumentHelp {
@@ -1214,7 +1214,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommandLine.Resources {
         /// <summary>
         ///   Looks up a localized string similar to --Platform|/Platform:&lt;Platform type&gt;
         ///      Target platform architecture to be used for test execution. 
-        ///      Valid values are x86, x64 and ARM..
+        ///      Valid values are x86, x64, ARM, ARM64, S390x, Ppc64le, RiscV64 and LoongArch64..
         /// </summary>
         internal static string PlatformArgumentHelp {
             get {

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -446,7 +446,7 @@
   <data name="PlatformArgumentHelp" xml:space="preserve">
     <value>--Platform|/Platform:&lt;Platform type&gt;
       Target platform architecture to be used for test execution. 
-      Valid values are x86, x64 and ARM.</value>
+      Valid values are x86, x64, ARM, ARM64, S390x, Ppc64le, RiscV64 and LoongArch64.</value>
   </data>
   <data name="PlatformTypeRequired" xml:space="preserve">
     <value>The /Platform argument requires the target platform type for the test run to be provided.   Example:  /Platform:x86</value>

--- a/src/vstest.console/Resources/Resources.resx
+++ b/src/vstest.console/Resources/Resources.resx
@@ -276,7 +276,7 @@
   <data name="FrameworkArgumentHelp" xml:space="preserve">
     <value>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
-      Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
+      Valid values are short names such as net48 and net10.0, or long names such as ".NETFramework,Version=v4.8" and ".NETCoreApp,Version=v10.0".
       Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</value>
   </data>
   <data name="FrameworkVersionRequired" xml:space="preserve">

--- a/src/vstest.console/Resources/xlf/Resources.cs.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.cs.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="cs">
     <body>

--- a/src/vstest.console/Resources/xlf/Resources.cs.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.cs.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="cs">
     <body>
@@ -384,8 +384,8 @@
       <trans-unit id="PlatformArgumentHelp">
         <source>--Platform|/Platform:&lt;Platform type&gt;
       Target platform architecture to be used for test execution. 
-      Valid values are x86, x64 and ARM.</source>
-        <target state="translated">--Platform|/Platform:&lt;typ platformy&gt;
+      Valid values are x86, x64, ARM, ARM64, S390x, Ppc64le, RiscV64 and LoongArch64.</source>
+        <target state="needs-review-translation">--Platform|/Platform:&lt;typ platformy&gt;
       Cílová architektura platformy, která se použije ke spuštění testu. 
       Platné hodnoty jsou x86, x64 a ARM.</target>
         <note />

--- a/src/vstest.console/Resources/xlf/Resources.cs.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.cs.xlf
@@ -398,9 +398,9 @@
       <trans-unit id="FrameworkArgumentHelp">
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
-      Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
+      Valid values are short names such as net48 and net10.0, or long names such as ".NETFramework,Version=v4.8" and ".NETCoreApp,Version=v10.0".
       Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;verze rozhraní&gt;
+        <target state="needs-review-translation">--Framework|/Framework:&lt;verze rozhraní&gt;
       Cílová verze rozhraní .NET Framework, která se použije ke spuštění testu. 
       Platné hodnoty jsou .NETFramework,Version=v4.5.1, .NETCoreApp,Version=v1.0 apod.
       Další podporované hodnoty jsou Framework40, Framework45, FrameworkCore10 a FrameworkUap10.</target>

--- a/src/vstest.console/Resources/xlf/Resources.de.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.de.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="de">
     <body>

--- a/src/vstest.console/Resources/xlf/Resources.de.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.de.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="de">
     <body>
@@ -384,8 +384,8 @@
       <trans-unit id="PlatformArgumentHelp">
         <source>--Platform|/Platform:&lt;Platform type&gt;
       Target platform architecture to be used for test execution. 
-      Valid values are x86, x64 and ARM.</source>
-        <target state="translated">--Platform|/Platform:&lt;Plattformtyp&gt;
+      Valid values are x86, x64, ARM, ARM64, S390x, Ppc64le, RiscV64 and LoongArch64.</source>
+        <target state="needs-review-translation">--Platform|/Platform:&lt;Plattformtyp&gt;
       Zielplattformarchitektur für die Testausführung. 
       Gültige Werte sind x86, x64 und ARM.</target>
         <note />

--- a/src/vstest.console/Resources/xlf/Resources.de.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.de.xlf
@@ -398,9 +398,9 @@
       <trans-unit id="FrameworkArgumentHelp">
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
-      Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
+      Valid values are short names such as net48 and net10.0, or long names such as ".NETFramework,Version=v4.8" and ".NETCoreApp,Version=v10.0".
       Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Frameworkversion&gt;
+        <target state="needs-review-translation">--Framework|/Framework:&lt;Frameworkversion&gt;
       Die .NET-Framework-Zielversion für die Testausführung. 
       Gültige Werte sind ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" usw.
       Weitere unterstützte Werte: Framework40, Framework45, FrameworkCore10, FrameworkUap10.</target>

--- a/src/vstest.console/Resources/xlf/Resources.es.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.es.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="es">
     <body>

--- a/src/vstest.console/Resources/xlf/Resources.es.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.es.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="es">
     <body>
@@ -386,8 +386,8 @@
       <trans-unit id="PlatformArgumentHelp">
         <source>--Platform|/Platform:&lt;Platform type&gt;
       Target platform architecture to be used for test execution. 
-      Valid values are x86, x64 and ARM.</source>
-        <target state="translated">--Platform|/Platform:&lt;tipoPlataforma&gt;
+      Valid values are x86, x64, ARM, ARM64, S390x, Ppc64le, RiscV64 and LoongArch64.</source>
+        <target state="needs-review-translation">--Platform|/Platform:&lt;tipoPlataforma&gt;
       Arquitectura de la plataforma de destino que se usará para la ejecución de pruebas. 
       Los valores válidos son x86, x64 y ARM.</target>
         <note />

--- a/src/vstest.console/Resources/xlf/Resources.es.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.es.xlf
@@ -400,9 +400,9 @@
       <trans-unit id="FrameworkArgumentHelp">
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
-      Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
+      Valid values are short names such as net48 and net10.0, or long names such as ".NETFramework,Version=v4.8" and ".NETCoreApp,Version=v10.0".
       Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Versión de Framework&gt;
+        <target state="needs-review-translation">--Framework|/Framework:&lt;Versión de Framework&gt;
       Versión de .NET Framework de destino que se usará para la ejecución de pruebas. 
       Los valores válidos son ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0", etc.
       Otros valores admitidos son Framework40, Framework45, FrameworkCore10 y FrameworkUap10.</target>

--- a/src/vstest.console/Resources/xlf/Resources.fr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.fr.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="fr">
     <body>

--- a/src/vstest.console/Resources/xlf/Resources.fr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.fr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="fr">
     <body>
@@ -384,8 +384,8 @@
       <trans-unit id="PlatformArgumentHelp">
         <source>--Platform|/Platform:&lt;Platform type&gt;
       Target platform architecture to be used for test execution. 
-      Valid values are x86, x64 and ARM.</source>
-        <target state="translated">--Platform|/Platform:&lt;Platform type&gt;
+      Valid values are x86, x64, ARM, ARM64, S390x, Ppc64le, RiscV64 and LoongArch64.</source>
+        <target state="needs-review-translation">--Platform|/Platform:&lt;Platform type&gt;
       Architecture de plate-forme cible à utiliser pour l'exécution des tests. 
       Les valeurs valides sont x86, x64 et ARM.</target>
         <note />

--- a/src/vstest.console/Resources/xlf/Resources.fr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.fr.xlf
@@ -398,9 +398,9 @@
       <trans-unit id="FrameworkArgumentHelp">
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
-      Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
+      Valid values are short names such as net48 and net10.0, or long names such as ".NETFramework,Version=v4.8" and ".NETCoreApp,Version=v10.0".
       Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Framework Version&gt;
+        <target state="needs-review-translation">--Framework|/Framework:&lt;Framework Version&gt;
       Version cible de .Net Framework à utiliser pour l'exécution des tests. 
       Les valeurs valides sont ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
       Les autres valeurs prises en charge sont Framework40, Framework45, FrameworkCore10 et FrameworkUap10.</target>

--- a/src/vstest.console/Resources/xlf/Resources.it.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.it.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="it">
     <body>

--- a/src/vstest.console/Resources/xlf/Resources.it.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.it.xlf
@@ -398,9 +398,9 @@
       <trans-unit id="FrameworkArgumentHelp">
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
-      Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
+      Valid values are short names such as net48 and net10.0, or long names such as ".NETFramework,Version=v4.8" and ".NETCoreApp,Version=v10.0".
       Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Framework Version&gt;
+        <target state="needs-review-translation">--Framework|/Framework:&lt;Framework Version&gt;
       Versione di .NET Framework di destinazione da usare per l'esecuzione dei test. 
       Valori validi: ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" e così via.
       Altri valori supportati: Framework40, Framework45, FrameworkCore10 e FrameworkUap10.</target>

--- a/src/vstest.console/Resources/xlf/Resources.it.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.it.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="it">
     <body>
@@ -384,8 +384,8 @@
       <trans-unit id="PlatformArgumentHelp">
         <source>--Platform|/Platform:&lt;Platform type&gt;
       Target platform architecture to be used for test execution. 
-      Valid values are x86, x64 and ARM.</source>
-        <target state="translated">--Platform|/Platform:&lt;Platform type&gt;
+      Valid values are x86, x64, ARM, ARM64, S390x, Ppc64le, RiscV64 and LoongArch64.</source>
+        <target state="needs-review-translation">--Platform|/Platform:&lt;Platform type&gt;
        Architettura della piattaforma di destinazione da usare per l'esecuzione dei test. 
        Valori validi: x86, x64 e ARM.</target>
         <note />

--- a/src/vstest.console/Resources/xlf/Resources.ja.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ja.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="ja">
     <body>

--- a/src/vstest.console/Resources/xlf/Resources.ja.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ja.xlf
@@ -398,9 +398,9 @@
       <trans-unit id="FrameworkArgumentHelp">
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
-      Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
+      Valid values are short names such as net48 and net10.0, or long names such as ".NETFramework,Version=v4.8" and ".NETCoreApp,Version=v10.0".
       Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Framework Version&gt;
+        <target state="needs-review-translation">--Framework|/Framework:&lt;Framework Version&gt;
       テストの実行に使用する、.Net Framework のターゲット バージョン。
       有効な値は ".NETFramework,Version=v4.5.1"、".NETCoreApp,Version=v1.0" などです。
       サポートされている他の値は、Framework40、Framework45、FrameworkCore10、FrameworkUap10 です。</target>

--- a/src/vstest.console/Resources/xlf/Resources.ja.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ja.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="ja">
     <body>
@@ -384,8 +384,8 @@
       <trans-unit id="PlatformArgumentHelp">
         <source>--Platform|/Platform:&lt;Platform type&gt;
       Target platform architecture to be used for test execution. 
-      Valid values are x86, x64 and ARM.</source>
-        <target state="translated">--Platform|/Platform:&lt;Platform type&gt;
+      Valid values are x86, x64, ARM, ARM64, S390x, Ppc64le, RiscV64 and LoongArch64.</source>
+        <target state="needs-review-translation">--Platform|/Platform:&lt;Platform type&gt;
       テストの実行に使用するターゲット プラットフォームのアーキテクチャです。
       有効な値は、x86、x64、ARM です。</target>
         <note />

--- a/src/vstest.console/Resources/xlf/Resources.ko.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ko.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="ko">
     <body>

--- a/src/vstest.console/Resources/xlf/Resources.ko.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ko.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="ko">
     <body>
@@ -384,8 +384,8 @@
       <trans-unit id="PlatformArgumentHelp">
         <source>--Platform|/Platform:&lt;Platform type&gt;
       Target platform architecture to be used for test execution. 
-      Valid values are x86, x64 and ARM.</source>
-        <target state="translated">--Platform|/Platform:&lt;Platform type&gt;
+      Valid values are x86, x64, ARM, ARM64, S390x, Ppc64le, RiscV64 and LoongArch64.</source>
+        <target state="needs-review-translation">--Platform|/Platform:&lt;Platform type&gt;
       테스트를 실행하는 데 사용할 대상 플랫폼 아키텍처입니다. 
       유효한 값은 x86, x64 및 ARM입니다.</target>
         <note />

--- a/src/vstest.console/Resources/xlf/Resources.ko.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ko.xlf
@@ -398,9 +398,9 @@
       <trans-unit id="FrameworkArgumentHelp">
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
-      Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
+      Valid values are short names such as net48 and net10.0, or long names such as ".NETFramework,Version=v4.8" and ".NETCoreApp,Version=v10.0".
       Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Framework Version&gt;
+        <target state="needs-review-translation">--Framework|/Framework:&lt;Framework Version&gt;
       테스트 실행에 사용할 대상 .NET Framework 버전입니다. 
       유효한 값은 ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" 등입니다.
       기타 지원되는 값은 Framework40, Framework45, FrameworkCore10 및 FrameworkUap10입니다.</target>

--- a/src/vstest.console/Resources/xlf/Resources.pl.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pl.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="pl">
     <body>

--- a/src/vstest.console/Resources/xlf/Resources.pl.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pl.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="pl">
     <body>
@@ -384,8 +384,8 @@
       <trans-unit id="PlatformArgumentHelp">
         <source>--Platform|/Platform:&lt;Platform type&gt;
       Target platform architecture to be used for test execution. 
-      Valid values are x86, x64 and ARM.</source>
-        <target state="translated">--Platform|/Platform:&lt;Platform type&gt;
+      Valid values are x86, x64, ARM, ARM64, S390x, Ppc64le, RiscV64 and LoongArch64.</source>
+        <target state="needs-review-translation">--Platform|/Platform:&lt;Platform type&gt;
       Docelowa architektura platformy, która zostanie użyta do wykonania testu. 
       Prawidłowe wartości to x86, x64 i ARM.</target>
         <note />

--- a/src/vstest.console/Resources/xlf/Resources.pl.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pl.xlf
@@ -398,9 +398,9 @@
       <trans-unit id="FrameworkArgumentHelp">
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
-      Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
+      Valid values are short names such as net48 and net10.0, or long names such as ".NETFramework,Version=v4.8" and ".NETCoreApp,Version=v10.0".
       Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Framework Version&gt;
+        <target state="needs-review-translation">--Framework|/Framework:&lt;Framework Version&gt;
       Docelowa wersja platformy .NET, która zostanie użyta na potrzeby wykonania testu. 
       Prawidłowe wartości to „.NETFramework,Version=v4.5.1”, „.NETCoreApp,Version=v1.0” itp.
       Inne obsługiwane wartości to Framework40, Framework45, FrameworkCore10 i FrameworkUap10.</target>

--- a/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="pt-BR">
     <body>

--- a/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
@@ -398,9 +398,9 @@ Altere o prefixo de nível de diagnóstico do agente de console, como mostrado a
       <trans-unit id="FrameworkArgumentHelp">
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
-      Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
+      Valid values are short names such as net48 and net10.0, or long names such as ".NETFramework,Version=v4.8" and ".NETCoreApp,Version=v10.0".
       Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Versão do Framework&gt;
+        <target state="needs-review-translation">--Framework|/Framework:&lt;Versão do Framework&gt;
       Versão de destino do .NET Framework a ser usada para execução de teste. 
       Os valores válidos são ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
       Outros valores permitidos são Framework40, Framework45, FrameworkCore10 e FrameworkUap10.</target>

--- a/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.pt-BR.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="pt-BR">
     <body>
@@ -384,8 +384,8 @@ Altere o prefixo de nível de diagnóstico do agente de console, como mostrado a
       <trans-unit id="PlatformArgumentHelp">
         <source>--Platform|/Platform:&lt;Platform type&gt;
       Target platform architecture to be used for test execution. 
-      Valid values are x86, x64 and ARM.</source>
-        <target state="translated">--Platform|/Platform:&lt;Platform type&gt;
+      Valid values are x86, x64, ARM, ARM64, S390x, Ppc64le, RiscV64 and LoongArch64.</source>
+        <target state="needs-review-translation">--Platform|/Platform:&lt;Platform type&gt;
       Arquitetura da plataforma destino a ser usada na execução de teste. 
       Os valores válidos são x86, x64 e ARM.</target>
         <note />

--- a/src/vstest.console/Resources/xlf/Resources.ru.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ru.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="ru">
     <body>

--- a/src/vstest.console/Resources/xlf/Resources.ru.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ru.xlf
@@ -398,9 +398,9 @@
       <trans-unit id="FrameworkArgumentHelp">
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
-      Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
+      Valid values are short names such as net48 and net10.0, or long names such as ".NETFramework,Version=v4.8" and ".NETCoreApp,Version=v10.0".
       Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;версия платформы&gt;
+        <target state="needs-review-translation">--Framework|/Framework:&lt;версия платформы&gt;
       Целевая версия платформы .NET Framework, используемая для выполнения тестов. 
       Допустимые значения: ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" и т. п.
       Другие поддерживаемые значения: Framework40, Framework45, FrameworkCore10 и FrameworkUap10.</target>

--- a/src/vstest.console/Resources/xlf/Resources.ru.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.ru.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="ru">
     <body>
@@ -384,8 +384,8 @@
       <trans-unit id="PlatformArgumentHelp">
         <source>--Platform|/Platform:&lt;Platform type&gt;
       Target platform architecture to be used for test execution. 
-      Valid values are x86, x64 and ARM.</source>
-        <target state="translated">--Platform|/Platform:&lt;тип_платформы&gt;
+      Valid values are x86, x64, ARM, ARM64, S390x, Ppc64le, RiscV64 and LoongArch64.</source>
+        <target state="needs-review-translation">--Platform|/Platform:&lt;тип_платформы&gt;
       Архитектура целевой платформы, в которой будут выполняться тесты. 
       Допустимые значения: x86, x64 и ARM.</target>
         <note />

--- a/src/vstest.console/Resources/xlf/Resources.tr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.tr.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="tr">
     <body>

--- a/src/vstest.console/Resources/xlf/Resources.tr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.tr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="tr">
     <body>
@@ -384,8 +384,8 @@
       <trans-unit id="PlatformArgumentHelp">
         <source>--Platform|/Platform:&lt;Platform type&gt;
       Target platform architecture to be used for test execution. 
-      Valid values are x86, x64 and ARM.</source>
-        <target state="translated">--Platform|/Platform:&lt;Platform türü&gt;
+      Valid values are x86, x64, ARM, ARM64, S390x, Ppc64le, RiscV64 and LoongArch64.</source>
+        <target state="needs-review-translation">--Platform|/Platform:&lt;Platform türü&gt;
       Test yürütmesi için kullanılacak hedef platform mimarisi. 
       Geçerli değerler x86, x64 ve ARM'dir.</target>
         <note />

--- a/src/vstest.console/Resources/xlf/Resources.tr.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.tr.xlf
@@ -398,9 +398,9 @@
       <trans-unit id="FrameworkArgumentHelp">
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
-      Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
+      Valid values are short names such as net48 and net10.0, or long names such as ".NETFramework,Version=v4.8" and ".NETCoreApp,Version=v10.0".
       Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Framework Sürümü&gt;
+        <target state="needs-review-translation">--Framework|/Framework:&lt;Framework Sürümü&gt;
       Test yürütme için kullanılacak hedef .Net Framework sürümü. 
       Geçerli değerler: ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" vb.
       Diğer desteklenen değerler: Framework40, Framework45, FrameworkCore10 ve FrameworkUap10.</target>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="zh-Hans">
     <body>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
@@ -398,9 +398,9 @@
       <trans-unit id="FrameworkArgumentHelp">
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
-      Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
+      Valid values are short names such as net48 and net10.0, or long names such as ".NETFramework,Version=v4.8" and ".NETCoreApp,Version=v10.0".
       Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Framework Version&gt;
+        <target state="needs-review-translation">--Framework|/Framework:&lt;Framework Version&gt;
       用于执行测试的目标 .Net Framework 版本。
       有效值为 ".NETFramework,Version=v4.5.1".NETCoreApp,Version=v1.0" 等。
       其他支持的值为 Framework40、Framework45、FrameworkCore10 和 FrameworkUap10。</target>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hans.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="zh-Hans">
     <body>
@@ -384,8 +384,8 @@
       <trans-unit id="PlatformArgumentHelp">
         <source>--Platform|/Platform:&lt;Platform type&gt;
       Target platform architecture to be used for test execution. 
-      Valid values are x86, x64 and ARM.</source>
-        <target state="translated">--Platform|/Platform:&lt;Platform type&gt;
+      Valid values are x86, x64, ARM, ARM64, S390x, Ppc64le, RiscV64 and LoongArch64.</source>
+        <target state="needs-review-translation">--Platform|/Platform:&lt;Platform type&gt;
       用于执行测试的目标平台体系结构。
    有效值为 x86、x64 和 ARM。</target>
         <note />

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="zh-Hant">
     <body>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
@@ -398,9 +398,9 @@
       <trans-unit id="FrameworkArgumentHelp">
         <source>--Framework|/Framework:&lt;Framework Version&gt;
       Target .Net Framework version to be used for test execution. 
-      Valid values are ".NETFramework,Version=v4.5.1", ".NETCoreApp,Version=v1.0" etc.
+      Valid values are short names such as net48 and net10.0, or long names such as ".NETFramework,Version=v4.8" and ".NETCoreApp,Version=v10.0".
       Other supported values are Framework40, Framework45, FrameworkCore10 and FrameworkUap10.</source>
-        <target state="translated">--Framework|/Framework:&lt;Framework 版本&gt;
+        <target state="needs-review-translation">--Framework|/Framework:&lt;Framework 版本&gt;
       用於測試執行的目標.Net Framework 版本。 
       有效的值為 ".NETFramework,Version=v4.5.1"、".NETCoreApp,Version=v1.0" 等等。
       其他支援的值為 Framework40、Framework45、FrameworkCore10 與 FrameworkUap10。</target>

--- a/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/vstest.console/Resources/xlf/Resources.zh-Hant.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" original="../Resources.resx" target-language="zh-Hant">
     <body>
@@ -384,8 +384,8 @@
       <trans-unit id="PlatformArgumentHelp">
         <source>--Platform|/Platform:&lt;Platform type&gt;
       Target platform architecture to be used for test execution. 
-      Valid values are x86, x64 and ARM.</source>
-        <target state="translated">--Platform|/Platform:&lt;平台類型&gt;
+      Valid values are x86, x64, ARM, ARM64, S390x, Ppc64le, RiscV64 and LoongArch64.</source>
+        <target state="needs-review-translation">--Platform|/Platform:&lt;平台類型&gt;
       用於測試執行的目標平台架構。
       有效值為 x86、x64 和 ARM。</target>
         <note />

--- a/test/vstest.console.UnitTests/Processors/FrameworkArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/FrameworkArgumentProcessorTests.cs
@@ -50,7 +50,7 @@ public class FrameworkArgumentProcessorTests
     {
         var capabilities = new FrameworkArgumentProcessorCapabilities();
         Assert.AreEqual("/Framework", capabilities.CommandName);
-        Assert.Contains("Valid values are \".NETFramework,Version=v4.5.1\", \".NETCoreApp,Version=v1.0\"", capabilities.HelpContentResourceName);
+        Assert.Contains("Valid values are short names such as net48 and net10.0, or long names such as \".NETFramework,Version=v4.8\" and \".NETCoreApp,Version=v10.0\"", capabilities.HelpContentResourceName);
 
         Assert.AreEqual(HelpContentPriority.FrameworkArgumentProcessorHelpPriority, capabilities.HelpPriority);
         Assert.IsFalse(capabilities.IsAction);

--- a/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/PlatformArgumentProcessorTests.cs
@@ -54,7 +54,7 @@ public class PlatformArgumentProcessorTests
     {
         var capabilities = new PlatformArgumentProcessorCapabilities();
         Assert.AreEqual("/Platform", capabilities.CommandName);
-        var expected = "--Platform|/Platform:<Platform type>\r\n      Target platform architecture to be used for test execution. \r\n      Valid values are x86, x64 and ARM.";
+        var expected = "--Platform|/Platform:<Platform type>\r\n      Target platform architecture to be used for test execution. \r\n      Valid values are x86, x64, ARM, ARM64, S390x, Ppc64le, RiscV64 and LoongArch64.";
         Assert.AreEqual(expected: expected.NormalizeLineEndings().ShowWhiteSpace(), capabilities.HelpContentResourceName.NormalizeLineEndings().ShowWhiteSpace());
 
         Assert.AreEqual(HelpContentPriority.PlatformArgumentProcessorHelpPriority, capabilities.HelpPriority);


### PR DESCRIPTION
Part of a documentation completeness audit (checking docs against the actual code). This PR fills two gaps **not covered** by the other open docs PRs (#16277, #16278, #16279):

### 1. New `docs/commandline.md` — vstest.console.exe options reference
There was no in-repo reference for `vstest.console.exe` command line options; they were only discoverable via the runtime `--Help` output or external Microsoft Learn. This adds a source-grounded reference covering every user-facing option, generated from the argument processors in `src/vstest.console/Processors` and mirroring the `--Help` text: `/Tests`, `/TestCaseFilter`, `/ListTests`, `/Parallel`, `/InIsolation`, `/Platform`, `/Framework`, `/Environment`, `/TestAdapterPath`, `/Settings`, `-- [name]=[value]`, `/logger`, `/Collect`, `/Blame`, `/ResultsDirectory`, `/Diag`, `/Help`, `@<file>`, `/Port`, `/ParentProcessId`. Internal/hidden switches (including `/TestAdapterLoadingStrategy`) are enumerated in an "Omitted switches" section.

### 2. Missing environment variables in `docs/environment-variables.md`
Five variables referenced in `src/` were undocumented (verified they are not added by #16279):
- `VSTEST_DOTNET_ROOT_PATH`
- `VSTEST_DOTNET_ROOT_ARCHITECTURE`
- `VSTEST_BACKGROUND_DISCOVERY`
- `VSTEST_DISABLE_DOTNET_ROOT_ON_NONWINDOWS`
- `VSTEST_DISABLE_DYNAMICNATIVE_CODECOVERAGE_DEFAULT_SETTING`

### 3. README documentation index
Adds a **Guides** subsection linking the existing how-to docs (command line, filter, runsettings, configure, coverage, diagnostics), which previously were not indexed.

### 4. `--Help` text corrections (product resource change)
While grounding the CLI reference against the argument processors, two `vstest.console` `--Help` strings were found to be inaccurate and are corrected in `src/vstest.console/Resources/Resources.resx` (with matching `*.xlf` source updates, targets flagged for re-translation):
- `/Platform` now lists all supported architectures (`x86, x64, ARM, ARM64, S390x, Ppc64le, RiscV64, LoongArch64`) instead of only `x86/x64/ARM`.
- `/Framework` now points out the common short TFM monikers (`net48`, `net10.0`) alongside the long forms.

Apart from those corrected `--Help` resource strings, this is a documentation-only change.