### PR TITLE
[rel/18.10] Isolate code coverage files in published output

### DIFF
--- a/src/package/Microsoft.CodeCoverage/Microsoft.CodeCoverage.targets
+++ b/src/package/Microsoft.CodeCoverage/Microsoft.CodeCoverage.targets
@@ -18,10 +18,24 @@
 
     <ItemGroup>
       <TraceDataCollectorArtifacts Include="$(MSBuildThisFileDirectory)\**\*.*" />
+      <!-- The collector host discovers collectors recursively next to the test assembly and resolves
+           their dependencies in the collector's directory. Keep the complete native/resource layout,
+           but never overwrite the application's assemblies with the collector's private dependencies. -->
+      <ResolvedFileToPublish Include="@(TraceDataCollectorArtifacts)">
+        <RelativePath>Microsoft.CodeCoverage\%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
+        <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      </ResolvedFileToPublish>
     </ItemGroup>
 
-    <Copy SourceFiles="@(TraceDataCollectorArtifacts)" DestinationFolder="$(PublishDir)%(RecursiveDir)" />
+  </Target>
 
+  <!-- The browser-WASM SDK discovers managed bundle inputs with a recursive publish-directory glob,
+       including files left by earlier publishes. These tools run in the collector host, not in WASM. -->
+  <Target Name="ExcludeTraceDataCollectorArtifactsFromWasmBundle" AfterTargets="_GetDefaultWasmAssembliesToBundle">
+    <ItemGroup>
+      <WasmAssembliesToBundle Remove="$(PublishDir)Microsoft.CodeCoverage\**\*.dll" />
+    </ItemGroup>
   </Target>
 
   <PropertyGroup Condition="'$(NETCoreSdkVersion)' != '' and '$(DisableMsCoverageReferencedPathMaps)' != 'true'">

