### PR TITLE
[rel/18.10] Preserve application dependencies when publishing coverage

### DIFF
--- a/src/package/Microsoft.CodeCoverage/Microsoft.CodeCoverage.targets
+++ b/src/package/Microsoft.CodeCoverage/Microsoft.CodeCoverage.targets
@@ -14,14 +14,63 @@
 
   <!-- This target required to enable /collect:"Code Coverage" in "dotnet publish" scenario with "dotnet vstest".
        E.g: Release pipelines where user/project nuget cache not available on current machine. -->
-  <Target Name="CopyTraceDataCollectorArtifacts" AfterTargets="ComputeFilesToPublish">
-
+  <Target Name="CopyTraceDataCollectorArtifacts"
+          AfterTargets="ComputeFilesToPublish"
+          BeforeTargets="_HandleFileConflictsForPublish">
     <ItemGroup>
       <TraceDataCollectorArtifacts Include="$(MSBuildThisFileDirectory)\**\*.*" />
     </ItemGroup>
+    <ItemGroup>
+      <TraceDataCollectorArtifacts>
+        <RelativePath>%(TraceDataCollectorArtifacts.RecursiveDir)%(TraceDataCollectorArtifacts.Filename)%(TraceDataCollectorArtifacts.Extension)</RelativePath>
+      </TraceDataCollectorArtifacts>
+    </ItemGroup>
+    <ItemGroup>
+      <!-- The consuming application owns its publish destinations, including runtime-pack assets.
+           PathLike compares the whole destination path, normalizing separators and dot segments. -->
+      <_msCoverageNonConflictingArtifact Include="@(TraceDataCollectorArtifacts)" />
+      <_msCoverageNonConflictingArtifact Remove="@(ResolvedFileToPublish)"
+                                         MatchOnMetadata="RelativePath" MatchOnMetadataOptions="PathLike" />
+      <_msCoverageNonConflictingApplicationFile Include="@(ResolvedFileToPublish)" />
+      <_msCoverageNonConflictingApplicationFile Remove="@(TraceDataCollectorArtifacts)"
+                                              MatchOnMetadata="RelativePath" MatchOnMetadataOptions="PathLike" />
+    </ItemGroup>
+    <ItemGroup>
+      <_msCoverageApplicationFile Include="@(ResolvedFileToPublish)"
+                                  Condition="'%(ResolvedFileToPublish.CopyToPublishDirectory)' != 'Never'" />
+      <_msCoverageApplicationFile Remove="@(_msCoverageNonConflictingApplicationFile)"
+                                  MatchOnMetadata="RelativePath" MatchOnMetadataOptions="PathLike" />
 
-    <Copy SourceFiles="@(TraceDataCollectorArtifacts)" DestinationFolder="$(PublishDir)%(RecursiveDir)" />
+      <!-- Framework-dependent applications do not publish shared-framework assemblies. Do not
+           introduce private copies of those assemblies from the collector's bundled dependencies. -->
+      <_msCoverageFrameworkFile Include="@(ReferencePath)"
+                                Condition="'%(ReferencePath.FrameworkReferenceName)' != '' or '%(ReferencePath.FrameworkFile)' == 'true' or '%(ReferencePath.ResolvedFrom)' == '{TargetFrameworkDirectory}'">
+        <RelativePath>%(ReferencePath.Filename)%(ReferencePath.Extension)</RelativePath>
+      </_msCoverageFrameworkFile>
+    </ItemGroup>
+    <ItemGroup>
+      <_msCoverageFrameworkFile Remove="@(ResolvedFileToPublish)"
+                                MatchOnMetadata="RelativePath" MatchOnMetadataOptions="PathLike" />
+      <_msCoverageFrameworkArtifact Include="@(_msCoverageNonConflictingArtifact)" />
+      <_msCoverageNonConflictingArtifact Remove="@(_msCoverageFrameworkFile)"
+                                         MatchOnMetadata="RelativePath" MatchOnMetadataOptions="PathLike" />
+      <_msCoverageFrameworkArtifact Remove="@(_msCoverageNonConflictingArtifact)" />
 
