### PR TITLE
Quote boolean conditions in shipped Microsoft.TestPlatform.targets

### DIFF
--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
@@ -12,8 +12,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Load Microsoft.TestPlatform.Build.Tasks.dll, this can be overridden to use a different version with $(VSTestTaskAssemblyFile) -->
   <PropertyGroup>
-    <VSTestTaskAssemblyFile Condition="$(VSTestTaskAssemblyFile) == ''">Microsoft.TestPlatform.Build.dll</VSTestTaskAssemblyFile>
-    <VSTestConsolePath Condition="$(VSTestConsolePath) == ''">$([System.IO.Path]::Combine($(MSBuildThisFileDirectory),"vstest.console.dll"))</VSTestConsolePath>
+    <VSTestTaskAssemblyFile Condition="'$(VSTestTaskAssemblyFile)' == ''">Microsoft.TestPlatform.Build.dll</VSTestTaskAssemblyFile>
+    <VSTestConsolePath Condition="'$(VSTestConsolePath)' == ''">$([System.IO.Path]::Combine($(MSBuildThisFileDirectory),"vstest.console.dll"))</VSTestConsolePath>
     <VSTestNoBuild Condition="'$(VSTestNoBuild)' == ''">False</VSTestNoBuild>
     <VsTestUseMSBuildOutput Condition="'$(VsTestUseMSBuildOutput)' == ''">False</VsTestUseMSBuildOutput>
   </PropertyGroup>
@@ -30,10 +30,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="VSTest" DependsOnTargets="ShowInfoMessageIfProjectHasNoIsTestProjectProperty">
     <!-- Unloggable colorized output (cf. https://github.com/microsoft/vstest/issues/680) -->
     <!-- Fallback to this old view when terminal logger is not enabled (_MSBUILDTLENABLED==0) , or when user explicitly opts out (VsTestUseMSBuildOutput != true) -->
-    <CallTarget Targets="_VSTestConsole" Condition="$(_MSBUILDTLENABLED) == '0' OR !$(VsTestUseMSBuildOutput) OR $(MSBUILDENSURESTDOUTFORTASKPROCESSES) == '1'" />
+    <CallTarget Targets="_VSTestConsole" Condition="'$(_MSBUILDTLENABLED)' == '0' OR '$(VsTestUseMSBuildOutput)' != 'true' OR '$(MSBUILDENSURESTDOUTFORTASKPROCESSES)' == '1'" />
     <!-- Proper MSBuild integration, but no custom colorization -->
     <!-- Use the new view whe terminal logger is enabled (_MSBUILDTLENABLED==0), and user did not opt out (VsTestUseMSBuildOutput == true) -->
-    <CallTarget Targets="_VSTestMSBuild" Condition="$(_MSBUILDTLENABLED) == '1' AND $(VsTestUseMSBuildOutput)" />
+    <CallTarget Targets="_VSTestMSBuild" Condition="'$(_MSBUILDTLENABLED)' == '1' AND '$(VsTestUseMSBuildOutput)' == 'true'" />
   </Target>
 
   <!--
@@ -42,7 +42,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     the test running. This is used in MSBuild Terminal Logger to detect that the current project will run some tests.
   -->
   <Target Name="_VSTestMSBuild" Condition="'$(IsTestProject)' == 'true'">
-    <CallTarget Condition="!$(VSTestNoBuild)" Targets="BuildProject" />
+    <CallTarget Condition="'$(VSTestNoBuild)' != 'true'" Targets="BuildProject" />
     <CallTarget Targets="_TestRunStart" />
 
     <VSTestTask2

--- a/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
+++ b/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets
@@ -32,7 +32,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Fallback to this old view when terminal logger is not enabled (_MSBUILDTLENABLED==0) , or when user explicitly opts out (VsTestUseMSBuildOutput != true) -->
     <CallTarget Targets="_VSTestConsole" Condition="'$(_MSBUILDTLENABLED)' == '0' OR '$(VsTestUseMSBuildOutput)' != 'true' OR '$(MSBUILDENSURESTDOUTFORTASKPROCESSES)' == '1'" />
     <!-- Proper MSBuild integration, but no custom colorization -->
-    <!-- Use the new view whe terminal logger is enabled (_MSBUILDTLENABLED==0), and user did not opt out (VsTestUseMSBuildOutput == true) -->
+    <!-- Use the new view when terminal logger is enabled (_MSBUILDTLENABLED==1), and user did not opt out (VsTestUseMSBuildOutput == true) -->
     <CallTarget Targets="_VSTestMSBuild" Condition="'$(_MSBUILDTLENABLED)' == '1' AND '$(VsTestUseMSBuildOutput)' == 'true'" />
   </Target>
 


### PR DESCRIPTION
`dotnet test` fails the build when a boolean property holds something that is not a boolean:

```
> dotnet test Repro.csproj -tl:on -p:VSTestNoBuild=1
  Repro net11.0 failed with 1 error(s)
    Microsoft.TestPlatform.targets(45,17): error MSB4100: Expected "$(VSTestNoBuild)" to
    evaluate to a boolean instead of "1", in condition "!$(VSTestNoBuild)".
```

Bare `!$(X)` and `$(X)` in a condition require the value to parse as a boolean, and `1` is not one. Three ways in, all reproduced against the shipped file:

| command | before |
| --- | --- |
| `-p:VSTestNoBuild=1` | MSB4100 at line 45, `!$(VSTestNoBuild)` |
| `-p:VSTestNoBuild=` | MSB4100 at line 45, `!$(VSTestNoBuild)` |
| `-p:VsTestUseMSBuildOutput=1` | MSB4100 at line 33, `!$(VsTestUseMSBuildOutput)` |

`0`/`1` is a reasonable thing for a user to type, and this file already uses it for `_MSBUILDTLENABLED` two lines up, so copying the local idiom walks straight into it. The file ships in `Microsoft.TestPlatform.Build` and backs `dotnet test`, so this fails on the user machine, not on ours.

Compare against `'true'` instead. MSBuild's `==` is boolean aware, so `on`, `yes` and `TRUE` still route the same way. Line 45 now reads `'$(VSTestNoBuild)' != 'true'`, the same as the `_VSTestConsole` call site on line 81.

The two `VSTestTaskAssemblyFile` and `VSTestConsolePath` defaults are quoted for consistency with #16325, not because they were broken. MSBuild parses a condition from the raw string, so those already worked when the property was unset or held a path with spaces.

Verified by installing the built `Microsoft.TestPlatform.targets` into the SDK and running the same commands again. All three MSB4100 failures go away and the tests run; the other paths, including terminal logger on and off, `VsTestUseMSBuildOutput=false` and `MSBUILDENSURESTDOUTFORTASKPROCESSES=1`, produce the same output as before. `MSBuildLoggerCanBeEnabledByBuildPropertyAndDoesNotEatSpecialChars`, `MSBuildLoggerCanBeDisabledByBuildProperty` and `MSBuildLoggerCanBeDisabledByEnvironmentVariableProperty` pass with the new file, and passed before it as the control.

`CopyTraceDataCollectorArtifacts` in `Microsoft.CodeCoverage.targets` has the same problem, but #15794 is rewriting that target, so I left it there.

Fix #16396

🤖
