### PR TITLE
Fix the single-test command in AGENTS.md that eng/build.ps1 rejects

### DIFF
--- a/.github/skills/vstest-build-test/SKILL.md
+++ b/.github/skills/vstest-build-test/SKILL.md
@@ -125,31 +125,39 @@ These are **switches** handled by `eng/build.ps1` — NOT `-projects` values:
 ./test.cmd -performanceTest
 ./test.cmd -compatibilityTest
 
-# Linux / macOS use the same switch names
-./test.sh -smokeTest
+# Linux / macOS: only --integrationTest and --performanceTest exist, because test.sh
+# calls arcade's eng/common/build.sh directly and never goes through eng/build.ps1.
+./test.sh --integrationTest     # includes smoke; there is no -smokeTest switch here
 ```
 
 > `-smokeTest` and `-integrationTest` are mutually exclusive (smoke is a subset); passing both throws.
 
 ### Filter by Test Name
 
-Use the `-filter` parameter. Do **not** pass `--filter` inside `TestRunnerAdditionalArguments` —
+On Windows use the `-filter` parameter. Do **not** pass `--filter` inside `TestRunnerAdditionalArguments` —
 `eng/build.ps1` explicitly throws if you do.
+
+On Linux/macOS `test.sh` has no `-filter` parameter, so the filter goes in as an MSBuild property.
+The single quotes are required, otherwise bash interprets `&`, `|`, and the inner quotes.
 
 ```bash
 # Windows
 ./test.cmd -integrationTest -filter "FullyQualifiedName~MyScenario"
 
 # Linux / macOS
