### PR TITLE
Tell the user when a test extension fails to load

### DIFF
--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginCache.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginCache.cs
@@ -264,6 +264,13 @@ public class TestPluginCache
         _filterableExtensionPaths?.Clear();
         _unfilterableExtensionPaths?.Clear();
         TestExtensions?.InvalidateCache();
+
+        // Extensions are discovered from scratch after this, so a file that failed to load is worth another try,
+        // and a load failure the user was already told about is news again. Without this the runner reports a
+        // broken extension on the first request and then stays quiet about it for the rest of a design mode
+        // session that can last hours, and an extension whose missing dependency has since appeared stays
+        // skipped until the process exits.
+        TestPluginDiscoverer.ClearLoadFailures();
     }
 
     /// <summary>

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginCache.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginCache.cs
@@ -472,7 +472,7 @@ public class TestPluginCache
         // BUT for some unknown reason the point 10 is not working as explained.
         // Satellite resolution should fallback to the NeutralResourcesLanguageAttribute
         // that we set to en-US but don't and we fail with FileNotFoundException.
-        _ = Resources.Resources.FailedToLoadAdapaterFile;
+        _ = Resources.Resources.FailedToLoadExtensionFile;
 
         IList<string> resolutionPaths = extensionAssembly.IsNullOrEmpty()
             ? GetDefaultResolutionPaths()

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs
@@ -25,11 +25,36 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
 internal static class TestPluginDiscoverer
 {
     /// <summary>
-    /// Files that we already failed to load. The same file is scanned once per extension type we look for
-    /// (test adapters, loggers, data collectors, settings providers, ...), so this both avoids repeating a load
-    /// that is known to fail, and makes sure the user is told about the failure only once.
+    /// Files we already failed to load, and why. The same file is scanned once per extension type we look for
+    /// (test adapters, loggers, data collectors, settings providers, ...), so this avoids repeating a load that
+    /// is known to fail. <see cref="TestPluginCache.ClearExtensions"/> empties it, so an extension whose missing
+    /// dependency has since appeared is tried again on the next request instead of staying broken for the rest
+    /// of the process.
     /// </summary>
-    private static readonly ConcurrentDictionary<string, object?> UnloadableFiles = new();
+    private static readonly ConcurrentDictionary<string, string> UnloadableFiles = new();
+
+    /// <summary>
+    /// Files the user was already told about. This is kept apart from <see cref="UnloadableFiles"/> because the
+    /// two answer different questions: that one says whether loading the file is worth another try, this one says
+    /// whether the user has already seen the warning. <see cref="TestPluginCache.ClearExtensions"/> empties it,
+    /// which is what makes the warning once per run rather than once per process. An editor keeps the runner
+    /// alive across many discovery and run requests, and a broken extension is news again on each of them.
+    ///
+    /// Paths are compared ignoring case. On Windows two spellings of the same path are the same file, and a
+    /// second warning about it tells the user nothing the first one did not.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, object?> ReportedFiles = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Forgets which files failed to load and which of them the user was told about, so the next request tries
+    /// them again and reports them again. Called when the extension cache is cleared, because extensions are
+    /// then discovered from scratch.
+    /// </summary>
+    internal static void ClearLoadFailures()
+    {
+        UnloadableFiles.Clear();
+        ReportedFiles.Clear();
+    }
 
     /// <summary>
     /// Gets information about each of the test extensions available.
@@ -98,8 +123,12 @@ internal static class TestPluginDiscoverer
         // Scan each of the files for data extensions.
         foreach (var file in files)
         {
-            if (UnloadableFiles.ContainsKey(file))
+            if (UnloadableFiles.TryGetValue(file, out var knownReason))
             {
+                // We already failed to load this file while looking for another extension type. Don't pay for
+                // the failure again, but still hand it to the reporting, which decides on its own whether the
+                // user has heard about it.
+                ReportFailureToLoadExtensions(file, knownReason, reportFailures);
                 continue;
             }
 
@@ -114,13 +143,10 @@ internal static class TestPluginDiscoverer
                 EqtTrace.Warning("TestPluginDiscoverer: Failed to load extensions from file '{0}'.  Skipping test extension scan for this file.  Error: {1}", file, e);
 
                 // The file cannot be loaded at all, don't try again for the other extension types, and tell the user
-                // about it once. Without this the extension is just silently missing, and the tests it provides are
+                // about it. Without this the extension is just silently missing, and the tests it provides are
                 // silently not run.
-                var isFirstFailureForFile = UnloadableFiles.TryAdd(file, null);
-                if (isFirstFailureForFile && reportFailures)
-                {
-                    ReportFailureToLoadExtensions(file, e.Message);
-                }
+                UnloadableFiles[file] = e.Message;
+                ReportFailureToLoadExtensions(file, e.Message, reportFailures);
 
                 continue;
             }
@@ -151,7 +177,7 @@ internal static class TestPluginDiscoverer
     /// <typeparam name="TExtension">
     /// Type of Extensions.
     /// </typeparam>
-    private static void GetTestExtensionsFromAssembly<TPluginInfo, TExtension>(Assembly assembly, Dictionary<string, TPluginInfo> pluginInfos, string filePath, bool reportFailures)
+    internal static void GetTestExtensionsFromAssembly<TPluginInfo, TExtension>(Assembly assembly, Dictionary<string, TPluginInfo> pluginInfos, string filePath, bool reportFailures)
         where TPluginInfo : TestPluginInformation
     {
         TPDebug.Assert(assembly != null, "null assembly");
@@ -209,11 +235,9 @@ internal static class TestPluginDiscoverer
             // usually not extensions at all.
             if (types.Count == 0)
             {
-                var isFirstFailureForFile = UnloadableFiles.TryAdd(filePath, null);
-                if (isFirstFailureForFile && reportFailures)
-                {
-                    ReportFailureToLoadExtensions(filePath, GetLoaderExceptionsMessage(e));
-                }
+                var reason = GetLoaderExceptionsMessage(e);
+                UnloadableFiles[filePath] = reason;
+                ReportFailureToLoadExtensions(filePath, reason, reportFailures);
             }
         }
 
@@ -281,14 +305,23 @@ internal static class TestPluginDiscoverer
     }
 
     /// <summary>
