### PR TITLE
Address review comments from the TRX astral-plane fix (#16318)

### DIFF
--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/XML/XmlPersistence.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/XML/XmlPersistence.cs
@@ -694,7 +694,8 @@ internal class XmlPersistence
             // the last character correctly falls through to the invalid branch below.
             if (char.IsSurrogatePair(str, i))
             {
-                builder?.Append(str[i]).Append(str[i + 1]);
+                // Copy both code units in a single call, they encode one character.
+                builder?.Append(str, i, 2);
                 i++;
                 continue;
             }
@@ -706,7 +707,8 @@ internal class XmlPersistence
                 continue;
             }
 
-            builder ??= new StringBuilder(str.Length).Append(str, 0, i);
+            // The valid prefix we skipped over is copied as part of construction.
+            builder ??= new StringBuilder(str, 0, i, GetInvalidXmlCharBuilderCapacity(str.Length));
             builder.Append(@"\u").Append(((ushort)c).ToString("x4", CultureInfo.InvariantCulture));
         }
 
@@ -715,6 +717,24 @@ internal class XmlPersistence
 
     private static bool IsValidXmlChar(char c)
         => c is '\x09' or '\x0A' or '\x0D' or (>= '\x20' and <= '\uD7FF') or (>= '\uE000' and <= '\uFFFD');
+
+    /// <summary>
+    /// Gets the capacity to give the <see cref="StringBuilder"/> used to escape invalid characters.
+    /// </summary>
+    /// <remarks>
+    /// We only ever allocate the builder because at least one code unit needs escaping, and every
+    /// escaped code unit expands from 1 char to the 6 chars of a \uXXXX sequence, so the original
+    /// length on its own is always too small and would force at least one growth. Reserving 50%
+    /// more covers the realistic case of a handful of invalid characters without over-allocating
+    /// for long strings. The comparison guards against overflowing <see cref="int"/> for very long
+    /// strings. This mirrors TrxReportEngine.GetInvalidXmlCharBuilderCapacity in testfx, which
+    /// solves the identical problem, so the two implementations stay comparable.
+    /// </remarks>
+    private static int GetInvalidXmlCharBuilderCapacity(int length)
+    {
+        int extraCapacity = length / 2;
+        return length <= int.MaxValue - extraCapacity ? length + extraCapacity : length;
+    }
 
     private XmlNode? EnsureLocationExists(XmlElement xml, string location, string? nameSpaceUri)
     {

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -1036,9 +1036,8 @@ public class TrxLoggerTests
         // XmlPersistenceTests covers the sanitizer in isolation, but the thing users report is
         // about the bytes that end up in the .trx. This goes through the whole logger - test
         // result in, real file out, re-parsed from disk - so it would also catch a regression
-        // that lives outside the sanitizer, such as XmlWriterSettings.CheckCharacters being
-        // flipped in PopulateTrxFile or a string reaching the DOM without going through
-        // SaveSimpleData.
+        // that lives outside the sanitizer, such as a string reaching the DOM without going
+        // through SaveSimpleData.
         const string testName = "party \U0001F389 done";
         const string stdOut = "output \U0001F389 here";
 

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -1068,6 +1068,35 @@ public class TrxLoggerTests
         Assert.AreEqual(stdOut, resultNode.Descendants(ns + "StdOut").First().Value);
     }
 
