### PR TITLE
[rel/18.6] Remove dead DotNet-VSTS-Infra-Access variable group reference

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -91,8 +91,6 @@ variables:
     - name: Codeql.Cadence 
       value: 0
 
-  # Group gives access to $dn-bot-devdiv-drop-rw-code-rw and dn-bot-dnceng-build-rw-code-rw
-  - group: DotNet-VSTS-Infra-Access
   # DevDiv drop access token is acquired via WIF service connection (dnceng-devdiv-drop-rw-code-rw-wif)
   - name: _DevDivDropAccessToken
     value: ''


### PR DESCRIPTION
Backport of [#16203](https://github.com/microsoft/vstest/pull/16203) / commit `fdd72c52801887e61c69c91e93abdb655723176b` from `main` to `rel/18.6`, matching [#16269](https://github.com/microsoft/vstest/pull/16269) on `rel/18.8` and [#16357](https://github.com/microsoft/vstest/pull/16357) on `rel/18.9`.

## Symptom

The official pipeline cannot load from `rel/18.6` at all. The build ends after zero seconds with no timeline and no logs, because it fails during YAML compilation:

> An error occurred while loading the YAML build pipeline. Variable group was not found or is not authorized for use.

## Root cause

`azure-pipelines-official.yml` on `rel/18.6` still has an unconditional, root-level reference to the `DotNet-VSTS-Infra-Access` variable group. Root-level variable groups are resolved during YAML compilation, so a missing group makes the whole pipeline fail to load instead of failing a single step.

That group only held the `dn-bot-devdiv-drop-r-code-r` PAT, which was migrated to WIF (service connection `dnceng-devdiv-drop-rw-code-rw-wif`) by [#15792](https://github.com/microsoft/vstest/pull/15792). The group has since been deleted, so the reference is dead.

## Change

Removes the two dead lines from the root `variables:` block:

```yaml
  # Group gives access to $dn-bot-devdiv-drop-rw-code-rw and dn-bot-dnceng-build-rw-code-rw
  - group: DotNet-VSTS-Infra-Access
```

The following `# DevDiv drop access token is acquired via WIF service connection (dnceng-devdiv-drop-rw-code-rw-wif)` comment and the `_DevDivDropAccessToken` variable are left untouched. The diff is byte-identical to `2b12a89cee` restricted to this file.

## Verification

- `git grep DotNet-VSTS-Infra-Access`, `git grep dn-bot-devdiv-drop` and `git grep dn-bot-dnceng-build-rw-code-rw` all come back empty on this branch, so nothing consumed a variable that only this group provided.
- No build or test impact, this is pipeline YAML only.

One honest caveat: this unblocks YAML loading, it does not promise a green build. The last build that did compile from `rel/18.6` was back in July, and it then failed in secret download, SDL source analysis and managed source-build. Those steps come from the 1ES pipeline template rather than from this repo, and the template has moved on since. None of that can be looked at while the pipeline refuses to compile.

🤖
