### PR TITLE
[rel/18.7] Remove dead DotNet-VSTS-Infra-Access variable group reference

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -91,8 +91,6 @@ variables:
     - name: Codeql.Cadence 
       value: 0
 
-  # Group gives access to $dn-bot-devdiv-drop-rw-code-rw and dn-bot-dnceng-build-rw-code-rw
-  - group: DotNet-VSTS-Infra-Access
   # DevDiv drop access token is acquired via WIF service connection (dnceng-devdiv-drop-rw-code-rw-wif)
   - name: _DevDivDropAccessToken
     value: ''


### PR DESCRIPTION
Backport of [microsoft/vstest#16203](https://github.com/microsoft/vstest/pull/16203) (commit fdd72c52801887e61c69c91e93abdb655723176b) from `main` to `rel/18.7`. Same change as [microsoft/vstest#16269](https://github.com/microsoft/vstest/pull/16269) on `rel/18.8` and [microsoft/vstest#16357](https://github.com/microsoft/vstest/pull/16357) on `rel/18.9`.

## Root cause

`azure-pipelines-official.yml` on `rel/18.7` still has an unconditional, root-level reference to the `DotNet-VSTS-Infra-Access` variable group. Root-level variable groups are resolved during YAML compilation, so a group that is gone makes the whole pipeline fail to load, before any job runs. It is not a step failure, there is no log to read.

That group only held the DevDiv drop PAT, which was migrated to WIF in [microsoft/vstest#15792](https://github.com/microsoft/vstest/pull/15792) (service connection `dnceng-devdiv-drop-rw-code-rw-wif`). The PAT is expired and the group is no longer available, so the reference is dead weight.

## Change

Removes the two dead lines from the root `variables:` block:

```yaml
  # Group gives access to $dn-bot-devdiv-drop-rw-code-rw and dn-bot-dnceng-build-rw-code-rw
  - group: DotNet-VSTS-Infra-Access
```

The `# DevDiv drop access token is acquired via WIF service connection (...)` comment below it and the `_DevDivDropAccessToken` variable (empty value) are left untouched. The diff is identical to the patch on `main`.

## Why now

To be clear, this branch has not produced a failed build. Nothing has flowed into `rel/18.7` yet, so nothing has tried to compile the YAML. This is preventive: the official pipeline cannot load from this branch in its current state, and I would rather not discover that when an 18.7 servicing fix needs to ship in a hurry.

## Verification

`git grep` for `DotNet-VSTS-Infra-Access`, `dn-bot-devdiv-drop` and `dn-bot-dnceng-build-rw-code-rw` on this branch returns nothing after the change, so nothing consumed variables that only this group provided. `git diff --stat` is 1 file changed, 2 deletions. Pipeline YAML only, no build or test impact.

🤖
