### PR TITLE
Guard against a missing PATH in the NativeAOT publish test

### DIFF
--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/NativeAotCompatibilityTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/NativeAotCompatibilityTests.cs
@@ -65,7 +65,10 @@ public class NativeAotCompatibilityTests
                 Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
                 "Microsoft Visual Studio",
                 "Installer");
-            psi.Environment["PATH"] = $"{visualStudioInstallerPath}{Path.PathSeparator}{psi.Environment["PATH"]}";
+            // PATH is not guaranteed to be present, and the indexer throws when it is missing.
+            psi.Environment["PATH"] = psi.Environment.TryGetValue("PATH", out var existingPath) && !string.IsNullOrEmpty(existingPath)
+                ? $"{visualStudioInstallerPath}{Path.PathSeparator}{existingPath}"
+                : visualStudioInstallerPath;
         }
 
         var outputBuilder = new StringBuilder();


### PR DESCRIPTION
`psi.Environment["PATH"]` throws `KeyNotFoundException` when the runner has no PATH, so the NativeAOT publish test fails before it publishes anything. It reads PATH with `TryGetValue` now, and uses the Visual Studio Installer directory on its own when PATH is missing.

This was already reviewed and fixed on #16374, but #16356 merged first without carrying the fix, so it never reached main.

Verified: `build.cmd -c Release`, and CommunicationUtilities 614/614 on net11.0 including the NativeAOT publish test.

🤖
