### PR TITLE
Ship Microsoft.NET.Test.Sdk.props at the buildMultiTargeting root

### DIFF
--- a/eng/expected-nupkg-file-counts.json
+++ b/eng/expected-nupkg-file-counts.json
@@ -1,6 +1,6 @@
 {
   "Microsoft.CodeCoverage": 81,
-  "Microsoft.NET.Test.Sdk": 26,
+  "Microsoft.NET.Test.Sdk": 21,
   "Microsoft.TestPlatform": 540,
   "Microsoft.TestPlatform.AdapterUtilities": 66,
   "Microsoft.TestPlatform.Build": 22,

--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -17,6 +17,15 @@ Add-Type -AssemblyName System.IO.Compression.FileSystem
 $isCI = $env:TF_BUILD -eq 'true' -or $env:CI -eq 'true'
 $expectedCountsFile = Join-Path $PSScriptRoot "expected-nupkg-file-counts.json"
 
+# Files that must sit at an exact path inside a package, on top of the plain file count.
+# A file that moves between folders keeps the count identical, so the count check cannot see it.
+$expectedPackagePaths = @{
+    # NuGet imports buildMultiTargeting/<PackageId>.props into the outer build of a multi-targeting
+    # project. The outer build has no TargetFramework, so a copy under buildMultiTargeting/<tfm>/ is
+    # never read and the test project properties never get set (issue #15309).
+    "Microsoft.NET.Test.Sdk" = @("buildMultiTargeting/Microsoft.NET.Test.Sdk.props")
+}
+
 # Import binding redirect verification.
 . "$PSScriptRoot/verify-binding-redirects.ps1"
 
@@ -92,6 +101,7 @@ function Verify-Nuget-Packages {
 
     Write-Host "Verify NuGet packages files."
     $errors = @()
+    $layoutErrors = @()
     $actualCounts = @{}
     $hasCountMismatch = $false
     foreach ($unzipNugetPackageDir in $unzipNugetPackageDirs) {
@@ -114,9 +124,18 @@ function Verify-Nuget-Packages {
             $hasCountMismatch = $true
         }
 
+        $layoutErrors += Verify-PackageLayout -packageKey $packageKey -nugetDir $unzipNugetPackageDir
+
         if ($packageKey -eq "Microsoft.TestPlatform") {
             Verify-Version -nugetDir $unzipNugetPackageDir -errors $errors
         }
+    }
+
+    # Reported on its own, and not folded into the count errors above: locally a count mismatch is
+    # auto-fixed by rewriting the expected counts file, and a layout error must not be swallowed
+    # along with it.
+    if ($layoutErrors) {
+        Write-Error "There are $($layoutErrors.Count) package layout errors:`n$($layoutErrors -join "`n")"
     }
 
     if ($hasCountMismatch) {
@@ -219,6 +238,38 @@ function Verify-Version {
     $vsTestProductVersion = (Get-Item $vsTestExe).VersionInfo.ProductVersion
 
     Match-VersionAgainstBranch -vsTestVersion $vsTestProductVersion -branchName $currentBranch -errors $errors
+}
+
+# Verifies where files sit inside a package, which the file count cannot do: moving a file from one
+# folder to another leaves the count unchanged. Returns the errors it found.
+function Verify-PackageLayout {
+    param ([string] $packageKey, [string] $nugetDir)
+
+    $errs = @()
+    $packageRoot = (Resolve-Path -LiteralPath $nugetDir).Path
+
+    foreach ($relativePath in $expectedPackagePaths[$packageKey]) {
+        $fullPath = Join-Path $packageRoot ($relativePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+        if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
+            $errs += "Package '$packageKey' is missing '$relativePath'. Check the PackagePath of the matching None item in the package project."
+        }
+    }
+
+    # NuGet only reads buildMultiTargeting files that sit at the folder root, because the outer build
+    # of a multi-targeting project has no TargetFramework to resolve a subfolder against. A file in a
+    # subfolder there ships but is never imported.
+    $multiTargetingDir = Join-Path $packageRoot "buildMultiTargeting"
+    if (Test-Path -LiteralPath $multiTargetingDir -PathType Container) {
+        $multiTargetingRoot = (Resolve-Path -LiteralPath $multiTargetingDir).Path
+        foreach ($file in @(Get-ChildItem -LiteralPath $multiTargetingDir -Recurse -File)) {
+            if ($file.Directory.FullName -ne $multiTargetingRoot) {
+                $packageRelativePath = $file.FullName.Substring($packageRoot.Length + 1).Replace([System.IO.Path]::DirectorySeparatorChar, '/')
+                $errs += "Package '$packageKey' ships '$packageRelativePath' in a buildMultiTargeting subfolder, where NuGet never imports it. Move it to the buildMultiTargeting root, or to build/<tfm>/."
+            }
+        }
+    }
+
+    $errs
 }
 
 function Verify-NugetPackageExe {

--- a/src/package/Microsoft.NET.Test.Sdk/Microsoft.NET.Test.Sdk.csproj
+++ b/src/package/Microsoft.NET.Test.Sdk/Microsoft.NET.Test.Sdk.csproj
@@ -48,12 +48,22 @@
        The root .props goes to every TFM folder; the .targets vary by TFM:
          - net8.0   uses netcoreapp\Microsoft.NET.Test.Sdk.targets and the Program.* launcher files
          - net462   uses netfx\Microsoft.NET.Test.Sdk.targets
-         - netcoreapp2.0 / netstandard2.0 use the root Microsoft.NET.Test.Sdk.targets (incompatibility shim) -->
+         - netcoreapp2.0 / netstandard2.0 use the root Microsoft.NET.Test.Sdk.targets (incompatibility shim)
+
+       buildMultiTargeting gets the .props at the folder root, and nothing else. NuGet imports
+       buildMultiTargeting/$(PackageId).props|.targets into the outer build of a multi-targeting
+       project, and the outer build has no $(TargetFramework) to resolve a TFM subfolder against,
+       so anything under buildMultiTargeting/<tfm>/ is never read. That is why the outer build sees
+       no IsTestProject and pack produces a package for test projects (issue #15309).
+
+       No .targets goes there on purpose: the root Microsoft.NET.Test.Sdk.targets is the
+       unsupported-TFM shim, and its InitialTargets error is unconditional, so it would fail every
+       outer build. -->
   <ItemGroup>
     <!-- props (same file for all frameworks). Forward slashes: MSBuild Pack only treats a trailing OS directory
          separator as a folder marker, so a trailing '\' is honored on Windows but not on Linux (the VMR vertical
          build), where the files would be mis-placed (NU5129). '/' is a directory separator on both. -->
-    <None Include="Microsoft.NET.Test.Sdk.props" Pack="true" PackagePath="build/net8.0/;build/net462/;build/netcoreapp2.0/;build/netstandard2.0/;buildMultiTargeting/net8.0/;buildMultiTargeting/net462/;buildMultiTargeting/netcoreapp2.0/;buildMultiTargeting/netstandard2.0/" />
+    <None Include="Microsoft.NET.Test.Sdk.props" Pack="true" PackagePath="build/net8.0/;build/net462/;build/netcoreapp2.0/;build/netstandard2.0/;buildMultiTargeting/" />
 
     <!-- net8.0 targets + launcher program files -->
     <None Include="netcoreapp\Microsoft.NET.Test.Sdk.targets" Pack="true" PackagePath="build/net8.0/" />
@@ -65,7 +75,7 @@
     <None Include="netfx\Microsoft.NET.Test.Sdk.targets" Pack="true" PackagePath="build/net462/" />
 
     <!-- netcoreapp2.0 / netstandard2.0 incompatibility-shim targets (root targets file) -->
-    <None Include="Microsoft.NET.Test.Sdk.targets" Pack="true" PackagePath="build/netcoreapp2.0/;build/netstandard2.0/;buildMultiTargeting/netcoreapp2.0/;buildMultiTargeting/netstandard2.0/" />
+    <None Include="Microsoft.NET.Test.Sdk.targets" Pack="true" PackagePath="build/netcoreapp2.0/;build/netstandard2.0/" />
 
     <!-- Empty lib stubs (no assembly is shipped). lib/native/_._ marks the package compatible with
          native (C++) test projects. Note: the previous nuspec also declared an empty native0.0


### PR DESCRIPTION
`buildMultiTargeting/<PackageId>.props` is what NuGet imports into the outer build of a multi-targeting project. The outer build has no `TargetFramework`, so it cannot resolve a TFM subfolder. We shipped the props only as `buildMultiTargeting/net8.0/`, `net462/`, `netcoreapp2.0/` and `netstandard2.0/`, and nothing at the root, so the outer build imported nothing at all. `TestProject`, `IsTestProject` and the `TestContainer` capability were never set there. Pack reads `IsPackable` on the outer build, so a test project with `<TargetFrameworks>` produces a `.nupkg`.

This is a regression from the Arcade port. The hand-written nuspec had `<file src="Microsoft.NET.Test.Sdk.props" target="buildMultiTargeting\" />` at the root, and no `.targets` there at all.

The props now goes to the `buildMultiTargeting` root and the four TFM subfolder copies are gone. I removed them rather than leaving them, because a dead copy of the unsupported-TFM shim under `buildMultiTargeting/netstandard2.0/` reads like it can fire on an outer build, and it cannot. `build/<tfm>/` is untouched. No `.targets` goes to the root: `Microsoft.NET.Test.Sdk.targets` is the unsupported-TFM shim and its `InitialTargets` error has no `TargetFramework` condition, so it would fail every outer build.

`verify-nupkgs.ps1` only counted entries. Moving a file from one folder to another keeps the count the same, which is why this was invisible. It now also checks that the props sits at the `buildMultiTargeting` root, and that no file hides in a subfolder there.

Verified on a multi-targeting test project, reading the outer build evaluation out of a binlog:

| | `IsTestProject` (outer) | `IsPackable` (outer) | `dotnet pack` |
| --- | --- | --- | --- |
| 17.14.1, as shipped | unset | `true` | produces a package |
| this change | `true` | `false` | produces nothing |

Same result for `<Project Sdk="MSTest.Sdk/4.0.1">` with `UseVSTest`, which is the shape from the issue, and on both the 9.0.317 and 10.0.303 SDKs. `Microsoft.NET.Test.Sdk` goes from 26 files to 21; `eng/expected-nupkg-file-counts.json` is regenerated from a clean Release pack build. Reverting the csproj and re-running `verify-nupkgs.ps1` fails with exit code 1.

Fix #15309

🤖