+      <!-- Replace a newer collector dependency left in PublishDir by an older version of this
+           target. PreserveNewest would keep that file even after resolving the collision correctly. -->
+      <ResolvedFileToPublish Remove="@(_msCoverageApplicationFile)"
+                             MatchOnMetadata="RelativePath" MatchOnMetadataOptions="PathLike" />
+      <ResolvedFileToPublish Include="@(_msCoverageApplicationFile)" CopyToPublishDirectory="Always" />
+      <ResolvedFileToPublish Include="@(_msCoverageNonConflictingArtifact)"
+                             CopyToPublishDirectory="Always" ExcludeFromSingleFile="true" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_RemoveMsCoverageFrameworkArtifacts"
+          BeforeTargets="CopyFilesToPublishDirectory"
+          DependsOnTargets="CopyTraceDataCollectorArtifacts">
+    <!-- Remove private framework assemblies left by previous versions of this package. -->
+    <Delete Files="@(_msCoverageFrameworkArtifact->'$(PublishDir)%(RelativePath)')" />
   </Target>
 
   <PropertyGroup Condition="'$(NETCoreSdkVersion)' != '' and '$(DisableMsCoverageReferencedPathMaps)' != 'true'">

--- a/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/CodeCoveragePublishTests.cs
+++ b/test/Microsoft.TestPlatform.Acceptance.IntegrationTests/CodeCoveragePublishTests.cs
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Security;
+
+using Microsoft.TestPlatform.TestUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.TestPlatform.AcceptanceTests;
+
+[TestClass]
+public sealed class CodeCoveragePublishTests : AcceptanceTestBase
+{
+    [TestMethod]
+    [DataRow("Dependency.dll")]
+    [DataRow("./Dependency.dll")]
+    [DataRow("nested/../Dependency.dll")]
+    [DataRow(@"nested\..\Dependency.dll")]
+    public void PublishPreservesApplicationDependencyRegardlessOfTimestamp(string relativePath)
+    {
+        CreateProject(relativePath);
+        WriteFile("coverage", "Dependency.dll", "collector dependency", 2030);
+        WriteFile("coverage", Path.Combine("nested", "Dependency.dll"), "nested collector dependency", 2030);
+        WriteFile("application", "selected.txt", "application dependency", 2000);
+        WriteFile("publish", "Dependency.dll", "polluted dependency", 2040);
+
+        Publish();
+        AssertPublishedFile("Dependency.dll", "application dependency");
+        AssertPublishedFile(Path.Combine("nested", "Dependency.dll"), "nested collector dependency");
+
+        WriteFile("application", "selected.txt", "updated application dependency", 2040);
+        WriteFile("coverage", "Dependency.dll", "older collector dependency", 2000);
+        Publish();
+        Publish();
+        AssertPublishedFile("Dependency.dll", "updated application dependency");
+
+        Directory.Delete(Path.Combine(TempDirectory.Path, "publish"), recursive: true);
+        WriteFile("coverage", "Dependency.dll", "newer collector dependency", 2050);
+        Publish();
+        AssertPublishedFile("Dependency.dll", "updated application dependency");
+    }
+
+    [TestMethod]
+    public void PublishOmitsFrameworkDependenciesAndRemovesPollutedOutput()
+    {
+        CreateProject("application.txt");
+        WriteFile("application", "selected.txt", "application content", 2000);
+        WriteFile("coverage", "System.Memory.dll", "private framework dependency", 2030);
+        WriteFile("coverage", Path.Combine("nested", "System.Memory.dll"), "nested dependency", 2030);
+        WriteFile("publish", "System.Memory.dll", "polluted framework dependency", 2040);
+        WriteFile("publish", "unrelated.txt", "unrelated output", 2000);
+
+        Publish();
+        Publish();
+
+        Assert.IsFalse(File.Exists(Path.Combine(TempDirectory.Path, "publish", "System.Memory.dll")));
+        AssertPublishedFile(Path.Combine("nested", "System.Memory.dll"), "nested dependency");
+        AssertPublishedFile("application.txt", "application content");
+        AssertPublishedFile("unrelated.txt", "unrelated output");
+    }
+
+    [TestMethod]
+    public void PublishPreservesExplicitApplicationFileEvenWhenFrameworkProvidesAssembly()
+    {
+        CreateProject("./System.Memory.dll");
+        WriteFile("application", "selected.txt", "explicit application file", 2000);
+        WriteFile("coverage", "System.Memory.dll", "collector dependency", 2030);
+        WriteFile("publish", "System.Memory.dll", "polluted dependency", 2040);
+
+        Publish();
+        Publish();
+
+        AssertPublishedFile("System.Memory.dll", "explicit application file");
+    }
+
+    [TestMethod]
+    public void PublishHandlesOneApplicationSourceWithMultipleDestinations()
+    {
+        CreateProject("Dependency.dll", includeSecondDestination: true);
+        WriteFile("application", "selected.txt", "application dependency", 2000);
+        WriteFile("coverage", "Dependency.dll", "collector dependency", 2030);
+        WriteFile("publish", "Dependency.dll", "polluted dependency", 2040);
+
+        Publish();
+        Publish();
+
+        AssertPublishedFile("Dependency.dll", "application dependency");
+        AssertPublishedFile(Path.Combine("other", "Dependency.dll"), "application dependency");
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void PublishMatchesDestinationCasingOnWindows()
+    {
+        CreateProject("DEPENDENCY.dll");
+        WriteFile("application", "selected.txt", "application dependency", 2000);
+        WriteFile("coverage", "Dependency.dll", "collector dependency", 2030);
+        WriteFile("publish", "Dependency.dll", "polluted dependency", 2040);
+
+        Publish();
+
+        AssertPublishedFile("Dependency.dll", "application dependency");
+    }
+
+    private void CreateProject(string relativePath, bool includeSecondDestination = false)
+    {
+        var coverageDirectory = TempDirectory.CreateDirectory("coverage").FullName;
+        File.Copy(
+            Path.Combine(IntegrationTestEnvironment.RepoRootDirectory, "src", "package", "Microsoft.CodeCoverage", "Microsoft.CodeCoverage.targets"),
+            Path.Combine(coverageDirectory, "Microsoft.CodeCoverage.targets"));
+
+        // A private collector payload lets these tests control timestamps without touching the NuGet cache.
+        File.WriteAllText(Path.Combine(TempDirectory.Path, "Publish.csproj"), $"""
+            <Project>
+              <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+              <PropertyGroup>
+                <TargetFramework>{Core11TargetFramework}</TargetFramework>
+                <EnableDefaultItems>false</EnableDefaultItems>
+                <NuGetAudit>false</NuGetAudit>
+              </PropertyGroup>
+              <ItemGroup>
+                <Content Include="application/selected.txt" TargetPath="{SecurityElement.Escape(relativePath)}" CopyToPublishDirectory="PreserveNewest" />
+                <Content Include="application/selected.txt" TargetPath="other/Dependency.dll" CopyToPublishDirectory="PreserveNewest" Condition="{includeSecondDestination}" />
+              </ItemGroup>
+              <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+              <Import Project="coverage/Microsoft.CodeCoverage.targets" />
+            </Project>
+            """);
+    }
+
+    private void Publish()
+    {
+        var dotnetPath = Path.Combine(IntegrationTestEnvironment.RepoRootDirectory, ".dotnet", OSUtils.IsWindows ? "dotnet.exe" : "dotnet");
+        ExecuteApplication(
+            dotnetPath,
+            "publish Publish.csproj --nologo -v:quiet -o publish",
+            out var output,
+            out var error,
+            out var exitCode,
+            workingDirectory: TempDirectory.Path);
+
+        Assert.AreEqual(0, exitCode, $"Publish failed.\n{output}\n{error}");
+    }
+
+    private void WriteFile(string directory, string relativePath, string contents, int year)
+    {
+        var path = Path.Combine(TempDirectory.Path, directory, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, contents);
+        File.SetLastWriteTimeUtc(path, new DateTime(year, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    private void AssertPublishedFile(string relativePath, string expected)
+    {
+        var path = Path.Combine(TempDirectory.Path, "publish", relativePath);
+        Assert.IsTrue(File.Exists(path), $"Missing published file: {path}");
+        Assert.AreEqual(expected, File.ReadAllText(path), $"Unexpected published file: {path}");
+    }
+}


### PR DESCRIPTION
Addresses the publish failures in microsoft/testfx#11178.

Keep application-selected DLLs when coverage files target the same publish path. Replace stale conflicting output regardless of timestamps and avoid copying private assemblies supplied by the application runtime.