-    /// Tells the user that a file that looks like a test extension could not be loaded.
+    /// Tells the user that a file that looks like a test extension could not be loaded, unless they were already
+    /// told about that file in this run.
     /// </summary>
     /// <param name="filePath">File path of the extension.</param>
     /// <param name="reason">Why the file could not be loaded.</param>
-    private static void ReportFailureToLoadExtensions(string filePath, string reason)
-        => TestSessionMessageLogger.Instance.SendMessage(
+    /// <param name="reportFailures">When false the failure is expected and stays invisible to the user.</param>
+    private static void ReportFailureToLoadExtensions(string filePath, string reason, bool reportFailures)
+    {
+        if (!reportFailures || !ReportedFiles.TryAdd(filePath, null))
+        {
+            return;
+        }
+
+        TestSessionMessageLogger.Instance.SendMessage(
             TestMessageLevel.Warning,
             string.Format(CultureInfo.CurrentCulture, CommonResources.FailedToLoadExtensionFile, filePath, reason));
+    }
 
     /// <summary>
     /// Joins the messages of the loader exceptions, they say why the types could not be loaded, e.g. which

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -23,7 +24,12 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
 /// </summary>
 internal static class TestPluginDiscoverer
 {
-    private static readonly HashSet<string> UnloadableFiles = new();
+    /// <summary>
+    /// Files that we already failed to load. The same file is scanned once per extension type we look for
+    /// (test adapters, loggers, data collectors, settings providers, ...), so this both avoids repeating a load
+    /// that is known to fail, and makes sure the user is told about the failure only once.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, object?> UnloadableFiles = new();
 
     /// <summary>
     /// Gets information about each of the test extensions available.
@@ -41,12 +47,15 @@ internal static class TestPluginDiscoverer
         var pluginInfos = new Dictionary<string, TPluginInfo>();
 
         // C++ UWP adapters do not follow TestAdapater naming convention, so making this exception
-        if (!extensionPaths.Any())
+        var probeForKnownExtensions = !extensionPaths.Any();
+        if (probeForKnownExtensions)
         {
             AddKnownExtensions(ref extensionPaths);
         }
 
-        GetTestExtensionsFromFiles<TPluginInfo, TExtension>(extensionPaths.ToArray(), pluginInfos);
+        // The known extensions are just a guess, they are not expected to be present, so failing to load them is
+        // normal and must not be reported to the user.
+        GetTestExtensionsFromFiles<TPluginInfo, TExtension>(extensionPaths.ToArray(), pluginInfos, reportFailures: !probeForKnownExtensions);
 
         return pluginInfos;
     }
@@ -74,9 +83,13 @@ internal static class TestPluginDiscoverer
     /// <param name="pluginInfos">
     /// Test plugins collection to add to.
     /// </param>
+    /// <param name="reportFailures">
+    /// When true, files that fail to load are reported to the user as warnings.
+    /// </param>
     private static void GetTestExtensionsFromFiles<TPluginInfo, TExtension>(
         string[] files,
-        Dictionary<string, TPluginInfo> pluginInfos)
+        Dictionary<string, TPluginInfo> pluginInfos,
+        bool reportFailures)
         where TPluginInfo : TestPluginInformation
     {
         TPDebug.Assert(files != null, "null files");
@@ -85,29 +98,42 @@ internal static class TestPluginDiscoverer
         // Scan each of the files for data extensions.
         foreach (var file in files)
         {
-            if (UnloadableFiles.Contains(file))
+            if (UnloadableFiles.ContainsKey(file))
             {
                 continue;
             }
+
+            Assembly assembly;
             try
             {
                 var assemblyName = Path.GetFileNameWithoutExtension(file);
-                var assembly = Assembly.Load(new AssemblyName(assemblyName));
-                if (assembly != null)
-                {
-                    GetTestExtensionsFromAssembly<TPluginInfo, TExtension>(assembly, pluginInfos, file);
-                }
-            }
-            catch (FileLoadException e)
-            {
-                EqtTrace.Warning("TestPluginDiscoverer-FileLoadException: Failed to load extensions from file '{0}'.  Skipping test extension scan for this file.  Error: {1}", file, e);
-                string fileLoadErrorMessage = string.Format(CultureInfo.CurrentCulture, CommonResources.FailedToLoadAdapaterFile, file);
-                TestSessionMessageLogger.Instance.SendMessage(TestMessageLevel.Warning, fileLoadErrorMessage);
-                UnloadableFiles.Add(file);
+                assembly = Assembly.Load(new AssemblyName(assemblyName));
             }
             catch (Exception e)
             {
                 EqtTrace.Warning("TestPluginDiscoverer: Failed to load extensions from file '{0}'.  Skipping test extension scan for this file.  Error: {1}", file, e);
+
+                // The file cannot be loaded at all, don't try again for the other extension types, and tell the user
+                // about it once. Without this the extension is just silently missing, and the tests it provides are
+                // silently not run.
+                var isFirstFailureForFile = UnloadableFiles.TryAdd(file, null);
+                if (isFirstFailureForFile && reportFailures)
+                {
+                    ReportFailureToLoadExtensions(file, e.Message);
+                }
+
+                continue;
+            }
+
+            try
+            {
+                GetTestExtensionsFromAssembly<TPluginInfo, TExtension>(assembly, pluginInfos, file, reportFailures);
+            }
+            catch (Exception e)
+            {
+                // The assembly itself loaded, only inspecting it failed. Keep this quiet, it is a problem of a
+                // single extension type and the file may still provide extensions of another type.
+                EqtTrace.Warning("TestPluginDiscoverer: Failed to get extensions from file '{0}'.  Skipping test extension scan for this file.  Error: {1}", file, e);
             }
         }
     }
