### PR TITLE
Report raw invalid IsTargetPlatformInferred value, cover host x64 forcing

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
@@ -1065,7 +1065,7 @@ public class RunConfiguration : TestRunSettings
                             if (!bool.TryParse(element, out boolValue))
                             {
                                 throw new SettingsException(string.Format(CultureInfo.CurrentCulture,
-                                    Resources.Resources.InvalidSettingsIncorrectValue, Constants.RunConfigurationSettingsName, boolValue, elementName));
+                                    Resources.Resources.InvalidSettingsIncorrectValue, Constants.RunConfigurationSettingsName, element, elementName));
                             }
 
                             runConfiguration.IsTargetPlatformInferred = boolValue;

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunConfigurationTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunConfigurationTests.cs
@@ -446,8 +446,6 @@ public class RunConfigurationTests
 
         var exception = Assert.ThrowsExactly<SettingsException>(
                 () => XmlRunSettingsUtilities.GetRunConfigurationNode(settingsXml));
-
-        // The error must report the actual invalid value the user provided, not the parsed bool default.
-        Assert.Contains("Invalid value 'InvalidValue'", exception.Message);
+        Assert.AreEqual("Invalid settings 'RunConfiguration'.  Invalid value 'InvalidValue' specified for 'IsTargetPlatformInferred'.", exception.Message);
     }
 }

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunConfigurationTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunConfigurationTests.cs
@@ -444,7 +444,10 @@ public class RunConfigurationTests
                      </RunConfiguration>
                 </RunSettings>";
 
-        Assert.ThrowsExactly<SettingsException>(
+        var exception = Assert.ThrowsExactly<SettingsException>(
                 () => XmlRunSettingsUtilities.GetRunConfigurationNode(settingsXml));
+
+        // The error must report the actual invalid value the user provided, not the parsed bool default.
+        Assert.Contains("Invalid value 'InvalidValue'", exception.Message);
     }
 }

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -14,6 +14,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.VisualStudio.TestPlatform.CoreUtilities.Helpers;
 using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Helpers;
 using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Helpers.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting;
@@ -586,6 +587,52 @@ public class DotnetTestHostManagerTests
         var exception = Assert.ThrowsExactly<TestPlatformException>(action);
         var expectedMessage = string.Format(CultureInfo.CurrentCulture, HostProviderResources.CouldNotFindTesthost, sourcePath, Path.GetDirectoryName(sourcePath));
         Assert.AreEqual(expectedMessage, exception.Message);
+    }
+
+
+    [TestMethod]
+    [DataRow("<IsTargetPlatformInferred>true</IsTargetPlatformInferred>", "X64")]
+    [DataRow("", "X64")]
+    [DataRow("<IsTargetPlatformInferred>false</IsTargetPlatformInferred>", "ARM64")]
+    public void GetTestHostProcessStartInfoSilentlyForcesX64OnlyWhenTargetPlatformIsInferred(string isTargetPlatformInferredElement, string expectedMuxerArchitecture)
+    {
+        // Reproduces the silent x64 forcing scenario: an arm64 machine running a pre-net6.0 target framework, where
+        // no arm64 apphost exists, so the in-box host manager falls back to the x64 muxer. That fallback must happen
+        // only when the target platform was inferred; when the user pinned it (IsTargetPlatformInferred=false), the
+        // requested architecture must be honored instead. osx-arm64 is used so the test stays off the Windows
+        // testhost.exe path (which reads the real machine's PROCESSOR_ARCHITECTURE) and is deterministic on every CI OS.
+        _mockEnvironment.Setup(e => e.OperatingSystem).Returns(PlatformOperatingSystem.OSX);
+        _mockEnvironment.SetupGet(e => e.Architecture).Returns(PlatformArchitecture.ARM64);
+
+        // A mock host helper lets us observe which architecture's muxer the host manager decided to search for.
+        var mockDotnetHostHelper = new Mock<IDotnetHostHelper>();
+        string? resolvedMuxerPath = Path.Combine(_temp, "dotnet");
+        mockDotnetHostHelper
+            .Setup(dh => dh.TryGetDotnetPathByArchitecture(It.IsAny<PlatformArchitecture>(), It.IsAny<DotnetMuxerResolutionStrategy>(), out resolvedMuxerPath))
+            .Returns(true);
+
+        var dotnetHostManager = new TestableDotnetTestHostManager(
+            _mockProcessHelper.Object,
+            _mockFileHelper.Object,
+            mockDotnetHostHelper.Object,
+            _mockEnvironment.Object,
+            _mockWindowsRegistry.Object,
+            _mockEnvironmentVariable.Object);
+
+        // The runner runs as x64 (the default in this fixture) while targeting arm64, so we never short-circuit to the
+        // current process and always resolve a muxer, which is what makes the searched architecture observable.
+        var sourcePath = Path.Combine(_temp, "test.dll");
+        _mockFileHelper.Setup(fh => fh.Exists(Path.Combine(_temp, "testhost.dll"))).Returns(true);
+
+        var runsettings = $"<RunSettings><RunConfiguration><TargetPlatform>ARM64</TargetPlatform><TargetFrameworkVersion>net5.0</TargetFrameworkVersion>{isTargetPlatformInferredElement}</RunConfiguration></RunSettings>";
+        dotnetHostManager.Initialize(_mockMessageLogger.Object, runsettings);
+
+        dotnetHostManager.GetTestHostProcessStartInfo(new[] { sourcePath }, null, _defaultConnectionInfo);
+
+        var expectedArchitecture = (PlatformArchitecture)Enum.Parse(typeof(PlatformArchitecture), expectedMuxerArchitecture);
+        mockDotnetHostHelper.Verify(
+            dh => dh.TryGetDotnetPathByArchitecture(expectedArchitecture, It.IsAny<DotnetMuxerResolutionStrategy>(), out resolvedMuxerPath),
+            Times.Once);
     }
 
 


### PR DESCRIPTION
Follow-up to the review on #16271.

Two things from Amaury's review:

- The `SettingsException` for an invalid `<IsTargetPlatformInferred>` reported the parsed bool (always `False`) instead of the value the user actually wrote. It now reports the raw text, the same way the other RunConfiguration bool elements do.

- Added `DotnetTestHostManager` coverage that pins the target platform (`<IsTargetPlatformInferred>false</IsTargetPlatformInferred>`) and proves the host is not silently forced to x64, while an inferred platform still is. The test simulates osx-arm64 on a pre-net6.0 target so it stays off the Windows testhost.exe path and is deterministic on every CI OS.

Verified locally in Release: RunConfiguration tests (29), TestHostProvider.UnitTests (117), ObjectModel.UnitTests (208) all pass.

🤖
