### PR TITLE
Fix logger concurrency correctness and TRX write reliability

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/HtmlLogger.cs
@@ -169,21 +169,11 @@ public class HtmlLogger : ITestLoggerWithParameters
         switch (e.Level)
         {
             case TestMessageLevel.Informational:
-                if (TestRunDetails.RunLevelMessageInformational == null)
-                {
-                    TestRunDetails.RunLevelMessageInformational = new List<string>();
-                }
-
-                TestRunDetails.RunLevelMessageInformational.Add(e.Message);
+                TestRunDetails.AddInformationalMessage(e.Message);
                 break;
             case TestMessageLevel.Warning:
             case TestMessageLevel.Error:
-                if (TestRunDetails.RunLevelMessageErrorAndWarning == null)
-                {
-                    TestRunDetails.RunLevelMessageErrorAndWarning = new List<string>();
-                }
-
-                TestRunDetails.RunLevelMessageErrorAndWarning.Add(e.Message);
+                TestRunDetails.AddErrorOrWarningMessage(e.Message);
                 break;
             default:
                 EqtTrace.Info("htmlLogger.TestMessageHandler: The test message level is unrecognized: {0}",
@@ -219,13 +209,19 @@ public class HtmlLogger : ITestLoggerWithParameters
         ResultCollectionDictionary.TryGetValue(e.Result.TestCase.Source, out var testResultCollection);
         if (testResultCollection == null)
         {
-            testResultCollection = new TestResultCollection(e.Result.TestCase.Source)
+            var newTestResultCollection = new TestResultCollection(e.Result.TestCase.Source)
             {
                 ResultList = new List<ObjectModel.TestResult>(),
                 FailedResultList = new List<ObjectModel.TestResult>(),
             };
-            ResultCollectionDictionary.TryAdd(e.Result.TestCase.Source, testResultCollection);
-            TestRunDetails.ResultCollectionList!.Add(testResultCollection);
+
+            // GetOrAdd is atomic: only the thread whose instance was actually stored publishes it
+            // to the result collection list, so no duplicate entries can appear there.
+            testResultCollection = ResultCollectionDictionary.GetOrAdd(e.Result.TestCase.Source, newTestResultCollection);
+            if (ReferenceEquals(testResultCollection, newTestResultCollection))
+            {
+                TestRunDetails.AddResultCollection(testResultCollection);
+            }
         }
 
         Interlocked.Increment(ref _totalTests);
@@ -249,12 +245,7 @@ public class HtmlLogger : ITestLoggerWithParameters
         // Check for parent execution id to store the test results in hierarchical way
         if (parentExecutionId == Guid.Empty)
         {
-            if (e.Result.Outcome == TestOutcome.Failed)
-            {
-                testResultCollection.FailedResultList!.Add(testResult);
-            }
-
-            testResultCollection.ResultList!.Add(testResult);
+            testResultCollection.AddResult(testResult, e.Result.Outcome == TestOutcome.Failed);
         }
         else
         {
@@ -268,9 +259,7 @@ public class HtmlLogger : ITestLoggerWithParameters
 
         if (Results.TryGetValue(parentExecutionId, out var parentTestResult))
         {
-            parentTestResult.InnerTestResults ??= new List<ObjectModel.TestResult>();
-
-            parentTestResult.InnerTestResults.Add(testResult);
+            parentTestResult.AddInnerTestResult(testResult);
         }
     }
 

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/ObjectModel/HtmlTestResult.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/ObjectModel/HtmlTestResult.cs
@@ -16,6 +16,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger.ObjectModel;
 public class TestResult
 {
     /// <summary>
+    /// Guards <see cref="InnerTestResults"/>, which is appended to from multiple threads when
+    /// data driven results are reported concurrently during parallel execution.
+    /// </summary>
+    private readonly object _innerResultsLock = new();
+
+    /// <summary>
     /// Fully qualified name of the Test Result.
     /// </summary>
     [DataMember] public string? FullyQualifiedName { get; set; }
@@ -54,4 +60,16 @@ public class TestResult
     /// The list of TestResults that are children to the current Test Result.
     /// </summary>
     [DataMember] public List<TestResult>? InnerTestResults { get; set; }
+
+    /// <summary>
+    /// Adds a child result. Safe to call concurrently from multiple threads.
+    /// </summary>
+    internal void AddInnerTestResult(TestResult innerTestResult)
+    {
+        lock (_innerResultsLock)
+        {
+            InnerTestResults ??= new List<TestResult>();
+            InnerTestResults.Add(innerTestResult);
+        }
+    }
 }

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/ObjectModel/TestResultCollection.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/ObjectModel/TestResultCollection.cs
@@ -15,6 +15,12 @@ public class TestResultCollection
 {
     private readonly string _source;
 
+    /// <summary>
+    /// Guards <see cref="ResultList"/> and <see cref="FailedResultList"/>, which are appended to
+    /// from multiple threads while tests execute in parallel.
+    /// </summary>
+    private readonly object _resultsLock = new();
+
     public TestResultCollection(string source) => _source = source ?? throw new ArgumentNullException(nameof(source));
 
     /// <summary>
@@ -46,4 +52,23 @@ public class TestResultCollection
     /// List of failed test results.
     /// </summary>
     [DataMember] public List<TestResult>? FailedResultList { get; set; }
+
+    /// <summary>
+    /// Adds a result to <see cref="ResultList"/>, and to <see cref="FailedResultList"/> when the
+    /// result is a failure. Safe to call concurrently from multiple threads.
+    /// </summary>
+    internal void AddResult(TestResult testResult, bool isFailed)
+    {
+        lock (_resultsLock)
+        {
+            if (isFailed)
+            {
+                FailedResultList ??= new List<TestResult>();
+                FailedResultList.Add(testResult);
+            }
+
+            ResultList ??= new List<TestResult>();
+            ResultList.Add(testResult);
+        }
+    }
 }

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/ObjectModel/TestRunDetails.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/ObjectModel/TestRunDetails.cs
@@ -15,6 +15,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger.ObjectModel;
 public sealed class TestRunDetails
 {
     /// <summary>
+    /// Guards the lazily created run level message lists and <see cref="ResultCollectionList"/>,
+    /// all of which are mutated from multiple threads while tests execute in parallel.
+    /// </summary>
+    private readonly object _syncLock = new();
+
+    /// <summary>
     /// Test run summary of all test results.
     /// </summary>
     [DataMember] public TestRunSummary? Summary { get; set; }
@@ -33,4 +39,40 @@ public sealed class TestRunDetails
     /// List of all the results
     /// </summary>
     [DataMember] public List<TestResultCollection>? ResultCollectionList = new();
+
+    /// <summary>
+    /// Adds an informational run level message. Safe to call concurrently from multiple threads.
+    /// </summary>
+    internal void AddInformationalMessage(string message)
+    {
+        lock (_syncLock)
+        {
+            RunLevelMessageInformational ??= new List<string>();
+            RunLevelMessageInformational.Add(message);
+        }
+    }
+
+    /// <summary>
+    /// Adds an error or warning run level message. Safe to call concurrently from multiple threads.
+    /// </summary>
+    internal void AddErrorOrWarningMessage(string message)
+    {
+        lock (_syncLock)
+        {
+            RunLevelMessageErrorAndWarning ??= new List<string>();
+            RunLevelMessageErrorAndWarning.Add(message);
+        }
+    }
+
+    /// <summary>
+    /// Adds a result collection. Safe to call concurrently from multiple threads.
+    /// </summary>
+    internal void AddResultCollection(TestResultCollection resultCollection)
+    {
+        lock (_syncLock)
+        {
+            ResultCollectionList ??= new List<TestResultCollection>();
+            ResultCollectionList.Add(resultCollection);
+        }
+    }
 }

--- a/src/Microsoft.TestPlatform.Extensions.HtmlLogger/ObjectModel/TestRunDetails.cs
+++ b/src/Microsoft.TestPlatform.Extensions.HtmlLogger/ObjectModel/TestRunDetails.cs
@@ -15,8 +15,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger.ObjectModel;
 public sealed class TestRunDetails
 {
     /// <summary>
-    /// Guards the lazily created run level message lists and <see cref="ResultCollectionList"/>,
-    /// all of which are mutated from multiple threads while tests execute in parallel.
+    /// Guards the run level message lists, which are created on first use, and
+    /// <see cref="ResultCollectionList"/>. All of them are mutated from multiple threads while
+    /// tests execute in parallel.
     /// </summary>
     private readonly object _syncLock = new();
 

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Interfaces/ITestAggregation.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Interfaces/ITestAggregation.cs
@@ -8,5 +8,13 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel;
 
 internal interface ITestAggregation : ITestElement
 {
-    Dictionary<Guid, TestLink> TestLinks { get; }
+    /// <summary>
+    /// Gets a snapshot of the test links.
+    /// </summary>
+    IReadOnlyDictionary<Guid, TestLink> TestLinks { get; }
+
+    /// <summary>
+    /// Adds a test link, unless a link with the same id was already added.
+    /// </summary>
+    void AddTestLink(TestLink testLink);
 }

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestElementAggregation.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/ObjectModel/TestElementAggregation.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Microsoft.TestPlatform.Extensions.TrxLogger.XML;
 
@@ -13,26 +14,60 @@ namespace Microsoft.TestPlatform.Extensions.TrxLogger.ObjectModel;
 /// </summary>
 internal abstract class TestElementAggregation : TestElement, ITestAggregation
 {
-    protected Dictionary<Guid, TestLink> _testLinks = new();
+    /// <summary>
+    /// Guards <see cref="_testLinks"/>, which is mutated from multiple threads when test results
+    /// are reported concurrently during parallel execution. A lock is used instead of a
+    /// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey, TValue}"/> so that the
+    /// insertion order of the test links, which is meaningful for ordered tests, is preserved.
+    /// </summary>
+    private readonly object _testLinksLock = new();
+
+    private readonly Dictionary<Guid, TestLink> _testLinks = new();
 
     public TestElementAggregation(Guid id, string name, string adapter) : base(id, name, adapter) { }
 
     /// <summary>
-    /// Test links.
+    /// Gets a snapshot of the test links.
     /// </summary>
-    public Dictionary<Guid, TestLink> TestLinks
+    public IReadOnlyDictionary<Guid, TestLink> TestLinks
     {
-        get { return _testLinks; }
+        get
+        {
+            lock (_testLinksLock)
+            {
+                return new Dictionary<Guid, TestLink>(_testLinks);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Adds a test link, unless a link with the same id was already added.
+    /// </summary>
+    public void AddTestLink(TestLink testLink)
+    {
+        lock (_testLinksLock)
+        {
+            if (!_testLinks.ContainsKey(testLink.Id))
+            {
+                _testLinks.Add(testLink.Id, testLink);
+            }
+        }
     }
 
     public override void Save(System.Xml.XmlElement element, XmlTestStoreParameters? parameters)
     {
         base.Save(element, parameters);
 
-        XmlPersistence h = new();
-        if (_testLinks.Count > 0)
+        List<TestLink> testLinks;
+        lock (_testLinksLock)
         {
-            h.SaveIEnumerable(_testLinks.Values, element, "TestLinks", ".", "TestLink", parameters);
+            testLinks = _testLinks.Values.ToList();
+        }
+
+        XmlPersistence h = new();
+        if (testLinks.Count > 0)
+        {
+            h.SaveIEnumerable(testLinks, element, "TestLinks", ".", "TestLink", parameters);
         }
     }
 }

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/TrxResource.Designer.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/TrxResource.Designer.cs
@@ -341,6 +341,15 @@ namespace Microsoft.VisualStudio.TestPlatform.Extensions.TrxLogger.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to write the results file &apos;{0}&apos;. {1}.
+        /// </summary>
+        internal static string TrxLoggerWriteFailed {
+            get {
+                return ResourceManager.GetString("TrxLoggerWriteFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to All Loaded Results.
         /// </summary>
         internal static string TS_AllResults {

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/TrxResource.resx
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/TrxResource.resx
@@ -217,4 +217,7 @@ Error Details: {1}:{2}</value>
   <data name="Common_CannotGetNextTimestampFileName" xml:space="preserve">
     <value>Cannot get find an available filename for {0} using timestamp format '{2}' at {1}.</value>
   </data>
+  <data name="TrxLoggerWriteFailed" xml:space="preserve">
+    <value>Failed to write the results file '{0}'. {1}</value>
+  </data>
 </root>

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.cs.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.cs.xlf
@@ -308,6 +308,11 @@ Fehlerdetails: {1}: {2}</target>
         <target state="translated">Nepovedlo se najít dostupný název souboru pro {0} pomocí formátu časového razítka {2} v {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TrxLoggerWriteFailed">
+        <source>Failed to write the results file '{0}'. {1}</source>
+        <target state="new">Failed to write the results file '{0}'. {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.de.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.de.xlf
@@ -308,6 +308,11 @@ Fehlerdetails: {1}: {2}</target>
         <target state="translated">Unter "{1}" wurde kein verfügbarer Dateiname für "{0}" mit dem Zeitstempelformat "{2}" abgerufen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TrxLoggerWriteFailed">
+        <source>Failed to write the results file '{0}'. {1}</source>
+        <target state="new">Failed to write the results file '{0}'. {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.es.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.es.xlf
@@ -308,6 +308,11 @@ Fehlerdetails: {1}: {2}</target>
         <target state="translated">No se encuentra ningún nombre de archivo disponible para {0} con el formato de marca de tiempo "{2}" en {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TrxLoggerWriteFailed">
+        <source>Failed to write the results file '{0}'. {1}</source>
+        <target state="new">Failed to write the results file '{0}'. {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.fr.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.fr.xlf
@@ -308,6 +308,11 @@ Fehlerdetails: {1}: {2}</target>
         <target state="translated">Impossible de trouver un nom de fichier disponible pour {0} avec le format d'horodatage '{2}' à l'emplacement {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TrxLoggerWriteFailed">
+        <source>Failed to write the results file '{0}'. {1}</source>
+        <target state="new">Failed to write the results file '{0}'. {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.it.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.it.xlf
@@ -308,6 +308,11 @@ Fehlerdetails: {1}: {2}</target>
         <target state="translated">Non è possibile ottenere o trovare un nome file disponibile per {0} che usa il formato timestamp '{2}' nella directory {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TrxLoggerWriteFailed">
+        <source>Failed to write the results file '{0}'. {1}</source>
+        <target state="new">Failed to write the results file '{0}'. {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.ja.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.ja.xlf
@@ -308,6 +308,11 @@ Fehlerdetails: {1}: {2}</target>
         <target state="translated">{1} でタイムスタンプ形式 '{2}' を使用して {0} の使用可能なファイル名を取得できません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TrxLoggerWriteFailed">
+        <source>Failed to write the results file '{0}'. {1}</source>
+        <target state="new">Failed to write the results file '{0}'. {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.ko.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.ko.xlf
@@ -308,6 +308,11 @@ Fehlerdetails: {1}: {2}</target>
         <target state="translated">{1}에서 타임스탬프 형식 '{2}'을(를) 사용하는 {0}의 사용 가능한 파일 이름을 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TrxLoggerWriteFailed">
+        <source>Failed to write the results file '{0}'. {1}</source>
+        <target state="new">Failed to write the results file '{0}'. {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.pl.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.pl.xlf
@@ -308,6 +308,11 @@ Fehlerdetails: {1}: {2}</target>
         <target state="translated">Nie można znaleźć dostępnej nazwy pliku dla elementu {0} przy użyciu formatu sygnatury czasowej „{2}” o {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TrxLoggerWriteFailed">
+        <source>Failed to write the results file '{0}'. {1}</source>
+        <target state="new">Failed to write the results file '{0}'. {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.pt-BR.xlf
@@ -308,6 +308,11 @@ Fehlerdetails: {1}: {2}</target>
         <target state="translated">Não é possível localizar um nome de arquivo disponível para {0} usando o formato de carimbo de data/hora '{2}' em {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TrxLoggerWriteFailed">
+        <source>Failed to write the results file '{0}'. {1}</source>
+        <target state="new">Failed to write the results file '{0}'. {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.ru.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.ru.xlf
@@ -308,6 +308,11 @@ Fehlerdetails: {1}: {2}</target>
         <target state="translated">Не удается найти доступное имя файла в {0} с использованием формата метки времени "{2}" в {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TrxLoggerWriteFailed">
+        <source>Failed to write the results file '{0}'. {1}</source>
+        <target state="new">Failed to write the results file '{0}'. {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.tr.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.tr.xlf
@@ -308,6 +308,11 @@ Fehlerdetails: {1}: {2}</target>
         <target state="translated">{1} konumundaki '{2}' zaman damgası biçimi kullanılarak {0} için kullanılabilir bir dosya adı alınamıyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TrxLoggerWriteFailed">
+        <source>Failed to write the results file '{0}'. {1}</source>
+        <target state="new">Failed to write the results file '{0}'. {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.zh-Hans.xlf
@@ -308,6 +308,11 @@ Fehlerdetails: {1}: {2}</target>
         <target state="translated">无法在 {1} 处为 {0} 找到使用时间戳格式“{2}”的可用文件名。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TrxLoggerWriteFailed">
+        <source>Failed to write the results file '{0}'. {1}</source>
+        <target state="new">Failed to write the results file '{0}'. {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Resources/xlf/TrxResource.zh-Hant.xlf
@@ -308,6 +308,11 @@ Fehlerdetails: {1}: {2}</target>
         <target state="translated">無法在 {1} 中使用時間戳記格式 '{2}' 找到 {0} 的可用檔案名。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TrxLoggerWriteFailed">
+        <source>Failed to write the results file '{0}'. {1}</source>
+        <target state="new">Failed to write the results file '{0}'. {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -650,7 +650,7 @@ public class TrxLogger : ITestLoggerWithParameters
 
             // We cannot rely on the StartTime for the first test result
             // In case of parallel, first test result is the fastest test and not the one which started first.
-            // Setting Started to DateTime.Now in Initialize will make sure we include the startup cost, which was being ignored earlier.
+            // Setting Started to the time captured in Initialize will make sure we include the startup cost, which was being ignored earlier.
             // This is in parity with the way we set this.testRun.Finished
             testRun.Started = TestRunStartTime;
 

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
+using System.Security;
 using System.Text;
 using System.Threading;
 using System.Xml;
@@ -71,13 +72,21 @@ public class TrxLogger : ITestLoggerWithParameters
     private readonly TrxFileHelper _trxFileHelper;
 
     /// <summary>
-    /// Specifies the run level "out" messages
+    /// Specifies the run level "out" messages. Appended to from multiple threads during parallel
+    /// execution, so a thread-safe collection is used instead of a <see cref="StringBuilder"/>.
     /// </summary>
-    private StringBuilder? _runLevelStdOut;
+    private ConcurrentQueue<string>? _runLevelStdOut;
 
     // List of run level errors and warnings generated. These are logged in the Trx in the Results Summary.
-    private List<RunInfo>? _runLevelErrorsAndWarnings;
+    // Appended to from multiple threads during parallel execution, hence the thread-safe collection.
+    private ConcurrentQueue<RunInfo>? _runLevelErrorsAndWarnings;
     private readonly string _trxFileExtension = ".trx";
+
+    /// <summary>
+    /// Guards the creation of <see cref="LoggerTestRun"/>, which can be requested concurrently
+    /// from <see cref="TestResultHandler"/> and <see cref="TestRunCompleteHandler"/>.
+    /// </summary>
+    private readonly object _testRunCreationLock = new();
 
     /// <summary>
     /// Parameters dictionary for logger. Ex: {"LogFileName":"TestResults.trx"}.
@@ -115,12 +124,12 @@ public class TrxLogger : ITestLoggerWithParameters
         _testElements = new ConcurrentDictionary<Guid, ITestElement>();
         _entries = new ConcurrentDictionary<Guid, TestEntry>();
         _innerTestEntries = new ConcurrentDictionary<Guid, TestEntry>();
-        _runLevelErrorsAndWarnings = new List<RunInfo>();
+        _runLevelErrorsAndWarnings = new ConcurrentQueue<RunInfo>();
         LoggerTestRun = null;
         TotalTestCount = 0;
         PassedTestCount = 0;
         FailedTestCount = 0;
-        _runLevelStdOut = new StringBuilder();
+        _runLevelStdOut = new ConcurrentQueue<string>();
         TestRunStartTime = DateTime.UtcNow;
 
         IsInitialized = true;
@@ -188,18 +197,35 @@ public class TrxLogger : ITestLoggerWithParameters
     internal string GetRunLevelInformationalMessage()
     {
         TPDebug.Assert(IsInitialized, "Logger is not initialized");
-        return _runLevelStdOut.ToString();
+        var builder = new StringBuilder();
+        foreach (var message in _runLevelStdOut)
+        {
+            builder.AppendLine(message);
+        }
+
+        return builder.ToString();
     }
 
     internal List<RunInfo> GetRunLevelErrorsAndWarnings()
     {
         TPDebug.Assert(IsInitialized, "Logger is not initialized");
-        return _runLevelErrorsAndWarnings;
+        return new List<RunInfo>(_runLevelErrorsAndWarnings);
     }
 
     internal DateTime TestRunStartTime { get; private set; }
 
-    internal TestRun? LoggerTestRun { get; private set; }
+    private TestRun? _loggerTestRun;
+
+    /// <summary>
+    /// The test run. Read from multiple threads, so accesses go through <see cref="Volatile"/> to
+    /// guarantee that a reader that observes a non-null reference also observes a fully
+    /// initialized <see cref="TestRun"/>.
+    /// </summary>
+    internal TestRun? LoggerTestRun
+    {
+        get => Volatile.Read(ref _loggerTestRun);
+        private set => Volatile.Write(ref _loggerTestRun, value);
+    }
 
     private int _totalTestCount;
     private int _passedTestCount;
@@ -267,7 +293,7 @@ public class TrxLogger : ITestLoggerWithParameters
                 break;
             case TestMessageLevel.Warning:
                 runMessage = new RunInfo(e.Message, null, Environment.MachineName, TrxLoggerObjectModel.TestOutcome.Warning);
-                _runLevelErrorsAndWarnings.Add(runMessage);
+                _runLevelErrorsAndWarnings.Enqueue(runMessage);
                 break;
             case TestMessageLevel.Error:
                 if (!_treatErrorMessagesAsWarnings)
@@ -276,7 +302,7 @@ public class TrxLogger : ITestLoggerWithParameters
                 }
 
                 runMessage = new RunInfo(e.Message, null, Environment.MachineName, TrxLoggerObjectModel.TestOutcome.Error);
-                _runLevelErrorsAndWarnings.Add(runMessage);
+                _runLevelErrorsAndWarnings.Enqueue(runMessage);
                 break;
             default:
                 Debug.Fail("TrxLogger.TestMessageHandler: The test message level is unrecognized: {0}", e.Level.ToString());
@@ -296,8 +322,7 @@ public class TrxLogger : ITestLoggerWithParameters
     internal void TestResultHandler(object? sender, TestResultEventArgs e)
     {
         // Create test run
-        if (LoggerTestRun == null)
-            CreateTestRun();
+        var loggerTestRun = GetOrCreateTestRun();
 
         // Convert skipped test to a log entry as that is the behavior of mstest.
         if (e.Result.Outcome == ObjectModel.TestOutcome.Skipped)
@@ -327,7 +352,7 @@ public class TrxLogger : ITestLoggerWithParameters
 
         // Convert the rocksteady result to trx test result
         var testResult = CreateTestResult(executionId, parentExecutionId, testType, testElement, parentTestElement, parentTestResult, e.Result,
-            out bool isFirstDataDrivenInnerResult);
+            loggerTestRun, out bool isFirstDataDrivenInnerResult);
 
         // Update test entries
         UpdateTestEntries(executionId, parentExecutionId, testElement, parentTestElement);
@@ -377,8 +402,7 @@ public class TrxLogger : ITestLoggerWithParameters
         // Create test run
         // If abort occurs there is no call to TestResultHandler which results in testRun not created.
         // This happens when some test aborts in the first batch of execution.
-        if (LoggerTestRun == null)
-            CreateTestRun();
+        var loggerTestRun = GetOrCreateTestRun();
 
         TPDebug.Assert(IsInitialized, "Logger is not initialized");
 
@@ -387,11 +411,11 @@ public class TrxLogger : ITestLoggerWithParameters
         XmlElement rootElement = helper.CreateRootElement("TestRun");
 
         // Save runId/username/creation time etc.
-        LoggerTestRun.Finished = DateTime.UtcNow;
-        helper.SaveSingleFields(rootElement, LoggerTestRun, parameters);
+        loggerTestRun.Finished = DateTime.UtcNow;
+        helper.SaveSingleFields(rootElement, loggerTestRun, parameters);
 
         // Save test settings
-        helper.SaveObject(LoggerTestRun.RunConfiguration, rootElement, "TestSettings", parameters);
+        helper.SaveObject(loggerTestRun.RunConfiguration, rootElement, "TestSettings", parameters);
 
         // Save test results
         helper.SaveIEnumerable(_results.Values, rootElement, "Results", ".", null, parameters);
@@ -419,8 +443,8 @@ public class TrxLogger : ITestLoggerWithParameters
         TestResultOutcome = ChangeTestOutcomeIfNecessary(TestResultOutcome);
 
         List<string> errorMessages = [];
-        List<CollectorDataEntry> collectorEntries = _converter.ToCollectionEntries(e.AttachmentSets, LoggerTestRun, _testResultsDirPath);
-        IList<string> resultFiles = _converter.ToResultFiles(e.AttachmentSets, LoggerTestRun, _testResultsDirPath, errorMessages);
+        List<CollectorDataEntry> collectorEntries = _converter.ToCollectionEntries(e.AttachmentSets, loggerTestRun, _testResultsDirPath);
+        IList<string> resultFiles = _converter.ToResultFiles(e.AttachmentSets, loggerTestRun, _testResultsDirPath, errorMessages);
 
         if (errorMessages.Count > 0)
         {
@@ -429,7 +453,7 @@ public class TrxLogger : ITestLoggerWithParameters
             foreach (string msg in errorMessages)
             {
                 RunInfo runMessage = new(msg, null, Environment.MachineName, TrxLoggerObjectModel.TestOutcome.Error);
-                _runLevelErrorsAndWarnings.Add(runMessage);
+                _runLevelErrorsAndWarnings.Enqueue(runMessage);
             }
         }
 
@@ -439,8 +463,8 @@ public class TrxLogger : ITestLoggerWithParameters
             PassedTestCount,
             FailedTestCount,
             TestResultOutcome,
-            _runLevelErrorsAndWarnings,
-            _runLevelStdOut.ToString(),
+            GetRunLevelErrorsAndWarnings(),
+            GetRunLevelInformationalMessage(),
             resultFiles,
             collectorEntries);
 
@@ -474,9 +498,10 @@ public class TrxLogger : ITestLoggerWithParameters
             ConsoleOutput.Instance.Information(false, resultsFileMessage);
             EqtTrace.Info(resultsFileMessage);
         }
-        catch (UnauthorizedAccessException fileWriteException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or XmlException or NotSupportedException or SecurityException)
         {
-            ConsoleOutput.Instance.Error(false, fileWriteException.Message);
+            EqtTrace.Error("TrxLogger: Failed to write trx file '{0}'. Exception: {1}", trxFileName, ex);
+            ConsoleOutput.Instance.Error(false, string.Format(CultureInfo.CurrentCulture, TrxLoggerResources.TrxLoggerWriteFailed, trxFileName, ex.Message));
         }
     }
 
@@ -489,7 +514,7 @@ public class TrxLogger : ITestLoggerWithParameters
     private void AddRunLevelInformationalMessage(string message)
     {
         TPDebug.Assert(IsInitialized, "Logger is not initialized");
-        _runLevelStdOut.AppendLine(message);
+        _runLevelStdOut.Enqueue(message);
     }
 
     // Handle the skipped test result
@@ -603,29 +628,43 @@ public class TrxLogger : ITestLoggerWithParameters
     }
 
     /// <summary>
-    /// Creates test run.
+    /// Gets the test run, creating it on first use.
     /// </summary>
-    [MemberNotNull(nameof(LoggerTestRun))]
-    private void CreateTestRun()
+    /// <remarks>
+    /// Called concurrently from <see cref="TestResultHandler"/>, so creation is guarded by a lock
+    /// to guarantee that exactly one <see cref="TestRun"/> is created for the whole run.
+    /// </remarks>
+    private TestRun GetOrCreateTestRun()
     {
         // Skip run creation if already exists.
         if (LoggerTestRun != null)
-            return;
+            return LoggerTestRun;
 
-        Guid runId = Guid.NewGuid();
-        LoggerTestRun = new TestRun(runId);
+        lock (_testRunCreationLock)
+        {
+            if (LoggerTestRun != null)
+                return LoggerTestRun;
 
-        // We cannot rely on the StartTime for the first test result
-        // In case of parallel, first test result is the fastest test and not the one which started first.
-        // Setting Started to DateTime.Now in Initialize will make sure we include the startup cost, which was being ignored earlier.
-        // This is in parity with the way we set this.testRun.Finished
-        LoggerTestRun.Started = TestRunStartTime;
+            Guid runId = Guid.NewGuid();
+            TestRun testRun = new(runId);
 
-        // Save default test settings
-        string runDeploymentRoot = TrxFileHelper.ReplaceInvalidFileNameChars(LoggerTestRun.Name);
-        TestRunConfiguration testrunConfig = new("default", _trxFileHelper);
-        testrunConfig.RunDeploymentRootDirectory = runDeploymentRoot;
-        LoggerTestRun.RunConfiguration = testrunConfig;
+            // We cannot rely on the StartTime for the first test result
+            // In case of parallel, first test result is the fastest test and not the one which started first.
+            // Setting Started to DateTime.Now in Initialize will make sure we include the startup cost, which was being ignored earlier.
+            // This is in parity with the way we set this.testRun.Finished
+            testRun.Started = TestRunStartTime;
+
+            // Save default test settings
+            string runDeploymentRoot = TrxFileHelper.ReplaceInvalidFileNameChars(testRun.Name);
+            TestRunConfiguration testrunConfig = new("default", _trxFileHelper);
+            testrunConfig.RunDeploymentRootDirectory = runDeploymentRoot;
+            testRun.RunConfiguration = testrunConfig;
+
+            // Publish only once the run is fully initialized, so that other threads never observe
+            // a partially configured test run.
+            LoggerTestRun = testRun;
+            return testRun;
+        }
     }
 
     /// <summary>
@@ -711,10 +750,7 @@ public class TrxLogger : ITestLoggerWithParameters
         }
 
         var orderedTest = (OrderedTestElement)parentTestElement;
-        if (!orderedTest.TestLinks.ContainsKey(testElement.Id.Id))
-        {
-            orderedTest.TestLinks.Add(testElement.Id.Id, new TestLink(testElement.Id.Id, testElement.Name, testElement.Storage));
-        }
+        orderedTest.AddTestLink(new TestLink(testElement.Id.Id, testElement.Name, testElement.Storage));
     }
 
     /// <summary>
@@ -727,19 +763,19 @@ public class TrxLogger : ITestLoggerWithParameters
     /// <param name="parentTestElement"></param>
     /// <param name="parentTestResult"></param>
     /// <param name="rocksteadyTestResult"></param>
+    /// <param name="loggerTestRun">The test run that owns this result.</param>
     /// <param name="isFirstDataDrivenInnerResult">Set to true when this is the first inner DataDriven result for the parent, indicating the parent count should be undone.</param>
     /// <returns>Trx test result</returns>
     private ITestResult CreateTestResult(Guid executionId, Guid parentExecutionId, TestType testType,
         ITestElement testElement, ITestElement? parentTestElement, ITestResult? parentTestResult, ObjectModel.TestResult rocksteadyTestResult,
-        out bool isFirstDataDrivenInnerResult)
+        TestRun loggerTestRun, out bool isFirstDataDrivenInnerResult)
     {
         TPDebug.Assert(IsInitialized, "Logger is not initialized");
         isFirstDataDrivenInnerResult = false;
         // Create test result
         TrxLoggerObjectModel.TestOutcome testOutcome = Converter.ToOutcome(rocksteadyTestResult.Outcome);
-        TPDebug.Assert(LoggerTestRun != null, "LoggerTestRun is null");
         var testResult = _converter.ToTestResult(testElement.Id.Id, executionId, parentExecutionId, testElement.Name,
-            _testResultsDirPath, testType, testElement.CategoryId, testOutcome, LoggerTestRun, rocksteadyTestResult);
+            _testResultsDirPath, testType, testElement.CategoryId, testOutcome, loggerTestRun, rocksteadyTestResult);
 
         // Normal result scenario
         if (parentTestResult == null)

--- a/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.HtmlLogger.UnitTests/HtmlLoggerTests.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger;
 using Microsoft.VisualStudio.TestPlatform.Extensions.HtmlLogger.ObjectModel;
@@ -34,6 +36,8 @@ public class HtmlLoggerTests
     private readonly Mock<IFileHelper> _mockFileHelper;
     private readonly Mock<XmlObjectSerializer> _mockXmlSerializer;
     private readonly Mock<IHtmlTransformer> _mockHtmlTransformer;
+
+    public TestContext TestContext { get; set; }
 
     public HtmlLoggerTests()
     {
@@ -675,6 +679,61 @@ public class HtmlLoggerTests
         Assert.IsNotNull(_htmlLogger.XmlFilePath);
         Assert.Contains("[1].xml", _htmlLogger.XmlFilePath);
         _mockFileHelper.Verify(x => x.GetStream(It.IsAny<string>(), FileMode.CreateNew, FileAccess.Write, FileShare.None), Times.AtLeast(2));
+    }
+
+    [TestMethod]
+    public void TestResultHandlerShouldCreateExactlyOneResultCollectionPerSourceUnderConcurrency()
+    {
+        const int threadCount = 10;
+        const int testsPerThread = 50;
+        var barrier = new Barrier(threadCount);
+
+        var tasks = Enumerable.Range(0, threadCount).Select(t => Task.Run(() =>
+        {
+            barrier.SignalAndWait(TestContext.CancellationToken);
+            for (int i = 0; i < testsPerThread; i++)
+            {
+                var testCase = CreateTestCase($"TestCase_{t}_{i}");
+                testCase.Source = "abc.dll";
+                var result = new ObjectModel.TestResult(testCase)
+                {
+                    Outcome = i % 2 == 0 ? TestOutcome.Passed : TestOutcome.Failed
+                };
+                _htmlLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(result).Object);
+            }
+        }, TestContext.CancellationToken)).ToArray();
+
+        Task.WaitAll(tasks, TestContext.CancellationToken);
+
+        var resultCollectionList = _htmlLogger.TestRunDetails!.ResultCollectionList!;
+        Assert.HasCount(1, resultCollectionList, "Only one result collection should be created per source");
+        Assert.HasCount(threadCount * testsPerThread, resultCollectionList[0].ResultList!,
+            "No result should be lost under concurrent updates");
+        Assert.HasCount(threadCount * (testsPerThread / 2), resultCollectionList[0].FailedResultList!,
+            "No failed result should be lost under concurrent updates");
+    }
+
+    [TestMethod]
+    public void TestMessageHandlerShouldNotLoseMessagesUnderConcurrency()
+    {
+        const int threadCount = 10;
+        const int messagesPerThread = 100;
+        var barrier = new Barrier(threadCount);
+
+        var tasks = Enumerable.Range(0, threadCount).Select(t => Task.Run(() =>
+        {
+            barrier.SignalAndWait(TestContext.CancellationToken);
+            for (int i = 0; i < messagesPerThread; i++)
+            {
+                _htmlLogger.TestMessageHandler(new object(), new TestRunMessageEventArgs(TestMessageLevel.Informational, $"info_{t}_{i}"));
+                _htmlLogger.TestMessageHandler(new object(), new TestRunMessageEventArgs(TestMessageLevel.Error, $"error_{t}_{i}"));
+            }
+        }, TestContext.CancellationToken)).ToArray();
+
+        Task.WaitAll(tasks, TestContext.CancellationToken);
+
+        Assert.HasCount(threadCount * messagesPerThread, _htmlLogger.TestRunDetails!.RunLevelMessageInformational!);
+        Assert.HasCount(threadCount * messagesPerThread, _htmlLogger.TestRunDetails.RunLevelMessageErrorAndWarning!);
     }
 
     private static TestCase CreateTestCase(string testCaseName)

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
@@ -13,6 +14,7 @@ using System.Xml;
 using System.Xml.Linq;
 
 using Microsoft.TestPlatform.Extensions.TrxLogger.Utility;
+using Microsoft.TestPlatform.Extensions.TrxLogger.XML;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -1108,6 +1110,92 @@ public class TrxLoggerTests
             "Passed test count should be exact under concurrent updates");
         Assert.AreEqual(expectedFailed, _testableTrxLogger.FailedTestCount,
             "Failed test count should be exact under concurrent updates");
+    }
+
+    [TestMethod]
+    public void TestMessageHandlerShouldBeThreadSafeForRunLevelErrorsAndWarnings()
+    {
+        const int threadCount = 10;
+        const int messagesPerThread = 100;
+        var barrier = new Barrier(threadCount);
+
+        var tasks = Enumerable.Range(0, threadCount).Select(t => Task.Run(() =>
+        {
+            barrier.SignalAndWait(TestContext.CancellationToken);
+            for (int i = 0; i < messagesPerThread; i++)
+            {
+                var args = new TestRunMessageEventArgs(TestMessageLevel.Warning, $"warning_{t}_{i}");
+                _testableTrxLogger.TestMessageHandler(new object(), args);
+            }
+        }, TestContext.CancellationToken)).ToArray();
+
+        Task.WaitAll(tasks, TestContext.CancellationToken);
+
+        Assert.HasCount(threadCount * messagesPerThread, _testableTrxLogger.GetRunLevelErrorsAndWarnings(),
+            "No run level warning should be lost under concurrent updates");
+    }
+
+    [TestMethod]
+    public void TestMessageHandlerShouldBeThreadSafeForRunLevelInformationalMessages()
+    {
+        const int threadCount = 10;
+        const int messagesPerThread = 100;
+        var barrier = new Barrier(threadCount);
+
+        var tasks = Enumerable.Range(0, threadCount).Select(t => Task.Run(() =>
+        {
+            barrier.SignalAndWait(TestContext.CancellationToken);
+            for (int i = 0; i < messagesPerThread; i++)
+            {
+                var args = new TestRunMessageEventArgs(TestMessageLevel.Informational, $"info_{t}_{i}");
+                _testableTrxLogger.TestMessageHandler(new object(), args);
+            }
+        }, TestContext.CancellationToken)).ToArray();
+
+        Task.WaitAll(tasks, TestContext.CancellationToken);
+
+        var lines = _testableTrxLogger.GetRunLevelInformationalMessage()
+            .Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+        Assert.HasCount(threadCount * messagesPerThread, lines,
+            "No run level informational message should be lost or corrupted under concurrent updates");
+    }
+
+    [TestMethod]
+    public void TestResultHandlerShouldCreateExactlyOneTestRunUnderConcurrency()
+    {
+        const int threadCount = 10;
+        const int testsPerThread = 50;
+        var barrier = new Barrier(threadCount);
+        var observedRunIds = new ConcurrentBag<Guid>();
+
+        var tasks = Enumerable.Range(0, threadCount).Select(t => Task.Run(() =>
+        {
+            barrier.SignalAndWait(TestContext.CancellationToken);
+            for (int i = 0; i < testsPerThread; i++)
+            {
+                var testCase = CreateTestCase($"Test_{t}_{i}");
+                var result = new VisualStudio.TestPlatform.ObjectModel.TestResult(testCase) { Outcome = TestOutcome.Passed };
+                _testableTrxLogger.TestResultHandler(new object(), new Mock<TestResultEventArgs>(result).Object);
+                observedRunIds.Add(_testableTrxLogger.LoggerTestRun!.Id);
+            }
+        }, TestContext.CancellationToken)).ToArray();
+
+        Task.WaitAll(tasks, TestContext.CancellationToken);
+
+        Assert.HasCount(1, observedRunIds.Distinct().ToList(),
+            "Only a single test run should be created, even when results arrive concurrently");
+    }
+
+    [TestMethod]
+    public void PopulateTrxFileShouldNotThrowWhenTheFileCannotBeWritten()
+    {
+        var rootElement = new XmlPersistence().CreateRootElement("TestRun");
+
+        // The file does not exist, so opening it with FileMode.Truncate raises a FileNotFoundException,
+        // which is an IOException. It should be reported, not propagated.
+        var missingFile = Path.Combine(DefaultTestRunDirectory, $"missing_{Guid.NewGuid():N}.trx");
+
+        _testableTrxLogger.PopulateTrxFile(missingFile, rootElement);
     }
 
     private static TestCase CreateTestCase(string testCaseName)


### PR DESCRIPTION
Fixes #16320

Both `TrxLogger` and `HtmlLogger` register event handlers (`TestResultHandler`, `TestMessageHandler`) that are invoked concurrently during parallel test execution, but several pieces of their mutable state were plain non-thread-safe collections. This makes those paths thread-safe and stops the TRX file from being silently dropped on IO failures.

### TrxLogger

- **Task 1** - `_runLevelErrorsAndWarnings` is now a `ConcurrentQueue<RunInfo>`; `GetRunLevelErrorsAndWarnings()` returns a snapshot.
- **Task 2** - `_runLevelStdOut` is now a `ConcurrentQueue<string>` instead of a `StringBuilder`. The run-level informational message is materialized on read with the same `AppendLine`-per-message formatting as before, so the TRX output is unchanged.
  `CreateTestRun()` had a check-then-act race that could create more than one `TestRun`. It is replaced by `GetOrCreateTestRun()` using double-checked locking, and `LoggerTestRun` is published via `Volatile` so a reader that observes a non-null reference also observes a fully initialized `TestRun`.
- **Task 3** - `TestElementAggregation._testLinks` was a plain `Dictionary` mutated through a non-atomic `ContainsKey` + `Add`. Mutation and enumeration are now guarded by a lock, exposed via a new `ITestAggregation.AddTestLink`. A lock is used rather than `ConcurrentDictionary` because the insertion order of test links is meaningful for ordered tests and `ConcurrentDictionary` does not preserve it.
- **Task 5** - `PopulateTrxFile` only caught `UnauthorizedAccessException`, so a disk-full or any other IO failure escaped uncaught and silently dropped the TRX. It now reports `IOException`, `UnauthorizedAccessException`, `XmlException`, `NotSupportedException` and `SecurityException` using a new localized `TrxLoggerWriteFailed` resource (added to `TrxResource.resx`, `TrxResource.Designer.cs` and all 13 `*.xlf` files).

### HtmlLogger (Task 4)

- `TestResultHandler` used `TryGetValue` + `TryAdd` + `ResultCollectionList.Add`, which could publish duplicate collections for the same source. It now uses the atomic `GetOrAdd` and only the thread whose instance actually won publishes it to `ResultCollectionList`.
- `ResultList`, `FailedResultList`, `InnerTestResults` and the run-level message lists are appended through lock-protected helpers, so no result or message can be lost.
- The lists are still created lazily rather than eagerly in `Initialize`, so the null-vs-empty semantics observed by the serialized XML (and therefore by `Html.xslt`) are unchanged - this is covered by the existing `TestMessageHandlerShouldNotInitializelistForInformationErrorAndWarningMessages` test.

### Tests

New regression tests:

- `TrxLoggerTests.TestMessageHandlerShouldBeThreadSafeForRunLevelErrorsAndWarnings`
- `TrxLoggerTests.TestMessageHandlerShouldBeThreadSafeForRunLevelInformationalMessages`
- `TrxLoggerTests.TestResultHandlerShouldCreateExactlyOneTestRunUnderConcurrency`
- `TrxLoggerTests.PopulateTrxFileShouldNotThrowWhenTheFileCannotBeWritten`
- `HtmlLoggerTests.TestResultHandlerShouldCreateExactlyOneResultCollectionPerSourceUnderConcurrency`
- `HtmlLoggerTests.TestMessageHandlerShouldNotLoseMessagesUnderConcurrency`

All TrxLogger (154) and HtmlLogger (78) unit tests pass on `net481` and `net11.0` with `-c Release`.