### PR TITLE
Stop sending after a partial frame write

### DIFF
--- a/src/Microsoft.TestPlatform.CommunicationUtilities/LengthPrefixCommunicationChannel.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/LengthPrefixCommunicationChannel.cs
@@ -18,9 +18,13 @@ namespace Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 /// </summary>
 public class LengthPrefixCommunicationChannel : ICommunicationChannel
 {
+    private readonly Stream _stream;
+
     private readonly BinaryReader _reader;
 
     private readonly BinaryWriter _writer;
+
+    private Exception? _sendFailure;
 
     /// <summary>
     /// Sync object for sending messages
@@ -30,6 +34,7 @@ public class LengthPrefixCommunicationChannel : ICommunicationChannel
 
     public LengthPrefixCommunicationChannel(Stream stream)
     {
+        _stream = stream;
         _reader = new BinaryReader(stream, Encoding.UTF8, true);
 
         // Using the Buffered stream while writing, improves the write performance. By reducing the number of writes.
@@ -42,29 +47,47 @@ public class LengthPrefixCommunicationChannel : ICommunicationChannel
     /// <inheritdoc />
     public Task Send(string data)
     {
-        try
+        // Writing Message on binarywriter is not Thread-Safe
+        // Need to sync one by one to avoid buffer corruption
+        lock (_writeSyncObject)
         {
-            // Writing Message on binarywriter is not Thread-Safe
-            // Need to sync one by one to avoid buffer corruption
-            lock (_writeSyncObject)
+            if (_sendFailure is not null)
+            {
+                throw new CommunicationException("Unable to send data over channel because a previous send failed.", _sendFailure);
+            }
+
+            try
             {
                 _writer.Write(data);
                 _writer.Flush();
             }
-        }
-        catch (NotSupportedException ex) when (!_writer.BaseStream.CanWrite)
-        {
-            // As we are simply creating streams around some stream passed as ctor argument, we
-            // end up in some unsynchronized behavior where it's possible that the outside stream
-            // was disposed and we are still trying to write something. In such case we would fail
-            // with "System.NotSupportedException: Stream does not support writing.".
-            // To avoid being too generic in that catch, I am checking if the stream is not writable.
-            EqtTrace.Verbose("LengthPrefixCommunicationChannel.Send: BaseStream is not writable (most likely it was dispose). {0}", ex);
-        }
-        catch (Exception ex)
-        {
-            EqtTrace.Error("LengthPrefixCommunicationChannel.Send: Error sending data: {0}.", ex);
-            throw new CommunicationException("Unable to send data over channel.", ex);
+            catch (NotSupportedException ex) when (!_stream.CanWrite)
+            {
+                // As we are simply creating streams around some stream passed as ctor argument, we
+                // end up in some unsynchronized behavior where it's possible that the outside stream
+                // was disposed and we are still trying to write something. In such case we would fail
+                // with "System.NotSupportedException: Stream does not support writing.".
+                // To avoid being too generic in that catch, I am checking if the stream is not writable.
+                EqtTrace.Verbose("LengthPrefixCommunicationChannel.Send: Stream is not writable (most likely it was disposed). {0}", ex);
+            }
+            catch (Exception ex)
+            {
+                _sendFailure = ex;
+
+                try
+                {
+                    // A failed write may have left a length prefix or a partial payload on the wire.
+                    // Close the stream before another send can reuse the broken frame boundary.
+                    _stream.Dispose();
+                }
+                catch (Exception disposeException)
+                {
+                    EqtTrace.Error("LengthPrefixCommunicationChannel.Send: Error closing stream after send failure: {0}.", disposeException);
+                }
+
+                EqtTrace.Error("LengthPrefixCommunicationChannel.Send: Error sending data: {0}.", ex);
+                throw new CommunicationException("Unable to send data over channel.", ex);
+            }
         }
 
         return Task.CompletedTask;
@@ -107,15 +130,36 @@ public class LengthPrefixCommunicationChannel : ICommunicationChannel
     /// <inheritdoc />
     public void Dispose()
     {
+        // Dispose can run while another thread is inside Send. Take the write lock when it is
+        // free, so disposal never flushes the writer mid-frame, but never wait for it: blocking
+        // here would turn a stuck socket write into a shutdown hang.
+        var lockTaken = false;
         try
         {
+            Monitor.TryEnter(_writeSyncObject, ref lockTaken);
+
             EqtTrace.Verbose("LengthPrefixCommunicationChannel.Dispose: Dispose reader and writer.");
             _reader.Dispose();
-            _writer.Dispose();
+
+            // BinaryWriter.Dispose flushes its BufferedStream. Skip that flush after a failed
+            // send, where the buffer can still hold part of an incomplete frame that must not
+            // reach the peer, and skip it while a send holds the lock, to avoid racing that
+            // writer. Neither skip loses data: Send flushes after every message it completes.
+            if (lockTaken && _sendFailure is null)
+            {
+                _writer.Dispose();
+            }
         }
         catch (ObjectDisposedException)
         {
             // We don't own the underlying stream lifecycle so it's possible that it's already disposed.
+        }
+        finally
+        {
+            if (lockTaken)
+            {
+                Monitor.Exit(_writeSyncObject);
+            }
         }
 
         GC.SuppressFinalize(this);

--- a/src/Microsoft.TestPlatform.CommunicationUtilities/LengthPrefixCommunicationChannel.cs
+++ b/src/Microsoft.TestPlatform.CommunicationUtilities/LengthPrefixCommunicationChannel.cs
@@ -72,25 +72,49 @@ public class LengthPrefixCommunicationChannel : ICommunicationChannel
             }
             catch (Exception ex)
             {
-                _sendFailure = ex;
-
-                try
-                {
-                    // A failed write may have left a length prefix or a partial payload on the wire.
-                    // Close the stream before another send can reuse the broken frame boundary.
-                    _stream.Dispose();
-                }
-                catch (Exception disposeException)
-                {
-                    EqtTrace.Error("LengthPrefixCommunicationChannel.Send: Error closing stream after send failure: {0}.", disposeException);
-                }
-
-                EqtTrace.Error("LengthPrefixCommunicationChannel.Send: Error sending data: {0}.", ex);
+                FaultChannel(ex);
                 throw new CommunicationException("Unable to send data over channel.", ex);
             }
         }
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Marks the channel unusable after a failed write, and closes the transport.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="BinaryWriter.Write(string)"/> does not report how many bytes it wrote, so once it
+    /// throws we cannot know whether the length prefix reached the peer without its payload. If it
+    /// did, the peer is waiting for a body that will never arrive, and every later message would be
+    /// consumed as part of that frame.
+    /// </para>
+    /// <para>
+    /// There is no way to tell the peer in band, because the framing it is reading is the thing that
+    /// broke. Closing the transport is the only signal left: the peer reads end of stream, which it
+    /// already handles.
+    /// </para>
+    /// <para>
+    /// Both callers, SocketClient and SocketServer, build this channel over a TcpClient stream and
+    /// close that client in their own error paths, so this closes a stream that was already on its
+    /// way down. Dispose still leaves the stream open, which DisposeShouldNotCloseTheStream pins.
+    /// </para>
+    /// </remarks>
+    private void FaultChannel(Exception ex)
+    {
+        _sendFailure = ex;
+
+        try
+        {
+            _stream.Dispose();
+        }
+        catch (Exception disposeException)
+        {
+            EqtTrace.Error("LengthPrefixCommunicationChannel.Send: Error closing stream after send failure: {0}.", disposeException);
+        }
+
+        EqtTrace.Error("LengthPrefixCommunicationChannel.Send: Error sending data: {0}.", ex);
     }
 
     /// <inheritdoc />

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/LengthPrefixCommunicationChannelTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/LengthPrefixCommunicationChannelTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,6 +25,8 @@ public class LengthPrefixCommunicationChannelTests : IDisposable
     private readonly BinaryReader _reader;
 
     private readonly BinaryWriter _writer;
+
+    public TestContext TestContext { get; set; } = null!;
 
     public LengthPrefixCommunicationChannelTests()
     {
@@ -120,6 +123,31 @@ public class LengthPrefixCommunicationChannelTests : IDisposable
         Assert.IsTrue(_stream.CanWrite);
     }
 
+    /// <summary>
+    /// Characterization test: it passes on main unchanged, and it passes here. It asserts no new
+    /// behavior and claims no documented guarantee. Two implementation details combine to let a
+    /// send after Dispose still reach the stream. BinaryWriter does not track its own disposal, so
+    /// Write has nothing to reject, and the writer holds the stream with leaveOpen, so disposing
+    /// the writer flushes rather than closing the stream underneath it. Shutdown leans on the
+    /// resulting tolerance, because Dispose runs while timer driven sends are still in flight.
+    /// Pinning it here means a future change surfaces as a failing test rather than as a silent
+    /// change to shutdown.
+    /// </summary>
+    [TestMethod]
+    public async Task SendAfterDisposeShouldStillWriteToTheStream()
+    {
+        using var stream = new MemoryStream();
+        var channel = new LengthPrefixCommunicationChannel(stream);
+        channel.Dispose();
+
+        await channel.Send(Dummydata);
+
+        Assert.IsTrue(stream.CanWrite);
+        SeekToBeginning(stream);
+        using var reader = new BinaryReader(stream);
+        Assert.AreEqual(Dummydata, reader.ReadString());
+    }
+
     [TestMethod]
     public async Task DoNotFailWhenWritingOnADisposedBaseStream()
     {
@@ -136,6 +164,90 @@ public class LengthPrefixCommunicationChannelTests : IDisposable
         // Dispose base stream
         _stream.Dispose();
         await _channel.NotifyDataAvailable(new CancellationToken());
+    }
+
+    [TestMethod]
+    public async Task SendShouldCloseStreamAndRejectLaterMessagesAfterPartialFrame()
+    {
+        using var stream = new FailingWriteStream(bytesBeforeFailure: 3);
+        var channel = new LengthPrefixCommunicationChannel(stream);
+        var message = new string('x', SocketConstants.BufferSize + 1);
+
+        await Assert.ThrowsExactlyAsync<CommunicationException>(() => channel.Send(message));
+
+        Assert.HasCount(3, stream.WrittenBytes);
+        using (var prefixStream = new MemoryStream(stream.WrittenBytes))
+        using (var prefixReader = new BinaryReader(prefixStream))
+        {
+            Assert.AreEqual(message.Length, Read7BitEncodedInt(prefixReader));
+        }
+
+        var writeCallCount = stream.WriteCallCount;
+        await Assert.ThrowsExactlyAsync<CommunicationException>(() => channel.Send(Dummydata));
+
+        Assert.IsTrue(stream.IsDisposed);
+        Assert.AreEqual(writeCallCount, stream.WriteCallCount);
+        Assert.HasCount(3, stream.WrittenBytes);
+    }
+
+    [TestMethod]
+    public async Task DisposeShouldNotFlushBufferedDataAfterSendFailure()
+    {
+        using var stream = new FailingWriteStream(bytesBeforeFailure: 0);
+        var channel = new LengthPrefixCommunicationChannel(stream);
+
+        await Assert.ThrowsExactlyAsync<CommunicationException>(() => channel.Send(Dummydata));
+        var writeCallCount = stream.WriteCallCount;
+
+        channel.Dispose();
+
+        Assert.AreEqual(writeCallCount, stream.WriteCallCount);
+    }
+
+    [TestMethod]
+    public async Task ConcurrentSendShouldNotWriteAfterFirstSendFails()
+    {
+        using var stream = new FailingWriteStream(bytesBeforeFailure: 3, blockFirstWrite: true);
+        var channel = new LengthPrefixCommunicationChannel(stream);
+        var message = new string('x', SocketConstants.BufferSize + 1);
+
+        var firstSend = Task.Run(() => channel.Send(message), TestContext.CancellationToken);
+        Assert.IsTrue(stream.WriteStarted.Wait(TimeSpan.FromSeconds(5), TestContext.CancellationToken));
+
+        var secondSend = Task.Run(() => channel.Send(Dummydata), TestContext.CancellationToken);
+        await Task.Delay(50, TestContext.CancellationToken);
+        Assert.IsFalse(secondSend.IsCompleted);
+
+        stream.ReleaseWrite.Set();
+
+        await Assert.ThrowsExactlyAsync<CommunicationException>(() => firstSend);
+        await Assert.ThrowsExactlyAsync<CommunicationException>(() => secondSend);
+        Assert.IsTrue(stream.IsDisposed);
+        Assert.AreEqual(1, stream.WriteCallCount);
+    }
+
+    [TestMethod]
+    public async Task DisposeShouldNeitherWriteNorBlockWhileASendIsInFlight()
+    {
+        using var stream = new FailingWriteStream(bytesBeforeFailure: 3, blockFirstWrite: true);
+        var channel = new LengthPrefixCommunicationChannel(stream);
+        var message = new string('x', SocketConstants.BufferSize + 1);
+
+        var send = Task.Run(() => channel.Send(message), TestContext.CancellationToken);
+        Assert.IsTrue(stream.WriteStarted.Wait(TimeSpan.FromSeconds(5), TestContext.CancellationToken));
+
+        var writeCallCount = stream.WriteCallCount;
+        var stopwatch = Stopwatch.StartNew();
+        channel.Dispose();
+        stopwatch.Stop();
+
+        // The in-flight write is held for up to five seconds. Disposal must not wait for it,
+        // and must not flush the writer underneath it.
+        Assert.IsLessThan(TimeSpan.FromSeconds(2), stopwatch.Elapsed, $"Dispose blocked for {stopwatch.Elapsed}.");
+        Assert.AreEqual(writeCallCount, stream.WriteCallCount);
+
+        stream.ReleaseWrite.Set();
+        await Assert.ThrowsExactlyAsync<CommunicationException>(() => send);
     }
 
     // TODO
@@ -172,5 +284,78 @@ public class LengthPrefixCommunicationChannelTests : IDisposable
         while ((b & 0x80) != 0);
 
         return count;
+    }
+
+    private sealed class FailingWriteStream : MemoryStream
+    {
+        private readonly int _bytesBeforeFailure;
+        private readonly bool _blockFirstWrite;
+
+        private int _acceptedBytes;
+        private bool _failureInjected;
+
+        public FailingWriteStream(int bytesBeforeFailure, bool blockFirstWrite = false)
+        {
+            _bytesBeforeFailure = bytesBeforeFailure;
+            _blockFirstWrite = blockFirstWrite;
+        }
+
+        public bool IsDisposed { get; private set; }
+
+        public int WriteCallCount { get; private set; }
+
+        public byte[] WrittenBytes => ToArray();
+
+        public ManualResetEventSlim WriteStarted { get; } = new(false);
+
+        public ManualResetEventSlim ReleaseWrite { get; } = new(false);
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            if (IsDisposed)
+            {
+                throw new ObjectDisposedException(nameof(FailingWriteStream));
+            }
+
+            WriteCallCount++;
+            WriteStarted.Set();
+            if (!_failureInjected)
+            {
+                if (_blockFirstWrite && !ReleaseWrite.Wait(TimeSpan.FromSeconds(5)))
+                {
+                    throw new TimeoutException("Timed out waiting to release the injected write failure.");
+                }
+
+                _failureInjected = true;
+                var remainingBytes = _bytesBeforeFailure - _acceptedBytes;
+                if (remainingBytes > 0)
+                {
+                    var acceptedCount = Math.Min(remainingBytes, count);
+                    base.Write(buffer, offset, acceptedCount);
+                    _acceptedBytes += acceptedCount;
+                }
+
+                throw new IOException("Injected write failure.");
+            }
+
+            base.Write(buffer, offset, count);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            IsDisposed = true;
+            if (disposing)
+            {
+                WriteStarted.Dispose();
+                ReleaseWrite.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
     }
 }

--- a/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/LengthPrefixCommunicationChannelTests.cs
+++ b/test/Microsoft.TestPlatform.CommunicationUtilities.UnitTests/LengthPrefixCommunicationChannelTests.cs
@@ -190,6 +190,78 @@ public class LengthPrefixCommunicationChannelTests : IDisposable
         Assert.HasCount(3, stream.WrittenBytes);
     }
 
