### PR TITLE
Fix TRX logger mangling astral-plane (non-BMP) characters

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/XML/XmlPersistence.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/XML/XmlPersistence.cs
@@ -675,16 +675,31 @@ internal class XmlPersistence
 
         // From xml spec (http://www.w3.org/TR/xml/#charsets) valid chars:
         // #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
-
-        // we are handling only #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD]
-        // because C# support unicode character in range \u0000 to \uFFFF
+        //
+        // In .NET a string is a sequence of UTF-16 code units, so characters in the
+        // [#x10000-#x10FFFF] (astral) range are represented by a surrogate pair: a high
+        // surrogate (\uD800-\uDBFF) followed by a low surrogate (\uDC00-\uDFFF). Such a
+        // pair is perfectly valid XML and must be preserved as-is, so the pattern below
+        // matches it first (and the evaluator passes it through untouched).
+        //
+        // A *lone* surrogate, on the other hand, is not a valid Unicode scalar value and
+        // is not valid XML - XmlWriter would throw on it - so it still has to be escaped.
+        // That is why we cannot simply add \uD800-\uDFFF to the allowed set: only properly
+        // paired surrogates are allowed through.
         MatchEvaluator evaluator = new(ReplaceInvalidCharacterWithUniCodeEscapeSequence);
-        string invalidChar = @"[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD]";
+        const string invalidChar = @"([\uD800-\uDBFF][\uDC00-\uDFFF])|([^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD])";
         return Regex.Replace(str, invalidChar, evaluator);
     }
 
     private static string ReplaceInvalidCharacterWithUniCodeEscapeSequence(Match match)
     {
+        // A well-formed surrogate pair matched the first alternation: it is valid XML,
+        // return it unchanged.
+        if (match.Groups[1].Success)
+        {
+            return match.Value;
+        }
+
         char x = match.Value[0];
         return $@"\u{(ushort)x:x4}";
     }

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/XML/XmlPersistence.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/XML/XmlPersistence.cs
@@ -10,7 +10,6 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Xml;
 
 using Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel;
@@ -679,30 +678,43 @@ internal class XmlPersistence
         // In .NET a string is a sequence of UTF-16 code units, so characters in the
         // [#x10000-#x10FFFF] (astral) range are represented by a surrogate pair: a high
         // surrogate (\uD800-\uDBFF) followed by a low surrogate (\uDC00-\uDFFF). Such a
-        // pair is perfectly valid XML and must be preserved as-is, so the pattern below
-        // matches it first (and the evaluator passes it through untouched).
+        // pair is perfectly valid XML and must be preserved as-is, so we look ahead with
+        // char.IsSurrogatePair and copy both code units through untouched.
         //
         // A *lone* surrogate, on the other hand, is not a valid Unicode scalar value and
         // is not valid XML - XmlWriter would throw on it - so it still has to be escaped.
-        // That is why we cannot simply add \uD800-\uDFFF to the allowed set: only properly
-        // paired surrogates are allowed through.
-        MatchEvaluator evaluator = new(ReplaceInvalidCharacterWithUniCodeEscapeSequence);
-        const string invalidChar = @"([\uD800-\uDBFF][\uDC00-\uDFFF])|([^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD])";
-        return Regex.Replace(str, invalidChar, evaluator);
-    }
-
-    private static string ReplaceInvalidCharacterWithUniCodeEscapeSequence(Match match)
-    {
-        // A well-formed surrogate pair matched the first alternation: it is valid XML,
-        // return it unchanged.
-        if (match.Groups[1].Success)
+        // That is why we cannot simply treat \uD800-\uDFFF as valid: doing so would trade
+        // a mangled-string bug for a "we emit unparseable XML" bug, which is worse because
+        // it breaks every consumer of the trx at read time. Only properly paired
+        // surrogates are allowed through.
+        StringBuilder? builder = null;
+        for (int i = 0; i < str.Length; i++)
         {
-            return match.Value;
+            // IsSurrogatePair also covers the end-of-string case, so a high surrogate as
+            // the last character correctly falls through to the invalid branch below.
+            if (char.IsSurrogatePair(str, i))
+            {
+                builder?.Append(str[i]).Append(str[i + 1]);
+                i++;
+                continue;
+            }
+
+            char c = str[i];
+            if (IsValidXmlChar(c))
+            {
+                builder?.Append(c);
+                continue;
+            }
+
+            builder ??= new StringBuilder(str.Length).Append(str, 0, i);
+            builder.Append(@"\u").Append(((ushort)c).ToString("x4", CultureInfo.InvariantCulture));
         }
 
-        char x = match.Value[0];
-        return $@"\u{(ushort)x:x4}";
+        return builder?.ToString() ?? str;
     }