@@ -118,13 +144,14 @@ internal static class TestPluginDiscoverer
     /// <param name="assembly">Assembly to check for test extension availability</param>
     /// <param name="pluginInfos">Test extensions collection to add to.</param>
     /// <param name="filePath">File path of the assembly.</param>
+    /// <param name="reportFailures">When true, an assembly from which no type can be loaded is reported to the user as a warning.</param>
     /// <typeparam name="TPluginInfo">
     /// Type of Test Plugin Information.
     /// </typeparam>
     /// <typeparam name="TExtension">
     /// Type of Extensions.
     /// </typeparam>
-    private static void GetTestExtensionsFromAssembly<TPluginInfo, TExtension>(Assembly assembly, Dictionary<string, TPluginInfo> pluginInfos, string filePath)
+    private static void GetTestExtensionsFromAssembly<TPluginInfo, TExtension>(Assembly assembly, Dictionary<string, TPluginInfo> pluginInfos, string filePath, bool reportFailures)
         where TPluginInfo : TestPluginInformation
     {
         TPDebug.Assert(assembly != null, "null assembly");
@@ -174,6 +201,18 @@ internal static class TestPluginDiscoverer
                 foreach (var ex in e.LoaderExceptions)
                 {
                     EqtTrace.Warning("LoaderExceptions: {0}", ex);
+                }
+            }
+
+            // Not a single type came out of the assembly, so it cannot provide any extension. When some types did
+            // load we stay quiet, the extension most likely still works, and the types that did not load are
+            // usually not extensions at all.
+            if (types.Count == 0)
+            {
+                var isFirstFailureForFile = UnloadableFiles.TryAdd(filePath, null);
+                if (isFirstFailureForFile && reportFailures)
+                {
+                    ReportFailureToLoadExtensions(filePath, GetLoaderExceptionsMessage(e));
                 }
             }
         }
@@ -241,4 +280,30 @@ internal static class TestPluginDiscoverer
         }
     }
 
