### PR TITLE
Bump Microsoft.VisualStudio.Diagnostics.Utilities to a release-branch build to fix SymbolCheck

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,7 +57,7 @@
       Make sure you are taking a version from a release branch (rel/d*) in VS. Otherwise there won't be symbols for the dlls in package,
       a and it will create a symcheck bug on re-insertion into VS.
     -->
-    <MicrosoftVisualStudioDiagnosticsUtilitiesVersion>18.3.11611.365</MicrosoftVisualStudioDiagnosticsUtilitiesVersion>
+    <MicrosoftVisualStudioDiagnosticsUtilitiesVersion>18.3.11527.243</MicrosoftVisualStudioDiagnosticsUtilitiesVersion>
     <MicrosoftVisualStudioEnterpriseAspNetHelper>$(MicrosoftVisualStudioDiagnosticsUtilitiesVersion)</MicrosoftVisualStudioEnterpriseAspNetHelper>
     <MicrosoftVisualStudioInteropVersion>17.13.39960</MicrosoftVisualStudioInteropVersion>
     <MicrosoftVSTelemetryVersion>17.13.24</MicrosoftVSTelemetryVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,7 +57,7 @@
       Make sure you are taking a version from a release branch (rel/d*) in VS. Otherwise there won't be symbols for the dlls in package,
       a and it will create a symcheck bug on re-insertion into VS.
     -->
-    <MicrosoftVisualStudioDiagnosticsUtilitiesVersion>18.3.11401.5</MicrosoftVisualStudioDiagnosticsUtilitiesVersion>
+    <MicrosoftVisualStudioDiagnosticsUtilitiesVersion>18.3.11611.365</MicrosoftVisualStudioDiagnosticsUtilitiesVersion>
     <MicrosoftVisualStudioEnterpriseAspNetHelper>$(MicrosoftVisualStudioDiagnosticsUtilitiesVersion)</MicrosoftVisualStudioEnterpriseAspNetHelper>
     <MicrosoftVisualStudioInteropVersion>17.13.39960</MicrosoftVisualStudioInteropVersion>
     <MicrosoftVSTelemetryVersion>17.13.24</MicrosoftVSTelemetryVersion>


### PR DESCRIPTION
Fixes the `SymbolCheck` failure blocking VS Test Platform insertions into VS.

## Problem

The VS insertion PR for `rel/18.10/20260727.2` ([VS !763202](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/763202)) fails `Insertion Symbol Check` with 4 unarchived files in `Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI`:

- `microsoft.visualstudio.enterprise.aspnethelper.dll`
- `microsoft.visualstudio.diagnostics.utilities.dll`
- `microsoft.visualstudio.architecturetools.pereader.dll`
- `extensions\microsoft.visualstudio.architecturetools.pereader.dll`

Auto-filed bug: 3038905.

## Cause

All four come from a single version property in `eng/Versions.props`, which drives three `PackageReference`s in `Microsoft.TestPlatform.csproj` (lines 98-100) whose DLLs are bundled into the CLI vsix (`...V2.CLI.csproj` lines 104-109; PEReader ships twice, root + `Extensions\`).

The pin sits directly under a comment warning about this exact failure:

> Make sure you are taking a version from a release branch (`rel/d*`) in VS. Otherwise there won't be symbols for the dlls in package, and it will create a symcheck bug on re-insertion into VS.

`18.3.11401.5` has never been touched since `d187201` ("Onboard to arcade") and is not a release-branch build, so no symbols were ever published for it.

## Fix

Bump to `18.3.11527.243` - the newest stable on the `vs-impl` feed, and **already used by `MicrosoftInternalTestPlatformExtensions` on line 76 of this same file**, so it is a known-good release-branch build.

One line, covers all three packages and all four files.

## Notes

- Targets `rel/18.10` because that is what the failing insertion is built from. **Needs forward-porting to `main`**, which carries the same stale pin (18.11 would otherwise regress).
- Does not address the other failure on !763202, `BackwardCompatibilityTest` - that is handled VS-side by [VS !764445](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/764445), adding APICompat suppressions for the test-session APIs removed in #16231.
- Symbol availability is only truly verified at insertion time, so the real confirmation is a green SymbolCheck on the next insertion.


## Verification

Checked with `symchk` from `VS.Tools.VerifyInsertion.Tools` against msdl, per the guidance on bug 3038905:

```
symchk.exe /s SRV*http://msdl.microsoft.com/download/symbols <dll>
```

Control - `Microsoft.VisualStudio.Interop.dll`, bundled in the same vsix and **not** reported by the failing check - `PASSED`, confirming the method is sound.

Scan of recent versions of `Microsoft.VisualStudio.Diagnostics.Utilities`:

| Version | symchk |
|--|--|
| 18.3.11611.365 | FAILED |
| **18.3.11527.243** | **PASSED** |
| 18.3.11524.190 | PASSED |
| 18.3.11520.95 | PASSED |
| 18.3.11518.184 | PASSED |
| 18.3.11517.146 | FAILED |
| 18.3.11512.103 | PASSED |
| 18.3.11511.245 | FAILED |
| 18.3.11510.144 | FAILED |
| 18.3.11505.172 | PASSED |
| 18.3.11503.203 | PASSED |
| 18.3.11429.125 | PASSED |
| 18.3.11401.5 (current) | FAILED |

Symbol publishing is evidently inconsistent across builds, so the version cannot be picked by recency alone - it has to be checked.

At **18.3.11527.243**, all three packages pass:

```
SYMCHK: FAILED files = 0
SYMCHK: PASSED + IGNORED files = 3
```

(`Diagnostics.Utilities`, `Enterprise.AspNetHelper`, `ArchitectureTools.PEReader`)
