### PR TITLE
Follow-up: Simplify MTP outcome matching and tuple handling

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpProxyExecutionManager.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpProxyExecutionManager.cs
@@ -218,9 +218,9 @@ internal sealed class MtpProxyExecutionManager : IProxyExecutionManager, IDispos
 
         if (_dataCollectionEventsHandler.Messages.Count > 0)
         {
-            foreach (Tuple<ObjectModel.Logging.TestMessageLevel, string?> message in _dataCollectionEventsHandler.Messages)
+            foreach (var (level, message) in _dataCollectionEventsHandler.Messages)
             {
-                eventHandler.HandleLogMessage(message.Item1, message.Item2);
+                eventHandler.HandleLogMessage(level, message);
             }
 
             _dataCollectionEventsHandler.Messages.Clear();

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpTestNodeConverter.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/MTP/MtpTestNodeConverter.cs
@@ -145,9 +145,7 @@ internal static class MtpTestNodeConverter
         => state switch
         {
             StatePassed => TestOutcome.Passed,
-            StateFailed => TestOutcome.Failed,
-            StateError => TestOutcome.Failed,
-            StateTimedOut => TestOutcome.Failed,
+            StateFailed or StateError or StateTimedOut => TestOutcome.Failed,
             StateSkipped => TestOutcome.Skipped,
             _ => TestOutcome.None,
         };


### PR DESCRIPTION
Opened [microsoft/vstest#16369](https://github.com/microsoft/vstest/pull/16369); targeted CrossPlatEngine tests pass.

Used existing commit 7d38a7b5dc without duplicate changes. All 1,424 tests passed across net11.0 and net481, with 2 skipped. The PR is mergeable and CI is queued.

Evidence:
- [microsoft/vstest#16369](https://github.com/microsoft/vstest/pull/16369)
- [microsoft/vstest@7d38a7b5dc](https://github.com/microsoft/vstest/commit/7d38a7b5dc5b30716f1aeff55c4f431fe4dbef8b)
- CrossPlatEngine Release unit tests: 1,424 total, 0 failed, 2 skipped

Written by a Pilot worker from task `issue-researcher-30-p1-n`.

🤖