### PR TITLE
[link-checker] Fix broken v16.5.0 compare link in releases.md

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1479,7 +1479,7 @@ See full log [here](https://github.com/microsoft/vstest/compare/v16.5.0-preview-
 * Correct name and link for RFC 17 [#2232](https://github.com/microsoft/vstest/pull/2232)
 
 See full log [here](https://github.com/microsoft/vstest/compare/v16.4.0...v16.5.0)
-See changes since the last preview [here](https://github.com/microsoft/vstest/compare/16.5.0-preview-20200203-01...v16.5.0)
+See changes since the last preview [here](https://github.com/microsoft/vstest/compare/v16.5.0-preview-20200203-01...v16.5.0)
 
 ### Drops
 


### PR DESCRIPTION
Fixes the broken compare link reported in #16306.

`docs/releases.md` linked to `https://github.com/microsoft/vstest/compare/16.5.0-preview-20200203-01...v16.5.0`. The left-hand tag was missing its `v` prefix, so the URL 404'd.

## Verification

```
v16.5.0-preview-20200203-01...v16.5.0  ->  200   (fixed)
 16.5.0-preview-20200203-01...v16.5.0  ->  404   (old)
```

The tag `refs/tags/v16.5.0-preview-20200203-01` exists; `refs/tags/16.5.0-preview-20200203-01` does not.

I also scanned every `github.com/microsoft/vstest/compare/...` URL in `releases.md` for the same mistake — this was the only one (the remaining non-`v` ref is a raw commit SHA, which is valid).

The other broken external links listed in #16306 (myget.org, `vsdrop.corp.microsoft.com`, deleted branches) are not fixable — the services or refs no longer exist.