+    [TestMethod]
+    public void TrxFileShouldRemainParseableWhenTestNameContainsLoneSurrogate()
+    {
+        // The counterpart to the test above, and the reason the fix escapes lone surrogates
+        // instead of simply allowing all of \uD800-\uDFFF through. A lone surrogate is not a
+        // valid Unicode scalar value and XmlWriter throws on one, so escaping it is what keeps
+        // the trx writable and parseable at all. Letting it through would trade a bug that
+        // mangles one string for a bug that breaks every consumer of the file at read time.
+        const string testName = "lone \ud800 surrogate";
+
+        _parameters[TrxLoggerConstants.LogFileNameKey] = "lone-surrogate.trx";
+        _testableTrxLogger.Initialize(_events.Object, _parameters);
+
+        var pass = CreatePassTestResultEventArgsMock(testName);
+        _testableTrxLogger.TestResultHandler(new object(), pass.Object);
+        _testableTrxLogger.TestRunCompleteHandler(new object(), CreateTestRunCompleteEventArgs());
+
+        var trxFile = _testableTrxLogger.TrxFile!;
+        Assert.IsTrue(File.Exists(trxFile), "The trx must still be written when a test name contains a lone surrogate.");
+
+        using FileStream file = File.OpenRead(trxFile);
+        using XmlReader reader = XmlReader.Create(file);
+        XDocument document = XDocument.Load(reader);
+        var ns = document.Root!.GetDefaultNamespace();
+
+        var resultNode = document.Descendants(ns + "UnitTestResult").First();
+        Assert.AreEqual(@"lone \ud800 surrogate", resultNode.Attributes("testName").First().Value);
+    }
+
     private void ValidateTestIdAndNameInTrx()
     {
         TestCase testCase = CreateTestCase("TestCase");

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/TrxLoggerTests.cs
@@ -1030,6 +1030,44 @@ public class TrxLoggerTests
         File.Delete(logger.TrxFile);
     }
 
