### PR TITLE
docs: fix typo explicitely -> explicitly

### DIFF
--- a/docs/analyze.md
+++ b/docs/analyze.md
@@ -132,7 +132,7 @@ below runsettings:
 </RunSettings>
 ```
 
-A specific DataCollector can be explicitely enabled using the `/collect:<friendly name>` command line switch.
+A specific DataCollector can be explicitly enabled using the `/collect:<friendly name>` command line switch.
 
 For example, below command line will enable a DataCollector named `MyDataCollector1`
 (and disable other DataCollectors mentioned in .runsettings):


### PR DESCRIPTION
One-word typo fix in `docs/analyze.md:135`: "A specific DataCollector can be explicitely..." -> "explicitly".

I left the matching spellings in `docs/RFCs/` and `docs/releases.md` alone, since those are historical records.
