### PR TITLE
[breaking] Escalate IDataCollectorAttachments and RunConfiguration.TargetFrameworkVersion obsoletions to errors

### DIFF
--- a/src/Microsoft.TestPlatform.ObjectModel/DataCollector/IDataCollectorAttachments.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/DataCollector/IDataCollectorAttachments.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
 /// <summary>
 /// Interface for data collectors add-ins that choose to handle attachment(s) generated
 /// </summary>
-[Obsolete("Interface is deprecated. Please use IDataCollectorAttachmentProcessor instead")]
+[Obsolete("Interface is deprecated. Please use IDataCollectorAttachmentProcessor instead", error: true)]
 public interface IDataCollectorAttachments
 {
     /// <summary>

--- a/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
+++ b/src/Microsoft.TestPlatform.ObjectModel/RunSettings/RunConfiguration.cs
@@ -273,7 +273,7 @@ public class RunConfiguration : TestRunSettings
     /// <summary>
     /// Gets or sets the target Framework this run is targeting. Possible values are Framework3.5|Framework4.0|Framework4.5
     /// </summary>
-    [Obsolete("Use TargetFramework instead")]
+    [Obsolete("Use TargetFramework instead", error: true)]
     public FrameworkVersion TargetFrameworkVersion
     {
         get => _framework?.Name switch

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/ObsoleteApiRegressionTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/ObsoleteApiRegressionTests.cs
@@ -33,7 +33,8 @@ public class ObsoleteApiRegressionTests
 
         Assert.IsNotNull(obsolete);
         Assert.IsTrue(obsolete.IsError, "IDataCollectorAttachments must stay obsolete as an error.");
-        Assert.Contains(nameof(IDataCollectorAttachmentProcessor), obsolete.Message!);
+        Assert.IsNotNull(obsolete.Message, "The obsoletion must keep carrying a message that names the replacement.");
+        Assert.Contains(nameof(IDataCollectorAttachmentProcessor), obsolete.Message);
     }
 
     [TestMethod]
@@ -62,7 +63,8 @@ public class ObsoleteApiRegressionTests
 
         Assert.IsNotNull(obsolete);
         Assert.IsTrue(obsolete.IsError, "RunConfiguration.TargetFrameworkVersion must stay obsolete as an error.");
-        Assert.Contains(nameof(RunConfiguration.TargetFramework), obsolete.Message!);
+        Assert.IsNotNull(obsolete.Message, "The obsoletion must keep carrying a message that names the replacement.");
+        Assert.Contains(nameof(RunConfiguration.TargetFramework), obsolete.Message);
     }
 
     [TestMethod]
@@ -71,12 +73,20 @@ public class ObsoleteApiRegressionTests
         // Assemblies compiled against an older ObjectModel still call these accessors, so the shim must keep
         // working. Looked up by name so that this test needs no [Obsolete] marker of its own.
         var runConfiguration = new RunConfiguration();
-        var property = typeof(RunConfiguration).GetProperty("TargetFrameworkVersion")!;
+        var property = typeof(RunConfiguration).GetProperty("TargetFrameworkVersion");
+
+        Assert.IsNotNull(property, "The property must stay on the type so that existing compiled callers still bind to it.");
 
         property.SetValue(runConfiguration, FrameworkVersion.Framework45);
 
-        Assert.AreEqual(Framework.FromString("Framework45")!.Name, runConfiguration.TargetFramework!.Name);
-        Assert.AreEqual(FrameworkVersion.Framework45, (FrameworkVersion)property.GetValue(runConfiguration)!);
+        var expected = Framework.FromString("Framework45");
+        Assert.IsNotNull(expected, "Framework.FromString must keep resolving Framework45.");
+        Assert.IsNotNull(runConfiguration.TargetFramework, "Setting TargetFrameworkVersion must keep populating TargetFramework.");
+        Assert.AreEqual(expected.Name, runConfiguration.TargetFramework.Name);
+
+        var actual = property.GetValue(runConfiguration);
+        Assert.IsNotNull(actual, "The TargetFrameworkVersion getter must keep returning the value that was set.");
+        Assert.AreEqual(FrameworkVersion.Framework45, (FrameworkVersion)actual);
     }
 
     [TestMethod]