+    /// <summary>
+    /// The corruption this change prevents, asserted at the peer instead of at the sender. A send
+    /// that fails once its length prefix has reached the peer leaves a frame header on the wire
+    /// promising a body that never arrives. On unmodified main the next message is consumed as that
+    /// body, and the peer decodes a string nobody ever sent, which is where the
+    /// "Unexpected character encountered while parsing value" JSON abort comes from. Every other
+    /// test here asserts what the sender does; this one asserts what the peer can observe.
+    /// </summary>
+    [TestMethod]
+    public async Task PeerShouldNotDecodeAMessageThatWasNeverSent()
+    {
+        var message1 = new string('a', SocketConstants.BufferSize + 1);
+        var message2 = new string('b', SocketConstants.BufferSize + 1);
+
+        // The payload does not fit in what is left of the buffer, so the length prefix is flushed as
+        // its own write and reaches the peer before the payload write fails.
+        using var wire = new FailingWriteStream(bytesBeforeFailure: 3);
+        var sender = new LengthPrefixCommunicationChannel(wire);
+
+        await Assert.ThrowsExactlyAsync<CommunicationException>(() => sender.Send(message1));
+
+        try
+        {
+            // The injected failure fires once, so on unmodified main this second message is written
+            // and lands directly behind the orphaned prefix.
+            await sender.Send(message2);
+        }
+        catch (CommunicationException)
+        {
+            // Expected once the channel refuses to send after a failed frame.
+        }
+
+        var received = ReadFirstMessageFromWire(wire.WrittenBytes);
+
+        var decoded = received is null ? string.Empty : DescribeFirstChars(received);
+        Assert.IsNull(
+            received,
+            $"The peer decoded a {received?.Length ?? 0} character frame that was never sent as a message, starting {decoded}.");
+    }
+
+    private static string? ReadFirstMessageFromWire(byte[] bytesOnTheWire)
+    {
+        using var peerStream = new MemoryStream(bytesOnTheWire);
+        using var peer = new LengthPrefixCommunicationChannel(peerStream);
+
+        string? received = null;
+        peer.MessageReceived.Subscribe((sender, messageEventArgs) => received = messageEventArgs.Data);
+
+        try
+        {
+            peer.NotifyDataAvailable(CancellationToken.None).GetAwaiter().GetResult();
+        }
+        catch (EndOfStreamException)
+        {
+            // An incomplete frame is the correct outcome. The peer has nothing to act on.
+        }
+
+        return received;
+    }
+
+    private static string DescribeFirstChars(string value)
+    {
+        var count = Math.Min(3, value.Length);
+        var parts = new string[count];
+        for (var i = 0; i < count; i++)
+        {
+            parts[i] = $"U+{(int)value[i]:X4}";
+        }
+
+        return string.Join(" ", parts);
+    }
+
     [TestMethod]
     public async Task DisposeShouldNotFlushBufferedDataAfterSendFailure()
     {


### PR DESCRIPTION
A test run can lose results and still report success.

When a socket write fails partway through a message, the runner and the testhost can lose track of where
one message ends and the next begins. From there the receiver is reading at the wrong offset. It either
deserializes garbage and aborts the run, or waits for a message that will never arrive. Neither side
reports that anything went wrong.

This is the `Unexpected character encountered while parsing value` abort at `Path '', line 0, position 0`.
#2879 was closed for want of a repro. There is one below, as a test.

It is not rare where the conditions line up. On one CI pipeline over three weeks, 141 of 379 pull request
builds aborted mid run, and 106 of those still reported success.

The green ones are the problem. An aborted run does not turn failing tests into passing tests, it stops
running them, and a test that never ran reports nothing. For 39 pull requests in that window there is both
a clean successful build and an aborted successful build of the same PR. In 38 of the 39, the aborted build
published coverage for about half as many lines. Same commit, same suite, both green.

**What this PR does:** once a `Send` has failed, stop using that channel. Latch the failure, close the
transport, and reject later sends with `CommunicationException`.

It cannot un-send bytes that already left. What it prevents is the next message being read as the body of a
message that was never finished.

## How the two sides get out of sync

Two messages, sizes and prefix bytes taken from a real capture:

```
intended    a1 83 02 [33,185 byte payload]   ee ab 02 [38,382 byte payload]
                     ^ this write throws

actual      a1 83 02 ee ab 02 [38,382 byte payload]
            ^^^^^^^^ orphaned prefix: "the next 33,185 bytes are one message"
```

The first message's payload never left, but its 3 byte prefix did, and the channel stayed open. So the
receiver takes `a1 83 02` at face value and consumes 33,185 bytes as that message's body: the second
message's prefix, plus the first 33,182 bytes of its payload.

`ee ab` is not valid UTF-8, so it decodes to `U+FFFD`, and `02` to `U+0002`. The result is not JSON. The
position is 0 because the corruption starts at the first byte of the frame, which is why the error names no
useful location.

The receiver cannot recover on its own. A length prefixed stream has no marker to resync on, so once the
boundary is lost, every later message is garbage.

## Why the prefix goes out alone

This is the part that makes it look impossible. `BinaryWriter.Write(string)` writes the prefix and the
payload in one call, so how does one arrive without the other?

From a verbose `/Diag` capture:

1. A timer callback sends a 33,185 byte `TestExecution.StatsChange`. `BinaryWriter` puts the 3 byte prefix
   into the `BufferedStream`, then writes the payload.
2. The payload does not fit in what is left of the 16 KB buffer, so `BufferedStream` flushes the 3 buffered
   prefix bytes as their own write and passes the payload straight through. **The prefix flush succeeds.**
3. The payload write throws `SocketException 10038`. `Send` wraps it in `CommunicationException`,
   `TestRunCache.OnCacheTimeHit` swallows that, and the run continues.
4. 126 ms later, on another thread, the 38,382 byte message is written to the same channel and succeeds.

So it needs a buffer boundary, a mid message write failure, a caller that swallows it, and a second send.
That combination is why it presents as intermittent and why it resisted reproduction. The arithmetic
matches the log at every step.

## The change

In `LengthPrefixCommunicationChannel`, a failed send records the failure, closes the transport, and every
later send on that channel throws.

The failure path is a named method, `FaultChannel`, rather than the body of a `catch`, because the part that
needs justifying deserves somewhere to put it.

`Send` also moved fully inside the existing `_writeSyncObject` lock, and `Dispose` now takes that lock with
`Monitor.TryEnter` instead of not taking it at all.

This does not stop the underlying write from failing. That is not vstest's to stop. It stops a failed write
from silently corrupting the next message.

## What you will want to push back on

Three things, in the order I would raise them.

**It closes a stream the channel does not own.** `Dispose` deliberately leaves the stream open, and
`DisposeShouldNotCloseTheStream` pins that. This change does not touch either. What closes the stream is a
failed send, and that is a different situation, because only that one leaves the peer holding a prefix for a
body that will never arrive.

There is no way to tell the peer in band. The framing it is reading is the thing that broke, so a
"disregard that" message would just be consumed as the missing body. End of stream is the only signal left,
and the peer already handles it. Latching without closing stops the corruption but leaves the peer blocked
until some outer timeout fires.

On the ownership itself: both callers build this channel over a `TcpClient` stream, in `SocketServer.cs` and
`SocketClient.cs`, and both close that client in their own error path. `SocketServer` spells out what that
means in a comment: "Close the client and dispose the underlying stream". So the stream this closes was
already on its way down. What changes is that it closes when the framing breaks rather than whenever the
read side eventually notices.

**It is more than one change.** Three things move: the latch, closing the transport, and the locking. That
is worth being precise about, because they are not three independent ideas.

The lock is not a separate improvement. On `main` the `try`/`catch` sits outside the lock, so without
widening it a concurrent send can slip in between another send's failure and the latch being set. That is
the exact race this fix exists to close.

The `Dispose` change fixes something already broken on `main`. `Dispose` there takes no lock at all, so it
can race an in flight write, and since `BinaryWriter.Dispose` flushes the `BufferedStream`, it blocks behind
that write. The test below measures 5 seconds on unmodified `main`. `TryEnter` is not compensating for the
wider lock, it fixes what was already there.

The latch alone is what fixes the reported corruption. If you would rather take that first and consider the
rest separately, say so and I will split it. Same if you want the latch without closing the transport, or
want it limited to `IOException` and `SocketException`.

**It will fail runs that pass today.** Yes. After a send throws there is no way to know whether the frame
was actually damaged, so this will also close channels that were fine, and where the failed send was the
last one, `main` would have finished the run and this will not.

What it will not do is turn working builds red. The 106 green builds above had already stopped testing
partway through, and the paired comparison puts the median one at roughly half the code of a clean build of
the same pull request. Those builds are not passing, they are declining to report. Whether you want that
made visible by default in a released product is yours to decide, but I would rather you decided it with
that number in front of you than without it.

## How to verify it

`PeerShouldNotDecodeAMessageThatWasNeverSent` runs a real `LengthPrefixCommunicationChannel` on both ends.
It fails the first send after its prefix has been flushed, sends a second message, then asks the peer to
read one message. On unmodified `main`:

```
failed PeerShouldNotDecodeAMessageThatWasNeverSent (2ms)
  Assert.IsNull failed. 'value' expression: 'received'.
  The peer decoded a 16385 character frame that was never sent as a message,
  starting U+FFFD U+FFFD U+0001.
```

Same shape as production. The byte values differ only because the test uses `SocketConstants.BufferSize + 1`
rather than the sizes that happened to occur in the capture.

Five tests fail on unmodified `main` and pass with this change:

| Test | What `main` does |
| --- | --- |
| `PeerShouldNotDecodeAMessageThatWasNeverSent` | the peer decodes a frame neither send produced |
| `SendShouldCloseStreamAndRejectLaterMessagesAfterPartialFrame` | the second `Send` succeeds instead of throwing |
| `DisposeShouldNotFlushBufferedDataAfterSendFailure` | `Dispose` performs a second write |
| `ConcurrentSendShouldNotWriteAfterFirstSendFails` | the queued `Send` writes after the first one failed |
| `DisposeShouldNeitherWriteNorBlockWhileASendIsInFlight` | `Dispose` blocks for 5 seconds behind the in flight write |

`SendAfterDisposeShouldStillWriteToTheStream` passes before and after. It is there to catch any change to
post `Dispose` behavior.

I ran these against a worktree at unmodified `origin/main` with only the test file applied, to confirm they
fail for the stated reason rather than through test setup: 15 total, 5 failed. With the change: 15 total,
0 failed. The nine existing tests in the file pass unchanged.

If you would rather watch it over a real socket, there is a standalone program at
https://gist.github.com/damianhorna/7677d1050b2fcc93464f73f302594fe3 that runs with `dotnet run` and prints
the production byte values exactly. It reimplements the write path rather than referencing the assembly, so
treat it as an illustration. The tests are the load bearing evidence.

## Other questions

**Why fail the channel on any exception, rather than only on the ones that leave a partial frame?**
Because `BinaryWriter.Write(string)` does not report how much it wrote. After it throws, the number of bytes
that reached the peer is unknown, so whether the frame is intact is also unknown.

**Why `Monitor.TryEnter` in `Dispose` rather than `lock`?** Because waiting is the harmful part. A plain
`lock` would keep the 5 second stall described above and add a shutdown hang whenever a socket write is
stuck. Taking the lock only when it is free gives the same protection against flushing mid frame, and
skipping the flush loses nothing, because `Send` flushes after every message it completes. The only thing
the buffer can still hold is part of a frame that failed, which is exactly what must not go out.

**Why no `_isDisposed` guard on `Send`?** I tried one and reverted it. Shutdown legitimately sends after
`Dispose`, because `Dispose` runs while timer driven sends are still in flight, so the guard silently
dropped real messages. `SendAfterDisposeShouldStillWriteToTheStream` pins the current behavior instead.

**Why no new exception type?** `Send` already threw `CommunicationException` on write failure. No caller
retries a failed `Send` or catches that type, so rejecting later sends the same way changes no handling.

**Why is the `NotSupportedException` filter now on `_stream` instead of `_writer.BaseStream`?** Reading
`BaseStream` flushes the writer, and an exception filter runs while the exception is still in flight. On a
channel that has just failed mid frame, that flush is the last thing you want. The channel already holds
the stream, so it can check that instead. The log message was updated to match.