+    [TestMethod]
+    public void TrxFileShouldPreserveAstralCharactersInTestNameAndStdOut()
+    {
+        // XmlPersistenceTests covers the sanitizer in isolation, but the thing users report is
+        // about the bytes that end up in the .trx. This goes through the whole logger - test
+        // result in, real file out, re-parsed from disk - so it would also catch a regression
+        // that lives outside the sanitizer, such as XmlWriterSettings.CheckCharacters being
+        // flipped in PopulateTrxFile or a string reaching the DOM without going through
+        // SaveSimpleData.
+        const string testName = "party \U0001F389 done";
+        const string stdOut = "output \U0001F389 here";
+
+        _parameters[TrxLoggerConstants.LogFileNameKey] = "astral.trx";
+        _testableTrxLogger.Initialize(_events.Object, _parameters);
+
+        var pass = CreatePassTestResultEventArgsMock(testName, new List<TestResultMessage> { new(TestResultMessage.StandardOutCategory, stdOut) });
+        _testableTrxLogger.TestResultHandler(new object(), pass.Object);
+        _testableTrxLogger.TestRunCompleteHandler(new object(), CreateTestRunCompleteEventArgs());
+
+        var trxFile = _testableTrxLogger.TrxFile!;
+
+        // The emoji must be in the file as a real character, not as the literal text \ud83c\udf89.
+        var rawTrxContent = File.ReadAllText(trxFile);
+        Assert.Contains(testName, rawTrxContent, "The astral character in the test name was mangled on the way into the trx.");
+        Assert.DoesNotContain(@"\ud83c", rawTrxContent, "The astral character was escaped into literal text instead of being written as-is.");
+
+        // And the file must still be parseable, with the character surviving the round trip
+        // through both an attribute value and element text.
+        using FileStream file = File.OpenRead(trxFile);
+        using XmlReader reader = XmlReader.Create(file);
+        XDocument document = XDocument.Load(reader);
+        var ns = document.Root!.GetDefaultNamespace();
+
+        var resultNode = document.Descendants(ns + "UnitTestResult").First();
+        Assert.AreEqual(testName, resultNode.Attributes("testName").First().Value);
+        Assert.AreEqual(stdOut, resultNode.Descendants(ns + "StdOut").First().Value);
+    }
+
     private void ValidateTestIdAndNameInTrx()
     {
         TestCase testCase = CreateTestCase("TestCase");

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/XmlPersistenceTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/XmlPersistenceTests.cs
@@ -49,6 +49,11 @@ public class XmlPersistenceTests
         XmlPersistence xmlPersistence = new();
         var node = xmlPersistence.CreateRootElement("TestRun");
 
+        // Unlike the sibling test below, expected here is the input itself, so a row whose
+        // text was mangled in transit would assert sanitize(mangled) == mangled and pass
+        // while proving nothing - U+FFFD is a valid XML character and survives sanitizing.
+        Assert.DoesNotContain("\ufffd", text, "A surrogate pair did not survive the data row transport - this row would assert nothing.");
+
         XmlPersistence.SaveObject(text, node, null, "dummy");
 
         Assert.AreEqual(text, node.InnerXml);
@@ -154,7 +159,9 @@ public class XmlPersistenceTests
     /// for it before the row reaches the test method. U+FFFD is itself a valid XML character,
     /// so every such row would silently degrade into an assertion that proves nothing. Only
     /// well-formed pairs survive the transport, which is why
-    /// <see cref="SaveObjectShouldNotReplaceValidText"/> can inline them.
+    /// <see cref="SaveObjectShouldNotReplaceValidText"/> can inline them - it asserts the same
+    /// way for the same reason, because its expected value is the input and would otherwise go
+    /// vacuous if the transport ever stopped round-tripping them.
     /// </remarks>
     private static string WithLoneSurrogates(string text)
     {

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/XmlPersistenceTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/XmlPersistenceTests.cs
@@ -34,31 +34,51 @@ public class XmlPersistenceTests
     }
 
     [TestMethod]
-    public void SaveObjectShouldNotReplaceAdjacentHighAndLowSurrogate()
+    // A well-formed surrogate pair encodes a character in [#x10000-#x10FFFF], which the XML
+    // spec lists as valid, so it must survive untouched - as must every ordinary BMP
+    // character. Escaping either of those is what this whole area of code got wrong.
+    [DataRow("", DisplayName = "empty string")]
+    [DataRow("Grüße 日本語 Čau", DisplayName = "non-ASCII BMP characters")]
+    [DataRow("party \U0001F389 done", DisplayName = "surrogate pair surrounded by ASCII")]
+    [DataRow("\ud800\udc00", DisplayName = "lowest surrogate pair, U+10000")]
+    [DataRow("\udbff\udfff", DisplayName = "highest surrogate pair, U+10FFFF")]
+    [DataRow("\U0001F389\U0001F389", DisplayName = "two consecutive surrogate pairs")]
+    [DataRow("\U0001F389", DisplayName = "surrogate pair is the entire string")]
+    public void SaveObjectShouldNotReplaceValidText(string text)
     {
-        // 0xd800 immediately followed by 0xdc00 is not two invalid characters - it is the
-        // UTF-16 encoding of U+10000, which the XML spec lists as valid. It must round-trip
-        // unescaped. This case used to be asserted the other way around.
         XmlPersistence xmlPersistence = new();
         var node = xmlPersistence.CreateRootElement("TestRun");
 
-        string validSurrogatePair = new(new[] { (char)0xd800, (char)0xdc00 });
-        XmlPersistence.SaveObject(validSurrogatePair, node, null, "dummy");
+        XmlPersistence.SaveObject(text, node, null, "dummy");
 
-        Assert.AreEqual(validSurrogatePair, node.InnerXml);
+        Assert.AreEqual(text, node.InnerXml);
     }
 
     [TestMethod]
-    public void SaveObjectShouldNotReplaceWellFormedSurrogatePairInElementText()
+    // Unlike a pair, a lone surrogate is not a valid Unicode scalar value and is not valid
+    // XML - XmlWriter would throw on it - so it must still be escaped. Allowing all of
+    // \uD800-\uDFFF through would be the naive fix and would trade a mangled-string bug for
+    // an unparseable-trx bug, which is worse because it breaks every consumer of the trx.
+    //
+    // {H} and {L} stand for a lone high and a lone low surrogate. They cannot be written
+    // into the row directly - see WithLoneSurrogates below.
+    [DataRow("a{H}b", @"a\ud800b", DisplayName = "lone high surrogate between valid characters")]
+    [DataRow("a{L}b", @"a\udc00b", DisplayName = "lone low surrogate between valid characters")]
+    [DataRow("{L}b", @"\udc00b", DisplayName = "low surrogate as the first character")]
+    [DataRow("ab{H}", @"ab\ud800", DisplayName = "high surrogate as the last character")]
+    [DataRow("{H}", @"\ud800", DisplayName = "high surrogate is the entire string")]
+    [DataRow("{H}{H}", @"\ud800\ud800", DisplayName = "two consecutive high surrogates")]
+    [DataRow("{L}{L}", @"\udc00\udc00", DisplayName = "two consecutive low surrogates")]
+    [DataRow("{L}{H}", @"\udc00\ud800", DisplayName = "low surrogate followed by high surrogate")]
+    [DataRow("\U0001F389{H}\v{L}", "\U0001F389" + @"\ud800\u000b\udc00", DisplayName = "valid pair, lone surrogates and a control character mixed")]
+    public void SaveObjectShouldReplaceLoneSurrogate(string text, string expected)
     {
-        // A surrogate pair encodes a character in [#x10000-#x10FFFF], which the XML spec
-        // lists as valid, so it must survive untouched. Here U+1F389 (🎉).
         XmlPersistence xmlPersistence = new();
         var node = xmlPersistence.CreateRootElement("TestRun");
 
-        XmlPersistence.SaveObject("party \U0001F389 done", node, null, "dummy");
+        XmlPersistence.SaveObject(WithLoneSurrogates(text), node, null, "dummy");
 
-        Assert.AreEqual("party \U0001F389 done", node.InnerXml);
+        Assert.AreEqual(expected, node.InnerXml);
     }
 
     [TestMethod]
@@ -70,67 +90,6 @@ public class XmlPersistenceTests
         xmlPersistence.SaveObject("party \U0001F389 done", node, "@testName", null);
 
         Assert.AreEqual("party \U0001F389 done", node.GetAttribute("testName"));
-    }
-
-    [TestMethod]
-    public void SaveObjectShouldReplaceLoneHighSurrogate()
-    {
-        // Unlike a pair, a lone high surrogate is not a valid Unicode scalar value and is
-        // not valid XML (XmlWriter would throw on it), so it must still be escaped.
-        XmlPersistence xmlPersistence = new();
-        var node = xmlPersistence.CreateRootElement("TestRun");
-
-        XmlPersistence.SaveObject("a" + (char)0xd800 + "b", node, null, "dummy");
-
-        Assert.AreEqual("a\\ud800b", node.InnerXml);
-    }
-
-    [TestMethod]
-    public void SaveObjectShouldReplaceLoneLowSurrogate()
-    {
-        // A low surrogate that is not preceded by a high surrogate is equally invalid.
-        XmlPersistence xmlPersistence = new();
-        var node = xmlPersistence.CreateRootElement("TestRun");
-
-        XmlPersistence.SaveObject((char)0xdc00 + "b", node, null, "dummy");
-
-        Assert.AreEqual("\\udc00b", node.InnerXml);
-    }
-
-    [TestMethod]
-    public void SaveObjectShouldReplaceHighSurrogateAtEndOfString()
-    {
-        // The pair-matching logic must not read past the end of the string.
-        XmlPersistence xmlPersistence = new();
-        var node = xmlPersistence.CreateRootElement("TestRun");
-
-        XmlPersistence.SaveObject("ab" + (char)0xd800, node, null, "dummy");
-
-        Assert.AreEqual("ab\\ud800", node.InnerXml);
-    }
-
-    [TestMethod]
-    public void SaveObjectShouldHandleMixOfValidPairLoneSurrogateAndInvalidCharacters()
-    {
-        XmlPersistence xmlPersistence = new();
-        var node = xmlPersistence.CreateRootElement("TestRun");
-
-        XmlPersistence.SaveObject("\U0001F389" + (char)0xd800 + "\v" + (char)0xdc00, node, null, "dummy");
-
-        // The pair is preserved; the lone high surrogate, the vertical tab and the
-        // trailing lone low surrogate are all escaped.
-        Assert.AreEqual("\U0001F389\\ud800\\u000b\\udc00", node.InnerXml);
-    }
-
-    [TestMethod]
-    public void SaveObjectShouldNotReplaceNonAsciiBmpCharacters()
-    {
-        XmlPersistence xmlPersistence = new();
-        var node = xmlPersistence.CreateRootElement("TestRun");
-
-        XmlPersistence.SaveObject("Grüße 日本語 Čau", node, null, "dummy");
-
-        Assert.AreEqual("Grüße 日本語 Čau", node.InnerXml);
     }
 
     [TestMethod]
