### PR TITLE
Bump Microsoft.VisualStudio.Diagnostics.Utilities to a release-branch build to fix SymbolCheck (main)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,7 +57,7 @@
       Make sure you are taking a version from a release branch (rel/d*) in VS. Otherwise there won't be symbols for the dlls in package,
       a and it will create a symcheck bug on re-insertion into VS.
     -->
-    <MicrosoftVisualStudioDiagnosticsUtilitiesVersion>18.3.11611.365</MicrosoftVisualStudioDiagnosticsUtilitiesVersion>
+    <MicrosoftVisualStudioDiagnosticsUtilitiesVersion>18.3.11527.243</MicrosoftVisualStudioDiagnosticsUtilitiesVersion>
     <MicrosoftVisualStudioEnterpriseAspNetHelper>$(MicrosoftVisualStudioDiagnosticsUtilitiesVersion)</MicrosoftVisualStudioEnterpriseAspNetHelper>
     <MicrosoftVisualStudioInteropVersion>17.13.39960</MicrosoftVisualStudioInteropVersion>
     <MicrosoftVSTelemetryVersion>17.13.24</MicrosoftVSTelemetryVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,7 +57,7 @@
       Make sure you are taking a version from a release branch (rel/d*) in VS. Otherwise there won't be symbols for the dlls in package,
       a and it will create a symcheck bug on re-insertion into VS.
     -->
-    <MicrosoftVisualStudioDiagnosticsUtilitiesVersion>18.3.11401.5</MicrosoftVisualStudioDiagnosticsUtilitiesVersion>
+    <MicrosoftVisualStudioDiagnosticsUtilitiesVersion>18.3.11611.365</MicrosoftVisualStudioDiagnosticsUtilitiesVersion>
     <MicrosoftVisualStudioEnterpriseAspNetHelper>$(MicrosoftVisualStudioDiagnosticsUtilitiesVersion)</MicrosoftVisualStudioEnterpriseAspNetHelper>
     <MicrosoftVisualStudioInteropVersion>17.13.39960</MicrosoftVisualStudioInteropVersion>
     <MicrosoftVSTelemetryVersion>17.13.24</MicrosoftVSTelemetryVersion>


### PR DESCRIPTION
Forward-port of #16322 to `main`.

## Why

`main` carries the same stale pin as `rel/18.10`:

```xml
<MicrosoftVisualStudioDiagnosticsUtilitiesVersion>18.3.11401.5</MicrosoftVisualStudioDiagnosticsUtilitiesVersion>
```

`18.3.11401.5` is not a VS release-branch build, so no symbols were ever published for its DLLs. That fails `Insertion Symbol Check` on every VS insertion - see [VS !763202](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/763202) and bug 3038905, where it reported 4 unarchived files:

- `microsoft.visualstudio.enterprise.aspnethelper.dll`
- `microsoft.visualstudio.diagnostics.utilities.dll`
- `microsoft.visualstudio.architecturetools.pereader.dll`
- `extensions\microsoft.visualstudio.architecturetools.pereader.dll`

The property drives three `PackageReference`s in `Microsoft.TestPlatform.csproj` (lines 98-100) whose DLLs are bundled into the CLI vsix (`...V2.CLI.csproj` lines 104-109, PEReader shipping twice). The pin sits right under a comment warning about exactly this:

> Make sure you are taking a version from a release branch (`rel/d*`) in VS. Otherwise there won't be symbols for the dlls in package, and it will create a symcheck bug on re-insertion into VS.

#16322 fixes `rel/18.10` (the branch the failing insertion is built from). Without this companion PR, 18.11 would ship the same bug.

## Fix

Bump to `18.3.11527.243` - newest stable on the `vs-impl` feed and **already used by `MicrosoftInternalTestPlatformExtensions` in this same file**, so a known-good release-branch build.

One line, covers all three packages and all four files.


## Verification

Checked with `symchk` from `VS.Tools.VerifyInsertion.Tools` against msdl, per the guidance on bug 3038905:

```
symchk.exe /s SRV*http://msdl.microsoft.com/download/symbols <dll>
```

Control - `Microsoft.VisualStudio.Interop.dll`, bundled in the same vsix and **not** reported by the failing check - `PASSED`, confirming the method is sound.

Scan of recent versions of `Microsoft.VisualStudio.Diagnostics.Utilities`:

| Version | symchk |
|--|--|
| 18.3.11611.365 | FAILED |
| **18.3.11527.243** | **PASSED** |
| 18.3.11524.190 | PASSED |
| 18.3.11520.95 | PASSED |
| 18.3.11518.184 | PASSED |
| 18.3.11517.146 | FAILED |
| 18.3.11512.103 | PASSED |
| 18.3.11511.245 | FAILED |
| 18.3.11510.144 | FAILED |
| 18.3.11505.172 | PASSED |
| 18.3.11503.203 | PASSED |
| 18.3.11429.125 | PASSED |
| 18.3.11401.5 (current) | FAILED |

Symbol publishing is evidently inconsistent across builds, so the version cannot be picked by recency alone - it has to be checked.

At **18.3.11527.243**, all three packages pass:

```
SYMCHK: FAILED files = 0
SYMCHK: PASSED + IGNORED files = 3
```

(`Diagnostics.Utilities`, `Enterprise.AspNetHelper`, `ArchitectureTools.PEReader`)
