### PR TITLE
Enable CA1310 and make culture-sensitive string comparisons ordinal

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -257,6 +257,15 @@ dotnet_diagnostic.CA1304.severity = warning # not default, increased severity to
 # CA1305: Specify IFormatProvider
 dotnet_diagnostic.CA1305.severity = warning # not default, increased severity to ensure it is applied
 
+# CA1310: Specify StringComparison for correctness
+dotnet_diagnostic.CA1310.severity = warning # not default, increased severity to ensure it is applied
+
+# CA1307 (Specify StringComparison for clarity) is deliberately not enabled: it fires at 293 call
+# sites, 166 of them string.Contains(string) and string.Replace(string, string), whose
+# StringComparison overloads do not exist on net462 / netstandard2.0, so the suggested fix does not
+# compile there.
+# CA1309 (Use ordinal string comparison) is a separate 128-site change, tracked apart from this one.
+
 # CA1822: Mark members as static
 dotnet_diagnostic.CA1822.severity = warning # not default, increased severity to ensure it is applied
 

--- a/src/AttachVS/AttachVs.cs
+++ b/src/AttachVS/AttachVs.cs
@@ -123,7 +123,7 @@ internal class DebuggerUtility
 
                 moniker[0].GetDisplayName(bindCtx, null, out string dn);
 
