### PR TITLE
Isolate attachment manager test temporary files

### DIFF
--- a/test/datacollector.UnitTests/DataCollectionAttachmentManagerTests.cs
+++ b/test/datacollector.UnitTests/DataCollectionAttachmentManagerTests.cs
@@ -25,7 +25,8 @@ public class DataCollectionAttachmentManagerTests
     private readonly DataCollectionAttachmentManager _attachmentManager;
     private readonly Mock<IMessageSink> _messageSink;
     private readonly SessionId _sessionId;
-    private static readonly string TempDirectoryPath = Path.GetTempPath();
+
+    private string TempDirectoryPath { get; }
 
     public TestContext TestContext { get; set; }
 
@@ -35,13 +36,13 @@ public class DataCollectionAttachmentManagerTests
         _messageSink = new Mock<IMessageSink>();
         var guid = Guid.NewGuid();
         _sessionId = new SessionId(guid);
+        TempDirectoryPath = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), guid.ToString())).FullName;
     }
 
     [TestCleanup]
     public void Cleanup()
     {
-        File.Delete(Path.Combine(TempDirectoryPath, "filename.txt"));
-        File.Delete(Path.Combine(TempDirectoryPath, "filename1.txt"));
+        Directory.Delete(TempDirectoryPath, recursive: true);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Description

Give each `DataCollectionAttachmentManagerTests` instance its own temporary root using its existing session GUID, and delete only that root during cleanup. This isolates input files and outputs without changing filenames or test bodies. The existing `TempDirectory` helper requires NuGet configuration that this fixture does not need.

The fixture previously shared `%TEMP%\filename.txt` and `%TEMP%\filename1.txt`, including cleanup. [Build 1581131](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1581131) had overlapping net11.0/net481 runs and an attachment-count failure ([failure log](https://dev.azure.com/dnceng-public/public/_apis/build/builds/1581131/logs/19?api-version=7.1)); retry passed unchanged. Concurrent-TFM interference is probable, but the exact trigger has not been reproduced or confirmed.

Validation: Release build passed. All 14 fixture tests passed ten times per TFM with net11.0 and net481 processes running concurrently: **280 passed, 0 failed**. Used the repo SDK and built test executables directly to bypass unrelated local VS MSBuild version and wrapper category-filter parsing issues. No product, callback/assertion, or CI changes.

## Related issue

Observed in #16440's CI build; no separate issue filed.

- [ ] I have ensured that there is a previously discussed and approved issue.