### PR TITLE
Quote left side of MSBuild condition expressions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -58,7 +58,7 @@
       https://github.com/dotnet/arcade/blob/66c9c5397d599af40f2a94989241944f5a73442a/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetFrameworkDefaults.props#L16-L18
       Because I don't want to complexify further the logic on VSTest just for that, I will set it to NetMinimum.
     -->
-    <NetPrevious Condition=" $(NetPrevious) == '' ">$(NetMinimum)</NetPrevious>
+    <NetPrevious Condition=" '$(NetPrevious)' == '' ">$(NetMinimum)</NetPrevious>
 
     <!--
       vstest.console.exe is shipped with VS, we can use the version of .NET Framework that VS requires to run (this might differ from the version is requires to install).

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -37,7 +37,7 @@
 
   <!-- Test project settings -->
   <Choose>
-    <When Condition="$(TestProject) == 'true' AND '$(ExcludeRepoTestProjectSettings)' != 'true'">
+    <When Condition="'$(TestProject)' == 'true' AND '$(ExcludeRepoTestProjectSettings)' != 'true'">
       <PropertyGroup>
         <!-- Suppress warnings about testhost being x64 (AMD64)/x86 when imported into AnyCPU (MSIL) test projects. -->
         <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>


### PR DESCRIPTION
Fixes the two rule B-2 findings reported in #16308.

- `Directory.Build.props`: `<NetPrevious Condition=" $(NetPrevious) == '' ">` → `'$(NetPrevious)'`
- `Directory.Build.targets`: `<When Condition="$(TestProject) == 'true' AND ...">` → `'$(TestProject)'`

Unquoted properties on the left of `==` expand to nothing when unset, which can yield a malformed condition expression. Quoting is the standard MSBuild pattern and is semantically equivalent when the property is set.

Verified with a full `build.cmd -c Release` — all projects including test projects build (exercising the `TestProject` condition). The only failure is a pre-existing `VSSDK1025` packaging error for an internal-only Cpp extension file, unrelated to this change.

Fixes #16308
