### PR TITLE
Report raw invalid value for the remaining RunConfiguration bool settings

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
@@ -1065,7 +1065,7 @@ public class RunConfiguration : TestRunSettings
                             if (!bool.TryParse(element, out boolValue))
                             {
                                 throw new SettingsException(string.Format(CultureInfo.CurrentCulture,
-                                    Resources.Resources.InvalidSettingsIncorrectValue, Constants.RunConfigurationSettingsName, boolValue, elementName));
+                                    Resources.Resources.InvalidSettingsIncorrectValue, Constants.RunConfigurationSettingsName, element, elementName));
                             }
 
                             runConfiguration.IsTargetPlatformInferred = boolValue;

--- a/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
@@ -1030,7 +1030,7 @@ public class RunConfiguration : TestRunSettings
                             if (!bool.TryParse(element, out boolValue))
                             {
                                 throw new SettingsException(string.Format(CultureInfo.CurrentCulture,
-                                    Resources.Resources.InvalidSettingsIncorrectValue, Constants.RunConfigurationSettingsName, boolValue, elementName));
+                                    Resources.Resources.InvalidSettingsIncorrectValue, Constants.RunConfigurationSettingsName, element, elementName));
                             }
 
                             runConfiguration.DisableSharedTestHost = boolValue;
@@ -1046,7 +1046,7 @@ public class RunConfiguration : TestRunSettings
                             if (!bool.TryParse(element, out boolValue))
                             {
                                 throw new SettingsException(string.Format(CultureInfo.CurrentCulture,
-                                    Resources.Resources.InvalidSettingsIncorrectValue, Constants.RunConfigurationSettingsName, boolValue, elementName));
+                                    Resources.Resources.InvalidSettingsIncorrectValue, Constants.RunConfigurationSettingsName, element, elementName));
                             }
 
                             runConfiguration.SkipDefaultAdapters = boolValue;

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -507,7 +507,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
                 EqtTrace.Verbose($"DotnetTestHostmanager: Searching muxer for the architecture '{targetArchitecture}', OS '{_platformEnvironment.OperatingSystem}' framework '{_targetFramework}' SDK platform architecture '{_platformEnvironment.Architecture}'");
                 if (forceToX64)
                 {
-                    EqtTrace.Verbose($"DotnetTestHostmanager: Forcing the search to x64 architecure, IsDefaultTargetArchitecture '{_isDefaultTargetArchitecture}' OS '{_platformEnvironment.OperatingSystem}' framework '{_targetFramework}'");
+                    EqtTrace.Verbose($"DotnetTestHostmanager: Forcing the search to x64 architecture, IsTargetPlatformInferred '{_isDefaultTargetArchitecture}' OS '{_platformEnvironment.OperatingSystem}' framework '{_targetFramework}'");
                 }
 
                 // Check if DOTNET_ROOT resolution should be bypassed.

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunConfigurationTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunConfigurationTests.cs
@@ -447,4 +447,36 @@ public class RunConfigurationTests
         Assert.ThrowsExactly<SettingsException>(
                 () => XmlRunSettingsUtilities.GetRunConfigurationNode(settingsXml));
     }
+
+    [TestMethod]
+    public void RunConfigurationFromXmlThrowsSettingsExceptionIfDisableSharedTestHostIsInvalid()
+    {
+        string settingsXml =
+            @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <RunSettings>
+                     <RunConfiguration>
+                       <DisableSharedTestHost>InvalidValue</DisableSharedTestHost>
+                     </RunConfiguration>
+                </RunSettings>";
+
+        var exception = Assert.ThrowsExactly<SettingsException>(
+                () => XmlRunSettingsUtilities.GetRunConfigurationNode(settingsXml));
+        Assert.AreEqual("Invalid settings 'RunConfiguration'.  Invalid value 'InvalidValue' specified for 'DisableSharedTestHost'.", exception.Message);
+    }
+
+    [TestMethod]
+    public void RunConfigurationFromXmlThrowsSettingsExceptionIfSkipDefaultAdaptersIsInvalid()
+    {
+        string settingsXml =
+            @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <RunSettings>
+                     <RunConfiguration>
+                       <SkipDefaultAdapters>InvalidValue</SkipDefaultAdapters>
+                     </RunConfiguration>
+                </RunSettings>";
+
+        var exception = Assert.ThrowsExactly<SettingsException>(
+                () => XmlRunSettingsUtilities.GetRunConfigurationNode(settingsXml));
+        Assert.AreEqual("Invalid settings 'RunConfiguration'.  Invalid value 'InvalidValue' specified for 'SkipDefaultAdapters'.", exception.Message);
+    }
 }

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunConfigurationTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/RunSettings/RunConfigurationTests.cs
@@ -444,8 +444,9 @@ public class RunConfigurationTests
                      </RunConfiguration>
                 </RunSettings>";
 
-        Assert.ThrowsExactly<SettingsException>(
+        var exception = Assert.ThrowsExactly<SettingsException>(
                 () => XmlRunSettingsUtilities.GetRunConfigurationNode(settingsXml));
+        Assert.AreEqual("Invalid settings 'RunConfiguration'.  Invalid value 'InvalidValue' specified for 'IsTargetPlatformInferred'.", exception.Message);
     }
 
     [TestMethod]


### PR DESCRIPTION
More follow-ups from the review on #16271, split out from #16295 so each PR stays focused.

Two RunConfiguration bool settings had the same bug #16295 fixes for `IsTargetPlatformInferred`: an invalid `<DisableSharedTestHost>` or `<SkipDefaultAdapters>` value threw a `SettingsException` that reported the parsed bool (always `False`) instead of the text the user actually wrote. Both report the raw value now, matching `CreateNoNewWindow`, and each has a test that asserts the full message.

Also fixed the forced-x64 verbose trace in `DotnetTestHostManager`: it still called the flag `IsDefaultTargetArchitecture` and misspelled `architecture` as `architecure`. The value comes from `IsTargetPlatformInferred` now, so the trace says that.

Verified locally in Release: ObjectModel.UnitTests (210, includes the two new ones) and TestHostProvider.UnitTests (114) pass.

🤖
