### PR TITLE
Fix broken XML escaping documentation link

### DIFF
--- a/docs/RFCs/0029-Passing-TestRunParameters-via-CLI.md
+++ b/docs/RFCs/0029-Passing-TestRunParameters-via-CLI.md
@@ -44,4 +44,4 @@ The arguments are parsed and `attribute name` and `attribute value` are fetched 
 
 ### Note
 Some special characters like &,<,> are converted to their escaped form and stored in runsettings. <br>
-For more info on escaped strings refer [this](https://www.ibm.com/support/knowledgecenter/en/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/rwlp_xml_escape.html).
+For more info on escaped strings, refer to [Predefined Entities in the XML specification](https://www.w3.org/TR/xml/#sec-predefined-ent).


### PR DESCRIPTION
Fixes #16474.

Replace the retired IBM Knowledge Center link with the W3C XML specification's section on predefined entities. Use descriptive link text instead of 'this'. IBM's [current documentation](https://www.ibm.com/docs/en/was-liberty/base?topic=liberty-administering-manually) also points to W3C for XML escaping.