-./test.sh -integrationTest -filter "FullyQualifiedName~MyScenario"
+./test.sh --integrationTest --property:'TestRunnerAdditionalArguments=--filter "FullyQualifiedName~MyScenario"'
 ```
 
-### Running integration / smoke tests locally (DOTNET_ROOT gotcha)
+See [CONTRIBUTING.md](../../../CONTRIBUTING.md#running-a-specific-test) for more filtering examples.
 
-Integration and smoke tests self-host: they launch test-asset apphosts built against the repo's
-preview TFM (e.g. `net11.0`). An apphost resolves its shared runtime from `DOTNET_ROOT`, falling
-back to the machine-wide install (`C:\Program Files\dotnet`), which usually lacks the preview
-runtime — so it fails instantly with *"You must install or update .NET to run this application."*
+### Running tests locally (DOTNET_ROOT gotcha)
+
+Test executables are built against the repo's preview TFM (e.g. `net11.0`), and integration and
+smoke tests additionally launch test-asset apphosts built the same way. An apphost resolves its
+shared runtime from `DOTNET_ROOT`, falling back to the machine-wide install
+(`C:\Program Files\dotnet`), which usually lacks the preview runtime — so it fails instantly with
+*"You must install or update .NET to run this application."* This hits plain unit test runs too,
+not only integration and smoke tests.
 
 - `test.sh` (Linux/macOS) sets `DOTNET_ROOT` to the repo `.dotnet` automatically.
 - `test.cmd` (Windows) does **not** — set it yourself before running:
@@ -185,7 +193,8 @@ After building with `--pack` / `-pack`, validate vstest.console changes by unzip
 ## Troubleshooting
 
 - **OS mismatch errors:** If you see SDK load failures, run the mismatch detection script above to clean and re-bootstrap.
-- **Integration/smoke tests fail instantly on Windows with "You must install or update .NET to run this application":** `test.cmd` does not set `DOTNET_ROOT`, so the self-hosted preview-TFM apphosts look in `C:\Program Files\dotnet` (which lacks the preview runtime). Set `$env:DOTNET_ROOT = "$PWD\.dotnet"` before running — see "Running integration / smoke tests locally".
+- **`Toolset version <version> has not been restored.`:** `test.cmd` / `test.sh` do not restore. Build once (`./build.cmd -c Release`) first, or pass `-restore -build` to the test command.
+- **Tests fail instantly on Windows with "You must install or update .NET to run this application":** `test.cmd` does not set `DOTNET_ROOT`, so the preview-TFM apphosts look in `C:\Program Files\dotnet` (which lacks the preview runtime). Set `$env:DOTNET_ROOT = "$PWD\.dotnet"` before running — see "Running tests locally".
 - If build fails asking for .NET 4.6 targeting pack, install it from [Microsoft Downloads](https://www.microsoft.com/download/details.aspx?id=48136)
 - Enable verbose diagnostics: see `docs/diagnose.md`
 - For debugging, add `Debugger.Launch` at process entry points (testhost.exe, vstest.console.exe)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,14 +43,28 @@ vstest.console (entry point)
 | Build + Pack | `./build.cmd -pack` | `./build.sh --pack` |
 | Release config | `./build.cmd -c Release -pack` | `./build.sh -c Release --pack` |
 | Unit tests | `./test.cmd` | `./test.sh` |
-| Specific tests | `./test.cmd -projects <pattern>` | `./test.sh -p <pattern>` |
-| Several test projects | `./test.cmd -projects "test\A\A.csproj;test\B\B.csproj"` | `./test.sh -p "test/A/A.csproj;test/B/B.csproj"` |
-| Smoke tests | `./test.cmd -projects smoke` | `./test.sh -p smoke` |
-| Single test by name | `./test.cmd -bl -c release /p:TestRunnerAdditionalArguments="--filter TestName"` | Similar |
+| Specific tests | `./test.cmd -projects <path-or-glob>` | `./test.sh --projects <path-or-glob>` |
+| Several test projects | `./test.cmd -projects "test\A\A.csproj;test\B\B.csproj"` | `./test.sh --projects "test/A/A.csproj;test/B/B.csproj"` |
+| Smoke tests | `./test.cmd -smokeTest` | `./test.sh --integrationTest` (smoke is a subset) |
+| Single test by name | `./test.cmd -c Release -filter "FullyQualifiedName~TestName"` | `./test.sh --property:'TestRunnerAdditionalArguments=--filter "FullyQualifiedName~TestName"'` |
 
 CI builds use `-c Release`. Always build with Release config before submitting PRs.
 
+`-projects` is resolved with `Resolve-Path`, so it takes a path or a glob. A bare nickname such as `smoke` or `htmllogger` fails with `Cannot find path`. Test categories are switches instead: `-smokeTest`, `-integrationTest`, `-compatibilityTest`, `-performanceTest`.
+
+Filtering by test name is a Windows-only wrapper parameter. `test.cmd` goes through `eng/build.ps1`, which owns `-filter` and the category switches; `test.sh` calls Arcade's `eng/common/build.sh` directly and has neither, so on Linux/macOS the filter is passed as an MSBuild property. Do not pass the filter as `/p:TestRunnerAdditionalArguments="--filter ..."` on Windows — `eng/build.ps1` throws *"Use --filter instead of passing filter as an additional argument to TestRunnerAdditionalArguments."* See [CONTRIBUTING.md](CONTRIBUTING.md#running-a-specific-test) for the Linux/macOS quoting rules.
+
+`test.cmd` does not set `DOTNET_ROOT`, so test executables built against the repo's preview TFM fail with *"You must install or update .NET to run this application."* This hits unit tests too, not only integration and smoke tests. Set it first:
+
+```powershell
+$env:DOTNET_ROOT = "$PWD\.dotnet"
+```
+
+`test.cmd` does not restore either. On a fresh clone, build once (`./build.cmd -c Release`) before running it, or pass `-restore -build`, otherwise it stops with `Toolset version <version> has not been restored.`
+
 The `.cmd` wrappers pass arguments to PowerShell literally. See [Wrapper scripts pass arguments literally](#wrapper-scripts-pass-arguments-literally) before changing one.
+
+[`.github/skills/vstest-build-test/SKILL.md`](.github/skills/vstest-build-test/SKILL.md) is the fuller build and test reference. Keep it and this section in agreement.
 
 ## Test Structure
 
@@ -77,10 +91,10 @@ They previously used the form `-command "& """<script>""" %*"`, which spliced `%
 
 Use `-File` in any new `.cmd` wrapper. Do not switch back to `-command`.
 
-Because arguments are no longer re-parsed, MSBuild properties need one level of quoting instead of two:
+Because arguments are no longer re-parsed, one level of quoting is enough instead of two, for wrapper parameters and `/p:` MSBuild properties alike. A single pair of quotes now reaches the target script intact:
 
 ```
-./test.cmd -bl -c release /p:TestRunnerAdditionalArguments="--filter TestName"
+./test.cmd -c Release -projects "test\Microsoft.TestPlatform.CrossPlatEngine.UnitTests\Microsoft.TestPlatform.CrossPlatEngine.UnitTests.csproj" -filter "FullyQualifiedName~MtpProxyExecutionManagerTests"
 ```
 
 `eng/common/*` comes from Arcade and still uses `-command`. Do not edit those files here; fix them in the Arcade repository.


### PR DESCRIPTION
`AGENTS.md` documented the single-test command as
`./test.cmd -bl -c release /p:TestRunnerAdditionalArguments="--filter TestName"`,
in the build table and again as the argument-quoting example. `eng/build.ps1`
throws on exactly that string: *"Use --filter instead of passing filter as an
additional argument to TestRunnerAdditionalArguments."* It now uses the `-filter`
parameter.

Two neighbouring rows failed the same way. `-projects` is resolved with
`Resolve-Path`, so `-projects smoke` fails with `Cannot find path` — smoke tests
are the `-smokeTest` switch. And `-p` is not an arcade alias for `--projects`.

The skill file said `test.sh` takes `-filter` and `-smokeTest`. It does not:
`test.sh` calls arcade's `eng/common/build.sh` directly and never goes through
`eng/build.ps1`, so on Linux/macOS the filter is passed as an MSBuild property,
as `CONTRIBUTING.md` already describes. `AGENTS.md` now points at the skill file
as the fuller reference so the two stop drifting apart.

Also documents two things that stop `test.cmd` before it runs anything: it does
not restore, and it does not set `DOTNET_ROOT`, which unit tests need as well as
integration tests.

Verified: `./test.cmd -c Release -filter "FullyQualifiedName~MtpProxyExecutionManagerTests"`
exits 0 and selects 7 tests across 40 test runs; the two replaced commands both
still fail as described.

🤖
