### PR TITLE
Stop the discovery manager factory from shadowing discoveryCriteria

### DIFF
--- a/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
@@ -119,9 +119,10 @@ public class TestEngine : ITestEngine
         // other managers.
         var discoveryDataAggregator = new DiscoveryDataAggregator();
 
-        // The criteria handed to this creator is not the discoveryCriteria this method received. ParallelProxyDiscoveryManager
-        // splits the overall criteria into per-workload pieces (SplitToWorkloads), normally a single source each, and passes
-        // that piece here. Read the sources from the criteria we are given, not from the overall one.
+        // The criteria handed to this creator is not the same as the discoveryCriteria this method received.
+        // ParallelProxyDiscoveryManager splits the overall criteria into per-workload pieces (SplitToWorkloads),
+        // normally a single source each, and passes that piece here. Read the sources from the criteria we are
+        // given, not from the overall one.
         Func<TestRuntimeProviderInfo, DiscoveryCriteria, IProxyDiscoveryManager> proxyDiscoveryManagerCreator = (runtimeProviderInfo, workloadCriteria) =>
         {
             var sources = workloadCriteria.Sources.ToList();

--- a/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
+++ b/src/Microsoft.TestPlatform.CrossPlatEngine/TestEngine.cs
@@ -118,9 +118,13 @@ public class TestEngine : ITestEngine
         // discovery manager to publish its current state. But doing so we are losing the collected state of all the
         // other managers.
         var discoveryDataAggregator = new DiscoveryDataAggregator();
-        Func<TestRuntimeProviderInfo, DiscoveryCriteria, IProxyDiscoveryManager> proxyDiscoveryManagerCreator = (runtimeProviderInfo, discoveryCriteria) =>
+
+        // The criteria handed to this creator is not the discoveryCriteria this method received. ParallelProxyDiscoveryManager
+        // splits the overall criteria into per-workload pieces (SplitToWorkloads), normally a single source each, and passes
+        // that piece here. Read the sources from the criteria we are given, not from the overall one.
+        Func<TestRuntimeProviderInfo, DiscoveryCriteria, IProxyDiscoveryManager> proxyDiscoveryManagerCreator = (runtimeProviderInfo, workloadCriteria) =>
         {
-            var sources = discoveryCriteria.Sources.ToList();
+            var sources = workloadCriteria.Sources.ToList();
             var hostManager = _testHostProviderManager.GetTestHostManagerByRunConfiguration(runtimeProviderInfo.RunSettings, sources);
 
             // A runtime provider may host the run over its own protocol (e.g. Microsoft.Testing.Platform's


### PR DESCRIPTION
The factory lambda in `TestEngine.GetDiscoveryManager` named its parameter `discoveryCriteria`, the same name as the method parameter, but the two hold different data. The method receives the full criteria with every source. The lambda receives the per-workload piece that `ParallelProxyDiscoveryManager.SplitToWorkloads` produces, normally a single source. Rename the lambda parameter to `workloadCriteria` and add a comment saying which of the two arrives there.

`GetExecutionManager` in the same file already does this — its lambda parameter is `runCriteria` and a comment explains the split.

No behaviour change. The lambda still reads sources from the criteria it is handed.

Related: #16386. The repeated enumeration that issue reports does not exist — `Sources` is read once in the method and once per workload inside the lambda, on two different objects. The fix it proposes, hoisting the outer `Sources` into a shared local, would pass every source to `GetTestHostManagerByRunConfiguration` for every parallel slot instead of that slot's own source. The shadowing is what made that look correct, and this change removes it. It does not fix the issue, because there is nothing there to fix.

Verified: `build.cmd -c Release` compiles clean, `Microsoft.TestPlatform.CrossPlatEngine.UnitTests` passes on net11.0 and net481.

🤖