-                if (dn.StartsWith("!VisualStudio.DTE.") && dn.EndsWith(dteSuffix))
+                if (dn.StartsWith("!VisualStudio.DTE.", StringComparison.Ordinal) && dn.EndsWith(dteSuffix, StringComparison.Ordinal))
                 {
                     object dbg, lps;
                     runningObjectTable.GetObject(moniker[0], out object dte);

--- a/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask2.cs
+++ b/src/Microsoft.TestPlatform.Build/Tasks/VSTestTask2.cs
@@ -74,7 +74,7 @@ public class VSTestTask2 : ToolTask, ITestTask
 
         if (_canBePrependedWithAnsi)
         {
-            while (singleLine.StartsWith(_ansiReset))
+            while (singleLine.StartsWith(_ansiReset, StringComparison.Ordinal))
             {
                 wasPrependedWithAnsi = true;
                 singleLine = singleLine.Substring(_ansiReset.Length);
@@ -261,7 +261,7 @@ public class VSTestTask2 : ToolTask, ITestTask
 
     private bool TryGetMessage(string singleLine, out string name, out string?[] data)
     {
-        if (singleLine.StartsWith(_messageSplitter))
+        if (singleLine.StartsWith(_messageSplitter, StringComparison.Ordinal))
         {
             var parts = singleLine.Split(_messageSplitterArray, StringSplitOptions.None);
             name = parts[1];

--- a/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionTelemetryManager.cs
+++ b/src/Microsoft.TestPlatform.Common/DataCollection/DataCollectionTelemetryManager.cs
@@ -73,8 +73,8 @@ internal class DataCollectionTelemetryManager : IDataCollectionTelemetryManager
         if (ClrIeProfilerGuid == existingProfilerGuid)
         {
             if (dataCollectorInformation.TestExecutionEnvironmentVariables != null &&
-                dataCollectorInformation.TestExecutionEnvironmentVariables.Any(pair => pair.Key.StartsWith(ClrIeInstrumentationMethodConfigurationPrefix32Variable)) &&
-                dataCollectorInformation.TestExecutionEnvironmentVariables.Any(pair => pair.Key.StartsWith(ClrIeInstrumentationMethodConfigurationPrefix64Variable)))
+                dataCollectorInformation.TestExecutionEnvironmentVariables.Any(pair => pair.Key.StartsWith(ClrIeInstrumentationMethodConfigurationPrefix32Variable, StringComparison.Ordinal)) &&
+                dataCollectorInformation.TestExecutionEnvironmentVariables.Any(pair => pair.Key.StartsWith(ClrIeInstrumentationMethodConfigurationPrefix64Variable, StringComparison.Ordinal)))
             {
                 _requestData.MetricsCollection.Add(GetTelemetryKey(telemetryPrefix, dataCollectorInformation), ClrIeProfilerGuid.ToString());
                 return;

--- a/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs
@@ -121,7 +121,7 @@ internal class AssemblyResolver : IDisposable
 
             TPDebug.Assert(requestedName != null && !requestedName.Name.IsNullOrEmpty(), "AssemblyResolver.OnResolve: requested is null or name is empty!");
 
-            var isResource = requestedName.Name.EndsWith(".resources");
+            var isResource = requestedName.Name.EndsWith(".resources", StringComparison.Ordinal);
             foreach (var dir in _searchDirectories)
             {
                 if (dir.IsNullOrEmpty())

--- a/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
+++ b/src/Microsoft.TestPlatform.Common/Utilities/RunSettingsProviderExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Xml;
@@ -130,7 +131,7 @@ internal static class RunSettingsProviderExtensions
     {
         foreach (XmlNode node in xmlNode.ChildNodes)
         {
-            if (string.Compare(node.Attributes![NameString]!.Value, attrName) == 0)
+            if (string.Equals(node.Attributes![NameString]!.Value, attrName, StringComparison.Ordinal))
             {
                 node.Attributes[ValueString]!.Value = attrValue;
                 return true;

--- a/src/Microsoft.TestPlatform.CoreUtilities/Helpers/CommandLineArgumentsHelper.cs
+++ b/src/Microsoft.TestPlatform.CoreUtilities/Helpers/CommandLineArgumentsHelper.cs
@@ -26,9 +26,9 @@ public class CommandLineArgumentsHelper
 
         for (int i = 0; i < args.Length; i++)
         {
-            if (args[i].StartsWith("-"))
+            if (args[i].StartsWith("-", StringComparison.Ordinal))
             {
-                if (i < args.Length - 1 && !args[i + 1].StartsWith("-"))
+                if (i < args.Length - 1 && !args[i + 1].StartsWith("-", StringComparison.Ordinal))
                 {
                     argsDictionary.Add(args[i], args[i + 1]);
                     i++;

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/DataCollectorAttachmentProcessorAppDomain.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/AttachmentsProcessing/DataCollectorAttachmentProcessorAppDomain.cs
@@ -99,7 +99,7 @@ internal class DataCollectorAttachmentProcessorAppDomain : IDataCollectorAttachm
                 {
                     string messagePayload = sr.ReadLine().Replace("\0", Environment.NewLine);
 
-                    if (messagePayload.StartsWith(_pipeShutdownMessagePrefix))
+                    if (messagePayload.StartsWith(_pipeShutdownMessagePrefix, StringComparison.Ordinal))
                     {
                         EqtTrace.Info($"DataCollectorAttachmentProcessorAppDomain.PipeReaderTask: Shutdown message received, message: {messagePayload}");
                         return;

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelDiscoveryEventsHandler.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Client/Parallel/ParallelDiscoveryEventsHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 
 using Microsoft.VisualStudio.TestPlatform.Common.Telemetry;
@@ -168,7 +169,7 @@ internal class ParallelDiscoveryEventsHandler : ITestDiscoveryEventsHandler2
 
         // Do not send CancellationRequested message to Output window in IDE, as it is not useful for user
         if (string.Equals(message.MessageType, MessageType.TestMessage)
-            && rawMessage.IndexOf(CommonResources.CancellationRequested) >= 0)
+            && rawMessage.IndexOf(CommonResources.CancellationRequested, StringComparison.Ordinal) >= 0)
         {
             return;
         }

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/BaseRunTests.cs
@@ -498,7 +498,7 @@ internal abstract class BaseRunTests
                     // Only enable this for MSTestV1 telemetry for now, this might become more generic later.
                     if (MsTestV1TelemetryHelper.IsMsTestV1Adapter(executorUri))
                     {
-                        foreach (var adapterMetrics in TestRunCache.AdapterTelemetry.Keys.Where(k => k.StartsWith(executorUri)))
+                        foreach (var adapterMetrics in TestRunCache.AdapterTelemetry.Keys.Where(k => k.StartsWith(executorUri, StringComparison.Ordinal)))
                         {
                             var value = TestRunCache.AdapterTelemetry[adapterMetrics];
 

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/MSTestV1TelemetryHelper.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/Execution/MSTestV1TelemetryHelper.cs
@@ -52,7 +52,7 @@ internal class MsTestV1TelemetryHelper
                 var testExtension = testResult.GetPropertyValue<string?>(s_extensionIdProperty, null);
                 var hasExtension = !testExtension.IsNullOrWhiteSpace();
 
-                if (hasExtension && testExtension!.StartsWith("urn:"))
+                if (hasExtension && testExtension!.StartsWith("urn:", StringComparison.Ordinal))
                 {
                     // remove urn: prefix
                     testExtension = testExtension.Remove(0, 4);

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameLogger.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/BlameLogger.cs
@@ -130,7 +130,7 @@ public class BlameLogger : ITestLogger
             }
 
             // Process only Sequence_<GUID>.xml attachments
-            var uriDataAttachment = attachmentSet.Attachments.LastOrDefault((attachment) => attachment.Uri.ToString().EndsWith(".xml"));
+            var uriDataAttachment = attachmentSet.Attachments.LastOrDefault((attachment) => attachment.Uri.ToString().EndsWith(".xml", StringComparison.Ordinal));
 
             if (uriDataAttachment == null)
             {

--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcDumpDumper.cs
+++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcDumpDumper.cs
@@ -261,7 +261,7 @@ public class ProcDumpDumper : ICrashDumper, IHangDumper
         // There can be more dumps in the crash folder from the child processes that were .NET5 or newer and crashed
         // get only the ones that match the path we provide to procdump. And get the last one created.
         var allTargetProcessDumps = allDumps
-            .Where(dump => Path.GetFileNameWithoutExtension(dump).StartsWith(_outputFilePrefix ?? string.Empty))
+            .Where(dump => Path.GetFileNameWithoutExtension(dump).StartsWith(_outputFilePrefix ?? string.Empty, StringComparison.Ordinal))
             .Select(dump => new FileInfo(dump))
             .OrderBy(dump => dump.LastWriteTime).ThenBy(dump => dump.Name)
             .ToList();

--- a/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
+++ b/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs
@@ -596,7 +596,7 @@ internal class Converter
 
         // In case, fullyQualifiedName ends with testName, className is checked within remaining value of fullyQualifiedName.
         // Example: In case, testName = TestMethod1(2, 3, 4.0d) and fullyQualifiedName = TestProject1.Class1.TestMethod1(2, 3, 4.0d), className will be checked within 'TestProject1.Class1.' only
-        var nameToCheck = !fullyQualifiedName.Equals(testName, StringComparison.OrdinalIgnoreCase) && fullyQualifiedName.EndsWith(testName) ?
+        var nameToCheck = !fullyQualifiedName.Equals(testName, StringComparison.OrdinalIgnoreCase) && fullyQualifiedName.EndsWith(testName, StringComparison.Ordinal) ?
             fullyQualifiedName.Substring(0, fullyQualifiedName.Length - testName.Length) :
             fullyQualifiedName;
 
@@ -609,7 +609,7 @@ internal class Converter
         // C++ test case scenario (we would have a "::" instead of a '.')
         if (nameToCheck.Contains("::"))
         {
-            className = nameToCheck.Substring(0, nameToCheck.LastIndexOf("::"));
+            className = nameToCheck.Substring(0, nameToCheck.LastIndexOf("::", StringComparison.Ordinal));
 
             // rename for a consistent behavior for all tests.
             return className.Replace("::", ".");
@@ -653,7 +653,7 @@ internal class Converter
 
         var codeBase = source;
         var className = GetTestClassName(name, fullyQualifiedName, source);
-        var testMethodName = fullyQualifiedName.StartsWith($"{className}.") ? fullyQualifiedName.Remove(0, $"{className}.".Length) : fullyQualifiedName;
+        var testMethodName = fullyQualifiedName.StartsWith($"{className}.", StringComparison.Ordinal) ? fullyQualifiedName.Remove(0, $"{className}.".Length) : fullyQualifiedName;
         var testMethod = new TestMethod(testMethodName, className);
 
         var testElement = new UnitTestElement(testId, name, adapter, testMethod);

--- a/src/Microsoft.TestPlatform.ObjectModel/TestProperty/TestProperty.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/TestProperty/TestProperty.cs
@@ -193,28 +193,28 @@ public class TestProperty : IEquatable<TestProperty>
             type ??= Type.GetType(typeName.Replace("Version=4.0.0.0", "Version=2.0.0.0"));
 
             // For UAP the type namespace for System.Uri,System.TimeSpan and System.DateTimeOffset differs from the desktop version.
-            if (type == null && typeName.StartsWith("System.Uri"))
+            if (type == null && typeName.StartsWith("System.Uri", StringComparison.Ordinal))
             {
                 type = typeof(Uri);
             }
-            else if (type == null && typeName.StartsWith("System.TimeSpan"))
+            else if (type == null && typeName.StartsWith("System.TimeSpan", StringComparison.Ordinal))
             {
                 type = typeof(TimeSpan);
             }
-            else if (type == null && typeName.StartsWith("System.DateTimeOffset"))
+            else if (type == null && typeName.StartsWith("System.DateTimeOffset", StringComparison.Ordinal))
             {
                 type = typeof(DateTimeOffset);
             }
-            else if (type == null && typeName.StartsWith("System.Int16"))
+            else if (type == null && typeName.StartsWith("System.Int16", StringComparison.Ordinal))
             {
                 // For LineNumber property - Int is required
                 type = typeof(Int16);
             }
-            else if (type == null && typeName.StartsWith("System.Int32"))
+            else if (type == null && typeName.StartsWith("System.Int32", StringComparison.Ordinal))
             {
                 type = typeof(Int32);
             }
-            else if (type == null && typeName.StartsWith("System.Int64"))
+            else if (type == null && typeName.StartsWith("System.Int64", StringComparison.Ordinal))
             {
                 type = typeof(Int64);
             }

--- a/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/PlatformEqtTrace.cs
+++ b/src/Microsoft.TestPlatform.PlatformAbstractions/common/Tracing/PlatformEqtTrace.cs
@@ -346,7 +346,7 @@ public partial class PlatformEqtTrace : IPlatformEqtTrace
             try
             {
                 // If we point to a folder we create default filename
-                if (LogFile.EndsWith(@"\") || LogFile.EndsWith("/"))
+                if (LogFile.EndsWith(@"\", StringComparison.Ordinal) || LogFile.EndsWith("/", StringComparison.Ordinal))
                 {
                     if (!Directory.Exists(LogFile))
                     {

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs
@@ -261,7 +261,7 @@ public class DefaultTestHostManager : ITestRuntimeProvider2
 
         StringBuilder testHostProcessName = new("testhost");
 
-        if (targetFramework.Name.StartsWith(".NETFramework,Version=v"))
+        if (targetFramework.Name.StartsWith(".NETFramework,Version=v", StringComparison.Ordinal))
         {
             // Transform target framework name into moniker.
             // e.g. ".NETFramework,Version=v4.7.2" -> "net472".

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -1023,7 +1023,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
                             testHostPath = Path.Combine(testhostPackage.Path, testHostPath);
                         }
                         _hostPackageVersion = testhostPackage.Version;
-                        IsVersionCheckRequired = !_hostPackageVersion.StartsWith("15.0.0");
+                        IsVersionCheckRequired = !_hostPackageVersion.StartsWith("15.0.0", StringComparison.Ordinal);
                         EqtTrace.Verbose("DotnetTestHostmanager: Relative path of testhost.dll with respect to package folder is {0}", testHostPath);
                     }
 #else

--- a/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
+++ b/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DotnetTestHostManager.cs
@@ -162,7 +162,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
     /// <summary>
     /// Gets a value indicating whether the test host supports protocol version check
     /// </summary>
-    internal bool MakeRunsettingsCompatible => _hostPackageVersion.StartsWith("15.0.0-preview");
+    internal bool MakeRunsettingsCompatible => _hostPackageVersion.StartsWith("15.0.0-preview", StringComparison.Ordinal);
 
     /// <summary>
     /// Gets callback on process exit
@@ -1040,7 +1040,7 @@ public class DotnetTestHostManager : ITestRuntimeProvider2
                         }
 
                         _hostPackageVersion = library.Version;
-                        IsVersionCheckRequired = !_hostPackageVersion.StartsWith("15.0.0");
+                        IsVersionCheckRequired = !_hostPackageVersion.StartsWith("15.0.0", StringComparison.Ordinal);
                         EqtTrace.Verbose("DotnetTestHostmanager: Relative path of testhost.dll with respect to package folder is {0}", testHostPath);
                     }
 #endif

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleProcessManager.cs
@@ -91,7 +91,7 @@ internal sealed class VsTestConsoleProcessManager : IProcessManager, IDisposable
             throw new Exception(string.Format(CultureInfo.CurrentCulture, Resources.InvalidFilePath, vstestConsolePath));
         }
         _vstestConsolePath = vstestConsolePath;
-        _isNetCoreRunner = vstestConsolePath.EndsWith(".dll");
+        _isNetCoreRunner = vstestConsolePath.EndsWith(".dll", StringComparison.Ordinal);
     }
 
     public VsTestConsoleProcessManager(string vstestConsolePath, string dotnetExePath) : this(vstestConsolePath)

--- a/src/vstest.console/CommandLine/CommandLineOptions.cs
+++ b/src/vstest.console/CommandLine/CommandLineOptions.cs
@@ -274,7 +274,7 @@ internal class CommandLineOptions
             // Get matching files from file pattern parser
             matchingFiles = FilePatternParser.GetMatchingFiles(source);
         }
-        catch (TestSourceException ex) when (source.StartsWith("-") || source.StartsWith("/"))
+        catch (TestSourceException ex) when (source.StartsWith("-", StringComparison.Ordinal) || source.StartsWith("/", StringComparison.Ordinal))
         {
             throw new TestSourceException(
                 string.Format(CultureInfo.CurrentCulture, CommandLineResources.InvalidArgument, source), ex);

--- a/src/vstest.console/CommandLine/Executor.cs
+++ b/src/vstest.console/CommandLine/Executor.cs
@@ -466,7 +466,7 @@ internal class Executor
         string? assemblyVersion = Product.Version;
         if (!isDiag)
         {
-            var end = Product.Version?.IndexOf("-release");
+            var end = Product.Version?.IndexOf("-release", StringComparison.Ordinal);
 
             if (end >= 0)
             {

--- a/src/vstest.console/Internal/MSBuildLogger.cs
+++ b/src/vstest.console/Internal/MSBuildLogger.cs
@@ -79,7 +79,7 @@ internal class MSBuildLogger : ITestLoggerWithParameters
                 break;
             case TestMessageLevel.Warning:
                 // Downgrade xUnit skip warning to info, otherwise any skipped test will report warning, which is often upgraded to error.
-                if (e.Message.EndsWith("[SKIP]"))
+                if (e.Message.EndsWith("[SKIP]", StringComparison.Ordinal))
                 {
                     SendMessage($"output-info", e.Message);
                 }

--- a/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
+++ b/src/vstest.console/Processors/CLIRunSettingsArgumentProcessor.cs
@@ -136,7 +136,7 @@ internal class CliRunSettingsArgumentExecutor : IArgumentsExecutor
             // but does not end with ") we start merging the params
             if (arg.StartsWith("TestRunParameters", StringComparison.OrdinalIgnoreCase))
             {
-                if (arg.EndsWith("\")"))
+                if (arg.EndsWith("\")", StringComparison.Ordinal))
                 {
                     // this parameter is complete
                     mergedArgs.Add(arg);
@@ -161,7 +161,7 @@ internal class CliRunSettingsArgumentExecutor : IArgumentsExecutor
             }
 
             // once we detect the end we add the whole parameter to the args
-            if (merge && arg.EndsWith("\")"))
+            if (merge && arg.EndsWith("\")", StringComparison.Ordinal))
             {
                 mergedArgs.Add(mergedArg);
                 mergedArg = string.Empty;
@@ -188,7 +188,7 @@ internal class CliRunSettingsArgumentExecutor : IArgumentsExecutor
                 continue;
             }
 
-            var indexOfSeparator = arg.IndexOf("=");
+            var indexOfSeparator = arg.IndexOf("=", StringComparison.Ordinal);
 
             if (indexOfSeparator <= 0 || indexOfSeparator >= arg.Length - 1)
             {
@@ -219,7 +219,7 @@ internal class CliRunSettingsArgumentExecutor : IArgumentsExecutor
 
         var match = runSettingsProvider.GetTestRunParameterNodeMatch(node);
 
-        if (string.Compare(match.Value, node) == 0)
+        if (string.Equals(match.Value, node, StringComparison.Ordinal))
         {
             runSettingsProvider.UpdateTestRunParameterSettingsNode(match);
             return true;

--- a/src/vstest.console/Processors/EnableDiagArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnableDiagArgumentProcessor.cs
@@ -217,7 +217,7 @@ internal class EnableDiagArgumentExecutor : IArgumentExecutor
         diagFilePathArgument = diagFilePathArgument.Replace("\"", "");
 
         // If we provide a directory we don't need to create the base directory.
-        if (!diagFilePathArgument.EndsWith(@"\") && !diagFilePathArgument.EndsWith("/"))
+        if (!diagFilePathArgument.EndsWith(@"\", StringComparison.Ordinal) && !diagFilePathArgument.EndsWith("/", StringComparison.Ordinal))
         {
             // Create base directory for diag file path (if doesn't exist)
             CreateDirectoryIfNotExists(diagFilePathArgument);

--- a/src/vstest.console/Processors/EnvironmentArgumentProcessor.cs
+++ b/src/vstest.console/Processors/EnvironmentArgumentProcessor.cs
@@ -100,8 +100,8 @@ internal class EnvironmentArgumentProcessor : IArgumentProcessor
 
             if (key.Contains("="))
             {
-                value = key.Substring(key.IndexOf("=") + 1);
-                key = key.Substring(0, key.IndexOf("="));
+                value = key.Substring(key.IndexOf("=", StringComparison.Ordinal) + 1);
+                key = key.Substring(0, key.IndexOf("=", StringComparison.Ordinal));
             }
 
             var node = _runSettingsProvider.QueryRunSettingsNode($"RunConfiguration.EnvironmentVariables.{key}");

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/BlameDataCollectorTests.cs
@@ -320,7 +320,7 @@ public class BlameDataCollectorTests : AcceptanceTestBase
         // We cannot be precise here procdump is at machine level so we can have more than one dump and not only the one for our test
         // We look for "at least" one dump file, is the best we can do without locking all tests.
         Assert.IsNotEmpty(Directory.GetFiles(TempDirectory.Path, "*.dmp", SearchOption.AllDirectories)
-            .Where(x => Path.GetFileNameWithoutExtension(x).StartsWith("testhost")));
+            .Where(x => Path.GetFileNameWithoutExtension(x).StartsWith("testhost", StringComparison.Ordinal)));
     }
 
     private static bool IsAdministrator()
@@ -346,7 +346,7 @@ public class BlameDataCollectorTests : AcceptanceTestBase
         }
 
         var dumps = attachments
-            .Where(a => a.EndsWith(".dmp"))
+            .Where(a => a.EndsWith(".dmp", StringComparison.Ordinal))
             // On Windows we might collect conhost which tells us nothing
             // or WerFault in case we would start hanging during crash
             // we don't want these to make cross-platform checks more difficult

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/DotnetTestTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 
 using Microsoft.TestPlatform.TestUtilities;
@@ -13,7 +14,7 @@ public class DotnetTestTests : AcceptanceTestBase
 {
     private static string GetFinalVersion(string version)
     {
-        var end = version.IndexOf("-release");
+        var end = version.IndexOf("-release", StringComparison.Ordinal);
         return (end >= 0) ? version.Substring(0, end) : version;
     }
 

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/EventLogCollectorTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/EventLogCollectorTests.cs
@@ -136,7 +136,7 @@ public class EventLogCollectorTests : AcceptanceTestBase
         for (int i = 0; i < eventIds.Length; i++)
         {
             int currentIndex = 0;
-            currentIndex = content.IndexOf(eventIds[i], currentIndex);
+            currentIndex = content.IndexOf(eventIds[i], currentIndex, StringComparison.Ordinal);
             if (currentIndex == -1)
             {
                 return false;

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/ExecutionTests.cs
@@ -505,7 +505,7 @@ public class ExecutionTests : AcceptanceTestBase
         SetTestEnvironment(_testEnvironment, runnerInfo);
 
         var testAssemblyPath = _testEnvironment.GetTestAsset("SimpleTestProject.dll");
-        var allDllsMatchingTestPattern = Directory.GetFiles(Path.GetDirectoryName(testAssemblyPath)!, "*test*.dll").Where(f => !f.EndsWith("SimpleTestProject.dll"));
+        var allDllsMatchingTestPattern = Directory.GetFiles(Path.GetDirectoryName(testAssemblyPath)!, "*test*.dll").Where(f => !f.EndsWith("SimpleTestProject.dll", StringComparison.Ordinal));
 
         string assemblyPaths = string.Join(" ", allDllsMatchingTestPattern.Select(s => s.AddDoubleQuote()));
         InvokeVsTestForExecution(assemblyPaths, testAdapterPath: string.Empty, FrameworkArgValue, string.Empty);

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/FrameworkTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/FrameworkTests.cs
@@ -88,7 +88,7 @@ public class FrameworkTests : AcceptanceTestBase
         //
         // This test is Windows-Review only, so it does not run on Linux or Mac in CI. If it is run there manually,
         // forcing .NET Framework now fails fast, because the .NET Framework test host is no longer launched through Mono.
-        var isWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win");
+        var isWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win", StringComparison.Ordinal);
         if (!isWindows)
         {
             StdErrorContains("Running .NET Framework tests is supported on Windows only");
@@ -118,7 +118,7 @@ public class FrameworkTests : AcceptanceTestBase
 
         InvokeVsTest(arguments);
 
-        var isWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win");
+        var isWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win", StringComparison.Ordinal);
         if (isWindows)
         {
             // On Windows the .NET Framework test host is available, so the "Windows only" error must not appear.

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Discovery/DiscovererEnumeratorTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/Discovery/DiscovererEnumeratorTests.cs
@@ -835,7 +835,7 @@ public class DiscovererEnumeratorTests
             var shouldTestDiscovered = false;
             foreach (var source in sources)
             {
-                if (source.Equals("native.dll") || source.Equals("managed.dll") || source.EndsWith("CrossPlatEngine.UnitTests.dll") || source.EndsWith("CrossPlatEngine.UnitTests.exe"))
+                if (source.Equals("native.dll") || source.Equals("managed.dll") || source.EndsWith("CrossPlatEngine.UnitTests.dll", StringComparison.Ordinal) || source.EndsWith("CrossPlatEngine.UnitTests.exe", StringComparison.Ordinal))
                 {
                     shouldTestDiscovered = true;
                     break;

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/PostProcessing/ArtifactProcessingTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/PostProcessing/ArtifactProcessingTests.cs
@@ -144,12 +144,12 @@ public class ArtifactProcessingTests
         _fileHelperMock.Setup(x => x.GetStream(It.IsAny<string>(), It.IsAny<FileMode>(), It.IsAny<FileAccess>()))
             .Returns((string path, FileMode mode, FileAccess access) =>
             {
-                if (path.EndsWith("runsettings.xml"))
+                if (path.EndsWith("runsettings.xml", StringComparison.Ordinal))
                 {
                     return new MemoryStream(Encoding.UTF8.GetBytes(RunSettingsProviderExtensions.EmptyRunSettings));
                 }
 
-                if (path.EndsWith("executionComplete.json"))
+                if (path.EndsWith("executionComplete.json", StringComparison.Ordinal))
                 {
                     var testRunCompleteEventArgs = new TestRunCompleteEventArgs(null,
                     false,
@@ -192,7 +192,7 @@ public class ArtifactProcessingTests
         _fileHelperMock.Setup(x => x.GetStream(It.IsAny<string>(), It.IsAny<FileMode>(), It.IsAny<FileAccess>()))
             .Returns((string path, FileMode mode, FileAccess access) =>
             {
-                if (path.EndsWith("executionComplete.json"))
+                if (path.EndsWith("executionComplete.json", StringComparison.Ordinal))
                 {
                     var testRunCompleteEventArgs = new TestRunCompleteEventArgs(null,
                     false,
@@ -235,7 +235,7 @@ public class ArtifactProcessingTests
         _fileHelperMock.Setup(x => x.GetStream(It.IsAny<string>(), It.IsAny<FileMode>(), It.IsAny<FileAccess>()))
             .Returns((string path, FileMode mode, FileAccess access) =>
             {
-                if (path.EndsWith("runsettings.xml"))
+                if (path.EndsWith("runsettings.xml", StringComparison.Ordinal))
                 {
                     return new MemoryStream(Encoding.UTF8.GetBytes(RunSettingsProviderExtensions.EmptyRunSettings));
                 }
@@ -270,7 +270,7 @@ public class ArtifactProcessingTests
         _fileHelperMock.Setup(x => x.GetStream(It.IsAny<string>(), It.IsAny<FileMode>(), It.IsAny<FileAccess>()))
             .Returns((string path, FileMode mode, FileAccess access) =>
             {
-                if (path.EndsWith("executionComplete.json"))
+                if (path.EndsWith("executionComplete.json", StringComparison.Ordinal))
                 {
                     var testRunCompleteEventArgs = new TestRunCompleteEventArgs(null,
                     false,

--- a/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestLoggerManagerTests.cs
+++ b/test/Microsoft.TestPlatform.CrossPlatEngine.UnitTests/TestLoggerManagerTests.cs
@@ -85,7 +85,7 @@ public class TestLoggerManagerTests
     </RunSettings> ";
 
         var result = TestLoggerManager.GetResultsDirectory(runSettingsXml);
-        Assert.AreEqual(0, string.Compare("DummyTestResultsFolder", result));
+        Assert.AreEqual(0, string.Compare("DummyTestResultsFolder", result, StringComparison.Ordinal));
     }
 
     [TestMethod]
@@ -102,7 +102,7 @@ public class TestLoggerManagerTests
 
         var result = TestLoggerManager.GetResultsDirectory(runSettingsXml);
 
-        Assert.AreEqual(0, string.Compare(Constants.DefaultResultsDirectory, result));
+        Assert.AreEqual(0, string.Compare(Constants.DefaultResultsDirectory, result, StringComparison.Ordinal));
     }
 
     [TestMethod]

--- a/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/XmlPersistenceTests.cs
+++ b/test/Microsoft.TestPlatform.Extensions.TrxLogger.UnitTests/XmlPersistenceTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Xml;
 
 using Microsoft.TestPlatform.Extensions.TrxLogger.XML;
@@ -30,7 +31,7 @@ public class XmlPersistenceTests
         XmlPersistence.SaveObject(strWithInvalidCharForXml, node, null, "dummy");
 
         string expectedResult = "\\u0005\\u000b\\u000f\\ufffe\\u0000";
-        Assert.AreEqual(0, string.Compare(expectedResult, node.InnerXml));
+        Assert.AreEqual(0, string.Compare(expectedResult, node.InnerXml, StringComparison.Ordinal));
     }
 
     [TestMethod]
@@ -135,7 +136,7 @@ public class XmlPersistenceTests
         XmlPersistence.SaveObject(strWithValidCharForXml, node, null, "dummy");
 
         string expectedResult = "\t\n\r 섣�";
-        Assert.AreEqual(0, string.Compare(expectedResult, node.InnerXml));
+        Assert.AreEqual(0, string.Compare(expectedResult, node.InnerXml, StringComparison.Ordinal));
     }
 
     [TestMethod]
@@ -146,7 +147,7 @@ public class XmlPersistenceTests
         string strWithInvalidCharForXml = "This string has these \0 \v invalid characters";
         XmlPersistence.SaveObject(strWithInvalidCharForXml, node, null, "dummy");
         string expectedResult = "This string has these \\u0000 \\u000b invalid characters";
-        Assert.AreEqual(0, string.Compare(expectedResult, node.InnerXml));
+        Assert.AreEqual(0, string.Compare(expectedResult, node.InnerXml, StringComparison.Ordinal));
     }
 
     /// <summary>

--- a/test/Microsoft.TestPlatform.Library.IntegrationTests/AssemblyMetadataProviderTests.cs
+++ b/test/Microsoft.TestPlatform.Library.IntegrationTests/AssemblyMetadataProviderTests.cs
@@ -119,7 +119,7 @@ public class AssemblyMetadataProviderTests : AcceptanceTestBase
         var actualFx = _assemblyMetadataProvider.GetFrameworkName(assemblyPath);
         stopWatch.Stop();
 
-        if (framework.StartsWith("net4"))
+        if (framework.StartsWith("net4", StringComparison.Ordinal))
         {
             // Reason is unknown for why full framework it is taking more time. Need to investigate.
             expectedElapsedTime = 100;

--- a/test/Microsoft.TestPlatform.Library.IntegrationTests/TranslationLayerTests/CodeCoverageTests.cs
+++ b/test/Microsoft.TestPlatform.Library.IntegrationTests/TranslationLayerTests/CodeCoverageTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -65,7 +66,7 @@ public class CodeCoverageTests : CodeCoverageAcceptanceTestBase
 
         int expectedNumberOfAttachments = 1;
         Assert.HasCount(expectedNumberOfAttachments, _runEventHandler.Attachments, _runEventHandler.ToString());
-        Assert.IsNotEmpty(_telemetryEventsHandler.Events.Where(e => e.Name.StartsWith("vs/codecoverage") && e.Properties.Any()));
+        Assert.IsNotEmpty(_telemetryEventsHandler.Events.Where(e => e.Name.StartsWith("vs/codecoverage", StringComparison.Ordinal) && e.Properties.Any()));
 
         AssertCoverageResults(_runEventHandler.Attachments);
 
@@ -87,7 +88,7 @@ public class CodeCoverageTests : CodeCoverageAcceptanceTestBase
 
         // assert
         Assert.HasCount(6, _runEventHandler.TestResults, _runEventHandler.ToString());
-        Assert.IsNotEmpty(_telemetryEventsHandler.Events.Where(e => e.Name.StartsWith("vs/codecoverage") && e.Properties.Any()));
+        Assert.IsNotEmpty(_telemetryEventsHandler.Events.Where(e => e.Name.StartsWith("vs/codecoverage", StringComparison.Ordinal) && e.Properties.Any()));
 
         int expectedNumberOfAttachments = 1;
         Assert.HasCount(expectedNumberOfAttachments, _runEventHandler.Attachments, _runEventHandler.ToString());
@@ -113,7 +114,7 @@ public class CodeCoverageTests : CodeCoverageAcceptanceTestBase
         // assert
         Assert.HasCount(6, _runEventHandler.TestResults, _runEventHandler.ToString());
         Assert.ContainsSingle(_runEventHandler.Attachments, _runEventHandler.ToString());
-        Assert.IsNotEmpty(_telemetryEventsHandler.Events.Where(e => e.Name.StartsWith("vs/codecoverage") && e.Properties.Any()));
+        Assert.IsNotEmpty(_telemetryEventsHandler.Events.Where(e => e.Name.StartsWith("vs/codecoverage", StringComparison.Ordinal) && e.Properties.Any()));
 
         AssertCoverageResults(_runEventHandler.Attachments);
 

--- a/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
+++ b/test/Microsoft.TestPlatform.TestHostProvider.UnitTests/Hosting/DotnetTestHostManagerTests.cs
@@ -522,7 +522,7 @@ public class DotnetTestHostManagerTests
 
         char separator = ';';
         var dotnetExeName = "dotnet.exe";
-        if (!Environment.OSVersion.Platform.ToString().StartsWith("Win"))
+        if (!Environment.OSVersion.Platform.ToString().StartsWith("Win", StringComparison.Ordinal))
         {
             separator = ':';
             dotnetExeName = "dotnet";

--- a/test/Microsoft.TestPlatform.TestUtilities/CompatibilityRowsBuilder.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/CompatibilityRowsBuilder.cs
@@ -116,9 +116,9 @@ public class CompatibilityRowsBuilder
             afterAdapterVersion = ParseAndPatchSemanticVersion(feature.Version);
         }
 
-        var isWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win");
+        var isWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win", StringComparison.Ordinal);
         // Run .NET Framework tests only on Windows.
-        Func<string, bool> filter = tfm => isWindows || !tfm.StartsWith("net4");
+        Func<string, bool> filter = tfm => isWindows || !tfm.StartsWith("net4", StringComparison.Ordinal);
 
         // TODO: maybe we should throw if we don't end up generating any data
         // because none of the versions match, or some other way to identify tests that will never run because they are very outdated.
@@ -209,7 +209,7 @@ public class CompatibilityRowsBuilder
     {
         // Our developer version is 17.2.0-dev, but we release few preview, that are named 17.2.0-preview or 17.2.0-release, yet we still
         // want 17.2.0-dev to be considered the latest version. So we patch it.
-        var v = version != null && version.EndsWith("-dev") ? version?.Substring(0, version.Length - 4) + "-ZZZZZZZZZZ" : version;
+        var v = version != null && version.EndsWith("-dev", StringComparison.Ordinal) ? version?.Substring(0, version.Length - 4) + "-ZZZZZZZZZZ" : version;
         return SemanticVersion.Parse(v?.TrimStart('v'));
     }
 
@@ -221,7 +221,7 @@ public class CompatibilityRowsBuilder
             {
                 foreach (var hostFramework in _hostFrameworks)
                 {
-                    var isNetFramework = hostFramework.StartsWith("net4");
+                    var isNetFramework = hostFramework.StartsWith("net4", StringComparison.Ordinal);
 
                     foreach (var hostVersion in _hostVersions)
                     {
@@ -249,7 +249,7 @@ public class CompatibilityRowsBuilder
     {
         foreach (var runnerFramework in _runnerFrameworks)
         {
-            if (!runnerFramework.StartsWith("net4"))
+            if (!runnerFramework.StartsWith("net4", StringComparison.Ordinal))
             {
                 continue;
             }
@@ -381,7 +381,7 @@ public class CompatibilityRowsBuilder
             true when NuGetVersion.TryParse(version, out var v)
                 && new NuGetVersion(v.Major, v.Minor, v.Patch) < new NuGetVersion("17.3.0") => GetToolsPath("net451"),
             true => GetToolsPath("net462"),
-            false when version.StartsWith("15.") => GetContentFilesPath("netcoreapp2.0"),
+            false when version.StartsWith("15.", StringComparison.Ordinal) => GetContentFilesPath("netcoreapp2.0"),
             false when NuGetVersion.TryParse(version, out var v)
                 && new NuGetVersion(v.Major, v.Minor, v.Patch) < new NuGetVersion("17.4.0") => GetContentFilesPath("netcoreapp2.1"),
             false when NuGetVersion.TryParse(version, out var v)

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBase.cs
@@ -228,7 +228,7 @@ public class IntegrationTestBase
 
             // Insert --diag before the -- separator so it's treated as a vstest.console argument,
             // not as a runsettings parameter.
-            var separatorPos = arguments?.IndexOf(" -- ") ?? -1;
+            var separatorPos = arguments?.IndexOf(" -- ", StringComparison.Ordinal) ?? -1;
             if (separatorPos == -1)
             {
                 arguments = string.Concat(arguments, diagArg);
@@ -286,7 +286,7 @@ public class IntegrationTestBase
         if (arguments.Contains(".csproj"))
         {
             var consolePathParameter = $@" -p:VsTestConsolePath=""{vstestConsolePath}""";
-            var position = arguments.IndexOf(" -- ");
+            var position = arguments.IndexOf(" -- ", StringComparison.Ordinal);
             if (position == -1)
             {
                 // Add at the end.
@@ -311,7 +311,7 @@ public class IntegrationTestBase
             var diagArg = " --diag " + diagPath.AddDoubleQuote();
 
             // Insert --diag before the -- separator so dotnet test forwards it to vstest.console.
-            var separatorPos = arguments.IndexOf(" -- ");
+            var separatorPos = arguments.IndexOf(" -- ", StringComparison.Ordinal);
             if (separatorPos == -1)
             {
                 arguments += diagArg;
@@ -718,12 +718,12 @@ public class IntegrationTestBase
         if (testFramework == UnitTestFramework.MSTest)
         {
             var version = IntegrationTestEnvironment.DependencyVersions["MSTestTestAdapterVersion"];
-            if (version.StartsWith("4"))
+            if (version.StartsWith("4", StringComparison.Ordinal))
             {
                 var tfm = _testEnvironment.IsNetFrameworkTarget ? "net462" : "net9.0";
                 adapterRelativePath = string.Format(CultureInfo.InvariantCulture, _msTestAdapterRelativePath, version, tfm);
             }
-            else if (version.StartsWith("3"))
+            else if (version.StartsWith("3", StringComparison.Ordinal))
             {
                 var tfm = _testEnvironment.IsNetFrameworkTarget ? "net462" : "netcoreapp3.1";
                 adapterRelativePath = string.Format(CultureInfo.InvariantCulture, _msTestAdapterRelativePath, version, tfm);

--- a/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/IntegrationTestBuild.cs
@@ -597,7 +597,7 @@ public class IntegrationTestBuild : IntegrationTestBase
             {
                 foreach (var versionDir in Directory.GetDirectories(packageDir))
                 {
-                    if (versionDir.EndsWith("-dev") || versionDir.EndsWith("-ci"))
+                    if (versionDir.EndsWith("-dev", StringComparison.Ordinal) || versionDir.EndsWith("-ci", StringComparison.Ordinal))
                     {
                         Directory.Delete(versionDir, recursive: true);
                     }

--- a/test/Microsoft.TestPlatform.TestUtilities/NetCoreRunnerAttribute.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/NetCoreRunnerAttribute.cs
@@ -39,9 +39,9 @@ public class NetCoreRunnerAttribute : Attribute, ITestDataSource
     public IEnumerable<object[]> GetData(MethodInfo methodInfo)
     {
         var dataRows = new List<object[]>();
-        var isWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win");
+        var isWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win", StringComparison.Ordinal);
         // on non-windows we want to filter down only to netcoreapp runner, and net5.0 and newer.
-        Func<string, bool> filter = tfm => isWindows || !tfm.StartsWith("net4");
+        Func<string, bool> filter = tfm => isWindows || !tfm.StartsWith("net4", StringComparison.Ordinal);
         foreach (var fmw in _targetFrameworks.Split(';').Where(filter))
         {
             var runnerInfo = new RunnerInfo

--- a/test/Microsoft.TestPlatform.TestUtilities/NetCoreTargetFrameworkDataSourceAttribute.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/NetCoreTargetFrameworkDataSourceAttribute.cs
@@ -61,7 +61,7 @@ public class NetCoreTargetFrameworkDataSourceAttribute : Attribute, ITestDataSou
     public IEnumerable<object[]> GetData(MethodInfo methodInfo)
     {
         var dataRows = new List<object[]>();
-        var isWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win");
+        var isWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win", StringComparison.Ordinal);
         if (_useDesktopRunner && isWindows)
         {
             var runnerFramework = IntegrationTestBase.DesktopRunnerFramework;

--- a/test/Microsoft.TestPlatform.TestUtilities/NetFrameworkRunnerAttribute.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/NetFrameworkRunnerAttribute.cs
@@ -38,7 +38,7 @@ public class NetFrameworkRunnerAttribute : Attribute, ITestDataSource
     public IEnumerable<object[]> GetData(MethodInfo methodInfo)
     {
         var dataRows = new List<object[]>();
-        var isWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win");
+        var isWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win", StringComparison.Ordinal);
         if (!isWindows)
         {
             return dataRows;

--- a/test/Microsoft.TestPlatform.TestUtilities/NetFullTargetFrameworkDataSourceAttribute.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/NetFullTargetFrameworkDataSourceAttribute.cs
@@ -52,7 +52,7 @@ public class NetFullTargetFrameworkDataSourceAttribute : Attribute, ITestDataSou
     public IEnumerable<object[]> GetData(MethodInfo methodInfo)
     {
         var dataRows = new List<object[]>();
-        var isWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win");
+        var isWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win", StringComparison.Ordinal);
         if (_useCoreRunner && isWindows)
         {
             var runnerInfo = new RunnerInfo

--- a/test/Microsoft.TestPlatform.TestUtilities/OSUtils.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/OSUtils.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Microsoft.TestPlatform.TestUtilities;
 
 public static class OSUtils
 {
-    public static bool IsWindows { get; } = System.Environment.OSVersion.Platform.ToString().StartsWith("Win");
+    public static bool IsWindows { get; } = System.Environment.OSVersion.Platform.ToString().StartsWith("Win", StringComparison.Ordinal);
 }

--- a/test/Microsoft.TestPlatform.TestUtilities/TestMatrixAttribute.cs
+++ b/test/Microsoft.TestPlatform.TestUtilities/TestMatrixAttribute.cs
@@ -62,7 +62,7 @@ public sealed class TestMatrixAttribute : Attribute, ITestDataSource
     public IEnumerable<object[]> GetData(MethodInfo methodInfo)
     {
         var dataRows = new List<object[]>();
-        var isWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win");
+        var isWindows = Environment.OSVersion.Platform.ToString().StartsWith("Win", StringComparison.Ordinal);
 
         var wantNetFxConsole = _console is Target.Both or Target.NetFx;
         var wantNetConsole = _console is Target.Both or Target.Net;

--- a/test/TestAssets/ArchitectureSwitch/UnitTest1.cs
+++ b/test/TestAssets/ArchitectureSwitch/UnitTest1.cs
@@ -19,7 +19,7 @@ namespace TestProjectNetcore
         {
             foreach (DictionaryEntry envVar in Environment.GetEnvironmentVariables())
             {
-                if (envVar.Key.ToString().StartsWith("DOTNET_ROOT"))
+                if (envVar.Key.ToString().StartsWith("DOTNET_ROOT", StringComparison.Ordinal))
                 {
                     Console.WriteLine($"{envVar.Key}: {envVar.Value}");
                 }

--- a/test/vstest.ProgrammerTests/Fakes/FakeFileHelper.cs
+++ b/test/vstest.ProgrammerTests/Fakes/FakeFileHelper.cs
@@ -45,7 +45,7 @@ internal class FakeFileHelper : IFileHelper
     {
         TPDebug.Assert(path is not null, "path is null");
         // TODO: Check if any file has the directory in name. This will improve.
-        var directoryExists = Files.Select(f => Path.GetDirectoryName(f.Path)).Any(p => p != null && p.StartsWith(path!));
+        var directoryExists = Files.Select(f => Path.GetDirectoryName(f.Path)).Any(p => p != null && p.StartsWith(path!, StringComparison.Ordinal));
         return directoryExists;
     }
 

--- a/test/vstest.console.UnitTests/ExecutorUnitTests.cs
+++ b/test/vstest.console.UnitTests/ExecutorUnitTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -59,7 +60,7 @@ public class ExecutorUnitTests
         Assert.Contains(CommandLineResources.MicrosoftCommandLineTitle.Split(['{'], 2)[0],
             mockOutput.Messages.First().Message!);
 
-        var suffixIndex = assemblyVersion.IndexOf("-");
+        var suffixIndex = assemblyVersion.IndexOf("-", StringComparison.Ordinal);
         var version = suffixIndex == -1 ? assemblyVersion : assemblyVersion.Substring(0, suffixIndex);
         Assert.Contains(version,
             mockOutput.Messages.First().Message!);

--- a/test/vstest.console.UnitTests/Internal/FilePatternParserTests.cs
+++ b/test/vstest.console.UnitTests/Internal/FilePatternParserTests.cs
@@ -172,7 +172,7 @@ public class FilePatternParserTests
     private static string TranslatePath(string path)
     {
         // RuntimeInformation has conflict when used
-        return Environment.OSVersion.Platform.ToString().StartsWith("Win")
+        return Environment.OSVersion.Platform.ToString().StartsWith("Win", StringComparison.Ordinal)
             ? path
             : Regex.Replace(path.Replace("\\", "/"), @"(\w)\:/", @"/mnt/$1/");
     }

--- a/test/vstest.console.UnitTests/Processors/AeDebuggerArgumentProcessorTest.cs
+++ b/test/vstest.console.UnitTests/Processors/AeDebuggerArgumentProcessorTest.cs
@@ -103,9 +103,9 @@ public class AeDebuggerArgumentProcessorTest
     public void AeDebuggerArgumentExecutor_WrongDirectoryPaths(string command, string? directoryPath)
     {
         _fileHelper.Setup(x => x.DirectoryExists(It.IsAny<string>()))
-            .Returns((string path) => directoryPath is null || !directoryPath.EndsWith(path));
+            .Returns((string path) => directoryPath is null || !directoryPath.EndsWith(path, StringComparison.Ordinal));
         _fileHelper.Setup(x => x.Exists(It.IsAny<string>()))
-            .Returns((string path) => path.EndsWith("procdump.exe") && path != "procdump.exe");
+            .Returns((string path) => path.EndsWith("procdump.exe", StringComparison.Ordinal) && path != "procdump.exe");
         _executor.Initialize(string.Format(CultureInfo.InvariantCulture, command, directoryPath));
         Assert.AreEqual(ArgumentProcessorResult.Fail, _executor.Execute());
     }

--- a/test/vstest.console.UnitTests/Processors/ResultsDirectoryArgumentProcessorTests.cs
+++ b/test/vstest.console.UnitTests/Processors/ResultsDirectoryArgumentProcessorTests.cs
@@ -146,7 +146,7 @@ public class ResultsDirectoryArgumentProcessorTests
     private static string TranslatePath(string path)
     {
         // RuntimeInformation has conflict when used
-        if (Environment.OSVersion.Platform.ToString().StartsWith("Win"))
+        if (Environment.OSVersion.Platform.ToString().StartsWith("Win", StringComparison.Ordinal))
             return path;
 
         var prefix = Path.GetTempPath();


### PR DESCRIPTION
`StartsWith(string)`, `EndsWith(string)` and `string.Compare(string, string)` use the current culture on every platform, including .NET 8+. Most of the 89 sites don't care, but two decide real behaviour: whether the runner is launched through `dotnet` (`VsTestConsoleProcessManager`), and how runsettings XML attribute names are matched (`RunSettingsProviderExtensions`).

Every call now passes `StringComparison.Ordinal`, so nothing changes case sensitivity. The `.dll`, `.xml` and `.resources` checks stay case-sensitive, exactly as they are today. A few of those arguably should be `OrdinalIgnoreCase`, but that is a behaviour change and belongs in its own PR.

The two `string.Compare(a, b) == 0` sites read as `string.Equals(a, b, StringComparison.Ordinal)`, which is what they meant.

Measured on this branch, CA1310 is 89 lines / 95 call sites across 51 files. Because `TreatWarningsAsErrors` is on, the compiler proves when it is finished — but only for code it actually compiles. Two sites are invisible to a plain `build.cmd`: the `#if NETCOREAPP` branch in `DotnetTestHostManager`, which only compiles under source-build because that forces `TargetFrameworks` to `NetCurrent`, and `test/TestAssets`, which is a separate solution the main build never touches.

The two sibling rules stay off, and `.editorconfig` now records why, so they stop being proposed again:

- CA1307 fires at 293 call sites, 166 of them `string.Contains(string)` and `string.Replace(string, string)`. Those two only ever warn on net8.0/net10.0/net11.0 and never on net462/net47/net471/net472/net48/net481/netstandard2.0, because the `StringComparison` overloads don't exist there. The fix the analyzer suggests would not compile.
- CA1309 is a separate 128-site change across 53 files. It shares exactly one line with this one, so splitting them costs nothing.

Verified: `build.cmd -c Release` compiles all 75 projects with no CA1310 and no new warnings; `TestAssets.slnx` and a source-only build of `Microsoft.TestPlatform.TestHostProvider` are also clean. Unit tests for vstest.console, CrossPlatEngine, Common, TrxLogger and TestHostProvider pass on net11.0 and net481.

Fixes #16377

🤖