### PR TITLE
[code-simplifier] Simplify SocketServer: is null and Task.Run discard

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/SocketServer.cs
@@ -166,7 +166,7 @@ public class SocketServer : ICommunicationEndPoint
     {
         client.Client.NoDelay = true;
 
-        if (Connected == null)
+        if (Connected is null)
         {
             return;
         }
@@ -177,7 +177,7 @@ public class SocketServer : ICommunicationEndPoint
         EqtTrace.Verbose("SocketServer.OnClientConnected: Client connected for endPoint: {0}, starting MessageLoopAsync:", _endPoint);
 
         // Start the message loop
-        Task.Run(() => client.MessageLoopAsync(_channel, error => StopOnError(error), _cancellation.Token)).ConfigureAwait(false);
+        _ = Task.Run(() => client.MessageLoopAsync(_channel, error => StopOnError(error), _cancellation.Token));
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #16358

Two targeted style fixes in `SocketServer.cs` (introduced by #16348):

1. `Connected == null` -> `Connected is null`, per the repo convention of always using `is null` / `is not null`.
2. `Task.Run(...).ConfigureAwait(false);` -> `_ = Task.Run(...);`. `ConfigureAwait` returns a `ConfiguredTaskAwaitable` that is never awaited here, so the call is a no-op and misleading. The discard makes the fire-and-forget intent explicit.

No functional changes.

### Verification

- Verified both statements in the issue against current `main`: the `== null` comparison and the non-awaited `ConfigureAwait(false)` were both present.
- The remaining `ConfigureAwait(false)` in the file (on `_acceptClientAsync`) is genuinely awaited and was left alone.
- `build.cmd -c Release` builds `Microsoft.TestPlatform.CommunicationUtilities` with 0 errors.