### PR TITLE
Skip the diagnostic test results publish when there is nothing to publish

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -202,6 +202,15 @@ extends:
                 env:
                   DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
 
+              # The test results folder is not produced when the job fails before any test runs,
+              # and publishing a missing path would report a second, misleading failure.
+              - pwsh: |
+                  $dir = "$(Build.SourcesDirectory)/artifacts/TestResults/Release"
+                  $hasFiles = (Test-Path -LiteralPath $dir) -and (@(Get-ChildItem -LiteralPath $dir -File -Recurse -ErrorAction SilentlyContinue).Count -gt 0)
+                  Write-Host "##vso[task.setvariable variable=HasTestResults]$($hasFiles.ToString().ToLowerInvariant())"
+                displayName: 'Check for Test Results folders'
+                condition: failed()
+
               # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
               # through the console or trx
               - task: 1ES.PublishBuildArtifacts@1
@@ -209,7 +218,7 @@ extends:
                 inputs:
                   PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/Release'
                   ArtifactName: TestResults
-                condition: failed()
+                condition: and(failed(), eq(variables['HasTestResults'], 'true'))
               
               # Remove generated test projects from the compatibility matrix because they use older versions of our packages
               # and some of them use dependencies that are now vulnerable.
@@ -277,6 +286,15 @@ extends:
                     }
                   displayName: Remove artifacts/tmp/GeneratedTestAssets
 
+                # The test results folder is not produced when the job fails before any test runs,
+                # and publishing a missing path would report a second, misleading failure.
+                - pwsh: |
+                    $dir = "$(Build.SourcesDirectory)/artifacts/TestResults/Release"
+                    $hasFiles = (Test-Path -LiteralPath $dir) -and (@(Get-ChildItem -LiteralPath $dir -File -Recurse -ErrorAction SilentlyContinue).Count -gt 0)
+                    Write-Host "##vso[task.setvariable variable=HasTestResults]$($hasFiles.ToString().ToLowerInvariant())"
+                  displayName: 'Check for Test Results folders'
+                  condition: failed()
+
                 # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
                 # through the console or trx
                 - task: 1ES.PublishBuildArtifacts@1
@@ -284,7 +302,7 @@ extends:
                   inputs:
                     PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/Release'
                     ArtifactName: TestResults
-                  condition: failed()
+                  condition: and(failed(), eq(variables['HasTestResults'], 'true'))
           
           - job: Publish
             dependsOn:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,6 +118,15 @@ stages:
           env:
             DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
 
+        # The test results folder is not produced when the job fails before any test runs,
+        # and publishing a missing path would report a second, misleading failure.
+        - pwsh: |
+            $dir = "$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)"
+            $hasFiles = (Test-Path -LiteralPath $dir) -and (@(Get-ChildItem -LiteralPath $dir -File -Recurse -ErrorAction SilentlyContinue).Count -gt 0)
+            Write-Host "##vso[task.setvariable variable=HasTestResults]$($hasFiles.ToString().ToLowerInvariant())"
+          displayName: 'Check for Test Results folders'
+          condition: failed()
+
         # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
         # through the console or trx
         - task: PublishBuildArtifacts@1
@@ -125,7 +134,7 @@ stages:
           inputs:
             PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
             ArtifactName: TestResults
-          condition: failed()
+          condition: and(failed(), eq(variables['HasTestResults'], 'true'))
 
         - task: PublishBuildArtifacts@1
           displayName: 'Publish Shipping Packages'
@@ -204,6 +213,15 @@ stages:
           env:
             DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
 
+        # The test results folder is not produced when the job fails before any test runs,
+        # and publishing a missing path would report a second, misleading failure.
+        - pwsh: |
+            $dir = "$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)"
+            $hasFiles = (Test-Path -LiteralPath $dir) -and (@(Get-ChildItem -LiteralPath $dir -File -Recurse -ErrorAction SilentlyContinue).Count -gt 0)
+            Write-Host "##vso[task.setvariable variable=HasTestResults]$($hasFiles.ToString().ToLowerInvariant())"
+          displayName: 'Check for Test Results folders'
+          condition: failed()
+
         # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
         # through the console or trx
         - task: PublishBuildArtifacts@1
@@ -211,4 +229,4 @@ stages:
           inputs:
             PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
             ArtifactName: TestResults
-          condition: failed()
+          condition: and(failed(), eq(variables['HasTestResults'], 'true'))


### PR DESCRIPTION
The `Publish Test Results folders` steps run on `condition: failed()`, so they only run when the job has already failed. When a job fails before any test runs, `artifacts/TestResults` was never created and the publish task fails on the missing path:

```
##[error]Publishing build artifacts failed with an error: Not found PathtoPublish: D:\a\_work\1\s\artifacts\TestResults\Release
```

That happened in [build 3055759](https://dev.azure.com/dnceng/internal/_build/results?buildId=3055759), where the Windows job died at `Restore internal tools` and so never got to `Build`, `Unit Test` or `Integration Test`. The build reports two failed steps, and the second one is a diagnostic step complaining about a folder that could not exist yet, which sends whoever triages the build to the wrong place. The actual failure there was a transient MSBuild task host problem that did not repeat on the next build, this does not try to fix that, it only stops the publish step from adding a second error on top of it.

Set a `HasTestResults` variable first and publish only when the folder actually has files in it, the same guard already used for the NonShipping packages in `azure-pipelines.yml`. Four copies of the unguarded step exist, two in each pipeline file.

Verified: both files still parse, and the guard reports `false` for a missing folder, `false` for an empty one and `true` when there are files.

🤖