### PR TITLE
Pass arguments to PowerShell with -File instead of -command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@ vstest.console (entry point)
 
 CI builds use `-c Release`. Always build with Release config before submitting PRs.
 
+> On Windows, never put `;` (or `|`, `&`, `` ` ``, `$(...)`) in an argument to `build.cmd` / `test.cmd`. See [Build script argument injection](#build-script-argument-injection).
+
 ## Test Structure
 
 Test projects mirror source projects under `test/`:
@@ -62,6 +64,30 @@ src/vstest.console/                         → test/vstest.console.UnitTests/
 Test categories: Unit (fast, default), Smoke (P0 e2e), Acceptance (full e2e with `--integrationTest`).
 
 ## Known Gotchas
+
+### Build script argument injection
+
+`build.cmd` and `test.cmd` splice `%*` unquoted into a `powershell -command` string:
+
+```bat
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\Build.ps1""" -test %*"
+```
+
+PowerShell then parses your arguments as source code, and `;` is a statement separator. So this:
+
+```
+./test.cmd -projects "a\a.csproj;b\b.csproj"
+```
+
+runs `Build.ps1 -projects a\a.csproj`, then executes `b\b.csproj` as a separate statement. On Windows `.csproj` is file-associated with Visual Studio, so each extra entry opens a full VS IDE instance. This is not hypothetical — one such command opened six copies of Visual Studio, and three agents doing it at once opened eighteen.
+
+Rules:
+
+- Pass one project name or one wildcard pattern per invocation: `./test.cmd -projects Microsoft.TestPlatform.CoreUtilities.UnitTests`.
+- To cover several projects, use a pattern that matches them, or call the script once per project in a loop.
+- Never pass `;`, `|`, `&`, backtick, or `$(...)` in any argument to these scripts.
+- More generally, never run a `.csproj` / `.sln` path as a command. The path is always an argument: `dotnet test <path>.csproj`, `dotnet build <path>.csproj`.
+- `build.sh` / `test.sh` do not have this problem, but keep argument style consistent across platforms.
 
 ### Binding Redirects
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,12 +44,13 @@ vstest.console (entry point)
 | Release config | `./build.cmd -c Release -pack` | `./build.sh -c Release --pack` |
 | Unit tests | `./test.cmd` | `./test.sh` |
 | Specific tests | `./test.cmd -projects <pattern>` | `./test.sh -p <pattern>` |
+| Several test projects | `./test.cmd -projects "test\A\A.csproj;test\B\B.csproj"` | `./test.sh -p "test/A/A.csproj;test/B/B.csproj"` |
 | Smoke tests | `./test.cmd -projects smoke` | `./test.sh -p smoke` |
-| Single test by name | `./test.cmd -bl -c release /p:TestRunnerAdditionalArguments="'--filter TestName'"` | Similar |
+| Single test by name | `./test.cmd -bl -c release /p:TestRunnerAdditionalArguments="--filter TestName"` | Similar |
 
 CI builds use `-c Release`. Always build with Release config before submitting PRs.
 
-> On Windows, never put `;` (or `|`, `&`, `` ` ``, `$(...)`) in an argument to `build.cmd` / `test.cmd`. See [Build script argument injection](#build-script-argument-injection).
+The `.cmd` wrappers pass arguments to PowerShell literally. See [Wrapper scripts pass arguments literally](#wrapper-scripts-pass-arguments-literally) before changing one.
 
 ## Test Structure
 
@@ -65,29 +66,26 @@ Test categories: Unit (fast, default), Smoke (P0 e2e), Acceptance (full e2e with
 
 ## Known Gotchas
 
-### Build script argument injection
+### Wrapper scripts pass arguments literally
 
-`build.cmd` and `test.cmd` splice `%*` unquoted into a `powershell -command` string:
+`build.cmd`, `test.cmd`, `restore.cmd`, `open-vs.cmd`, `open-code.cmd`, and `eng/RestoreInternal.cmd` invoke PowerShell with `-File`, so everything after the script path reaches `eng/build.ps1` as a literal argument.
 
-```bat
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\Build.ps1""" -test %*"
+They previously used `-command "& """%~dp0eng\Build.ps1""" %*"`, which spliced `%*` into a string that PowerShell then parsed as source code. That caused two problems, both fixed:
+
+- `;` in an argument became a statement separator. `./test.cmd -projects "test\A\A.csproj;test\B\B.csproj"` ran `Build.ps1 -projects test\A\A.csproj` and then executed `test\B\B.csproj` as its own statement. On Windows `.csproj` is file-associated with Visual Studio, so every entry after the first opened a full IDE. Three agents ran this form at the same time and opened eighteen instances of Visual Studio.
+- Exit codes collapsed to `1`. `eng/build.ps1` ends with `exit $LastExitCode` to forward the real code, but `-command` discarded it, so `8` (filter matched no tests) and every other code arrived as `1`.
+
+Use `-File` in any new `.cmd` wrapper. Do not switch back to `-command`.
+
+Because arguments are no longer re-parsed, MSBuild properties need one level of quoting instead of two:
+
+```
+./test.cmd -bl -c release /p:TestRunnerAdditionalArguments="--filter TestName"
 ```
 
-PowerShell then parses your arguments as source code, and `;` is a statement separator. So this:
+`eng/common/*` comes from Arcade and still uses `-command`. Do not edit those files here; fix them in the Arcade repository.
 
-```
-./test.cmd -projects "a\a.csproj;b\b.csproj"
-```
-
-runs `Build.ps1 -projects a\a.csproj`, then executes `b\b.csproj` as a separate statement. On Windows `.csproj` is file-associated with Visual Studio, so each extra entry opens a full VS IDE instance. This is not hypothetical — one such command opened six copies of Visual Studio, and three agents doing it at once opened eighteen.
-
-Rules:
-
-- Pass one project name or one wildcard pattern per invocation: `./test.cmd -projects Microsoft.TestPlatform.CoreUtilities.UnitTests`.
-- To cover several projects, use a pattern that matches them, or call the script once per project in a loop.
-- Never pass `;`, `|`, `&`, backtick, or `$(...)` in any argument to these scripts.
-- More generally, never run a `.csproj` / `.sln` path as a command. The path is always an argument: `dotnet test <path>.csproj`, `dotnet build <path>.csproj`.
-- `build.sh` / `test.sh` do not have this problem, but keep argument style consistent across platforms.
+Independent of the wrappers: never run a `.csproj` or `.sln` path as a command. The path is always an argument, as in `dotnet test <path>.csproj`.
 
 ### Binding Redirects
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,9 +68,9 @@ Test categories: Unit (fast, default), Smoke (P0 e2e), Acceptance (full e2e with
 
 ### Wrapper scripts pass arguments literally
 
-`build.cmd`, `test.cmd`, `restore.cmd`, `open-vs.cmd`, `open-code.cmd`, and `eng/RestoreInternal.cmd` invoke PowerShell with `-File`, so everything after the script path reaches `eng/build.ps1` as a literal argument.
+`build.cmd`, `test.cmd`, `restore.cmd`, `open-vs.cmd`, `open-code.cmd`, and `eng/RestoreInternal.cmd` invoke PowerShell with `-File`, so everything after the script path reaches the target script as a literal argument. The first five call `eng/build.ps1`, `eng/RestoreInternal.cmd` calls `eng/common/build.ps1`.
 
-They previously used `-command "& """%~dp0eng\Build.ps1""" %*"`, which spliced `%*` into a string that PowerShell then parsed as source code. That caused two problems, both fixed:
+They previously used the form `-command "& """<script>""" %*"`, which spliced `%*` into a string that PowerShell then parsed as source code. That caused two problems, both fixed:
 
 - `;` in an argument became a statement separator. `./test.cmd -projects "test\A\A.csproj;test\B\B.csproj"` ran `Build.ps1 -projects test\A\A.csproj` and then executed `test\B\B.csproj` as its own statement. On Windows `.csproj` is file-associated with Visual Studio, so every entry after the first opened a full IDE. Three agents ran this form at the same time and opened eighteen instances of Visual Studio.
 - Exit codes collapsed to `1`. `eng/build.ps1` ends with `exit $LastExitCode` to forward the real code, but `-command` discarded it, so `8` (filter matched no tests) and every other code arrived as `1`.

--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0eng\Build.ps1" -restore -build %*
+powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0eng\build.ps1" -restore -build %*
 exit /b %ErrorLevel%

--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\Build.ps1""" -restore -build %*"
+powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0eng\Build.ps1" -restore -build %*
 exit /b %ErrorLevel%

--- a/eng/RestoreInternal.cmd
+++ b/eng/RestoreInternal.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0\common\build.ps1""" -build -restore %*"
+powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0common\build.ps1" -build -restore %*

--- a/open-code.cmd
+++ b/open-code.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\build.ps1""" -vscode %*"
+powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0eng\build.ps1" -vscode %*

--- a/open-vs.cmd
+++ b/open-vs.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\build.ps1""" -vs %*"
+powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0eng\build.ps1" -vs %*

--- a/restore.cmd
+++ b/restore.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0eng\Build.ps1" -restore %*
+powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0eng\build.ps1" -restore %*

--- a/restore.cmd
+++ b/restore.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\Build.ps1""" -restore %*"
+powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0eng\Build.ps1" -restore %*

--- a/test.cmd
+++ b/test.cmd
@@ -1,4 +1,4 @@
 @echo off
 if not defined MSBUILDTERMINALLOGGER set MSBUILDTERMINALLOGGER=off
-powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0eng\Build.ps1" -test %*
+powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0eng\build.ps1" -test %*
 exit /b %ErrorLevel%

--- a/test.cmd
+++ b/test.cmd
@@ -1,4 +1,4 @@
 @echo off
 if not defined MSBUILDTERMINALLOGGER set MSBUILDTERMINALLOGGER=off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\Build.ps1""" -test %*"
+powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0eng\Build.ps1" -test %*
 exit /b %ErrorLevel%


### PR DESCRIPTION
The `.cmd` wrappers spliced `%*` into a `powershell -command` string, so anything the caller passed was parsed by PowerShell as source code instead of being treated as data.

A semicolon inside an argument therefore became a statement separator. This:

```
test.cmd -projects "test\A\A.csproj;test\B\B.csproj"
```

ran `Build.ps1 -projects test\A\A.csproj` and then executed the remaining `.csproj` paths as their own statements. On Windows `.csproj` is file-associated with Visual Studio, so every entry after the first opened an IDE. Three agents ran that form at the same time and opened eighteen instances of Visual Studio, which is how I found this. The semicolon separated list is not user error, Arcade's own help text documents `-projects` as "Semi-colon delimited list of sln/proj's to build".

`-command` also collapsed every non-zero exit code to 1, so the `exit $LastExitCode` at the end of `eng/build.ps1` never forwarded the real code, including the 8 that means the filter matched no tests.

## Changes

Switch the repo owned wrappers to `-File`, which passes everything after the script path as a literal argument:

- `build.cmd`
- `test.cmd`
- `restore.cmd`
- `open-vs.cmd`
- `open-code.cmd`
- `eng/RestoreInternal.cmd`

`eng/common/*` is left alone, those files come from Arcade and would have to be fixed there.

Because arguments are no longer re-parsed, MSBuild properties need one level of quoting instead of two, so the documented single test command changes from `/p:TestRunnerAdditionalArguments="'--filter TestName'"` to `/p:TestRunnerAdditionalArguments="--filter TestName"`. Both deliver the same value to the script. AGENTS.md is updated, and gained a short section explaining why the wrappers use `-File`.

## Verification

| Check | Before | After |
|---|---|---|
| `-projects "a.csproj;<statement>"` | trailing entries executed, Visual Studio opened | passed through as a single string |
| exit code 8 | 1 | 8 |
| exit code 42 | 1 | 42 |
| `/p:X="--filter Name"` | needed the doubled `"'...'"` form | same value, single level of quoting |

`build.cmd` succeeds locally with 0 errors and returns 0. `test.cmd -help -projects "a.csproj;Write-Host INJECTED"` prints usage, returns 0, does not run the injected statement, and starts no Visual Studio.

🤖