@@ -95,7 +105,10 @@ public class ObsoleteApiRegressionTests
 
         var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(settingsXml);
 
-        Assert.AreEqual(Framework.FromString("Framework45")!.Name, runConfiguration.TargetFramework!.Name);
+        var expected = Framework.FromString("Framework45");
+        Assert.IsNotNull(expected, "Framework.FromString must keep resolving Framework45.");
+        Assert.IsNotNull(runConfiguration.TargetFramework, "The <TargetFrameworkVersion> element must keep populating TargetFramework.");
+        Assert.AreEqual(expected.Name, runConfiguration.TargetFramework.Name);
         Assert.Contains("<TargetFrameworkVersion>", runConfiguration.ToXml().OuterXml);
     }
 }

--- a/test/Microsoft.TestPlatform.ObjectModel.UnitTests/ObsoleteApiRegressionTests.cs
+++ b/test/Microsoft.TestPlatform.ObjectModel.UnitTests/ObsoleteApiRegressionTests.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection;
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.TestPlatform.ObjectModel.UnitTests;
+
+/// <summary>
+/// Guards the deprecation state of the ObjectModel members that were escalated to compile-time
+/// errors for https://github.com/microsoft/vstest/issues/16415.
+///
+/// Both members stay in the assembly, so this change is source breaking only: already-compiled
+/// assemblies keep loading and running unchanged. Only new source references are blocked.
+/// </summary>
+[TestClass]
+public class ObsoleteApiRegressionTests
+{
+    // Some test methods below are themselves marked [Obsolete], because that is the only mechanism that
+    // suppresses an error-level obsoletion. #pragma warning disable, NoWarn and .editorconfig severity
+    // overrides do not apply to obsoletions declared with error: true.
+
+    [TestMethod]
+    [Obsolete("IDataCollectorAttachments is obsolete, but we want to test its deprecation state.")]
+    public void IDataCollectorAttachmentsIsObsoleteAsError()
+    {
+        var obsolete = typeof(IDataCollectorAttachments).GetCustomAttribute<ObsoleteAttribute>();
+
+        Assert.IsNotNull(obsolete);
+        Assert.IsTrue(obsolete.IsError, "IDataCollectorAttachments must stay obsolete as an error.");
+        Assert.Contains(nameof(IDataCollectorAttachmentProcessor), obsolete.Message!);
+    }
+
+    [TestMethod]
+    public void IDataCollectorAttachmentsIsStillPresentForBinaryCompatibility()
+    {
+        // Deliberately looked up by name rather than with typeof/nameof, so that this test does not
+        // create a source reference to the interface and can assert on it without being [Obsolete] itself.
+        var type = typeof(AttachmentSet).Assembly
+            .GetType("Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection.IDataCollectorAttachments");
+
+        Assert.IsNotNull(type, "The interface must stay in the assembly so that existing compiled data collectors still load.");
+        Assert.IsTrue(type.IsInterface);
+        Assert.IsTrue(type.IsPublic);
+        Assert.IsNotNull(type.GetMethod("GetExtensionUri"));
+        Assert.IsNotNull(type.GetMethod("HandleDataCollectionAttachmentSets"));
+    }
+
+    [TestMethod]
+    [Obsolete("TargetFrameworkVersion is obsolete, but we want to test its deprecation state.")]
+    public void RunConfigurationTargetFrameworkVersionIsObsoleteAsError()
+    {
+        var property = typeof(RunConfiguration).GetProperty(nameof(RunConfiguration.TargetFrameworkVersion));
+
+        Assert.IsNotNull(property);
+        var obsolete = property.GetCustomAttribute<ObsoleteAttribute>();
+
+        Assert.IsNotNull(obsolete);
+        Assert.IsTrue(obsolete.IsError, "RunConfiguration.TargetFrameworkVersion must stay obsolete as an error.");
+        Assert.Contains(nameof(RunConfiguration.TargetFramework), obsolete.Message!);
+    }
+
+    [TestMethod]
+    public void RunConfigurationTargetFrameworkVersionStillRoundTripsThroughReflection()
+    {
+        // Assemblies compiled against an older ObjectModel still call these accessors, so the shim must keep
+        // working. Looked up by name so that this test needs no [Obsolete] marker of its own.
+        var runConfiguration = new RunConfiguration();
+        var property = typeof(RunConfiguration).GetProperty("TargetFrameworkVersion")!;
+
+        property.SetValue(runConfiguration, FrameworkVersion.Framework45);
+
+        Assert.AreEqual(Framework.FromString("Framework45")!.Name, runConfiguration.TargetFramework!.Name);
+        Assert.AreEqual(FrameworkVersion.Framework45, (FrameworkVersion)property.GetValue(runConfiguration)!);
+    }
+
+    [TestMethod]
+    public void TargetFrameworkVersionRunSettingsElementIsUnaffected()
+    {
+        // Only the CLR property is source-blocked, the runsettings element keeps working and keeps its name.
+        var settingsXml =
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <RunSettings>
+              <RunConfiguration>
+                <TargetFrameworkVersion>Framework45</TargetFrameworkVersion>
+              </RunConfiguration>
+            </RunSettings>
+            """;
+
+        var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(settingsXml);
+
+        Assert.AreEqual(Framework.FromString("Framework45")!.Name, runConfiguration.TargetFramework!.Name);
+        Assert.Contains("<TargetFrameworkVersion>", runConfiguration.ToXml().OuterXml);
+    }
+}


### PR DESCRIPTION
Part of #16415. **Breaking group** — intentionally source-breaking. Standalone; does not depend on #16420.

## What changed

Two long-deprecated ObjectModel members escalated from warning to error, plus `ObsoleteApiRegressionTests.cs` to guard the state:

| Member | Replacement |
| --- | --- |
| `IDataCollectorAttachments` | `IDataCollectorAttachmentProcessor` |
| `RunConfiguration.TargetFrameworkVersion` | `RunConfiguration.TargetFramework` |

## Compatibility

**Source breaking, not binary breaking.** `error: true` only picks a different `ObsoleteAttribute` overload — metadata only. Compiled assemblies keep working, public API surface is unchanged (no `PublicAPI.*.txt` edits), and serialization is unaffected. The `<TargetFrameworkVersion>` runsettings element still works — it's emitted unconditionally by `ToXml()` and is not the obsolete CLR property (regression test asserts this).

Only new C# source referencing these members stops compiling.

## Migration

```csharp
runConfiguration.TargetFramework = Framework.FromString("Framework45"); // was TargetFrameworkVersion
public class MyCollector : IDataCollectorAttachmentProcessor { ... }    // was IDataCollectorAttachments
```

If you can't migrate yet, the only opt-out is marking the **containing member** `[Obsolete]`. `#pragma`, `<NoWarn>` and editorconfig severity have no effect on `error: true` (compiler errors are non-configurable). That's why in-repo `RunConfigurationTests` needed no changes.

## Reviewer input wanted

1. **Counter-precedent.** `IFrameworkHandle.cs:21` deliberately spells out `error: false` on an ObjectModel contract. `objectmodel.instructions.md` asks for explicit approval here, so I'd like a maintainer decision recorded.
2. **`IDataCollectorAttachments` implementers have no clean opt-out** — suppressing at the base list means marking their own class `[Obsolete]`, which ripples to their consumers. Mitigating: the platform no longer consumes this interface at all, so implementers already get nothing at runtime.
3. **Versioning.** Should land on a major/minor boundary, not a patch.

## Deliberately out of scope

- **Custom diagnostic IDs (`TPVS003`/`TPVS004`).** `DiagnosticId` *replaces* the `CSxxxx` id, silently breaking existing consumer suppressions, and it's .NET 5+ only so it'd differ per TFM. It also buys nothing here — a custom id doesn't make an error-level obsoletion suppressible.
- **`FeatureFlag.Reset()` / `SetFlag()`.** The issue's premise is stale — they're already `internal` with IVT. But IVT is granted to ~26 *production* assemblies, so `[Obsolete]` is currently the only thing stopping production code from calling `Reset()` (which drops all cached flags mid-process). Removing it is a safety regression. Proper fix is `BannedApiAnalyzers`, but that's opt-in per project — follow-up issue.

## Validation

`./build.cmd -c Release` clean, 0 warnings. ObjectModel unit tests 213/213 on `net11.0`, 220/220 on `net481`, including the 5 new tests. No other in-repo or reflection-by-name usage of either member.