### PR TITLE
Compile the MTP client out of source-only builds

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/IProxyManagerFactory.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/IProxyManagerFactory.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client;
 /// <para>
 /// This interface is public because the runtime providers that implement it live in a separate assembly
 /// (<c>Microsoft.TestPlatform.TestHostRuntimeProvider</c>). The concrete proxy managers stay internal to this
-/// assembly; providers create them through the public <see cref="MTP.MtpProxyManagerFactory"/> helper.
+/// assembly; providers create them through the public <c>MtpProxyManagerFactory</c> helper.
 /// </para>
 /// </remarks>
 public interface IProxyManagerFactory

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Microsoft.TestPlatform.CrossPlatEngine.csproj
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Microsoft.TestPlatform.CrossPlatEngine.csproj
@@ -10,7 +10,7 @@
          on net462/netstandard2.0. CrossPlatEngine already imports the identical attributes from
          CoreUtilities (InternalsVisibleTo), so let the package defer to those to avoid CS0436
          duplicate-type conflicts. No-op on net8.0 where the attributes are in-box. -->
-    <DefineConstants>$(DefineConstants);MTP_CLIENT_EXCLUDE_NULLABLE_ATTRIBUTES</DefineConstants>
+    <DefineConstants Condition="'$(DotNetBuildSourceOnly)' != 'true'">$(DefineConstants);MTP_CLIENT_EXCLUDE_NULLABLE_ATTRIBUTES</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Update="Resources\Resources.resx">
@@ -30,7 +30,15 @@
   <ItemGroup>
     <!-- Source-only MTP server-mode JSON-RPC client: compiled into this assembly (no shipped DLL, no
          runtime dependency, no new public API). Shipped by microsoft/testfx#10085. -->
-    <PackageReference Include="Microsoft.Testing.Platform.ServerMode.Client.Sources" Version="$(MicrosoftTestingPlatformServerModeClientSourcesVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Testing.Platform.ServerMode.Client.Sources" Version="$(MicrosoftTestingPlatformServerModeClientSourcesVersion)" PrivateAssets="all" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <!-- Temporary, see dotnet/dotnet#8349: microsoft/testfx is not a VMR repo and does not produce
+         Microsoft.Testing.Platform.ServerMode.Client.Sources in source-only builds, so restoring it there
+         is a prebuilt and fails the build. Until the package is available to source-build, the MTP client
+         is compiled out, which drops running MTP applications under vstest (opt-in, off by default) from
+         source-only builds. Everything else is unaffected. -->
+    <Compile Remove="Client\MTP\**\*.cs" />
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '$(NetFrameworkMinimum)'))">
     <Reference Include="System" />

--- a/src/Microsoft.TestPlatform.TestHostProvider/Microsoft.TestPlatform.TestHostProvider.csproj
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Microsoft.TestPlatform.TestHostProvider.csproj
@@ -32,6 +32,11 @@
     -->
     <ProjectReference Include="..\Microsoft.TestPlatform.CrossPlatEngine\Microsoft.TestPlatform.CrossPlatEngine.csproj" />
   </ItemGroup>
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <!-- The MTP proxy managers this provider drives are compiled out of source-only builds, so the provider
+         goes with them. Temporary, see dotnet/dotnet#8349 and CrossPlatEngine.csproj. -->
+    <Compile Remove="Hosting\MtpTestRuntimeProvider.cs" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
   </ItemGroup>

--- a/src/Microsoft.TestPlatform.TestHostProvider/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Properties/AssemblyInfo.cs
@@ -4,4 +4,9 @@
 using Microsoft.VisualStudio.TestPlatform;
 using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Hosting;
 
+#if DOTNET_BUILD_FROM_SOURCE
+// MtpTestRuntimeProvider is compiled out of source-only builds, see dotnet/dotnet#8349.
+[assembly: TestExtensionTypes(typeof(DefaultTestHostManager), typeof(DotnetTestHostManager))]
+#else
 [assembly: TestExtensionTypes(typeof(DefaultTestHostManager), typeof(DotnetTestHostManager), typeof(MtpTestRuntimeProvider))]
+#endif

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Microsoft.TestPlatform.CrossPlatEngine.UnitTests.csproj
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Microsoft.TestPlatform.CrossPlatEngine.UnitTests.csproj
@@ -18,4 +18,9 @@
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.TestPlatform.TestUtilities\Microsoft.TestPlatform.TestUtilities.csproj" />
   </ItemGroup>
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <!-- The MTP client is compiled out of source-only builds, so its tests go with it.
+         Temporary, see dotnet/dotnet#8349 and CrossPlatEngine.csproj. -->
+    <Compile Remove="Client\MTP\**\*.cs" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
#16300 added a PackageReference to `Microsoft.Testing.Platform.ServerMode.Client.Sources`. microsoft/testfx is not a VMR repo, so that package is not produced in a source-only build and gets restored from an external feed. The VMR sees it as a prebuilt and fails, see dotnet/dotnet#8349. Since .NET 10 there is no per-repo prebuilt baseline, so there is nothing to exclude it with either.

Condition the PackageReference on `DotNetBuildSourceOnly` and compile out the code that needs it:

- `Client/MTP` in CrossPlatEngine
- `MtpTestRuntimeProvider` in TestHostProvider, and its entry in `TestExtensionTypes`
- the MTP unit tests

Running MTP applications under vstest is opt-in (`VSTEST_DISABLE_MTP_TESTHOST=0`) and off by default, so this only drops that feature from source-only builds. Normal builds are not affected.

Temporary. The real fix is either adding the package to dotnet/source-build-assets as a text-only package, or vendoring the source with drift tracking the way dotnet/sdk#55130 did for `Microsoft.Testing.Platform.Internal.DotnetTest`. When either of those lands this can be reverted.

Verified locally:

- `build.cmd -c Release` is green with no new warnings.
- `build.cmd -c Release /p:DotNetBuildSourceOnly=true` is green, and `Microsoft.Testing.Platform.ServerMode.Client.Sources` is gone from every `project.assets.json`.
- CrossPlatEngine unit tests pass, 73 of them cover the MTP client.

🤖
