### PR TITLE
Simplify MTP outcome matching and tuple handling

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpProxyExecutionManager.cs
@@ -218,9 +218,9 @@ internal sealed class MtpProxyExecutionManager : IProxyExecutionManager, IDispos
 
         if (_dataCollectionEventsHandler.Messages.Count > 0)
         {
-            foreach (Tuple<ObjectModel.Logging.TestMessageLevel, string?> message in _dataCollectionEventsHandler.Messages)
+            foreach (var (level, message) in _dataCollectionEventsHandler.Messages)
             {
-                eventHandler.HandleLogMessage(message.Item1, message.Item2);
+                eventHandler.HandleLogMessage(level, message);
             }
 
             _dataCollectionEventsHandler.Messages.Clear();

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpTestNodeConverter.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpTestNodeConverter.cs
@@ -145,9 +145,7 @@ internal static class MtpTestNodeConverter
         => state switch
         {
             StatePassed => TestOutcome.Passed,
-            StateFailed => TestOutcome.Failed,
-            StateError => TestOutcome.Failed,
-            StateTimedOut => TestOutcome.Failed,
+            StateFailed or StateError or StateTimedOut => TestOutcome.Failed,
             StateSkipped => TestOutcome.Skipped,
             _ => TestOutcome.None,
         };


### PR DESCRIPTION
Combines the identical failed MTP outcomes into one `or` pattern, and deconstructs buffered data collection messages instead of using `Item1` and `Item2`.

Verified with `test.cmd -c Release -projects "test\Microsoft.TestPlatform.CrossPlatEngine.UnitTests\Microsoft.TestPlatform.CrossPlatEngine.UnitTests.csproj"`: 1,424 tests, 0 failed, 2 skipped across net11.0 and net481.

Follow-up to #16362.

🤖