+
+    private static bool IsValidXmlChar(char c)
+        => c is '\x09' or '\x0A' or '\x0D' or (>= '\x20' and <= '\uD7FF') or (>= '\uE000' and <= '\uFFFD');
 
     private XmlNode? EnsureLocationExists(XmlElement xml, string location, string? nameSpaceUri)
     {

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/XmlPersistenceTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/XmlPersistenceTests.cs
@@ -34,6 +34,21 @@ public class XmlPersistenceTests
     }
 
     [TestMethod]
+    public void SaveObjectShouldNotReplaceAdjacentHighAndLowSurrogate()
+    {
+        // 0xd800 immediately followed by 0xdc00 is not two invalid characters - it is the
+        // UTF-16 encoding of U+10000, which the XML spec lists as valid. It must round-trip
+        // unescaped. This case used to be asserted the other way around.
+        XmlPersistence xmlPersistence = new();
+        var node = xmlPersistence.CreateRootElement("TestRun");
+
+        string validSurrogatePair = new(new[] { (char)0xd800, (char)0xdc00 });
+        XmlPersistence.SaveObject(validSurrogatePair, node, null, "dummy");
+
+        Assert.AreEqual(validSurrogatePair, node.InnerXml);
+    }
+
+    [TestMethod]
     public void SaveObjectShouldNotReplaceWellFormedSurrogatePairInElementText()
     {
         // A surrogate pair encodes a character in [#x10000-#x10FFFF], which the XML spec

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/XmlPersistenceTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/XmlPersistenceTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Xml;
+
 using Microsoft.TestPlatform.Extensions.TrxLogger.XML;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -15,21 +17,121 @@ public class XmlPersistenceTests
         XmlPersistence xmlPersistence = new();
         var node = xmlPersistence.CreateRootElement("TestRun");
 
-        // we are handling only #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD]
-        char[] invalidXmlCharacterArray = new char[7];
+        // we are handling only #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] plus
+        // well-formed surrogate pairs, which encode [#x10000-#x10FFFF].
+        char[] invalidXmlCharacterArray = new char[5];
         invalidXmlCharacterArray[0] = (char)0x5;
         invalidXmlCharacterArray[1] = (char)0xb;
         invalidXmlCharacterArray[2] = (char)0xf;
-        invalidXmlCharacterArray[3] = (char)0xd800;
-        invalidXmlCharacterArray[4] = (char)0xdc00;
-        invalidXmlCharacterArray[5] = (char)0xfffe;
-        invalidXmlCharacterArray[6] = (char)0x0;
+        invalidXmlCharacterArray[3] = (char)0xfffe;
+        invalidXmlCharacterArray[4] = (char)0x0;
 
         string strWithInvalidCharForXml = new(invalidXmlCharacterArray);
         XmlPersistence.SaveObject(strWithInvalidCharForXml, node, null, "dummy");
 
-        string expectedResult = "\\u0005\\u000b\\u000f\\ud800\\udc00\\ufffe\\u0000";
+        string expectedResult = "\\u0005\\u000b\\u000f\\ufffe\\u0000";
         Assert.AreEqual(0, string.Compare(expectedResult, node.InnerXml));
+    }
+
+    [TestMethod]
+    public void SaveObjectShouldNotReplaceWellFormedSurrogatePairInElementText()
+    {
+        // A surrogate pair encodes a character in [#x10000-#x10FFFF], which the XML spec
+        // lists as valid, so it must survive untouched. Here U+1F389 (🎉).
+        XmlPersistence xmlPersistence = new();
+        var node = xmlPersistence.CreateRootElement("TestRun");
+
+        XmlPersistence.SaveObject("party \U0001F389 done", node, null, "dummy");
+
+        Assert.AreEqual("party \U0001F389 done", node.InnerXml);
+    }
+
+    [TestMethod]
+    public void SaveObjectShouldNotReplaceWellFormedSurrogatePairInAttributeValue()
+    {
+        XmlPersistence xmlPersistence = new();
+        var node = xmlPersistence.CreateRootElement("TestRun");
+
+        xmlPersistence.SaveObject("party \U0001F389 done", node, "@testName", null);
+
+        Assert.AreEqual("party \U0001F389 done", node.GetAttribute("testName"));
+    }
+
+    [TestMethod]
+    public void SaveObjectShouldReplaceLoneHighSurrogate()
+    {
+        // Unlike a pair, a lone high surrogate is not a valid Unicode scalar value and is
+        // not valid XML (XmlWriter would throw on it), so it must still be escaped.
+        XmlPersistence xmlPersistence = new();
+        var node = xmlPersistence.CreateRootElement("TestRun");
+
+        XmlPersistence.SaveObject("a" + (char)0xd800 + "b", node, null, "dummy");
+
+        Assert.AreEqual("a\\ud800b", node.InnerXml);
+    }
+
+    [TestMethod]
+    public void SaveObjectShouldReplaceLoneLowSurrogate()
+    {
+        // A low surrogate that is not preceded by a high surrogate is equally invalid.
+        XmlPersistence xmlPersistence = new();
+        var node = xmlPersistence.CreateRootElement("TestRun");
+
+        XmlPersistence.SaveObject((char)0xdc00 + "b", node, null, "dummy");
+
+        Assert.AreEqual("\\udc00b", node.InnerXml);
+    }
+
+    [TestMethod]
+    public void SaveObjectShouldReplaceHighSurrogateAtEndOfString()
+    {
+        // The pair-matching logic must not read past the end of the string.
+        XmlPersistence xmlPersistence = new();
+        var node = xmlPersistence.CreateRootElement("TestRun");
+
+        XmlPersistence.SaveObject("ab" + (char)0xd800, node, null, "dummy");
+
+        Assert.AreEqual("ab\\ud800", node.InnerXml);
+    }
+
+    [TestMethod]
+    public void SaveObjectShouldHandleMixOfValidPairLoneSurrogateAndInvalidCharacters()
+    {
+        XmlPersistence xmlPersistence = new();
+        var node = xmlPersistence.CreateRootElement("TestRun");
+
+        XmlPersistence.SaveObject("\U0001F389" + (char)0xd800 + "\v" + (char)0xdc00, node, null, "dummy");
+
+        // The pair is preserved; the lone high surrogate, the vertical tab and the
+        // trailing lone low surrogate are all escaped.
+        Assert.AreEqual("\U0001F389\\ud800\\u000b\\udc00", node.InnerXml);
+    }
+
+    [TestMethod]
+    public void SaveObjectShouldNotReplaceNonAsciiBmpCharacters()
+    {
+        XmlPersistence xmlPersistence = new();
+        var node = xmlPersistence.CreateRootElement("TestRun");
+
+        XmlPersistence.SaveObject("Grüße 日本語 Čau", node, null, "dummy");
+
+        Assert.AreEqual("Grüße 日本語 Čau", node.InnerXml);
+    }
+
+    [TestMethod]
+    public void SaveObjectShouldProduceWellFormedXmlWithAstralCharacters()
+    {
+        XmlPersistence xmlPersistence = new();
+        var node = xmlPersistence.CreateRootElement("TestRun");
+
+        xmlPersistence.SaveObject("party \U0001F389 done", node, "@testName", null);
+        XmlPersistence.SaveObject("output \U0001F389 here", node, null, "dummy");
+
+        XmlDocument document = new();
+        document.LoadXml(node.OuterXml);
+
+        Assert.AreEqual("party \U0001F389 done", document.DocumentElement!.GetAttribute("testName"));
+        Assert.AreEqual("output \U0001F389 here", document.DocumentElement.InnerText);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Symptom

Every astral-plane (non-BMP) character written to a TRX file is corrupted into literal escape text. A test named `party 🎉 done` is recorded in the TRX as the literal text `party \ud83c\udf89 done`. The same happens to anything the emoji appears in: `Console.WriteLine` output (`Output/StdOut`, `StdErr`, `DebugTrace`), error messages and stack traces, `TestMethod/@name` and `@className`, computer name, attachment descriptions, owners and categories.

This hits emoji, rare CJK extensions, mathematical alphanumerics and several historic scripts. It affects the **classic vstest path and the Microsoft Testing Platform path equally**, because the bug is in the shared TRX writer, not in any adapter.

## Root cause

`XmlPersistence.RemoveInvalidXmlChar` operates on UTF-16 *code units*:

```csharp
// we are handling only #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD]
// because C# support unicode character in range \^@ to \uFFFF
string invalidChar = @"[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD]";
return Regex.Replace(str, invalidChar, evaluator);
```

The allowed set stops at `\uD7FF` and resumes at `\uE000`, so it skips U+D800–U+DFFF entirely — the surrogate range. Each half of a *valid, well-formed* surrogate pair is therefore independently classified as an invalid XML character and escaped. The comment is self-refuting: it quotes the XML spec including `[#x10000-#x10FFFF]` and then excludes the only mechanism by which UTF-16 can represent that range.

After — a surrogate-aware scan:

```csharp
if (char.IsSurrogatePair(str, i)) { /* copy both code units through untouched */ i++; continue; }
if (IsValidXmlChar(str[i])) { /* copy through */ continue; }
/* otherwise escape as \uXXXX */
```

This follows the same control flow as the Jsonite JSON writer in testfx (`JsonWriter.cs`), which solves the identical problem: look ahead on a high surrogate, emit both code units if a low surrogate follows, treat it as invalid otherwise. `char.IsSurrogatePair(str, i)` does the lookahead-and-validate in one call and is safe at end-of-string, so a trailing high surrogate correctly falls through to the invalid branch without any out-of-range indexing. As a side benefit the `StringBuilder` is allocated lazily, so the overwhelmingly common all-valid string is now returned as-is with no allocation, replacing an unconditional `Regex.Replace`.

## Lone surrogates are still escaped — deliberately

The fix is emphatically **not** "allow U+D800–U+DFFF". That would trade a string-mangling bug for a "vstest emits unparseable XML" bug, which is strictly worse — it fails at read time for every consumer of the TRX instead of degrading one string. A lone/unpaired surrogate is not a valid Unicode scalar value and is not valid XML — `XmlWriter` throws on it — so it must continue to be escaped. Only properly paired surrogates pass through. The comment in the source now spells this out, so it doesn't get "simplified" away later.

Covered cases: valid pair anywhere in the string survives byte-for-byte; lone high surrogate escaped; lone low surrogate escaped; high surrogate as the final character escaped without out-of-range indexing; low surrogate as the first character escaped. Behaviour for all other invalid characters (`\0`, `\v`, `\x05`, `\uFFFE`, …) and for all valid BMP characters is unchanged.

## An existing test encoded the old, wrong behaviour

`XmlPersistenceTests.SaveObjectShouldReplaceInvalidCharacter` put `(char)0xd800` and `(char)0xdc00` adjacent in its "invalid characters" array and asserted the output contained `\ud800\udc00`. Those two chars form a **valid** surrogate pair for U+10000, which is legal XML, so the assertion was wrong. Rather than deleting the test, it has been split so both halves of the behaviour are pinned:

- `SaveObjectShouldReplaceInvalidCharacter` keeps the genuinely invalid `0x5`, `0xb`, `0xf`, `0xfffe`, `0x0` with unchanged expectations, guarding against over-correcting.
- `SaveObjectShouldNotReplaceAdjacentHighAndLowSurrogate` asserts that the exact `(char)0xd800, (char)0xdc00` sequence now round-trips **unescaped**.
- `SaveObjectShouldReplaceLoneHighSurrogate` asserts a *lone* `(char)0xd800` still comes out as `\ud800`.

Further new tests: valid pair preserved through an attribute value and through element inner text; lone low surrogate escaped; high surrogate at end-of-string escaped; a string mixing a valid pair, a lone surrogate and other invalid characters handled correctly in one pass; BMP non-ASCII (`Grüße 日本語 Čau`) untouched; and a round-trip test asserting the produced XML still parses with `XmlDocument.LoadXml` with a real emoji present in both an attribute and element text.

## Validation

`Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests` — 164/164 passing in Release on both target frameworks (net481 and net11.0).

## Precedent: the HTML logger in this repo already gets this right

`Microsoft.TestPlatform.Extensions.HtmlLogger` has its own copy of this sanitization and already handles surrogate pairs correctly (`HtmlLogger.cs:44-46`):

```csharp
private static readonly Regex InvalidXmlCharsRegex = new(
    @"[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\uD800-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]",
    RegexOptions.Compiled);
```

That pattern excludes the surrogate range from the "invalid" class and then matches only *lone* surrogates via lookahead/lookbehind — semantically identical to what this change does for the TRX writer, just expressed as a regex rather than a scan.

So the correct behaviour was already established in this codebase; the TRX writer simply never received it. That makes the current TRX behaviour an inconsistency rather than a deliberate design choice, and it means the two loggers now agree on how a test name containing an emoji is recorded.
