### PR TITLE
Revive socket client and server tests

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
@@ -21,6 +21,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 public class SocketServer : ICommunicationEndPoint
 {
     private readonly CancellationTokenSource _cancellation;
+    private readonly Func<TcpListener, Task<TcpClient>> _acceptClientAsync;
     private readonly Func<Stream, ICommunicationChannel> _channelFactory;
     private readonly object _stateSyncObject = new();
 
@@ -45,11 +46,19 @@ public class SocketServer : ICommunicationEndPoint
     /// </summary>
     /// <param name="channelFactory">Factory to create communication channel.</param>
     protected SocketServer(Func<Stream, ICommunicationChannel> channelFactory)
+        : this(channelFactory, tcpListener => tcpListener.AcceptTcpClientAsync())
+    {
+    }
+
+    internal SocketServer(
+        Func<Stream, ICommunicationChannel> channelFactory,
+        Func<TcpListener, Task<TcpClient>> acceptClientAsync)
     {
         // Used to cancel the message loop
         _cancellation = new CancellationTokenSource();
 
         _channelFactory = channelFactory;
+        _acceptClientAsync = acceptClientAsync;
     }
 
     /// <inheritdoc />
@@ -62,6 +71,7 @@ public class SocketServer : ICommunicationEndPoint
     {
         try
         {
+            TcpListener tcpListener;
             lock (_stateSyncObject)
             {
                 if (_stopRequested != 0)
@@ -72,15 +82,16 @@ public class SocketServer : ICommunicationEndPoint
                 _tcpListener = new TcpListener(endPoint.GetIpEndPoint());
 
                 _tcpListener.Start();
+                tcpListener = _tcpListener;
 
                 _endPoint = _tcpListener.LocalEndpoint.ToString();
                 EqtTrace.Info("SocketServer.Start: Listening on endpoint : {0}", _endPoint);
-
-                // Serves a single client at the moment. An error in connection, or message loop just
-                // terminates the entire server.
-                _ = AcceptClientAsync();
-                return _endPoint;
             }
+
+            // Serves a single client at the moment. An error in connection, or message loop just
+            // terminates the entire server.
+            _ = AcceptClientAsync(tcpListener);
+            return _endPoint;
         }
         catch (SocketException ex)
         {
@@ -115,12 +126,12 @@ public class SocketServer : ICommunicationEndPoint
         }
     }
 
-    private async Task AcceptClientAsync()
+    private async Task AcceptClientAsync(TcpListener tcpListener)
     {
         TcpClient? client = null;
         try
         {
-            client = await _tcpListener!.AcceptTcpClientAsync().ConfigureAwait(false);
+            client = await _acceptClientAsync(tcpListener).ConfigureAwait(false);
             lock (_stateSyncObject)
             {
                 if (_stopRequested != 0)
@@ -129,8 +140,10 @@ public class SocketServer : ICommunicationEndPoint
                     return;
                 }
 
-                OnClientConnected(client);
+                _tcpClient = client;
             }
+
+            OnClientConnected(client);
         }
         catch (Exception ex) when (Volatile.Read(ref _stopRequested) != 0 && ex is ObjectDisposedException or SocketException)
         {
@@ -146,21 +159,20 @@ public class SocketServer : ICommunicationEndPoint
 
     private void OnClientConnected(TcpClient client)
     {
-        _tcpClient = client;
-        _tcpClient.Client.NoDelay = true;
+        client.Client.NoDelay = true;
 
         if (Connected == null)
         {
             return;
         }
 
-        _channel = _channelFactory(_tcpClient.GetStream());
+        _channel = _channelFactory(client.GetStream());
         Connected.SafeInvoke(this, new ConnectedEventArgs(_channel), "SocketServer: ClientConnected");
 
         EqtTrace.Verbose("SocketServer.OnClientConnected: Client connected for endPoint: {0}, starting MessageLoopAsync:", _endPoint);
 
         // Start the message loop
-        Task.Run(() => _tcpClient.MessageLoopAsync(_channel, error => StopOnError(error), _cancellation.Token)).ConfigureAwait(false);
+        Task.Run(() => client.MessageLoopAsync(_channel, error => StopOnError(error), _cancellation.Token)).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
@@ -22,10 +22,12 @@ public class SocketServer : ICommunicationEndPoint
 {
     private readonly CancellationTokenSource _cancellation;
     private readonly Func<Stream, ICommunicationChannel> _channelFactory;
+    private readonly object _stateSyncObject = new();
 
     private ICommunicationChannel? _channel;
     private TcpListener? _tcpListener;
     private TcpClient? _tcpClient;
+    private int _stopRequested;
     private bool _stopped;
     private string? _endPoint;
 
@@ -60,17 +62,25 @@ public class SocketServer : ICommunicationEndPoint
     {
         try
         {
-            _tcpListener = new TcpListener(endPoint.GetIpEndPoint());
+            lock (_stateSyncObject)
+            {
+                if (_stopRequested != 0)
+                {
+                    throw new ObjectDisposedException(nameof(SocketServer));
+                }
 
-            _tcpListener.Start();
+                _tcpListener = new TcpListener(endPoint.GetIpEndPoint());
 
-            _endPoint = _tcpListener.LocalEndpoint.ToString();
-            EqtTrace.Info("SocketServer.Start: Listening on endpoint : {0}", _endPoint);
+                _tcpListener.Start();
 
-            // Serves a single client at the moment. An error in connection, or message loop just
-            // terminates the entire server.
-            _tcpListener.AcceptTcpClientAsync().ContinueWith(t => OnClientConnected(t.Result));
-            return _endPoint;
+                _endPoint = _tcpListener.LocalEndpoint.ToString();
+                EqtTrace.Info("SocketServer.Start: Listening on endpoint : {0}", _endPoint);
+
+                // Serves a single client at the moment. An error in connection, or message loop just
+                // terminates the entire server.
+                _ = AcceptClientAsync();
+                return _endPoint;
+            }
         }
         catch (SocketException ex)
         {
@@ -83,10 +93,54 @@ public class SocketServer : ICommunicationEndPoint
     public void Stop()
     {
         EqtTrace.Info("SocketServer.Stop: Stop server endPoint: {0}", _endPoint);
-        if (!_stopped)
+        lock (_stateSyncObject)
         {
+            if (_stopRequested != 0)
+            {
+                return;
+            }
+
+            _stopRequested = 1;
             EqtTrace.Info("SocketServer.Stop: Cancellation requested. Stopping message loop.");
-            _cancellation.Cancel();
+            try
+            {
+                _cancellation.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // StopOnError disposed the cancellation source concurrently.
+            }
+
+            _tcpListener?.Stop();
+        }
+    }
+
+    private async Task AcceptClientAsync()
+    {
+        TcpClient? client = null;
+        try
+        {
+            client = await _tcpListener!.AcceptTcpClientAsync().ConfigureAwait(false);
+            lock (_stateSyncObject)
+            {
+                if (_stopRequested != 0)
+                {
+                    client.Close();
+                    return;
+                }
+
+                OnClientConnected(client);
+            }
+        }
+        catch (Exception ex) when (Volatile.Read(ref _stopRequested) != 0 && ex is ObjectDisposedException or SocketException)
+        {
+            EqtTrace.Verbose("SocketServer.AcceptClientAsync: Listener stopped before a client connected.");
+        }
+        catch (Exception ex)
+        {
+            EqtTrace.Error("SocketServer.AcceptClientAsync: Failed to accept a client: {0}", ex);
+            client?.Close();
+            Stop();
         }
     }
 

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
@@ -145,7 +145,7 @@ public class SocketServer : ICommunicationEndPoint
 
             OnClientConnected(client);
         }
-        catch (Exception ex) when (Volatile.Read(ref _stopRequested) != 0 && ex is ObjectDisposedException or SocketException)
+        catch (Exception ex) when (Volatile.Read(ref _stopRequested) != 0 && ex is ObjectDisposedException or SocketException or InvalidOperationException)
         {
             EqtTrace.Verbose("SocketServer.AcceptClientAsync: Listener stopped before a client connected.");
         }

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
@@ -131,7 +131,16 @@ public class SocketServer : ICommunicationEndPoint
         TcpClient? client = null;
         try
         {
-            client = await _acceptClientAsync(tcpListener).ConfigureAwait(false);
+            try
+            {
+                client = await _acceptClientAsync(tcpListener).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (Volatile.Read(ref _stopRequested) != 0 && ex is ObjectDisposedException or SocketException or InvalidOperationException)
+            {
+                EqtTrace.Verbose("SocketServer.AcceptClientAsync: Listener stopped before a client connected: {0}", ex);
+                return;
+            }
+
             lock (_stateSyncObject)
             {
                 if (_stopRequested != 0)
@@ -144,10 +153,6 @@ public class SocketServer : ICommunicationEndPoint
             }
 
             OnClientConnected(client);
-        }
-        catch (Exception ex) when (Volatile.Read(ref _stopRequested) != 0 && ex is ObjectDisposedException or SocketException or InvalidOperationException)
-        {
-            EqtTrace.Verbose("SocketServer.AcceptClientAsync: Listener stopped before a client connected.");
         }
         catch (Exception ex)
         {

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/SocketClientTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/SocketClientTests.cs
@@ -12,10 +12,11 @@ using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Moq;
+
 namespace Microsoft.TestPlatform.CommunicationUtilities.PlatformTests;
 
 [TestClass]
-[Ignore("Flaky tests")]
 public class SocketClientTests : SocketTestsBase, IDisposable
 {
     private readonly TcpListener _tcpListener;
@@ -23,8 +24,6 @@ public class SocketClientTests : SocketTestsBase, IDisposable
     private readonly ICommunicationEndPoint _socketClient;
 
     private TcpClient? _tcpClient;
-
-    public TestContext TestContext { get; set; }
 
     public SocketClientTests()
     {
@@ -39,6 +38,7 @@ public class SocketClientTests : SocketTestsBase, IDisposable
     public void Dispose()
     {
         _socketClient.Stop();
+        _tcpListener.Stop();
         // tcpClient.Close() calls tcpClient.Dispose().
         _tcpClient?.Close();
         GC.SuppressFinalize(this);
@@ -55,7 +55,8 @@ public class SocketClientTests : SocketTestsBase, IDisposable
         var acceptClientTask = _tcpListener.AcceptTcpClientAsync();
         Assert.IsTrue(acceptClientTask.Wait(Timeout));
 #pragma warning restore MSTEST0049
-        Assert.IsTrue(acceptClientTask.Result.Connected);
+        using var client = acceptClientTask.Result;
+        Assert.IsTrue(client.Connected);
     }
 
     [TestMethod]
@@ -87,55 +88,70 @@ public class SocketClientTests : SocketTestsBase, IDisposable
     [TestMethod]
     public void SocketClientStopShouldRaiseClientDisconnectedEventOnClientDisconnection()
     {
-        var waitEvent = SetupClientDisconnect(out ICommunicationChannel? _);
+        using var waitEvent = SetupClientDisconnect(out ICommunicationChannel? _);
 
         // Close the communication from client side
         _socketClient.Stop();
 
-        Assert.IsTrue(waitEvent.WaitOne(Timeout));
+        Assert.IsTrue(waitEvent.Wait(Timeout, TestContext.CancellationToken));
     }
 
     [TestMethod]
     public void SocketClientShouldRaiseClientDisconnectedEventIfConnectionIsBroken()
     {
-        var waitEvent = SetupClientDisconnect(out ICommunicationChannel? _);
+        using var waitEvent = SetupClientDisconnect(out ICommunicationChannel? _);
 
         // Close the communication from server side
         _tcpClient?.GetStream().Dispose();
         // tcpClient.Close() calls tcpClient.Dispose().
         _tcpClient?.Close();
-        Assert.IsTrue(waitEvent.WaitOne(Timeout));
+        Assert.IsTrue(waitEvent.Wait(Timeout, TestContext.CancellationToken));
     }
 
     [TestMethod]
     public void SocketClientStopShouldStopCommunication()
     {
-        var waitEvent = SetupClientDisconnect(out ICommunicationChannel? _);
+        using var waitEvent = SetupClientDisconnect(out ICommunicationChannel? _);
 
         // Close the communication from socket client side
         _socketClient.Stop();
 
-        // Validate that write on server side fails
-        waitEvent.WaitOne(Timeout);
-        Assert.ThrowsExactly<IOException>(() => WriteData(Client!));
+        // Validate that the server side observes the closed connection.
+        Assert.IsTrue(waitEvent.Wait(Timeout, TestContext.CancellationToken));
+        Assert.IsTrue(Client!.Client.Poll(Timeout * 1000, SelectMode.SelectRead));
+        Assert.AreEqual(0, Client.Client.Available);
     }
 
     [TestMethod]
     public void SocketClientStopShouldCloseChannel()
     {
-        var waitEvent = SetupClientDisconnect(out ICommunicationChannel? channel);
+        var channel = new Mock<ICommunicationChannel>();
+        var socketClient = new TestSocketClient(_ => channel.Object);
+        using ManualResetEventSlim waitEvent = new(false);
+        socketClient.Connected += (sender, eventArgs) => waitEvent.Set();
+        var connectionInfo = StartLocalServer();
+        socketClient.Start(connectionInfo);
 
-        _socketClient.Stop();
+#pragma warning disable MSTEST0049 // Use 'TestContext.CancellationToken' - AcceptTcpClientAsync/Wait overloads unavailable on .NET Framework
+        var acceptClientTask = _tcpListener.AcceptTcpClientAsync();
+        Assert.IsTrue(acceptClientTask.Wait(Timeout, TestContext.CancellationToken));
+#pragma warning restore MSTEST0049
+        _tcpClient = acceptClientTask.Result;
+        Assert.IsTrue(waitEvent.Wait(Timeout, TestContext.CancellationToken));
+        waitEvent.Reset();
+        socketClient.Disconnected += (sender, eventArgs) => waitEvent.Set();
 
-        waitEvent.WaitOne(Timeout);
-        Assert.ThrowsExactly<CommunicationException>(() => channel!.Send(Dummydata));
+        socketClient.Stop();
+
+        Assert.IsTrue(waitEvent.Wait(Timeout, TestContext.CancellationToken));
+        channel.Verify(communicationChannel => communicationChannel.Dispose(), Times.Once);
     }
 
     protected override ICommunicationChannel? SetupChannel(out ConnectedEventArgs? connectedEvent)
     {
         ICommunicationChannel? channel = null;
         ConnectedEventArgs? serverConnectedEvent = null;
-        ManualResetEvent waitEvent = new(false);
+        using ManualResetEventSlim waitEvent = new(false);
         _socketClient.Connected += (sender, eventArgs) =>
         {
             serverConnectedEvent = eventArgs;
@@ -148,20 +164,18 @@ public class SocketClientTests : SocketTestsBase, IDisposable
 
 #pragma warning disable MSTEST0049 // Use 'TestContext.CancellationToken' - AcceptTcpClientAsync/Wait overloads unavailable on .NET Framework
         var acceptClientTask = _tcpListener.AcceptTcpClientAsync();
-        if (acceptClientTask.Wait(TimeSpan.FromMilliseconds(1000)))
+        Assert.IsTrue(acceptClientTask.Wait(Timeout, TestContext.CancellationToken));
 #pragma warning restore MSTEST0049
-        {
-            _tcpClient = acceptClientTask.Result;
-            waitEvent.WaitOne(1000);
-        }
+        _tcpClient = acceptClientTask.Result;
+        Assert.IsTrue(waitEvent.Wait(Timeout, TestContext.CancellationToken));
 
         connectedEvent = serverConnectedEvent;
         return channel;
     }
 
-    private ManualResetEvent SetupClientDisconnect(out ICommunicationChannel? channel)
+    private ManualResetEventSlim SetupClientDisconnect(out ICommunicationChannel? channel)
     {
-        var waitEvent = new ManualResetEvent(false);
+        var waitEvent = new ManualResetEventSlim(false);
         _socketClient.Disconnected += (s, e) => waitEvent.Set();
         channel = SetupChannel(out ConnectedEventArgs? _);
         channel!.MessageReceived.Subscribe((sender, args) =>
@@ -176,4 +190,6 @@ public class SocketClientTests : SocketTestsBase, IDisposable
 
         return ((IPEndPoint)_tcpListener.LocalEndpoint).ToString();
     }
+
+    private sealed class TestSocketClient(Func<Stream, ICommunicationChannel> channelFactory) : SocketClient(channelFactory);
 }

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/SocketServerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/SocketServerTests.cs
@@ -105,26 +105,36 @@ public class SocketServerTests : SocketTestsBase, IDisposable
 
         var socketServer = new SocketServer(_ => channel.Object, _ => Task.FromResult(acceptedClient));
         using var handlerEntered = new ManualResetEventSlim(false);
+        using var handlerExited = new ManualResetEventSlim(false);
         using var releaseHandler = new ManualResetEventSlim(false);
         socketServer.Connected += (sender, eventArgs) =>
         {
             handlerEntered.Set();
-            Assert.IsTrue(releaseHandler.Wait(Timeout, TestContext.CancellationToken));
+            releaseHandler.Wait(Timeout * 2, TestContext.CancellationToken);
+            handlerExited.Set();
         };
 
         try
         {
-            var startTask = Task.Run(() => socketServer.Start(_defaultConnection), TestContext.CancellationToken);
-            Assert.IsTrue(handlerEntered.Wait(Timeout, TestContext.CancellationToken));
+            Task<string?> startTask;
+            try
+            {
+                startTask = Task.Run(() => socketServer.Start(_defaultConnection), TestContext.CancellationToken);
+                Assert.IsTrue(handlerEntered.Wait(Timeout, TestContext.CancellationToken));
 
-            var stopTask = Task.Run(socketServer.Stop, TestContext.CancellationToken);
-            Assert.IsTrue(stopTask.Wait(Timeout, TestContext.CancellationToken));
-            releaseHandler.Set();
+                var stopTask = Task.Run(socketServer.Stop, TestContext.CancellationToken);
+                Assert.IsTrue(stopTask.Wait(Timeout, TestContext.CancellationToken));
+            }
+            finally
+            {
+                releaseHandler.Set();
+            }
+
+            Assert.IsTrue(handlerExited.Wait(Timeout, TestContext.CancellationToken));
             Assert.IsTrue(startTask.Wait(Timeout, TestContext.CancellationToken));
         }
         finally
         {
-            releaseHandler.Set();
             socketServer.Stop();
             acceptedClient.Close();
         }

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/SocketServerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/SocketServerTests.cs
@@ -86,22 +86,9 @@ public class SocketServerTests : SocketTestsBase, IDisposable
     public async Task SocketServerStopShouldNotWaitForConnectedHandlerWhenAcceptCompletesSynchronously()
     {
         var channel = new Mock<ICommunicationChannel>();
-        using var tcpClient = new TcpClient();
-        var acceptingListener = new TcpListener(IPAddress.Loopback, 0);
-        acceptingListener.Start();
-        TcpClient acceptedClient;
-        try
-        {
-#pragma warning disable MSTEST0049 // Use 'TestContext.CancellationToken' - ConnectAsync CancellationToken overload unavailable on .NET Framework
-            var acceptClientTask = acceptingListener.AcceptTcpClientAsync();
-            await tcpClient.ConnectAsync(IPAddress.Loopback, ((IPEndPoint)acceptingListener.LocalEndpoint).Port);
-            acceptedClient = await acceptClientTask;
-#pragma warning restore MSTEST0049
-        }
-        finally
-        {
-            acceptingListener.Stop();
-        }
+        var connectedClients = await CreateConnectedTcpClients();
+        using var tcpClient = connectedClients.Client;
+        using var acceptedClient = connectedClients.AcceptedClient;
 
         var socketServer = new SocketServer(_ => channel.Object, _ => Task.FromResult(acceptedClient));
         using var handlerEntered = new ManualResetEventSlim(false);
@@ -137,6 +124,38 @@ public class SocketServerTests : SocketTestsBase, IDisposable
         {
             socketServer.Stop();
             acceptedClient.Close();
+        }
+    }
+
+    [TestMethod]
+    public async Task SocketServerShouldCloseAcceptedClientWhenChannelFactoryThrowsDuringStop()
+    {
+        var connectedClients = await CreateConnectedTcpClients();
+        using var tcpClient = connectedClients.Client;
+        using var acceptedClient = connectedClients.AcceptedClient;
+        using var channelFactoryCalled = new ManualResetEventSlim(false);
+        SocketServer? socketServer = null;
+        socketServer = new SocketServer(
+            _ =>
+            {
+                socketServer!.Stop();
+                channelFactoryCalled.Set();
+                throw new InvalidOperationException();
+            },
+            _ => Task.FromResult(acceptedClient));
+        socketServer.Connected += (sender, eventArgs) => { };
+
+        try
+        {
+            socketServer.Start(_defaultConnection);
+
+            Assert.IsTrue(channelFactoryCalled.Wait(Timeout, TestContext.CancellationToken));
+            Assert.IsTrue(tcpClient.Client.Poll(Timeout * 1000, SelectMode.SelectRead));
+            Assert.AreEqual(0, tcpClient.Client.Available);
+        }
+        finally
+        {
+            socketServer.Stop();
         }
     }
 
@@ -252,6 +271,31 @@ public class SocketServerTests : SocketTestsBase, IDisposable
 #pragma warning disable MSTEST0049 // Use 'TestContext.CancellationToken' - ConnectAsync CancellationToken overload unavailable on .NET Framework
         await _tcpClient.ConnectAsync(IPAddress.Loopback, port);
 #pragma warning restore MSTEST0049
+    }
+
+    private static async Task<(TcpClient Client, TcpClient AcceptedClient)> CreateConnectedTcpClients()
+    {
+        var client = new TcpClient();
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+#pragma warning disable MSTEST0049 // Use 'TestContext.CancellationToken' - overloads unavailable on .NET Framework
+            var acceptClientTask = listener.AcceptTcpClientAsync();
+            await client.ConnectAsync(IPAddress.Loopback, ((IPEndPoint)listener.LocalEndpoint).Port);
+            var acceptedClient = await acceptClientTask;
+#pragma warning restore MSTEST0049
+            return (client, acceptedClient);
+        }
+        catch
+        {
+            client.Close();
+            throw;
+        }
+        finally
+        {
+            listener.Stop();
+        }
     }
 
     private sealed class TestSocketServer(Func<Stream, ICommunicationChannel> channelFactory) : SocketServer(channelFactory);

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/SocketServerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/SocketServerTests.cs
@@ -83,6 +83,54 @@ public class SocketServerTests : SocketTestsBase, IDisposable
     }
 
     [TestMethod]
+    public async Task SocketServerStopShouldNotWaitForConnectedHandlerWhenAcceptCompletesSynchronously()
+    {
+        var channel = new Mock<ICommunicationChannel>();
+        using var tcpClient = new TcpClient();
+        var acceptingListener = new TcpListener(IPAddress.Loopback, 0);
+        acceptingListener.Start();
+        TcpClient acceptedClient;
+        try
+        {
+#pragma warning disable MSTEST0049 // Use 'TestContext.CancellationToken' - ConnectAsync CancellationToken overload unavailable on .NET Framework
+            var acceptClientTask = acceptingListener.AcceptTcpClientAsync();
+            await tcpClient.ConnectAsync(IPAddress.Loopback, ((IPEndPoint)acceptingListener.LocalEndpoint).Port);
+            acceptedClient = await acceptClientTask;
+#pragma warning restore MSTEST0049
+        }
+        finally
+        {
+            acceptingListener.Stop();
+        }
+
+        var socketServer = new SocketServer(_ => channel.Object, _ => Task.FromResult(acceptedClient));
+        using var handlerEntered = new ManualResetEventSlim(false);
+        using var releaseHandler = new ManualResetEventSlim(false);
+        socketServer.Connected += (sender, eventArgs) =>
+        {
+            handlerEntered.Set();
+            Assert.IsTrue(releaseHandler.Wait(Timeout, TestContext.CancellationToken));
+        };
+
+        try
+        {
+            var startTask = Task.Run(() => socketServer.Start(_defaultConnection), TestContext.CancellationToken);
+            Assert.IsTrue(handlerEntered.Wait(Timeout, TestContext.CancellationToken));
+
+            var stopTask = Task.Run(socketServer.Stop, TestContext.CancellationToken);
+            Assert.IsTrue(stopTask.Wait(Timeout, TestContext.CancellationToken));
+            releaseHandler.Set();
+            Assert.IsTrue(startTask.Wait(Timeout, TestContext.CancellationToken));
+        }
+        finally
+        {
+            releaseHandler.Set();
+            socketServer.Stop();
+            acceptedClient.Close();
+        }
+    }
+
+    [TestMethod]
     public void SocketServerStopShouldCloseClient()
     {
         using ManualResetEventSlim waitEvent = new(false);

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/SocketServerTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/SocketServerTests.cs
@@ -13,17 +13,16 @@ using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Moq;
+
 namespace Microsoft.TestPlatform.CommunicationUtilities.PlatformTests;
 
 [TestClass]
-[Ignore("Flaky")]
 public class SocketServerTests : SocketTestsBase, IDisposable
 {
     private readonly TcpClient _tcpClient;
     private readonly string _defaultConnection = IPAddress.Loopback.ToString() + ":0";
     private readonly ICommunicationEndPoint _socketServer;
-
-    public TestContext TestContext { get; set; }
 
     public SocketServerTests()
     {
@@ -53,41 +52,55 @@ public class SocketServerTests : SocketTestsBase, IDisposable
     }
 
     [TestMethod]
-    public void SocketServerStopShouldStopListening()
+    public async Task SocketServerStopShouldStopListening()
     {
+        var connected = false;
+        _socketServer.Connected += (sender, eventArgs) => connected = true;
         var connectionInfo = _socketServer.Start(_defaultConnection);
 
         _socketServer.Stop();
 
+        var connectionFailed = false;
         try
         {
-            // This method throws ExtendedSocketException (which is private). It is not possible
-            // to use Assert.ThrowsException in this case.
-            ConnectToServer(connectionInfo.GetIpEndPoint().Port).GetAwaiter().GetResult();
+            await ConnectToServer(connectionInfo.GetIpEndPoint().Port);
         }
         catch (SocketException)
         {
+            connectionFailed = true;
         }
+
+        Assert.IsTrue(connectionFailed);
+        Assert.IsFalse(connected);
+    }
+
+    [TestMethod]
+    public void SocketServerStartShouldThrowAfterStop()
+    {
+        _socketServer.Stop();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() => _socketServer.Start(_defaultConnection));
     }
 
     [TestMethod]
     public void SocketServerStopShouldCloseClient()
     {
-        ManualResetEvent waitEvent = new(false);
+        using ManualResetEventSlim waitEvent = new(false);
         _socketServer.Disconnected += (s, e) => waitEvent.Set();
         SetupChannel(out ConnectedEventArgs? clientConnected);
 
         _socketServer.Stop();
 
-        waitEvent.WaitOne();
-        Assert.ThrowsExactly<IOException>(() => WriteData(_tcpClient));
+        Assert.IsTrue(waitEvent.Wait(Timeout, TestContext.CancellationToken));
+        Assert.IsTrue(_tcpClient.Client.Poll(Timeout * 1000, SelectMode.SelectRead));
+        Assert.AreEqual(0, _tcpClient.Client.Available);
     }
 
     [TestMethod]
     public void SocketServerStopShouldRaiseClientDisconnectedEventOnClientDisconnection()
     {
         DisconnectedEventArgs? disconnected = null;
-        ManualResetEvent waitEvent = new(false);
+        using ManualResetEventSlim waitEvent = new(false);
         _socketServer.Disconnected += (s, e) =>
         {
             disconnected = e;
@@ -97,7 +110,7 @@ public class SocketServerTests : SocketTestsBase, IDisposable
 
         _socketServer.Stop();
 
-        waitEvent.WaitOne();
+        Assert.IsTrue(waitEvent.Wait(Timeout, TestContext.CancellationToken));
         Assert.IsNotNull(disconnected);
         Assert.IsNull(disconnected.Error);
     }
@@ -105,21 +118,27 @@ public class SocketServerTests : SocketTestsBase, IDisposable
     [TestMethod]
     public void SocketServerStopShouldCloseChannel()
     {
-        var waitEvent = new ManualResetEventSlim(false);
-        var channel = SetupChannel(out ConnectedEventArgs? clientConnected);
-        _socketServer.Disconnected += (s, e) => waitEvent.Set();
+        var channel = new Mock<ICommunicationChannel>();
+        var socketServer = new TestSocketServer(_ => channel.Object);
+        using var waitEvent = new ManualResetEventSlim(false);
+        socketServer.Connected += (sender, eventArgs) => waitEvent.Set();
+        var connectionInfo = socketServer.Start(_defaultConnection);
+        ConnectToServer(connectionInfo.GetIpEndPoint().Port).GetAwaiter().GetResult();
+        Assert.IsTrue(waitEvent.Wait(Timeout, TestContext.CancellationToken));
+        waitEvent.Reset();
+        socketServer.Disconnected += (sender, eventArgs) => waitEvent.Set();
 
-        _socketServer.Stop();
+        socketServer.Stop();
 
-        waitEvent.Wait(TestContext.CancellationToken);
-        Assert.ThrowsExactly<CommunicationException>(() => channel!.Send(Dummydata));
+        Assert.IsTrue(waitEvent.Wait(Timeout, TestContext.CancellationToken));
+        channel.Verify(communicationChannel => communicationChannel.Dispose(), Times.Once);
     }
 
     [TestMethod]
     public void SocketServerShouldRaiseClientDisconnectedEventIfConnectionIsBroken()
     {
         DisconnectedEventArgs? clientDisconnected = null;
-        ManualResetEvent waitEvent = new(false);
+        using ManualResetEventSlim waitEvent = new(false);
         _socketServer.Disconnected += (sender, eventArgs) =>
         {
             clientDisconnected = eventArgs;
@@ -135,8 +154,8 @@ public class SocketServerTests : SocketTestsBase, IDisposable
         // tcpClient.Close() calls tcpClient.Dispose().
         _tcpClient?.Close();
 
-        Assert.IsTrue(waitEvent.WaitOne(1000));
-        Assert.IsTrue(clientDisconnected!.Error is IOException);
+        Assert.IsTrue(waitEvent.Wait(Timeout, TestContext.CancellationToken));
+        Assert.IsNull(clientDisconnected!.Error);
     }
 
     [TestMethod]
@@ -153,7 +172,7 @@ public class SocketServerTests : SocketTestsBase, IDisposable
     {
         ICommunicationChannel? channel = null;
         ConnectedEventArgs? clientConnectedEvent = null;
-        ManualResetEvent waitEvent = new(false);
+        using ManualResetEventSlim waitEvent = new(false);
         _socketServer.Connected += (sender, eventArgs) =>
         {
             clientConnectedEvent = eventArgs;
@@ -164,7 +183,7 @@ public class SocketServerTests : SocketTestsBase, IDisposable
         var connectionInfo = _socketServer.Start(_defaultConnection);
         var port = connectionInfo.GetIpEndPoint().Port;
         ConnectToServer(port).GetAwaiter().GetResult();
-        waitEvent.WaitOne();
+        Assert.IsTrue(waitEvent.Wait(Timeout, TestContext.CancellationToken));
 
         connectedEvent = clientConnectedEvent;
         return channel;
@@ -176,4 +195,6 @@ public class SocketServerTests : SocketTestsBase, IDisposable
         await _tcpClient.ConnectAsync(IPAddress.Loopback, port);
 #pragma warning restore MSTEST0049
     }
+
+    private sealed class TestSocketServer(Func<Stream, ICommunicationChannel> channelFactory) : SocketServer(channelFactory);
 }

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/SocketTestsBase.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.Platform.UnitTests/SocketTestsBase.cs
@@ -17,6 +17,8 @@ public abstract class SocketTestsBase
     protected const string Dummydata = "Dummy Data";
     protected const int Timeout = 10 * 1000;
 
+    public TestContext TestContext { get; set; }
+
     protected abstract TcpClient? Client { get; }
 
     [TestMethod]
@@ -31,7 +33,7 @@ public abstract class SocketTestsBase
     public void SocketEndpointShouldNotifyChannelOnDataAvailable()
     {
         var message = string.Empty;
-        ManualResetEvent waitForMessage = new(false);
+        using ManualResetEventSlim waitForMessage = new(false);
         SetupChannel(out ConnectedEventArgs? _)!.MessageReceived.Subscribe((s, e) =>
         {
             message = e.Data;
@@ -40,7 +42,7 @@ public abstract class SocketTestsBase
 
         WriteData(Client!);
 
-        waitForMessage.WaitOne();
+        Assert.IsTrue(waitForMessage.Wait(Timeout, TestContext.CancellationToken));
         Assert.AreEqual(Dummydata, message);
     }
 


### PR DESCRIPTION
The socket tests already use dynamic loopback ports, but their class-level ignores hid unbounded waits and stale shutdown assertions.

Stop `SocketServer` listeners immediately, serialize start / accept / stop, and close clients accepted during shutdown. Re-enable `SocketClientTests` and `SocketServerTests` with bounded waits and direct checks for socket and channel cleanup.

`CommunicationLayerIntegrationTests` stays ignored. It also uses a dynamic port, but all three tests now fail because the custom data collector is no longer loaded. That needs a separate fix, it is not a port collision.

Verified the two revived classes 10 times on both `net11.0` and `net481`, plus the complete communication platform test project in Release.

Part of #16346

🤖