### PR TITLE
Match the HTTP link probe's open-PR guard on the real title prefix

### DIFF
--- a/.github/workflows/http-link-check-probe.yml
+++ b/.github/workflows/http-link-check-probe.yml
@@ -144,12 +144,12 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           # The search is only a coarse server-side filter. GitHub discards the brackets and
-          # matches the remaining phrase anywhere in the title, so '"[link-checker]" in:title'
-          # also returns PRs that merely mention the link checker: searching this repo returns
-          # 13 PRs, of which only 6 actually carry the prefix. Trusting that count lets an
-          # unrelated open PR suppress dispatch indefinitely — the probe keeps scanning, finds
-          # changed links, and silently declines to act on them. jq re-checks the real prefix
-          # so only an actual checker PR counts.
+          # matches the remaining words as a phrase anywhere in the title, so this query also
+          # returns PRs that merely mention the link checker rather than ones the checker
+          # opened. Trusting its count lets an unrelated open PR suppress dispatch for as long
+          # as it stays open, and it fails silently: the probe still scans, still sees the
+          # changed links, and just declines to act. jq re-checks the real prefix so only a
+          # PR the checker actually opened counts.
           OPEN_PR_COUNT=$(gh pr list --state open --search '"[link-checker]" in:title' \
             --limit 100 --json title \
             --jq '[.[] | select(.title | startswith("[link-checker] "))] | length')
@@ -157,6 +157,19 @@ jobs:
           if [ "$OPEN_PR_COUNT" -gt 0 ]; then
             echo "An HTTP link checker pull request is already open; skipping dispatch."
             echo "An HTTP link checker pull request is already open, so no new agent run was dispatched." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # An agent run that has started but not yet opened its PR is invisible to the check
+          # above, so look for one directly before adding a second. Scope it to the ref we
+          # would dispatch on: a manual run on another branch is unrelated work, and letting
+          # it count here would silently hold up the scheduled dispatch.
+          IN_FLIGHT=$(gh run list --workflow http-link-checker.lock.yml --branch "$REF_NAME" \
+            --limit 20 --json status --jq '[.[] | select(.status != "completed")] | length')
+
+          if [ "$IN_FLIGHT" -gt 0 ]; then
+            echo "An agentic HTTP link checker run is already in flight; skipping dispatch."
+            echo "An agentic HTTP link checker run is already in flight, so no new agent run was dispatched." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 

--- a/.github/workflows/http-link-check-probe.yml
+++ b/.github/workflows/http-link-check-probe.yml
@@ -143,8 +143,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REF_NAME: ${{ github.ref_name }}
         run: |
+          # The search is only a coarse server-side filter. GitHub discards the brackets and
+          # matches the remaining phrase anywhere in the title, so '"[link-checker]" in:title'
+          # also returns PRs that merely mention the link checker: searching this repo returns
+          # 13 PRs, of which only 6 actually carry the prefix. Trusting that count lets an
+          # unrelated open PR suppress dispatch indefinitely — the probe keeps scanning, finds
+          # changed links, and silently declines to act on them. jq re-checks the real prefix
+          # so only an actual checker PR counts.
           OPEN_PR_COUNT=$(gh pr list --state open --search '"[link-checker]" in:title' \
-            --limit 1 --json number --jq 'length')
+            --limit 100 --json title \
+            --jq '[.[] | select(.title | startswith("[link-checker] "))] | length')
 
           if [ "$OPEN_PR_COUNT" -gt 0 ]; then
             echo "An HTTP link checker pull request is already open; skipping dispatch."

--- a/.github/workflows/http-link-check-probe.yml
+++ b/.github/workflows/http-link-check-probe.yml
@@ -150,8 +150,13 @@ jobs:
           # as it stays open, and it fails silently: the probe still scans, still sees the
           # changed links, and just declines to act. jq re-checks the real prefix so only a
           # PR the checker actually opened counts.
+          #
+          # The limit has to leave room for the whole coarse result set: this is a correctness
+          # guard, and a prefixed PR truncated out of the window would look like "none open"
+          # and dispatch a duplicate. gh pages through the API, so the value is a ceiling on
+          # how many PRs we are willing to inspect, not a per-request cap.
           OPEN_PR_COUNT=$(gh pr list --state open --search '"[link-checker]" in:title' \
-            --limit 100 --json title \
+            --limit 500 --json title \
             --jq '[.[] | select(.title | startswith("[link-checker] "))] | length')
 
           if [ "$OPEN_PR_COUNT" -gt 0 ]; then
@@ -163,9 +168,11 @@ jobs:
           # An agent run that has started but not yet opened its PR is invisible to the check
           # above, so look for one directly before adding a second. Scope it to the ref we
           # would dispatch on: a manual run on another branch is unrelated work, and letting