@@ -183,5 +142,24 @@ public class XmlPersistenceTests
         XmlPersistence.SaveObject(strWithInvalidCharForXml, node, null, "dummy");
         string expectedResult = "This string has these \\u0000 \\u000b invalid characters";
         Assert.AreEqual(0, string.Compare(expectedResult, node.InnerXml));
+    }
+
+    /// <summary>
+    /// Substitutes the {H} and {L} placeholders used by <see cref="SaveObjectShouldReplaceLoneSurrogate"/>
+    /// with a lone high and a lone low surrogate respectively.
+    /// </summary>
+    /// <remarks>
+    /// A lone surrogate cannot be written into a <see cref="DataRowAttribute"/> directly: the
+    /// test platform's argument transport is not lone-surrogate safe and substitutes U+FFFD
+    /// for it before the row reaches the test method. U+FFFD is itself a valid XML character,
+    /// so every such row would silently degrade into an assertion that proves nothing. Only
+    /// well-formed pairs survive the transport, which is why
+    /// <see cref="SaveObjectShouldNotReplaceValidText"/> can inline them.
+    /// </remarks>
+    private static string WithLoneSurrogates(string text)
+    {
+        Assert.DoesNotContain("\ufffd", text, "Lone surrogates must be written as {H} or {L}, a literal one does not survive the data row transport.");
+
+        return text.Replace("{H}", "\ud800").Replace("{L}", "\udc00");
     }
 }


