### PR TITLE
[link-checker] Fix false positives in check-md-links.py

### DIFF
--- a/.github/workflows/scripts/check-md-links.py
+++ b/.github/workflows/scripts/check-md-links.py
@@ -36,10 +36,12 @@ import os
 import re
 import sys
 
-# Markdown link [text](url): require non-empty text and url, like the original
-# `grep -oP '\[([^\]]+)\]\(([^\)]+)\)'` followed by extracting the `(...)` part.
-_LINK_RE = re.compile(r"\[[^\]]+\]\([^\)]+\)")
-_PAREN_RE = re.compile(r"\([^\)]+\)")
+# Markdown link [text](url): require non-empty text and url, and capture only the
+# url. The original `grep -oP '\[([^\]]+)\]\(([^\)]+)\)'` piped into a second grep
+# for `(...)` also matched parentheses inside the link *text*, so a link such as
+# `[TestExecution.StatsChange notification (Runner)](#anchor)` yielded both `Runner`
+# and the real url, and `Runner` was then reported as a missing file.
+_LINK_RE = re.compile(r"\[[^\]]+\]\(([^\)]+)\)")
 
 # HTML anchor: value of a name= or id= attribute inside an <a ...> tag. The tag/attr
 # match is case-insensitive; the extracted value is compared case-sensitively (as the
@@ -141,15 +143,18 @@ def collect_default_files():
 
 
 def extract_links(path):
-    """Yield every url found in markdown `[text](url)` links, reproducing the
-    `grep ... | grep ... | tr -d '()'` pipeline (including its multi-paren quirk)."""
+    """Yield the url of every markdown `[text](url)` link found in `path`."""
     for line in read_lines(path):
-        for m1 in _LINK_RE.finditer(line):
-            for m2 in _PAREN_RE.finditer(m1.group(0)):
-                yield m2.group(0).replace("(", "").replace(")", "")
+        for m in _LINK_RE.finditer(line):
+            yield m.group(1)
 
 
 def main(argv):
+    # The report contains non-ASCII status marks; on Windows the console defaults
+    # to cp1252 and writing them would raise UnicodeEncodeError.
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
     out_dir = os.environ.get("OUT_DIR", "/tmp/gh-aw/agent")
     os.makedirs(out_dir, exist_ok=True)
 
@@ -246,7 +251,9 @@ def main(argv):
             if source_dir == "":
                 source_dir = "."
             target_path = normalize_target("{}/{}".format(source_dir, rel_path))
-            if not os.path.isfile(target_path):
+            # os.path.exists, not os.path.isfile: links may legitimately point at a
+            # directory (e.g. `./RFCs`), which isfile() would report as broken.
+            if not os.path.exists(target_path):
                 broken_count += 1
                 msg = "\u274c {} (file not found: {}) in {}".format(url, target_path, source_file)
                 results.append(msg)


### PR DESCRIPTION
Fixes the false positives reported by the weekly relative link checker (#16307). On current `main` the checker reports 9 broken links; all 9 are bugs in the checker, not broken links.

## `.github/workflows/scripts/check-md-links.py`

**1. Parenthetical text in link labels was extracted as a URL.** `extract_links()` matched the whole `[text](url)` span and then scanned it for *every* `(...)` group, so

```markdown
[TestExecution.StatsChange notification (Runner)](#testexecutionstatschange-notification-runner)
```

yielded both `Runner` and the real anchor as candidates — and `Runner` was then reported as a missing file. The regex now captures the URL directly.

**2. Links to directories were reported broken.** The existence check used `os.path.isfile()`, which is `False` for directories, so valid links such as `./RFCs` and `../src/vstest.console/Processors` were flagged. Changed to `os.path.exists()`.

**3. Windows console crash (additional fix, not in the issue).** The final `sys.stdout.write` of the report raised `UnicodeEncodeError: 'charmap' codec can't encode character '\u2705'` on a cp1252 console, which breaks the local `@md-link-checker` Windows invocation documented in `.github/agents/md-link-checker.md`. `sys.stdout` is now reconfigured to UTF-8.

## Verification

Default scope (`docs/**/*.md` + `README.md`), run on this branch's tree:

**Before** — 9 broken, all false positives (and it crashed while printing the report on Windows):

```
.runsettings (file not found: .runsettings) in README.md
Client (file not found: docs\Client) in docs\Overview.md
ConsoleParameters (file not found: docs\ConsoleParameters) in docs\Overview.md
Runner (file not found: docs\Runner) in docs\Overview.md
Testhost (file not found: docs\Testhost) in docs\Overview.md
../src/vstest.console/Processors (file not found: src\vstest.console\Processors) in docs\commandline.md
Microsoft Learn (file not found: docs\Microsoft Learn) in docs\commandline.md
./RFCs (file not found: docs\RFCs) in docs\quickstart.md
.runsettings (file not found: docs\.runsettings) in docs\quickstart.md
```

**After** — `190 working, 0 broken`.

Also validated against a synthetic fixture that real breakage is still caught: a missing `.md` target, a missing anchor in an existing file, and a missing image are all still reported, while a parenthetical label and a directory target are not.