-          # it count here would silently hold up the scheduled dispatch.
+          # it count here would silently hold up the scheduled dispatch. The limit is generous
+          # for the same reason as above — a burst of completed runs must not push the one
+          # in-flight run out of the window and make it look idle.
           IN_FLIGHT=$(gh run list --workflow http-link-checker.lock.yml --branch "$REF_NAME" \
-            --limit 20 --json status --jq '[.[] | select(.status != "completed")] | length')
+            --limit 200 --json status --jq '[.[] | select(.status != "completed")] | length')
 
           if [ "$IN_FLIGHT" -gt 0 ]; then
             echo "An agentic HTTP link checker run is already in flight; skipping dispatch."


### PR DESCRIPTION
## Problem

The probe's duplicate-run guard trusts a GitHub search count:

```bash
OPEN_PR_COUNT=$(gh pr list --state open --search '"[link-checker]" in:title' \
  --limit 1 --json number --jq 'length')
if [ "$OPEN_PR_COUNT" -gt 0 ]; then exit 0; fi   # skip dispatch
```

The intent is "does an open PR carry the `[link-checker] ` prefix?". GitHub discards the brackets and matches the remaining words as a phrase **anywhere in the title**, so it really asks "does any open PR mention the words *link checker*?".

Measured against this repo on 2026-08-27 — these return an identical set, which is what shows the brackets contribute nothing, while reversing the word order returns none, which is what shows it is a phrase match rather than loose keywords:

| Query | Hits |
| --- | ---: |
| `"[link-checker]"` | 13 |
| `"link-checker"` | 13 |
| `"link checker"` | 13 |
| `"checker link"` | 0 |

Only **6 of those 13** carried the prefix. The rest are ordinary PRs that merely mention the checker, e.g. #16104 *"Split the link checker workflow into HTTP and Relative link checker"* and #16093 *"Add agentic workflow link-checker"*.

The failure is silent and points the expensive way: the probe decides a checker PR is already open, skips dispatch, and reports success. The scan still runs, still finds changed links, and simply declines to act on them, for as long as the unrelated PR stays open. A guard meant to prevent duplicate work instead prevents all work.

**This was live, not hypothetical.** Open PR #16417 made the guard return 1, so the HTTP checker was suppressed.

## Fix

The search is a superset of what we want, so keep it as cheap server-side narrowing and re-check the real prefix with `jq`:

```bash
OPEN_PR_COUNT=$(gh pr list --state open --search '"[link-checker]" in:title' \
  --limit 500 --json title \
  --jq '[.[] | select(.title | startswith("[link-checker] "))] | length')
```

Review surfaced two further holes in the same guard, both now closed:

**Truncation.** Filtering client-side means the rows must actually be in the response, and a short window is a wrong answer rather than a shorter list. `gh` pages through the API rather than capping at one page, so a low `--limit` is a ceiling we impose on ourselves:

```
gh pr list --repo NixOS/nixpkgs --state open --search '"update" in:title' --limit 250  ->  215
gh pr list --repo NixOS/nixpkgs --state open --search '"update" in:title' --limit 100  ->  100
```

That second line is silent truncation: 215 matches available, exactly 100 returned, no error. A prefixed PR pushed out of the window reads as "none open" and dispatches a duplicate. Limits are now 500 for the PR query and 200 for the run query; both stop early at the real result count (21 open PRs, 11 runs here today).

**In-flight runs.** The open-PR query cannot see an agent that has started but not yet opened its PR, so a probe run in that window dispatched a duplicate. Added the in-flight check the markdown probe already has, scoped to the dispatch ref so a manual run on another branch doesn't hold up the scheduled one.

## Depends on #16417 for the full fix

Today both checkers share the `[link-checker] ` prefix, so an exact-prefix match still cannot tell them apart — this PR narrows the bug rather than eliminating it. #16417 renames the markdown checker's prefix to `[md-link-checker] `, which does not satisfy `startswith("[link-checker] ")`. **Merged together, the two checkers are fully disambiguated.** That PR carries the matching limit and in-flight fixes so the two probes don't drift.

## Validation

- Filter applied to live `microsoft/vstest` data keeps exactly the genuinely prefixed PRs and drops every false match.
- Live open-PR count: **1 (suppressed) → 0 (dispatches)**.
- Guard branch logic checked against a stubbed `gh` across open-PR × in-flight combinations (0/0, 1/0, 0/1, 1/1, 0/3).
- Pagination behaviour verified directly against a repo large enough to exceed one page.
- Workflow YAML parses; every `run:` block passes `bash -n`.

## Known defect in the surrounding design, not fixed here

While reviewing this I found that **the agent cannot commit the fingerprint it is instructed to update**, which breaks the loop both probes depend on. `create-pull-request` compiles with `protect_top_level_dot_folders: true` and no `protected_dot_folder_excludes`. Per gh-aw's `checkForTopLevelDotFolders`, any path whose first segment starts with `.` is rejected — including `.github/workflows/scripts/known-broken-links.txt` — and with `protected_files_policy: fallback-to-issue` the agent opens an issue instead of a PR. The fingerprint then never updates and the probe re-dispatches every week, which is the exact cost the design set out to avoid.

This affects the already-merged #16413 and the pending #16417 equally, and fixing it means changing the agentic workflow frontmatter plus regenerating its lock. Out of scope for this guard fix — filed as #16422.
