### PR TITLE
Exclude publish\ closure from playground .NET copy globs

### DIFF
--- a/playground/TestPlatform.Playground/TestPlatform.Playground.csproj
+++ b/playground/TestPlatform.Playground/TestPlatform.Playground.csproj
@@ -99,13 +99,15 @@
       <FileToCopy Include="$(SourcePath)bin\Microsoft.TestPlatform.Extensions.HtmlLogger\$(Configuration)\$(NetFrameworkMinimum)\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger*" SubFolder="netfx\Extensions\" />
       <FileToCopy Include="$(SourcePath)bin\Microsoft.TestPlatform.Extensions.TrxLogger\$(Configuration)\$(NetFrameworkMinimum)\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger*" SubFolder="netfx\Extensions\" />
 
-      <!-- .NET console -->
-      <FileToCopy Include="$(SourcePath)bin\vstest.console\$(Configuration)\$(NetCoreAppMinimum)\**\*.*" SubFolder="net" />
+      <!-- .NET console. Exclude the publish\ closure that PublishForPackaging emits under the
+           producer's own bin during -pack builds; it is a duplicate of the build output already
+           copied here and would otherwise be mirrored again under net\publish\. -->
+      <FileToCopy Include="$(SourcePath)bin\vstest.console\$(Configuration)\$(NetCoreAppMinimum)\**\*.*" Exclude="$(SourcePath)bin\vstest.console\$(Configuration)\$(NetCoreAppMinimum)\publish\**\*.*" SubFolder="net" />
       <!-- Copy only the runtime provider assembly (see the netfx note above for why the whole folder must not be copied). -->
       <FileToCopy Include="$(SourcePath)bin\Microsoft.TestPlatform.TestHostProvider\$(Configuration)\netstandard2.0\**\Microsoft.TestPlatform.TestHostRuntimeProvider*" SubFolder="net\Extensions\" />
 
-      <!-- copy testhost -->
-      <FileToCopy Include="$(SourcePath)bin\testhost\$(Configuration)\$(NetCoreAppMinimum)\**\*.*" SubFolder="net" />
+      <!-- copy testhost. Exclude the publish\ closure emitted for packaging (see the .NET console note above). -->
+      <FileToCopy Include="$(SourcePath)bin\testhost\$(Configuration)\$(NetCoreAppMinimum)\**\*.*" Exclude="$(SourcePath)bin\testhost\$(Configuration)\$(NetCoreAppMinimum)\publish\**\*.*" SubFolder="net" />
 
       <!-- copy datacollectors --><!--
       <FileToCopy Include="$(SourcePath)bin\datacollector\$(Configuration)\net472\**\*.*" SubFolder="net\" />


### PR DESCRIPTION
Follow-up to #16256 (Amaury's review). That PR moved each producer's packaging publish output under the producer's own bin, `$(ArtifactsBinDir)<Project>\<Config>\<TFM>\publish\`. The playground's two RID-less .NET copy globs recurse into `net8.0\**\*.*`, so `-pack` builds now pick up that `publish\` closure and duplicate the whole thing under the playground's `net\publish\` output.

Exclude `publish\**\*.*` from the `vstest.console` and `testhost` globs. The netfx globs are RID-qualified (`win7-x64\`, `win-x86\`) and the `publish\` folder is a RID-less sibling, so they never matched it and stay as-is.

Verified the glob semantics on a scratch tree: the `publish\` subtree (including nested folders) is dropped while the rest of the output, including the legitimate `Extensions\` subfolder, is kept.

Non-shipping change: playground only, no package payload touched.

🤖