+    /// <summary>
+    /// Tells the user that a file that looks like a test extension could not be loaded.
+    /// </summary>
+    /// <param name="filePath">File path of the extension.</param>
+    /// <param name="reason">Why the file could not be loaded.</param>
+    private static void ReportFailureToLoadExtensions(string filePath, string reason)
+        => TestSessionMessageLogger.Instance.SendMessage(
+            TestMessageLevel.Warning,
+            string.Format(CultureInfo.CurrentCulture, CommonResources.FailedToLoadExtensionFile, filePath, reason));
+
+    /// <summary>
+    /// Joins the messages of the loader exceptions, they say why the types could not be loaded, e.g. which
+    /// dependency is missing.
+    /// </summary>
+    private static string GetLoaderExceptionsMessage(ReflectionTypeLoadException exception)
+    {
+        var reasons = exception.LoaderExceptions?
+            .Where(loaderException => loaderException != null)
+            .Select(loaderException => loaderException!.Message)
+            .Distinct()
+            .ToArray();
+
+        return reasons?.Length > 0
+            ? string.Join(Environment.NewLine, reasons)
+            : exception.Message;
+    }
 }

--- a/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs
+++ b/src/Microsoft.TestPlatform.Common/ExtensionFramework/TestPluginDiscoverer.cs
@@ -46,7 +46,7 @@ internal static class TestPluginDiscoverer
 
         var pluginInfos = new Dictionary<string, TPluginInfo>();
 
