### PR TITLE
Document protocol version 5 and remove its leftovers

### DIFF
--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -580,7 +580,7 @@ public class DiscoveryRequestPayload
         set;
     }
 
-    // A set of pre-started testhosts that this request should use.
+    // Retained for binary and wire compatibility. Test sessions are no longer supported.
     public TestSessionInfo? TestSessionInfo { get; set; }
 }
 ```
@@ -757,7 +757,7 @@ public class DiscoveryCriteria
     // dependent.
     public string? TestCaseFilter { get; set; }
 
-    // TestSession (pre-started testhosts) on which this discovery should happen.
+    // Retained for binary and wire compatibility. Test sessions are no longer supported.
     public TestSessionInfo? TestSessionInfo { get; set; }
 }
 ```
@@ -1036,7 +1036,7 @@ public class TestRunRequestPayload
     // Test platform options.
     public TestPlatformOptions? TestPlatformOptions { get; set; }
 
-    // The set of pre-started testhosts on which this run should try to run.
+    // Retained for binary and wire compatibility. Test sessions are no longer supported.
     public TestSessionInfo? TestSessionInfo { get; set; }
 }
 ```
@@ -1954,12 +1954,13 @@ The operations you can call on `IVsTestConsoleWrapper` are:
 - `InitializeExtensions(IEnumerable<string> pathToAdditionalExtensions)` - registers extra
   extension DLLs (adapters, loggers, data collectors) by full path before discovery/execution.
 - `DiscoverTests(...)` - discovers tests in the given sources. Overloads accept an optional
-  `TestPlatformOptions` and `TestSessionInfo`, and report results through an
-  `ITestDiscoveryEventsHandler` (legacy) or `ITestDiscoveryEventsHandler2`.
+  `TestPlatformOptions` and report results through an `ITestDiscoveryEventsHandler` (legacy) or
+  `ITestDiscoveryEventsHandler2`. Overloads with `TestSessionInfo` remain for binary compatibility,
+  but test sessions are no longer supported.
 - `RunTests(...)` - runs tests, selected either by `sources` (assemblies) or by an explicit
-  list of `TestCase` objects. Overloads accept `TestPlatformOptions`, a `TestSessionInfo`
-  (to run against a pre-warmed test session), an `ITestRunEventsHandler`, and optionally an
-  `ITelemetryEventsHandler`.
+  list of `TestCase` objects. Overloads accept `TestPlatformOptions`, an `ITestRunEventsHandler`,
+  and optionally an `ITelemetryEventsHandler`. Overloads with `TestSessionInfo` remain for binary
+  compatibility, but test sessions are no longer supported.
 - `RunTestsWithCustomTestHost(...)` - same as `RunTests`, but the testhost process is
   launched by a caller-supplied `ITestHostLauncher`. This is how IDEs attach a debugger to
   the testhost or otherwise control how it is started.

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -138,7 +138,6 @@ The Run workflow described above is very common in command line tools, and proba
 - *Discovery* - discovers tests in given test sources, most commonly .NET dlls.
 - *Run* - runs tests from given libraries (test sources) or from a given list of pre-discovered tests.
 - *Session* - starts the runner and waits for requests.
-- *TestSession* - starts a set of testhosts for given test sources, to make the ready to run.
 - *AttachmentProcessing* - processes a given set of attachments that were produced during a previous test run, e.g. merges code coverage files.
 
 ## Communication Protocol
@@ -328,7 +327,7 @@ Versions:
 - 2: Changed serialization from a generic bag that described each property and its type, to explicit properties that are serialized without additional type info.
 - 3: Added AttachDebugger message.
 - 4: Added because version 3 did not update the serialization to use, and it will use v1 serialization (bag) rather than explicit properties. Right side should avoid negotiating 3 and downgrade to 2.
-- 5: Unknown in the core `ProtocolVersioning` table (the source still marks this version as `// 5: ???`). The TranslationLayer defines a private `MinimumProtocolVersionWithTestSessionSupport = 5` in `VsTestConsoleRequestSender`, but the constant is currently unused, so the exact change associated with v5 is unclear from the current source.
+- 5: Added the test session messages, which pre-started a set of testhosts so a later run could reuse them. The feature was experimental and its messages were removed in [microsoft/vstest#16231](https://github.com/microsoft/vstest/pull/16231), so nothing is gated on this version anymore.
 - 6: Added Abort and Cancel with handlers that report the status.
 - 7: Added SkippedDiscoveredSources.
 
@@ -403,8 +402,6 @@ public enum TestMessageLevel
 ### Session
 
 Session starts the runner process, and connects to it. This is used in two ways. First as a way to pre-start Runner before there is any work for it, this is done for example by Visual Studio to have the runner ready to receive work. Or the flow is run just before other requests (e.g. Discovery).
-
-> ⚠️ Do not confuse this with TestSession workflow that pre-starts testhosts.
 
 #### Start Runner process request (Runner)
 

--- a/docs/stj-migration-v1-v7-comparison.md
+++ b/docs/stj-migration-v1-v7-comparison.md
@@ -2,11 +2,11 @@
 
 ## Summary
 
-**18 messages are IDENTICAL** between V1 and V7 — only the outer envelope changes (V7 adds `"Version": 7`).
+**14 messages are IDENTICAL** between V1 and V7 — only the outer envelope changes (V7 adds `"Version": 7`).
 
 **5 messages are STRUCTURALLY DIFFERENT** — all because they contain `TestCase` and/or `TestResult` objects, which are serialized differently between protocol versions.
 
-## Identical Messages (18)
+## Identical Messages (14)
 
 These payloads are byte-for-byte identical between V1 and V7. The only difference is the message envelope:
 - V1: `{"MessageType":"...","Payload":{...}}`
@@ -28,10 +28,6 @@ These payloads are byte-for-byte identical between V1 and V7. The only differenc
 | AfterTestRunEnd | `bool` | IsCanceled |
 | AfterTestRunEndResult | `AfterTestRunEndResult` | Attachments + metrics |
 | TestHostLaunched | `TestHostLaunchedPayload` | Process ID |
-| StartTestSession | `StartTestSessionPayload` | Session creation |
-| StartTestSessionCallback | `StartTestSessionAckPayload` | Session ack |
-| StopTestSession | `StopTestSessionPayload` | Session teardown |
-| StopTestSessionCallback | `StopTestSessionAckPayload` | Session teardown ack |
 
 ## Different Messages (5)
 

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/ProtocolVersioning.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/ProtocolVersioning.cs
@@ -17,7 +17,8 @@ internal static class ProtocolVersioning
     // 3: introduced because of changes to allow attaching debugger to external process.
     // 4: introduced because 3 did not update this table and ended up using the serializer for protocol v1,
     //    which is extremely slow. We negotiate 2 or 4, but never 3 unless the flag above is set.
-    // 5: ???
+    // 5: added the test session messages, which pre-started a set of testhosts so a later run could
+    //    reuse them. The messages were removed, so nothing is gated on this version anymore.
     // 6: accepts abort and cancel with handlers that report the status.
     /// <summary>
     /// The original protocol with no versioning. It sends and receives a Message that carries just data
@@ -52,6 +53,16 @@ internal static class ProtocolVersioning
     // 4: introduced because 3 did not update this table and ended up using the serializer for protocol v1,
     //    which is extremely slow. We negotiate 2 or 4, but never 3 unless the flag above is set.
     public const int Version4 = 4;
+
+    /// <summary>
+    /// Added the test session messages, which pre-started a set of testhosts so a later run could
+    /// reuse them. Added in https://github.com/microsoft/vstest/pull/2584.
+    /// The feature was experimental, was never finalized, and was removed in
+    /// https://github.com/microsoft/vstest/pull/16231 together with its messages
+    /// (TestSession.StartTestSession, TestSession.StartTestSessionCallback,
+    /// TestSession.StopTestSession, TestSession.StopTestSessionCallback), so nothing is gated on
+    /// this version anymore. The version number stays reserved and negotiable.
+    /// </summary>
     public const int Version5 = 5;
     public const int Version6 = 6;
     public const int Version7 = 7;

--- a/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleRequestSender.cs
+++ b/src/Microsoft.TestPlatform.VsTestConsole.TranslationLayer/VsTestConsoleRequestSender.cs
@@ -29,11 +29,6 @@ namespace Microsoft.TestPlatform.VsTestConsole.TranslationLayer;
 /// </summary>
 internal class VsTestConsoleRequestSender : ITranslationLayerRequestSender
 {
-    /// <summary>
-    /// The minimum protocol version that has test session support.
-    /// </summary>
-    private const int MinimumProtocolVersionWithTestSessionSupport = 5;
-
     private readonly ICommunicationManager _communicationManager;
     private readonly IDataSerializer _dataSerializer;
     private readonly ITestPlatformEventSource _testPlatformEventSource;

--- a/test/TranslationLayer.UnitTests/VsTestConsoleRequestSenderTests.cs
+++ b/test/TranslationLayer.UnitTests/VsTestConsoleRequestSenderTests.cs
@@ -2303,12 +2303,6 @@ public class VsTestConsoleRequestSenderTests
 
     #endregion
 
-    #region Sessions API
-    private const int MinimumProtocolVersionWithTestSessionSupport = 5;
-    private const int TesthostPid = 5000;
-
-    #endregion
-
     #region Private Methods
 
     /// <summary>


### PR DESCRIPTION
`ProtocolVersioning.cs` said `// 5: ???` and `docs/Overview.md` said version 5 was unknown, but the answer is recoverable. Version 5 added the test session messages in [microsoft/vstest#2584](https://github.com/microsoft/vstest/pull/2584), and [microsoft/vstest#16231](https://github.com/microsoft/vstest/pull/16231) removed that feature end to end, including all four of those messages. So nothing is gated on version 5 anymore. The `Version5` constant stays, because 5 is still a negotiable value on the wire, it just gets a comment that says what it was and where it went.

The removal also left three dead things behind, which this deletes: an unused private `MinimumProtocolVersionWithTestSessionSupport` in `VsTestConsoleRequestSender`, an empty `Sessions API` region in `VsTestConsoleRequestSenderTests` holding two unused constants, and the *TestSession* workflow bullet in `docs/Overview.md` together with the warning that pointed at it.

Task 3 of [microsoft/vstest#16406](https://github.com/microsoft/vstest/issues/16406) asks for `MinimumProtocolVersionWithTestSessionSupport` to be enforced. This deletes it instead. There is no test session code left to gate, so a version check there would guard nothing. `TestSessionInfo` and the live `TestSession.Message`, `TestSession.Connected` and `TestSession.Terminate` messages are untouched, they are a different thing from the removed workflow.

Tasks 2, 4 and 5 of that issue are left alone. The `DesignModeClient` v3 downgrade asymmetry is real, but that channel is vstest.console answering Visual Studio and changing it is a compatibility call, not a cleanup.

Verified: Release build produces the same warnings as the unmodified branch, and `TranslationLayer.UnitTests` passes with the same 107 tests.

🤖