--- a/src/package/Microsoft.CodeCoverage/README.md
+++ b/src/package/Microsoft.CodeCoverage/README.md
@@ -16,6 +16,24 @@ Collect code coverage during a test run:
 dotnet test --collect "Code Coverage"
 ```
 
+## Published tests
+
+`dotnet publish` places the collector, tools, and their private dependencies in the
+`Microsoft.CodeCoverage` subdirectory. Deploy the entire publish directory. VSTest
+discovers the collector beside the published tests without a project or NuGet cache:
+
+```sh
+dotnet vstest publish/Tests.dll --collect:"Code Coverage"
+```
+
+For runners that require an explicit extension path, pass
+`--TestAdapterPath:publish/Microsoft.CodeCoverage`. Normal `dotnet test` runs continue
+to use the collector from the package directory.
+
+When upgrading from a package that copied coverage files into the publish root,
+delete the old publish directory before publishing again. Old private dependencies
+in that directory cannot safely be distinguished from application files.
+
 ## Links
 
 - [Visual Studio Test Platform Documentation](https://github.com/microsoft/vstest)

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/CodeCoveragePublishTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/CodeCoveragePublishTests.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml;
+
+using Microsoft.TestPlatform.TestUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.TestPlatform.AcceptanceTests;
+
+[TestClass]
+public sealed class CodeCoveragePublishTests : AcceptanceTestBase
+{
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(1)]
+    public void PublishKeepsPrivateDependenciesIsolatedRegardlessOfTimestamp(int coverageTimestampOffset)
+    {
+        var packageDirectory = TempDirectory.CreateDirectory("coverage-package").FullName;
+        var applicationDirectory = TempDirectory.CreateDirectory("application").FullName;
+        using var deployment = new TempDirectory();
+        string[] dependencies =
+        [
+            "System.Memory.dll", "System.Buffers.dll", "System.Runtime.CompilerServices.Unsafe.dll",
+            "System.Threading.Tasks.Extensions.dll", "System.Text.Json.dll", "System.Text.Encodings.Web.dll",
+            "Microsoft.Bcl.AsyncInterfaces.dll", "Microsoft.CodeCoverage.targets"
+        ];
+        var timestamp = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        foreach (var dependency in dependencies)
+        {
+            var applicationFile = Path.Combine(applicationDirectory, dependency);
+            File.WriteAllText(applicationFile, "application");
+            File.SetLastWriteTimeUtc(applicationFile, timestamp);
+            var coverageFile = Path.Combine(packageDirectory, dependency);
+            File.WriteAllText(coverageFile, "coverage");
+            File.SetLastWriteTimeUtc(coverageFile, timestamp.AddDays(coverageTimestampOffset));
+        }
+
+        File.Copy(
+            Path.Combine(IntegrationTestEnvironment.RepoRootDirectory, "src", "package", "Microsoft.CodeCoverage", "Microsoft.CodeCoverage.targets"),
+            Path.Combine(packageDirectory, "Microsoft.CodeCoverage.targets"),
+            overwrite: true);
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "x64"));
+        File.WriteAllText(Path.Combine(packageDirectory, "x64", "instrumentation.dll"), "native");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "fr"));
+        File.WriteAllText(Path.Combine(packageDirectory, "fr", "collector.resources.dll"), "resource");
+
+        var projectPath = Path.Combine(TempDirectory.Path, "Publish.csproj");
+        File.WriteAllText(Path.Combine(TempDirectory.Path, "Directory.Build.props"), "<Project />");
+        File.WriteAllText(Path.Combine(TempDirectory.Path, "Directory.Build.targets"), "<Project />");
+        File.WriteAllText(projectPath, $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>{Core11TargetFramework}</TargetFramework>
+                <EnableDefaultItems>false</EnableDefaultItems>
+                <DisableMsCoverageReferencedPathMaps>true</DisableMsCoverageReferencedPathMaps>
+              </PropertyGroup>
+              <ItemGroup>
+                <Content Include="application/*" CopyToPublishDirectory="PreserveNewest" TargetPath="%(Filename)%(Extension)" />
+              </ItemGroup>
+              <Import Project="coverage-package/Microsoft.CodeCoverage.targets" />
+              <Target Name="_GetDefaultWasmAssembliesToBundle">
+                <ItemGroup>
+                  <WasmAssembliesToBundle Include="$(PublishDir)**/*.dll" />
+                </ItemGroup>
+              </Target>
+              <Target Name="CheckWasmBundle" DependsOnTargets="PrepareForPublish;_GetDefaultWasmAssembliesToBundle">
+                <WriteLinesToFile File="$(PublishDir)wasm-inputs.txt" Lines="@(WasmAssembliesToBundle)" Overwrite="true" />
+              </Target>
+            </Project>
+            """);
+
+        for (var publish = 0; publish < 2; publish++)
+        {
+            RunDotnet($"""publish "{projectPath}" -c Release -o "{deployment.Path}" -bl:"{Path.Combine(TempDirectory.Path, $"publish-{publish}.binlog")}" """);
+            foreach (var dependency in dependencies)
+            {
+                Assert.AreEqual("application", File.ReadAllText(Path.Combine(deployment.Path, dependency)), dependency);
+                Assert.AreEqual(
+                    File.ReadAllText(Path.Combine(packageDirectory, dependency)),
+                    File.ReadAllText(Path.Combine(deployment.Path, "Microsoft.CodeCoverage", dependency)),
+                    dependency);
+            }
+
+            Assert.AreEqual("native", File.ReadAllText(Path.Combine(deployment.Path, "Microsoft.CodeCoverage", "x64", "instrumentation.dll")));
+            Assert.AreEqual("resource", File.ReadAllText(Path.Combine(deployment.Path, "Microsoft.CodeCoverage", "fr", "collector.resources.dll")));
+            RunDotnet($"""msbuild "{projectPath}" -t:CheckWasmBundle -p:PublishDir="{deployment.Path}" """);
+            var bundledFiles = File.ReadAllLines(Path.Combine(deployment.Path, "wasm-inputs.txt"));
+            Assert.Contains(path => path.EndsWith("System.Memory.dll", StringComparison.Ordinal), bundledFiles);
+            Assert.DoesNotContain(path => path.Contains($"Microsoft.CodeCoverage{Path.DirectorySeparatorChar}", StringComparison.Ordinal), bundledFiles);
+        }
+    }
+
+    [TestMethod]
+    [TestMatrix(console: Net, testHost: Net)]
+    [TestMatrix(console: Net, testHost: NetFx)]
+    public void PublishedTestsDiscoverCoverageWithoutPackageAdapterPath(RunnerInfo runnerInfo)
+    {
+        SetTestEnvironment(_testEnvironment, runnerInfo);
+        var projectPath = GetIsolatedTestAsset("SimpleTestProject.csproj", runnerInfo.TargetFramework);
+        using var deployment = new TempDirectory();
+        RunDotnet($"""publish "{projectPath}" -c Release -o "{deployment.Path}" -p:PackageVersion={IntegrationTestEnvironment.LatestLocallyBuiltNugetVersion} -bl:"{Path.Combine(TempDirectory.Path, "publish.binlog")}" """);
+        var collectorPath = Path.Combine(deployment.Path, "Microsoft.CodeCoverage", "Microsoft.VisualStudio.TraceDataCollector.dll");
+        Assert.IsTrue(File.Exists(collectorPath), collectorPath);
+        Assert.IsFalse(File.Exists(Path.Combine(deployment.Path, "Microsoft.VisualStudio.TraceDataCollector.dll")));
+
+        // Exercise the package with the SDK's existing runner; collector discovery must not depend
+        // on changes to the runner or on the project's package path supplied by dotnet test.
+        Directory.CreateDirectory(DiagLogsDirectory);
+        var output = RunDotnet(
+            $@"vstest ""{Path.Combine(deployment.Path, "SimpleTestProject.dll")}"" /collect:""Code Coverage;Format=cobertura"" /ResultsDirectory:""{deployment.Path}"" /logger:""console;verbosity=normal"" /Diag:""{Path.Combine(DiagLogsDirectory, "coverage.log")}""",
+            expectedExitCode: 1,
+            packagesDirectory: Path.Combine(deployment.Path, "empty-cache"));
+        Assert.Contains("Passed: 1", output);
+        Assert.Contains("Failed: 1", output);
+        Assert.Contains("Skipped: 1", output);
+        var report = Directory.GetFiles(deployment.Path, "*.cobertura.xml", SearchOption.AllDirectories).Single();
+        var coverage = new XmlDocument();
+        coverage.Load(report);
+        Assert.IsGreaterThan(0, int.Parse(coverage.DocumentElement!.GetAttribute("lines-covered"), System.Globalization.CultureInfo.InvariantCulture), report);
+
+        var diagnostics = string.Join(Environment.NewLine, Directory.GetFiles(DiagLogsDirectory, "*.log").Select(File.ReadAllText));
+        Assert.Contains(collectorPath, diagnostics);
+        Assert.Contains(Path.Combine(deployment.Path, "Microsoft.CodeCoverage", "Microsoft.CodeCoverage.Core.dll"), diagnostics);
+    }
+
+    private static string RunDotnet(string arguments, int expectedExitCode = 0, string? packagesDirectory = null)
+    {
+        var dotnet = Path.Combine(IntegrationTestEnvironment.RepoRootDirectory, ".dotnet", OSUtils.IsWindows ? "dotnet.exe" : "dotnet");
+        ExecuteApplication(dotnet, arguments, out var output, out var error, out var exitCode,
+            new Dictionary<string, string?> { ["NUGET_PACKAGES"] = packagesDirectory ?? IntegrationTestEnvironment.TestAssetsNuGetCacheDirectory });
+        Assert.AreEqual(expectedExitCode, exitCode, output + Environment.NewLine + error);
+
+        return output;
+    }
+}


### PR DESCRIPTION
Addresses the publish failures in microsoft/testfx#11178.

Publish coverage tools and their private dependencies under Microsoft.CodeCoverage instead of the application root. Keep those tools out of the WASM bundle and document the one-time cleanup needed for existing publish folders.