-        // C++ UWP adapters do not follow TestAdapater naming convention, so making this exception
+        // C++ UWP adapters do not follow TestAdapter naming convention, so making this exception
         var probeForKnownExtensions = !extensionPaths.Any();
         if (probeForKnownExtensions)
         {

--- a/src/Microsoft.TestPlatform.Common/Resources/Resources.Designer.cs
+++ b/src/Microsoft.TestPlatform.Common/Resources/Resources.Designer.cs
@@ -205,11 +205,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Common.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to load extensions from file &apos;{0}&apos;. Please use /diag for more information..
+        ///   Looks up a localized string similar to Failed to load extensions from file &apos;{0}&apos;. Reason: {1}.
         /// </summary>
-        internal static string FailedToLoadAdapaterFile {
+        internal static string FailedToLoadExtensionFile {
             get {
-                return ResourceManager.GetString("FailedToLoadAdapaterFile", resourceCulture);
+                return ResourceManager.GetString("FailedToLoadExtensionFile", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TestPlatform.Common/Resources/Resources.resx
+++ b/src/Microsoft.TestPlatform.Common/Resources/Resources.resx
@@ -165,8 +165,8 @@
   <data name="FailedToFindInstalledUnitTestExtensions" xml:space="preserve">
     <value>Failed to find the list of installed unit test extensions. Reason: {0}</value>
   </data>
-  <data name="FailedToLoadAdapaterFile" xml:space="preserve">
-    <value>Failed to load extensions from file '{0}'. Please use /diag for more information.</value>
+  <data name="FailedToLoadExtensionFile" xml:space="preserve">
+    <value>Failed to load extensions from file '{0}'. Reason: {1}</value>
   </data>
   <data name="FastFilterException" xml:space="preserve">
     <value>An error occurred while creating Fast filter.</value>

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.cs.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.cs.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Nepovedlo se najít datacollector s popisným názvem {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FailedToLoadAdapaterFile">
-        <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
-        <target state="translated">Nepovedlo se načíst rozšíření ze souboru {0}. Další informace získáte pomocí parametru /diag.</target>
+      <trans-unit id="FailedToLoadExtensionFile">
+        <source>Failed to load extensions from file '{0}'. Reason: {1}</source>
+        <target state="new">Failed to load extensions from file '{0}'. Reason: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessDenied">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.de.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.de.xlf
@@ -187,9 +187,9 @@
         <target state="translated">datacollector mit dem Anzeigenamen "{0}" wurde nicht gefunden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FailedToLoadAdapaterFile">
-        <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
-        <target state="translated">Fehler beim Laden von Erweiterungen aus der Datei "{0}". Verwenden Sie "/diag", um weitere Informationen zu erhalten.</target>
+      <trans-unit id="FailedToLoadExtensionFile">
+        <source>Failed to load extensions from file '{0}'. Reason: {1}</source>
+        <target state="new">Failed to load extensions from file '{0}'. Reason: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessDenied">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.es.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.es.xlf
@@ -187,9 +187,9 @@
         <target state="translated">No se encuentra ningún objeto datacollector con el nombre descriptivo "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="FailedToLoadAdapaterFile">
-        <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
-        <target state="translated">No se pudieron cargar las extensiones del archivo "{0}". Use /diag para obtener más información.</target>
+      <trans-unit id="FailedToLoadExtensionFile">
+        <source>Failed to load extensions from file '{0}'. Reason: {1}</source>
+        <target state="new">Failed to load extensions from file '{0}'. Reason: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessDenied">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.fr.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.fr.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Le datacollector ayant le nom convivial '{0}' est introuvable.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FailedToLoadAdapaterFile">
-        <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
-        <target state="translated">Le chargement des extensions à partir du fichier '{0}' a échoué. Pour plus d'informations, utilisez /diag.</target>
+      <trans-unit id="FailedToLoadExtensionFile">
+        <source>Failed to load extensions from file '{0}'. Reason: {1}</source>
+        <target state="new">Failed to load extensions from file '{0}'. Reason: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessDenied">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.it.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.it.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Non è possibile trovare un oggetto datacollector con nome descrittivo '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FailedToLoadAdapaterFile">
-        <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
-        <target state="translated">Non è stato possibile caricare le estensioni dal file '{0}'. Per altre informazioni, usare /diag.</target>
+      <trans-unit id="FailedToLoadExtensionFile">
+        <source>Failed to load extensions from file '{0}'. Reason: {1}</source>
+        <target state="new">Failed to load extensions from file '{0}'. Reason: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessDenied">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ja.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ja.xlf
@@ -187,9 +187,9 @@
         <target state="translated">フレンドリ名が '{0}' の datacollector が見つかりません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FailedToLoadAdapaterFile">
-        <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
-        <target state="translated">ファイル '{0}' から拡張機能を読み込めませんでした。詳細な情報を得るには、/diag をご使用ください。</target>
+      <trans-unit id="FailedToLoadExtensionFile">
+        <source>Failed to load extensions from file '{0}'. Reason: {1}</source>
+        <target state="new">Failed to load extensions from file '{0}'. Reason: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessDenied">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ko.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ko.xlf
@@ -187,9 +187,9 @@
         <target state="translated">이름이 '{0}'인 datacollector를 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FailedToLoadAdapaterFile">
-        <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
-        <target state="translated">'{0}' 파일에서 확장을 로드하지 못했습니다. 자세한 내용을 보려면 /diag를 사용하세요.</target>
+      <trans-unit id="FailedToLoadExtensionFile">
+        <source>Failed to load extensions from file '{0}'. Reason: {1}</source>
+        <target state="new">Failed to load extensions from file '{0}'. Reason: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessDenied">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pl.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pl.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Nie można znaleźć elementu datacollector o przyjaznej nazwie „{0}”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FailedToLoadAdapaterFile">
-        <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
-        <target state="translated">Nie można załadować rozszerzeń z pliku „{0}”. Aby uzyskać więcej informacji, użyj opcji /diag.</target>
+      <trans-unit id="FailedToLoadExtensionFile">
+        <source>Failed to load extensions from file '{0}'. Reason: {1}</source>
+        <target state="new">Failed to load extensions from file '{0}'. Reason: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessDenied">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.pt-BR.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Não é possível localizar um datacollector com o nome amigável '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FailedToLoadAdapaterFile">
-        <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
-        <target state="translated">Falha ao carregar as extensões do arquivo '{0}'. Use /diag para obter mais informações.</target>
+      <trans-unit id="FailedToLoadExtensionFile">
+        <source>Failed to load extensions from file '{0}'. Reason: {1}</source>
+        <target state="new">Failed to load extensions from file '{0}'. Reason: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessDenied">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ru.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.ru.xlf
@@ -187,9 +187,9 @@
         <target state="translated">Не удается найти datacollector с понятным именем "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="FailedToLoadAdapaterFile">
-        <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
-        <target state="translated">Не удалось загрузить расширения из файла "{0}". Для получения дополнительных сведений используйте /diag.</target>
+      <trans-unit id="FailedToLoadExtensionFile">
+        <source>Failed to load extensions from file '{0}'. Reason: {1}</source>
+        <target state="new">Failed to load extensions from file '{0}'. Reason: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessDenied">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.tr.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.tr.xlf
@@ -187,9 +187,9 @@
         <target state="translated">'{0}' kolay adına sahip bir datacollector bulunamadı.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FailedToLoadAdapaterFile">
-        <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
-        <target state="translated">Uzantılar '{0}' dosyasından yüklenemedi. Daha fazla bilgi için lütfen /diag kullanın.</target>
+      <trans-unit id="FailedToLoadExtensionFile">
+        <source>Failed to load extensions from file '{0}'. Reason: {1}</source>
+        <target state="new">Failed to load extensions from file '{0}'. Reason: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessDenied">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hans.xlf
@@ -187,9 +187,9 @@
         <target state="translated">找不到友好名称为“{0}”的 datacollector。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FailedToLoadAdapaterFile">
-        <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
-        <target state="translated">未能从文件 "{0}" 加载扩展。有关详细信息，请使用 /diag。</target>
+      <trans-unit id="FailedToLoadExtensionFile">
+        <source>Failed to load extensions from file '{0}'. Reason: {1}</source>
+        <target state="new">Failed to load extensions from file '{0}'. Reason: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessDenied">

--- a/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.TestPlatform.Common/Resources/xlf/Resources.zh-Hant.xlf
@@ -187,9 +187,9 @@
         <target state="translated">找不到易記名稱為 '{0}' 的 datacollector。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FailedToLoadAdapaterFile">
-        <source>Failed to load extensions from file '{0}'. Please use /diag for more information.</source>
-        <target state="translated">無法從檔案 '{0}' 載入延伸模組。如需詳細資訊，請使用 /diag。</target>
+      <trans-unit id="FailedToLoadExtensionFile">
+        <source>Failed to load extensions from file '{0}'. Reason: {1}</source>
+        <target state="new">Failed to load extensions from file '{0}'. Reason: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="AccessDenied">

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginDiscovererTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginDiscovererTests.cs
@@ -3,11 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 
+using Microsoft.TestPlatform.TestUtilities;
 using Microsoft.VisualStudio.TestPlatform.Common.DataCollector;
 using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
 using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework.Utilities;
@@ -24,6 +27,13 @@ namespace TestPlatform.Common.UnitTests.ExtensionFramework;
 [TestClass]
 public class TestPluginDiscovererTests
 {
+    [TestCleanup]
+    public void Cleanup()
+    {
+        // The plugin cache is a process wide singleton and one of the tests below clears it.
+        TestPluginCacheHelper.ResetExtensionsCache();
+    }
+
     [TestMethod]
     public void GetTestExtensionsInformationShouldNotThrowOnALoadException()
     {
@@ -176,6 +186,82 @@ public class TestPluginDiscovererTests
         Assert.IsEmpty(messages);
     }
 
+    [TestMethod]
+    public void GetTestExtensionsInformationShouldWarnAgainAfterTheExtensionCacheIsCleared()
+    {
+        var extension = GetPathToExtensionThatCannotBeLoaded();
+
+        var messages = CaptureSessionMessages(() =>
+        {
+            var paths = new List<string> { extension };
+
+            TestPluginDiscoverer.GetTestExtensionsInformation<TestLoggerPluginInformation, ITestLogger>(paths);
+
+            // This is what the runner does before every discovery or run request. Reporting once per run has to
+            // mean once per run even in an editor that keeps the runner alive across many of them, otherwise the
+            // user is told about a broken extension once and never again.
+            TestPluginCache.Instance.ClearExtensions();
+
+            TestPluginDiscoverer.GetTestExtensionsInformation<TestLoggerPluginInformation, ITestLogger>(paths);
+        });
+
+        Assert.HasCount(2, messages);
+    }
+
+    [TestMethod]
+    public void GetTestExtensionsInformationShouldWarnOnlyOnceForTheSameExtensionWhenTheCasingDiffers()
+    {
+        var extension = GetPathToExtensionThatCannotBeLoaded();
+
+        var messages = CaptureSessionMessages(() =>
+        {
+            // On Windows those two paths are the same file, and a second warning about it tells the user
+            // nothing they cannot already see in the first.
+            TestPluginDiscoverer.GetTestExtensionsInformation<TestLoggerPluginInformation, ITestLogger>(new List<string> { extension });
+            TestPluginDiscoverer.GetTestExtensionsInformation<TestLoggerPluginInformation, ITestLogger>(new List<string> { extension.ToUpperInvariant() });
+        });
+
+        Assert.ContainsSingle(messages);
+    }
+
+    [TestMethod]
+    public void GetTestExtensionsFromAssemblyShouldNotWarnWhenOnlySomeTypesFailToLoad()
+    {
+        var filePath = GetPathToExtensionThatCannotBeLoaded();
+        var assembly = new PartiallyLoadedAssembly(typeof(ValidDiscoverer), null);
+        var pluginInfos = new Dictionary<string, TestDiscovererPluginInformation>();
+
+        var messages = CaptureSessionMessages(
+            () => TestPluginDiscoverer.GetTestExtensionsFromAssembly<TestDiscovererPluginInformation, ITestDiscoverer>(assembly, pluginInfos, filePath, reportFailures: true));
+
+        // Adapters that reference an older ObjectModel throw this on a run that is otherwise completely fine,
+        // see https://github.com/microsoft/vstest/issues/290. Warning here would put a warning on green runs.
+        Assert.IsEmpty(messages);
+
+        // And the types that did load are still discovered.
+        var expected = new TestDiscovererPluginInformation(typeof(ValidDiscoverer));
+        Assert.IsTrue(pluginInfos.ContainsKey(expected.IdentifierData!));
+    }
+
+    [TestMethod]
+    public void GetTestExtensionsFromAssemblyShouldWarnWithTheReasonWhenNoTypeLoads()
+    {
+        var filePath = GetPathToExtensionThatCannotBeLoaded();
+        var assembly = new PartiallyLoadedAssembly();
+        var pluginInfos = new Dictionary<string, TestDiscovererPluginInformation>();
+
+        var messages = CaptureSessionMessages(
+            () => TestPluginDiscoverer.GetTestExtensionsFromAssembly<TestDiscovererPluginInformation, ITestDiscoverer>(assembly, pluginInfos, filePath, reportFailures: true));
+
+        var message = messages.Single();
+        Assert.AreEqual(TestMessageLevel.Warning, message.Level);
+        Assert.Contains(filePath, message.Message);
+
+        // The whole point of the message is to say which dependency is missing, instead of telling the user to
+        // re-run with /diag.
+        Assert.Contains(MissingDependencyName, message.Message);
+    }
+
     /// <summary>
     /// A file that is guaranteed to not be loadable, and that no other test has reported yet.
     /// </summary>
@@ -201,6 +287,36 @@ public class TestPluginDiscovererTests
     }
 
     #region Implementations
+
+    private const string MissingDependencyName = "Microsoft.Bcl.AsyncInterfaces";
+
+    /// <summary>
+    /// An assembly that loaded but whose types did not, the way a real adapter behaves when one of its
+    /// dependencies is missing. <see cref="ReflectionTypeLoadException.Types"/> holds null for every type that
+    /// failed, so passing no type at all stands for an assembly nothing could be loaded from.
+    /// </summary>
+    private sealed class PartiallyLoadedAssembly : Assembly
+    {
+        private readonly Type?[] _loadedTypes;
+
+        public PartiallyLoadedAssembly(params Type?[] loadedTypes) => _loadedTypes = loadedTypes;
+
+        public override string FullName => "PartiallyLoadedAssembly, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null";
+
+        public override Type[] GetTypes()
+            => throw new ReflectionTypeLoadException(
+                _loadedTypes,
+                new Exception[] { new FileNotFoundException($"Could not load file or assembly '{MissingDependencyName}, Version=9.0.0.8, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'. The system cannot find the file specified.") });
+
+        public override Type? GetType(string name, bool throwOnError, bool ignoreCase) => null;
+
+        // These have to hand back an Attribute[], the reflection helpers cast the result back to one.
+        public override object[] GetCustomAttributes(bool inherit) => Array.Empty<Attribute>();
+
+        public override object[] GetCustomAttributes(Type attributeType, bool inherit) => Array.Empty<Attribute>();
+
+        public override bool IsDefined(Type attributeType, bool inherit) => false;
+    }
 
     #region Discoverers
 

--- a/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginDiscovererTests.cs
+++ b/test/Microsoft.TestPlatform.Common.UnitTests/ExtensionFramework/TestPluginDiscovererTests.cs
@@ -11,6 +11,7 @@ using System.Xml;
 using Microsoft.VisualStudio.TestPlatform.Common.DataCollector;
 using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
 using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework.Utilities;
+using Microsoft.VisualStudio.TestPlatform.Common.Logging;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
@@ -131,6 +132,72 @@ public class TestPluginDiscovererTests
         _ = TestPluginDiscoverer.GetTestExtensionsInformation<FaultyTestExecutorPluginInformation, ITestExecutor>(pathToExtensions);
 
         _ = TestPluginDiscoverer.GetTestExtensionsInformation<FaultyTestExecutorPluginInformation, ITestExecutor>(pathToExtensions);
+    }
+
+    [TestMethod]
+    public void GetTestExtensionsInformationShouldWarnWhenAnExtensionCannotBeLoaded()
+    {
+        var extension = GetPathToExtensionThatCannotBeLoaded();
+
+        var messages = CaptureSessionMessages(
+            () => TestPluginDiscoverer.GetTestExtensionsInformation<TestLoggerPluginInformation, ITestLogger>(new List<string> { extension }));
+
+        var message = messages.Single();
+        Assert.AreEqual(TestMessageLevel.Warning, message.Level);
+        Assert.Contains(extension, message.Message);
+    }
+
+    [TestMethod]
+    public void GetTestExtensionsInformationShouldWarnOnlyOnceForTheSameExtension()
+    {
+        var extension = GetPathToExtensionThatCannotBeLoaded();
+
+        var messages = CaptureSessionMessages(() =>
+        {
+            var paths = new List<string> { extension };
+
+            // The same file is scanned once per extension type we look for, the user should hear about it once.
+            TestPluginDiscoverer.GetTestExtensionsInformation<TestLoggerPluginInformation, ITestLogger>(paths);
+            TestPluginDiscoverer.GetTestExtensionsInformation<TestDiscovererPluginInformation, ITestDiscoverer>(paths);
+            TestPluginDiscoverer.GetTestExtensionsInformation<TestExecutorPluginInformation, ITestExecutor>(paths);
+        });
+
+        Assert.ContainsSingle(messages);
+    }
+
+    [TestMethod]
+    public void GetTestExtensionsInformationShouldNotWarnWhenProbingForKnownExtensions()
+    {
+        // With no extension paths we probe for a few well known extensions that are usually not present,
+        // failing to load those is expected and must stay invisible to the user.
+        var messages = CaptureSessionMessages(
+            () => TestPluginDiscoverer.GetTestExtensionsInformation<TestLoggerPluginInformation, ITestLogger>(new List<string>()));
+
+        Assert.IsEmpty(messages);
+    }
+
+    /// <summary>
+    /// A file that is guaranteed to not be loadable, and that no other test has reported yet.
+    /// </summary>
+    private static string GetPathToExtensionThatCannotBeLoaded()
+        => $"ThisExtensionCannotBeLoaded{Guid.NewGuid():N}.dll";
+
+    private static List<TestRunMessageEventArgs> CaptureSessionMessages(Action action)
+    {
+        var messages = new List<TestRunMessageEventArgs>();
+        void OnTestRunMessage(object? sender, TestRunMessageEventArgs args) => messages.Add(args);
+
+        TestSessionMessageLogger.Instance.TestRunMessage += OnTestRunMessage;
+        try
+        {
+            action();
+        }
+        finally
+        {
+            TestSessionMessageLogger.Instance.TestRunMessage -= OnTestRunMessage;
+        }
+
+        return messages;
     }
 
     #region Implementations


### PR DESCRIPTION
Only `FileLoadException` reached the user. Every other reason a file could not be loaded - `BadImageFormatException`, a missing dependency, a wrong target framework - went to the diag log only, so the extension was silently missing and the tests it provides silently did not run. That is the worst failure mode we have: a green run that ran nothing.

Now any failure to load an extension file is a warning, and it carries the reason instead of only pointing at `/diag`:

```
Failed to load extensions from file 'C:\repro\Broken.TestAdapter.dll'. Reason: Could not load file or assembly 'Broken.TestAdapter' or one of its dependencies. The system cannot find the file specified.
```

An assembly where `GetTypes` throws and not a single type comes out is reported the same way. When some types do load we stay quiet - the extension usually still works, and the types that failed are usually not extensions at all. That is deliberate, #290 was about exactly that noise.

Two things keep it quiet in normal runs:

- The same file is scanned once per extension type we look for (adapters, loggers, data collectors, settings providers). The warning is emitted once per file, not four times.
- The two C++ UWP files we probe for when there are no extension paths at all are not expected to be present, so failing to load them reports nothing.

The warning is once per run, not once per process. It used to be deduplicated on `UnloadableFiles`, which is static and never cleared, so in design mode, where an editor keeps the runner alive across many discovery and run requests, the user heard about a broken extension on the first request and then never again. `UnloadableFiles` now answers only whether loading the file is worth another try, a separate `ReportedFiles` answers whether the user has already seen the warning, and `ClearExtensions()` empties both. The runner calls that before every discovery and run request. Clearing the first one also means an extension whose missing dependency has since appeared is tried again on the next request, instead of staying skipped until the process exits.

I also split the assembly load from the assembly inspection in `GetTestExtensionsFromFiles`. Before, one `catch` covered both, so a broken `TestPluginInformation` constructor looked the same as a file that could not be loaded. Inspection failures stay in the diag log as before.

`FailedToLoadAdapaterFile` is replaced by `FailedToLoadExtensionFile`, which takes the reason. The old string is gone from the resx and the xlf files.

Verified against a real run: a folder with a `Broken.TestAdapter.dll` that is not a managed assembly prints the warning once through `vstest.console /lt`, and the same run without it prints no new warnings.

Added tests for the warning, for the once-per-file behavior, for reporting again after the extension cache is cleared, for the casing of the path, for staying quiet on a partial type load, and for the probe files staying quiet.

Supersedes #16382, which fixed the same issue. Its once-per-run reset and its casing test are carried over here.

🤖