### PR TITLE
[rel/18.9] Remove dead DotNet-VSTS-Infra-Access variable group reference

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -91,8 +91,6 @@ variables:
     - name: Codeql.Cadence 
       value: 0
 
-  # Group gives access to $dn-bot-devdiv-drop-rw-code-rw and dn-bot-dnceng-build-rw-code-rw
-  - group: DotNet-VSTS-Infra-Access
   # DevDiv drop access token is acquired via WIF service connection (dnceng-devdiv-drop-rw-code-rw-wif)
   - name: _DevDivDropAccessToken
     value: ''


### PR DESCRIPTION
Backport of #16203 / commit fdd72c52801887e61c69c91e93abdb655723176b from `main` to `rel/18.9`.

## Symptom

Manually queuing the official pipeline from branch `rel/18.9` fails at **YAML load time**, before any job runs:

> An error occurred while loading the YAML build pipeline. Variable group was not found or is not authorized for use.

## Root cause

`azure-pipelines-official.yml` on `rel/18.9` still contained an unconditional, root-level reference to the `DotNet-VSTS-Infra-Access` variable group. Root-level variable groups are resolved during YAML compilation, so a missing/de-authorized group makes the entire pipeline fail to load rather than failing a single step.

That group only held the `dn-bot-devdiv-drop-r-code-r` PAT, which has since been migrated to WIF (service connection `dnceng-devdiv-drop-rw-code-rw-wif`). The PAT is expired and the group is de-authorized in `dnceng/internal`, so the reference is dead weight.

## Change

Removes the two dead lines from the root `variables:` block:

```yaml
  # Group gives access to $dn-bot-devdiv-drop-rw-code-rw and dn-bot-dnceng-build-rw-code-rw
  - group: DotNet-VSTS-Infra-Access
```

The following `# DevDiv drop access token is acquired via WIF service connection (dnceng-devdiv-drop-rw-code-rw-wif)` comment and the `_DevDivDropAccessToken` variable (empty value) are intentionally left untouched. The diff is byte-identical to the upstream patch on `main`.

## Verification

- `grep` for `DotNet-VSTS-Infra-Access` across the branch: no remaining references.
- `grep` for `dn-bot-devdiv-drop` and `dn-bot-dnceng-build-rw-code-rw`: no usages anywhere on the branch, so nothing consumed variables that were only provided by this group.
- No build/test impact — this is a pipeline YAML-only change.