### PR DESCRIPTION
Follow-up to #16318, which was merged before its review comments were resolved. This addresses all four of @Evangelink's comments.## 1. `Append(str, i, 2)` instead of the chained form> Nit: `builder?.Append(str, i, 2)` says the same thing in one call and makes it obvious the two code units are copied as a unit.Done. The chained `builder?.Append(str[i]).Append(str[i + 1])` was correct — the null-conditional short-circuits the whole chain — but it reads like it might append only the first half when `builder` is null, which is exactly the kind of thing that survives a fast review and then gets "fixed" into a real bug later.## 2. Builder capacity> this capacity hint is guaranteed to be too small … testfx solved the identical problem in `TrxReportEngine.Utilities.cs` with `length + length / 2` plus an overflow guardCorrect — the builder is only ever allocated because something needs escaping, and each escaped code unit expands 1 → 6 chars, so `new StringBuilder(str.Length)` always had to grow at least once. Added `GetInvalidXmlCharBuilderCapacity` matching testfx, and switched to the `StringBuilder(string, int, int, int)` constructor so the valid prefix is copied during construction rather than by a separate `Append`.The capacity is computed lazily at the `??=` site rather than eagerly at the top of the method, so the all-valid fast path still does no work at all.## 3. Unpinned edges + collapse the near-duplicates> two consecutive high surrogates … the inverted order … the empty string … A single `[DataRow]`-driven test would cover them and let you collapse some of the near-duplicate cases above.The six near-identical single-case tests are now two data-driven tests, and all three edges are pinned, plus a few more that came for free (`\udbff\udfff` as the top of the astral range, two consecutive low surrogates, a pair as the entire string).**One thing worth flagging: a lone surrogate cannot be passed through a `[DataRow]`.** My first attempt did exactly that and produced nine tests that looked fine and asserted nothing useful:```Expected: "a\ud800b"But was:  "a��b"```The argument arrives at the test method with the lone surrogate already replaced by U+FFFD. Since U+FFFD is itself a valid XML character, the sanitizer correctly passes it through — so the test fails today, but had the expectations been written against the observed output it would have "passed" forever while testing nothing. I confirmed this is the platform's data-row argument transport and not the C# compiler: a plain string literal round-trips a lone surrogate through metadata intact, and well-formed pairs (`\U0001F389`) survive the data row transport fine — it only breaks on unpaired surrogates, which is the expected UTF-8 behaviour.So the rows spell the lone surrogates as `{H}` and `{L}` and `WithLoneSurrogates` substitutes them inside the test body, after transport. It also asserts the incoming row contains no U+FFFD, so if anyone later inlines a literal lone surrogate the test fails loudly instead of silently going vacuous.## 4. Nothing covered the actual file> every new test targets `XmlPersistence` in isolation, but the premise of the PR is about the bytes that end up in the `.trx` file … Not a blocker for this PR, but I'd like it before this pattern gets copied again.Added `TrxLoggerTests.TrxFileShouldPreserveAstralCharactersInTestNameAndStdOut`. It runs a result with an emoji in both the test name and StdOut through the whole logger via the existing `PopulateTrxFile` harness, then re-reads the `.trx` from disk and asserts:- the raw file text contains the emoji as a real character,- the raw file text does **not** contain the literal `\ud83c`,- the file still parses, and the emoji survives in both an attribute value (`UnitTestResult/@testName`) and element text (`StdOut`).That last pair is what would catch a string reaching the DOM without going through `SaveSimpleData`.## VerificationI verified the tests have teeth rather than assuming it, by sabotaging the fix in each direction and checking what goes red.**Sabotage A — over-strict** (disable the pair branch, i.e. reinstate the original bug):| | ||---|---|| `TrxFileShouldPreserveAstralCharactersInTestNameAndStdOut` | red || 5 valid-pair rows of `SaveObjectShouldNotReplaceValidText` | red || `SaveObjectShouldNotReplaceWellFormedSurrogatePairInAttributeValue` | red || `SaveObjectShouldProduceWellFormedXmlWithAstralCharacters` | red || mixed row of `SaveObjectShouldReplaceLoneSurrogate` | red |**Sabotage B — too permissive** (`IsValidXmlChar` accepts all of `\uD800-\uDFFF`, the naive way to "fix" the astral bug):| | ||---|---|| all 9 rows of `SaveObjectShouldReplaceLoneSurrogate` | red || `TrxFileShouldRemainParseableWhenTestNameContainsLoneSurrogate` | red |Sabotage B is what prompted the second commit. Only one row of `SaveObjectShouldReplaceLoneSurrogate` shows up under sabotage A — that test guards the opposite direction — and nothing was exercising that direction through an actual file. So I added `TrxFileShouldRemainParseableWhenTestNameContainsLoneSurrogate`, which puts a lone high surrogate in a test name and asserts the trx is written, parses, and contains the escaped form. Under sabotage B it fails with exactly the exception the escaping exists to prevent:```System.ArgumentException: The surrogate pair (0xD800, 0x20) is invalid. A high surrogatecharacter (0xD800 - 0xDBFF) must always be paired with a low surrogate character(0xDC00 - 0xDFFF).  at System.Xml.XmlUtf8RawTextWriter.EncodeSurrogate(Char* pSrc, Char* pSrcEnd, Byte* pDst)  at System.Xml.XmlUtf8RawTextWriter.WriteAttributeTextBlock(Char* pSrc, Char* pSrcEnd)```That claim was prose in #16318; it is now pinned by a test. Both regression directions are covered at the file level, not just at the sanitizer.`Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests` — 186/186 passing in Release, 93 on net481 and 93 on net11.0.

## Review round 2

Both suggestions applied in `Apply review suggestions from #16335`.

**The `\ufffd` guard on `SaveObjectShouldNotReplaceValidText`** — fair, and I had the guard on the wrong test. `SaveObjectShouldReplaceLoneSurrogate` compares against hard-coded escaped literals so it cannot go vacuous; this one compares against its own input, so it can. Applied, and verified it fires by temporarily adding a row containing U+FFFD:

```
failed TEMP sabotage - simulates a mangled row
  Assert.DoesNotContain failed. String 'party ? done' does contain string '?'.
  A surrogate pair did not survive the data row transport - this row would assert nothing.
```

**The `CheckCharacters` example** — you are right and I should not have written it. I reproduced your result before removing it:

```
CheckCharacters=True  bytes=110 sha=3C465572775C747C
CheckCharacters=False bytes=110 sha=3C465572775C747C
```

Byte-identical, same hash, for an emoji in an attribute and an escaped lone surrogate in element text. Everything reaching the DOM has already been through `RemoveInvalidXmlChar`, so the writer never sees anything the flag could object to. Dropped from the comment here and from the PR description above, since claiming coverage that does not exist is worse than claiming none.